### PR TITLE
Added option for transparent background

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -78,6 +78,7 @@ Singleton {
         property bool showBrightness: true
         property bool showNotificationsHistory: true
         property bool showTray: true
+        property bool transparentBackground: false 
         property list<string> monitors: []
       }
 

--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -39,7 +39,7 @@ Variants {
         id: bar
 
         anchors.fill: parent
-        color: Color.mSurface
+        color: Settings.data.bar.transparentBackground ? "#66" + (Color.mSurface + "").substring(1) : Color.mSurface
         layer.enabled: true
       }
 

--- a/Modules/SettingsPanel/Tabs/BarTab.qml
+++ b/Modules/SettingsPanel/Tabs/BarTab.qml
@@ -84,6 +84,15 @@ ColumnLayout {
                        Settings.data.bar.showTray = checked
                      }
         }
+
+        NToggle {
+          label: "Transparent Background"
+          description: "Make the bar's background transparent"
+          checked: Settings.data.bar.transparentBackground
+          onToggled: checked => {
+                       Settings.data.bar.transparentBackground = checked
+                     }
+        }
       }
     }
   }


### PR DESCRIPTION
Currently there is no way of making the bar background transparent, this pr adds a new toggle option in the bar settings for a transparent background. When enabled, it adds `#66` to the beginning of the hex code which is 40% opacity.