### PR TITLE
Add Monochrome (Black & White) color scheme

### DIFF
--- a/Assets/ColorScheme/Monochrome.json
+++ b/Assets/ColorScheme/Monochrome.json
@@ -1,0 +1,34 @@
+{
+  "dark": {
+    "mPrimary": "#ffffff",
+    "mOnPrimary": "#000000",
+    "mSecondary": "#ffffff",
+    "mOnSecondary": "#000000",
+    "mTertiary": "#ffffff",
+    "mOnTertiary": "#000000",
+    "mError": "#ffffff",
+    "mOnError": "#000000",
+    "mSurface": "#000000",
+    "mOnSurface": "#ffffff",
+    "mSurfaceVariant": "#000000",
+    "mOnSurfaceVariant": "#ffffff",
+    "mOutline": "#ffffff",
+    "mShadow": "#000000"
+  },
+  "light": {
+    "mPrimary": "#000000",
+    "mOnPrimary": "#ffffff",
+    "mSecondary": "#000000",
+    "mOnSecondary": "#ffffff",
+    "mTertiary": "#000000",
+    "mOnTertiary": "#ffffff",
+    "mError": "#000000",
+    "mOnError": "#ffffff",
+    "mSurface": "#ffffff",
+    "mOnSurface": "#000000",
+    "mSurfaceVariant": "#ffffff",
+    "mOnSurfaceVariant": "#000000",
+    "mOutline": "#000000",
+    "mShadow": "#ffffff"
+  }
+}


### PR DESCRIPTION
[I saw this comment](https://old.reddit.com/r/unixporn/comments/1ndsdq0/niri_noctalia/ndogzrv/) in the reddit thread and said "HEY! I CAN DO THAT!" I did run into an issue where the check in the Wallpaper selector and ColorScheme selector are assigned to different colors. I think they should be consistent, but I don't know which of the two would be the best to keep. In any event, I've tested this in both Dark and Light mode, and it seems to be pretty usable everywhere, nothing besides that check stood out to me, but after swapping one set of blacks and whites around, that nitpik doesn't affect this color scheme. There are a few instances when alpha transparency is used which results in some grays. I doubt that's a big enough issue to need special attention for this one niche theme, but thought it worth mentioning. 