### PR TITLE
fix(clock): respect monthBeforeDay setting in vertical clock date dis…

### DIFF
--- a/Modules/Bar/Widgets/Clock.qml
+++ b/Modules/Bar/Widgets/Clock.qml
@@ -157,14 +157,12 @@ Rectangle {
             if (verticalMode) {
               // Compact mode: date section (last 2 lines)
               switch (index) {
-              case 0:
-                // Day
-                return now.getDate().toString().padStart(2, '0')
-              case 1:
-                // Month
-                return (now.getMonth() + 1).toString().padStart(2, '0')
-              default:
-                return ""
+                case 0:
+                  return monthBeforeDay ? (now.getMonth() + 1).toString().padStart(2, '0') : now.getDate().toString().padStart(2, '0')
+                case 1:
+                  return monthBeforeDay ? now.getDate().toString().padStart(2, '0') : (now.getMonth() + 1).toString().padStart(2, '0')
+                default:
+                  return ""
               }
             }
             return ""


### PR DESCRIPTION
- Fix vertical bar clock to show month before day when `monthBeforeDay` setting is enabled
- Ensures consistent date ordering across all clock display modes