### PR TITLE
feat(Modules/Notification): auto-close history panel on clear history

### DIFF
--- a/Modules/Notification/NotificationHistoryPanel.qml
+++ b/Modules/Notification/NotificationHistoryPanel.qml
@@ -56,7 +56,10 @@ NPanel {
           icon: "trash"
           tooltipText: "Clear history"
           sizeRatio: 0.8
-          onClicked: NotificationService.clearHistory()
+          onClicked: {
+            NotificationService.clearHistory()
+            root.close()
+          }
         }
 
         NIconButton {


### PR DESCRIPTION
I got annoyed by having to always click close after clearing history... I think it makes sense since after clearing the history you do not need to do anything else on the panel other than closing it.