### PR TITLE
Fix steam games not launching with app2unit

### DIFF
--- a/Modules/Launcher/Plugins/ApplicationsPlugin.qml
+++ b/Modules/Launcher/Plugins/ApplicationsPlugin.qml
@@ -83,7 +83,11 @@ Item {
 
         if (Settings.data.appLauncher.useApp2Unit && app.id) {
           Logger.log("ApplicationsPlugin", `Using app2unit for: ${app.id}`)
-          Quickshell.execDetached(["app2unit", "--", app.id + ".desktop"])
+          if (app.runInTerminal)
+              Quickshell.execDetached(["app2unit", "--", app.id + ".desktop"])
+          else
+              Quickshell.execDetached(["app2unit", "--"].concat(app.command))
+
         } else if (app.execute) {
           app.execute()
         } else if (app.exec) {


### PR DESCRIPTION
With these changes launching steam games works fine now. Everything else launches as well. 

Terminal applications like fish or btop don't launch, so if an application is specified as runInTerminal I just use the previous command.