### PR TITLE
Added kitty matugen template

### DIFF
--- a/Assets/Matugen/matugen.toml
+++ b/Assets/Matugen/matugen.toml
@@ -24,3 +24,8 @@ output_path = "~/.config/qt6ct/colors/noctalia.conf"
 [templates.qt5]
 input_path = "templates/qtct.conf"
 output_path = "~/.config/qt5ct/colors/noctalia.conf"
+
+[templates.kitty]
+input_path = "templates/kitty.conf"
+output_path = "~/.config/kitty/themes/noctalia.conf"
+post_hook   = 'kitty +kitten themes --reload-in=all noctalia'

--- a/Assets/Matugen/templates/kitty.conf
+++ b/Assets/Matugen/templates/kitty.conf
@@ -1,0 +1,25 @@
+color0 {{colors.surface.default.hex}}
+color1 {{colors.error.default.hex}}
+color2 {{colors.tertiary.default.hex}}
+color3 {{colors.secondary.default.hex}}
+color4 {{colors.primary.default.hex}}
+color5 {{colors.primary.default.hex}}
+color6 {{colors.secondary.default.hex}}
+color7 {{colors.on_background.default.hex}}
+color8 {{colors.outline.default.hex}}
+color9 {{colors.secondary_fixed_dim.default.hex}}
+color10 {{colors.tertiary_container.default.hex}}
+color11 {{colors.surface_container.default.hex}}
+color12 {{colors.primary_container.default.hex}}
+color13 {{colors.on_primary_container.default.hex}}
+color14 {{colors.surface_variant.default.hex}}
+color15 {{colors.on_background.default.hex}}
+
+cursor {{colors.primary.default.hex}}
+cursor_text_color {{colors.on_surface.default.hex}}
+
+foreground            {{colors.on_surface.default.hex}}
+background            {{colors.surface.default.hex}}
+selection_foreground  {{colors.on_secondary.default.hex}}
+selection_background  {{colors.secondary_fixed_dim.default.hex}}
+url_color             {{colors.primary.default.hex}}


### PR DESCRIPTION
Based off the previous version but I changed some that I found had too low contrast compared to the background. I also changed it so existing terminals will reload the color theme using the post_hook.
I've attached some screenshots with different color wallpapers. Let me know what you think.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b6bce33b-9e95-492b-ab30-5ed43806c44a" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5fdd126c-5f80-4f70-bab1-1e34d7665394" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/589f5ac3-501e-4f10-aa25-96511476d97b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ba786a75-cc86-4bf6-9ce0-24983d1504ab" />
