### PR TITLE
fix: align KeyboardLayout widget with other bar components

### DIFF
--- a/Modules/Bar/Widgets/KeyboardLayout.qml
+++ b/Modules/Bar/Widgets/KeyboardLayout.qml
@@ -7,7 +7,7 @@ import qs.Commons
 import qs.Services
 import qs.Widgets
 
-RowLayout {
+Item {
   id: root
 
   property ShellScreen screen
@@ -19,17 +19,13 @@ RowLayout {
   // Use the shared service for keyboard layout
   property string currentLayout: KeyboardLayoutService.currentLayout
 
-  Layout.preferredWidth: pill.implicitWidth
-  Layout.preferredHeight: pill.implicitHeight
-  spacing: 0
+  implicitWidth: pill.width
+  implicitHeight: pill.height
 
   NPill {
     id: pill
 
-    Layout.alignment: Qt.AlignCenter
-    Layout.fillWidth: false
-    Layout.fillHeight: false
-
+    anchors.verticalCenter: parent.verticalCenter
     rightOpen: BarWidgetRegistry.getNPillDirection(root)
     icon: "keyboard_alt"
     iconCircleColor: Color.mPrimary


### PR DESCRIPTION
<img width="165" height="32" alt="图片" src="https://github.com/user-attachments/assets/8f767986-efa5-4f28-9ee0-aa014a2411fa" />
