### PR TITLE
Update nix readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,15 @@ Alternatively, you can add it to your NixOS configuration or flake:
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-    noctalia = {
-      url = "github:noctalia-dev/noctalia-shell";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    # you need nixpkgs unstable
 
     quickshell = {
       url = "github:outfoxxed/quickshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia = {
+      url = "github:noctalia-dev/noctalia-shell";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.quickshell.follows = "quickshell"
     };


### PR DESCRIPTION
- Quickshell was stated as input for quickshell instead of noctalia
- Add emphasis on usage of nixpkgs unstable (won't compile otherwise)