### PR TITLE
fix(consistency): use unfilled pause icon for suspend in power menu

### DIFF
--- a/Commons/IconsSets/TablerIcons.qml
+++ b/Commons/IconsSets/TablerIcons.qml
@@ -46,7 +46,7 @@ Singleton {
     "lock": "lock",
     "logout": "logout",
     "reboot": "refresh",
-    "suspend": "player-pause-filled",
+    "suspend": "player-pause",
     "nightlight-on": "moon",
     "nightlight-off": "moon-off",
     "nightlight-forced": "moon-stars",


### PR DESCRIPTION
Before:

<img width="652" height="618" alt="image" src="https://github.com/user-attachments/assets/0e11a959-a3dd-443d-aa5e-a92848f7ff61" />

After:

<img width="652" height="618" alt="image" src="https://github.com/user-attachments/assets/efe6ebdf-f1f6-4786-953a-ea3a5819dd98" />
