### PR TITLE
Fix for fingerprint flow on lock screen

### DIFF
--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -28,12 +28,6 @@ Scope {
       return
     }
 
-    if (currentText === "") {
-      errorMessage = "Password required"
-      showFailure = true
-      return
-    }
-
     root.unlockInProgress = true
     errorMessage = ""
     showFailure = false

--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -12,6 +12,7 @@ Scope {
   property bool unlockInProgress: false
   property bool showFailure: false
   property string errorMessage: ""
+  property string infoMessage: ""
   property bool pamAvailable: typeof PamContext !== "undefined"
 
   onCurrentTextChanged: {
@@ -47,6 +48,8 @@ Scope {
 
       if (messageIsError) {
         errorMessage = message
+      } else {
+        infoMessage = message
       }
 
       if (responseRequired) {

--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -515,6 +515,7 @@ Loader {
                       width: 0
                       height: 0
                       visible: false
+                      enabled: !lockContext.unlockInProgress
                       font.family: Settings.data.ui.fontFixed
                       font.pointSize: Style.fontSizeL * scaling
                       color: Color.mOnSurface
@@ -544,7 +545,7 @@ Loader {
                       color: Color.mOnSurface
                       font.family: Settings.data.ui.fontFixed
                       font.pointSize: Style.fontSizeL * scaling
-                      visible: passwordInput.activeFocus
+                      visible: passwordInput.activeFocus && !lockContext.unlockInProgress
 
                       SequentialAnimation {
                         id: typingEffect
@@ -588,7 +589,7 @@ Loader {
                   NText {
                     text: {
                       if (lockContext.unlockInProgress)
-                        return "Authenticating..."
+                        return lockContext.infoMessage || "Authenticating..."
                       if (lockContext.showFailure && lockContext.errorMessage)
                         return lockContext.errorMessage
                       if (lockContext.showFailure)


### PR DESCRIPTION
Better fingerprint integration by removing the check for empty password.

With this change, fingerprint works the same way as everywhere else for me on NixOS:

In NixOS configuration:
```
services.fprintd.enable = true;
```

And in the lock screen:
1. Press Enter
2. "Authenticating..." is shown
3. In this moment scan your finger on fingerprint scanner
4. Screen unlocks

Note:
Without this change, it will ask for the password first, and since the password for `login` in PAM is always enabled on NixOS, you need to put something in, and obviously it has to be a correct password.