### PR TITLE
Side Panel Bottom was a lil too small

### DIFF
--- a/Modules/SidePanel/SidePanel.qml
+++ b/Modules/SidePanel/SidePanel.qml
@@ -11,7 +11,7 @@ NPanel {
   id: root
 
   panelWidth: 460 * scaling
-  panelHeight: 708 * scaling
+  panelHeight: 712 * scaling
 
   panelContent: Item {
     id: content


### PR DESCRIPTION
I run with no scaling. My SidePanel's margins at the top is 15px and between cards is 15px or 16px depending. Kinda odd, inconsistency, but I didn't fool with that. The the bottom was only 11px. So I increased the size of the panelHeight by 4 pixels so it matches the spacing on the top.

Side by Side comparison

<img width="595" height="837" alt="image" src="https://github.com/user-attachments/assets/7656a14d-a7f6-42e0-a319-6ffae3e2712d" />
