### PR TITLE
fix: divide instead of multiply animation speed

### DIFF
--- a/Commons/Style.qml
+++ b/Commons/Style.qml
@@ -57,10 +57,10 @@ Singleton {
   property real opacityFull: 1.0
 
   // Animation duration (ms)
-  property int animationFast: Math.round(150 * Settings.data.general.animationSpeed)
-  property int animationNormal: Math.round(300 * Settings.data.general.animationSpeed)
-  property int animationSlow: Math.round(450 * Settings.data.general.animationSpeed)
-  property int animationSlowest: Math.round(750 * Settings.data.general.animationSpeed)
+  property int animationFast: Math.round(150 / Settings.data.general.animationSpeed)
+  property int animationNormal: Math.round(300 / Settings.data.general.animationSpeed)
+  property int animationSlow: Math.round(450 / Settings.data.general.animationSpeed)
+  property int animationSlowest: Math.round(750 / Settings.data.general.animationSpeed)
 
   // Dimensions
   property int barHeight: 36


### PR DESCRIPTION
Right now, setting your animation speed to something like 150% will actually *slow down* your animations instead of speed them up, which is very unintuitive. This fixes that problem by dividing the base speed by the setting value rather than multiplying it.