### PR TITLE
fix: power toggle icon alignment

### DIFF
--- a/Modules/Bar/Widgets/PowerToggle.qml
+++ b/Modules/Bar/Widgets/PowerToggle.qml
@@ -11,13 +11,13 @@ NIconButton {
   property ShellScreen screen
   property real scaling: 1.0
 
-  sizeRatio: 0.8
-
   icon: "power"
   tooltipText: "Power Settings"
+  sizeRatio: 0.8
   colorBg: Color.mSurfaceVariant
   colorFg: Color.mError
   colorBorder: Color.transparent
   colorBorderHover: Color.transparent
+  anchors.verticalCenter: parent.verticalCenter
   onClicked: PanelService.getPanel("powerPanel")?.toggle()
 }


### PR DESCRIPTION
Top is before, bottom is after. It's *pretty much* unnoticeable but unless I'm going crazy this is a very minor alignment fix

<img width="56" height="114" alt="image" src="https://github.com/user-attachments/assets/c81fd0b1-fa24-4904-b02e-a810f717d305" />
