### PR TITLE
Add nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,17 @@
         });
 
       defaultPackage = eachSystem (system: self.packages.${system}.default);
+
+      devShells = eachSystem (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        default = pkgs.mkShell {
+          packages = [ pkgs.qt6Packages.qtdeclarative ];  # for qmlls executable
+          shellHook = ''
+            export QML_IMPORT_PATH="$PWD:${pkgs.qt6Packages.qtdeclarative}/lib/qt-6/qml:$QML_IMPORT_PATH"
+          '';
+        };
+      });
     };
 }
 


### PR DESCRIPTION
Add nix dev shell to flake.nix

Usage:

```shell
$ cd ./noctalia-shell
$ nix develop
```

it should open shell where you can launch the editor from, in my case I have neovim with qmlls language server enabled (using nvim-lspconfig)

Note: nvim-lspconfig uses `qmlls -E` (-E means that it reads imports from environment variable QML_IMPORTS_PATH, and not through the `.qmlls.ini`, which I think is better to read from env var since in that config you need to put static paths and not everyone have packages on the same path)

But I have some import issues with everything that is imported with `qs.` prefix

<img width="1806" height="468" alt="image" src="https://github.com/user-attachments/assets/063de9ad-2a94-4c1c-b821-ade37d02377a" />
