### PR TITLE
make default notification action text "Open"

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -273,7 +273,7 @@ Variants {
 
                   delegate: NButton {
                     text: {
-                      var actionText = modelData.text || "Action"
+                      var actionText = modelData.text || "Open"
                       // If text contains comma, take the part after the comma (the display text)
                       if (actionText.includes(",")) {
                         return actionText.split(",")[1] || actionText


### PR DESCRIPTION
99% of times an action on a notification will be opening the related content