### PR TITLE
fix(bluetooth): rename wifiSwitch to bluetoothSwitch

### DIFF
--- a/Modules/BluetoothPanel/BluetoothPanel.qml
+++ b/Modules/BluetoothPanel/BluetoothPanel.qml
@@ -42,7 +42,7 @@ NPanel {
         }
 
         NToggle {
-          id: wifiSwitch
+          id: bluetoothSwitch
           checked: Settings.data.network.bluetoothEnabled
           onToggled: checked => BluetoothService.setBluetoothEnabled(checked)
           baseSize: Style.baseWidgetSize * 0.65 * scaling


### PR DESCRIPTION
rename wifiSwitch to bluetoothSwitch to fix the toggle switch

not sure how renaming the id fixes the toggle switch, but it works now - I am very new to qml and qs