### PR TITLE
Added setting for workspace names

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -122,6 +122,7 @@ Singleton {
         property bool showActiveWindowIcon: true
         property bool alwaysShowBatteryPercentage: false
         property real backgroundOpacity: 1.0
+        property bool showWorkspaceNames: false
         property list<string> monitors: []
 
         // Widget configuration for modular bar system

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -161,6 +161,21 @@ Item {
         Rectangle {
           id: workspacePill
           anchors.fill: parent
+
+          Loader {
+            anchors.centerIn: parent
+            active: Settings.data.bar.showWorkspaceNames 
+            sourceComponent: Component {
+              Text {
+                text: model.name.substring(0,2)
+                font.pointSize: Style.fontSizeXS * scaling
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.Wrap
+              }
+            }
+          }
+
           radius: {
             if (model.isFocused)
               return Math.round(12 * scaling)

--- a/Modules/SettingsPanel/Tabs/BarTab.qml
+++ b/Modules/SettingsPanel/Tabs/BarTab.qml
@@ -127,6 +127,15 @@ ColumnLayout {
                        Settings.data.bar.alwaysShowBatteryPercentage = checked
                      }
         }
+        
+        NToggle {
+          label: "Show Workspace Names"
+          description: "Show the workspace names on the workspace indicators"
+          checked: Settings.data.bar.showWorkspaceNames
+          onToggled: checked => {
+                       Settings.data.bar.showWorkspaceNames = checked
+                     }
+        }
 
         NDivider {
           Layout.fillWidth: true


### PR DESCRIPTION
New option in settings for adding the workspace names onto the workspace indicator on the bar.
I use Hyprland but I installed Niri to see how workspaces are handled there and as far as I can tell, they don't have names, correct me if I am wrong though.