### PR TITLE
disable test mode for battery widget.

### DIFF
--- a/Modules/Bar/Widgets/Battery.qml
+++ b/Modules/Bar/Widgets/Battery.qml
@@ -65,7 +65,7 @@ Item {
     id: pill
 
     // Test mode
-    property bool testMode: true
+    property bool testMode: false
     property int testPercent: 20
     property bool testCharging: false
     property var battery: UPower.displayDevice


### PR DESCRIPTION
Assuming test mode is used to test out the battery widget when the machine has not battery; however, it was left enabled :D (I was confused why my laptop battery was low when it has been changing xD)