### PR TITLE
Fix audio related warnings

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -153,14 +153,14 @@ Scope {
     // --- NEW: Keep volume property in sync with actual Pipewire audio sink volume ---
 
     Connections {
-        target: defaultAudioSink.audio
-        onVolumeChanged: {
+        target: defaultAudioSink ? defaultAudioSink.audio : null
+        function onVolumeChanged() {
             if (defaultAudioSink.audio && !defaultAudioSink.audio.muted) {
                 volume = Math.round(defaultAudioSink.audio.volume * 100);
                 console.log("Volume changed externally to:", volume);
             }
         }
-        onMutedChanged: {
+        function onMutedChanged() {
             if (defaultAudioSink.audio) {
                 if (defaultAudioSink.audio.muted) {
                     volume = 0;


### PR DESCRIPTION
Fixes 3 audio warning on my setup.
1/ Sometimes my headset if off and I have no default audio sink
2/ Newer syntax for Connections.
