### PR TITLE
small flake.nix fix - providing a proper 'default' and fixing formatter errors

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,57 +11,83 @@
     };
   };
 
-  outputs = { self, nixpkgs, systems, quickshell, ... }:
-    let
-      eachSystem = nixpkgs.lib.genAttrs (import systems);
-    in {
-      formatter = eachSystem (pkgs: pkgs.alejandra);
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+    quickshell,
+    ...
+  }: let
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+  in {
+    formatter = eachSystem (
+      system:
+        nixpkgs.legacyPackages.${system}.alejandra
+    );
 
-      packages = eachSystem (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          qs = quickshell.packages.${system}.default.override {
-            withX11 = false;
-            withI3 = false;
-          };
+    packages = eachSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        qs = quickshell.packages.${system}.default.override {
+          withX11 = false;
+          withI3 = false;
+        };
 
-          runtimeDeps = with pkgs; [
-            bash bluez brightnessctl cava cliphist coreutils ddcutil file
-            findutils gpu-screen-recorder libnotify matugen networkmanager
-            swww wl-clipboard
+        runtimeDeps = with pkgs; [
+          bash
+          bluez
+          brightnessctl
+          cava
+          cliphist
+          coreutils
+          ddcutil
+          file
+          findutils
+          gpu-screen-recorder
+          libnotify
+          matugen
+          networkmanager
+          swww
+          wl-clipboard
+        ];
+
+        fontconfig = pkgs.makeFontsConf {
+          fontDirectories = [
+            pkgs.material-symbols
+            pkgs.roboto
+            pkgs.inter-nerdfont
           ];
-          fontconfig = pkgs.makeFontsConf {
-            fontDirectories = [ pkgs.material-symbols pkgs.roboto pkgs.inter-nerdfont ];
+        };
+      in {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "noctalia-shell";
+          version = self.rev or self.dirtyRev or "dirty";
+          src = ./.;
+
+          nativeBuildInputs = [pkgs.gcc pkgs.makeWrapper pkgs.qt6.wrapQtAppsHook];
+          buildInputs = [qs pkgs.xkeyboard-config pkgs.qt6.qtbase];
+          propagatedBuildInputs = runtimeDeps;
+
+          installPhase = ''
+            mkdir -p $out/share/noctalia-shell
+            cp -r ./* $out/share/noctalia-shell
+
+            makeWrapper ${qs}/bin/qs $out/bin/noctalia-shell \
+              --prefix PATH : "${pkgs.lib.makeBinPath runtimeDeps}" \
+              --set FONTCONFIG_FILE "${fontconfig}" \
+              --add-flags "-p $out/share/noctalia-shell"
+          '';
+
+          meta = {
+            description = "A sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell.";
+            homepage = "https://github.com/noctalia-dev/noctalia-shell";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "noctalia-shell";
           };
-        in
-          pkgs.stdenv.mkDerivation {
-            pname = "noctalia-shell";
-            version = self.rev or self.dirtyRev or "dirty";
-            src = ./.;
+        };
+      }
+    );
 
-            nativeBuildInputs = [ pkgs.gcc pkgs.makeWrapper pkgs.qt6.wrapQtAppsHook ];
-            buildInputs = [ qs pkgs.xkeyboard-config pkgs.qt6.qtbase ];
-            propagatedBuildInputs = runtimeDeps;
-
-            installPhase = ''
-              mkdir -p $out/share/noctalia-shell
-              cp -r ./* $out/share/noctalia-shell
-
-              makeWrapper ${qs}/bin/qs $out/bin/noctalia-shell \
-                --prefix PATH : "${pkgs.lib.makeBinPath runtimeDeps}" \
-                --set FONTCONFIG_FILE "${fontconfig}" \
-                --add-flags "-p $out/share/noctalia-shell"
-            '';
-
-            meta = {
-              description = "A sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell.";
-              homepage = "https://github.com/noctalia-dev/noctalia-shell";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "noctalia-shell";
-            };
-          }
-      );
-
-            defaultPackage = eachSystem (system: self.packages.${system});
-    };
+    defaultPackage = eachSystem (system: self.packages.${system}.default);
+  };
 }


### PR DESCRIPTION
There seems to be a small discrepancy between the NixOS install guide and what the flake.nix actually provides. Nothing major, but there are two solutions:

1. Change the "quickshell.packages.${system}.default" on step 2 to "inputs.noctalia.defaultPackage.${pkgs.system}"
2. Add a proper 'default' to the Flake.nix

Both options work just as well, but I think the latter is the 'proper' convention. I've gone ahead with doing the second solution on this pull request instead of changing the install guide.

I was also getting errors with how the 'formatter' was setup, so I sorted that too. 

**Side note:** I'm not sure if you have a preferred formatting for the code, so sorry ahead of time on that.