### PR TITLE
NixOS: Add Night Light Dependency and Enable Required Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,21 +140,15 @@ mkdir -p ~/.config/quickshell/noctalia-shell && curl -sL https://github.com/noct
 <details>
 <summary><strong>Nix Installation</strong></summary>
 
-You can run Noctalia directly using the `nix run` command:
-```bash
-nix run github:noctalia-dev/noctalia-shell
-```
+You can add it to your NixOS configuration or flake:
 
-Alternatively, you can add it to your NixOS configuration or flake:
-
-**Step 1**: Add Quickshell and Noctalia flakes to your `flake.nix`:
+Add this to your `flake.nix`:
 ```nix
 {
-  description = "Example Nix flake with Noctalia + Quickshell";
+  description = "Example Nix flake with Noctalia";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    # you need nixpkgs unstable
 
     quickshell = {
       url = "github:outfoxxed/quickshell";
@@ -164,28 +158,19 @@ Alternatively, you can add it to your NixOS configuration or flake:
     noctalia = {
       url = "github:noctalia-dev/noctalia-shell";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.quickshell.follows = "quickshell";
+      inputs.quickshell.follows = "quickshell";  # Use same quickshell version
     };
   };
 
-  outputs = { self, nixpkgs, noctalia, quickshell, ... }:
+  outputs = { self, nixpkgs, noctalia, ... }:
    {
     nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
       modules = [
         ./configuration.nix
+        noctalia.nixosModules.noctalia  # Import Noctalia module here
       ];
     };
   };
-}
-```
-
-**Step 2**: Add the packages to your `configuration.nix`:
-```nix
-{
-  environment.systemPackages = with pkgs; [
-    inputs.noctalia.packages.${system}.default
-    inputs.quickshell.packages.${system}.default
-  ];
 }
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
               libnotify
               matugen
               networkmanager
+              wlsunset
               wl-clipboard
             ] ++ lib.optionals (pkgs.stdenv.hostPlatform.isx86_64)
             [ gpu-screen-recorder ];

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,17 @@
         });
 
       defaultPackage = eachSystem (system: self.packages.${system}.default);
+
+      nixosModules = {
+        noctalia = { pkgs, lib, ... }: {
+          environment.systemPackages = [
+            self.packages.${pkgs.system}.default
+          ];
+          # Required services for proper functionality
+          services.power-profiles-daemon.enable = true;  # Power profile switching support
+          services.upower.enable = true;                 # Battery monitoring & power management
+        };
+      };
     };
 }
 


### PR DESCRIPTION
  This PR adds night light functionality and fixes power management issues for NixOS users:

  ### Changes

  - Added wlsunset dependency for night light feature
  - Added NixOS module that auto-enables required services:
    - power-profiles-daemon (power profile switching)
    - upower (battery status monitoring)
  - Updated README with simplified installation

  ### Problems solved

  - Night light now works out of the box
  - Power profiles now function properly
  - Battery status now displays correctly
  - Installation simplified with single module import