### PR TITLE
fix: message when no items on clipboard

### DIFF
--- a/Modules/Launcher/Plugins/ClipboardPlugin.qml
+++ b/Modules/Launcher/Plugins/ClipboardPlugin.qml
@@ -136,7 +136,7 @@ Item {
     const items = ClipboardService.items || []
 
     // If no items and we haven't tried loading yet, trigger a load
-    if (items.length === 0 && !ClipboardService.loading) {
+    if (items.count === 0 && !ClipboardService.loading) {
       isWaitingForData = true
       ClipboardService.list(100)
       return [{


### PR DESCRIPTION
To replicate with items no clipboard i go to ">clip clear" 
and next go to ">clip" 
doing that show message "Loading clipboard history..."
with no items on the clipboard.