### PR TITLE
nix flake: systemd service + home manager settings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,5 @@
 {
-  description =
-    "Noctalia shell - a Wayland desktop shell built with Quickshell";
+  description = "Noctalia shell - a Wayland desktop shell built with Quickshell";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -12,13 +11,22 @@
     };
   };
 
-  outputs = { self, nixpkgs, systems, quickshell, ... }:
-    let eachSystem = nixpkgs.lib.genAttrs (import systems);
-    in {
-      formatter =
-        eachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      quickshell,
+      ...
+    }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
 
-      packages = eachSystem (system:
+      packages = eachSystem (
+        system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
           qs = quickshell.packages.${system}.default.override {
@@ -26,7 +34,8 @@
             withI3 = false;
           };
 
-          runtimeDeps = with pkgs;
+          runtimeDeps =
+            with pkgs;
             [
               bash
               bluez
@@ -42,21 +51,32 @@
               networkmanager
               wlsunset
               wl-clipboard
-            ] ++ lib.optionals (pkgs.stdenv.hostPlatform.isx86_64)
-            [ gpu-screen-recorder ];
+            ]
+            ++ lib.optionals (pkgs.stdenv.hostPlatform.isx86_64) [ gpu-screen-recorder ];
 
           fontconfig = pkgs.makeFontsConf {
-            fontDirectories = [ pkgs.roboto pkgs.inter-nerdfont ];
+            fontDirectories = [
+              pkgs.roboto
+              pkgs.inter-nerdfont
+            ];
           };
-        in {
+        in
+        {
           default = pkgs.stdenv.mkDerivation {
             pname = "noctalia-shell";
             version = self.rev or self.dirtyRev or "dirty";
             src = ./.;
 
-            nativeBuildInputs =
-              [ pkgs.gcc pkgs.makeWrapper pkgs.qt6.wrapQtAppsHook ];
-            buildInputs = [ qs pkgs.xkeyboard_config pkgs.qt6.qtbase ];
+            nativeBuildInputs = [
+              pkgs.gcc
+              pkgs.makeWrapper
+              pkgs.qt6.wrapQtAppsHook
+            ];
+            buildInputs = [
+              qs
+              pkgs.xkeyboard_config
+              pkgs.qt6.qtbase
+            ];
             propagatedBuildInputs = runtimeDeps;
 
             installPhase = ''
@@ -70,14 +90,14 @@
             '';
 
             meta = {
-              description =
-                "A sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell.";
+              description = "A sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell.";
               homepage = "https://github.com/noctalia-dev/noctalia-shell";
               license = pkgs.lib.licenses.mit;
               mainProgram = "noctalia-shell";
             };
           };
-        });
+        }
+      );
 
       defaultPackage = eachSystem (system: self.packages.${system}.default);
 


### PR DESCRIPTION
Additions to the `flake.nix`:
- `nixosModule`: a systemd service which you activate with `services.noctalia-shell.enable = true`
- `homeModule`: an option to configure settings an attribute set, string or filepath
- `homeModule`: an option to configure colors an attribute set, string or filepath
- Formats the flake using `nixfmt-rfc-style`

### Nix Flake Installation
        
For Nix users, Noctalia provides both NixOS and home-manager modules:
        
#### NixOS Module (systemd service)

This will automatically start after Niri. 

>[!NOTE]
> For **Hyprland**, it depends on how you configure your systemd service. Many options like UWSM will setup `graphical-session.target` for you an _should_ work by default. This has not been tested, let us know if you find bugs.
```nix
{
  imports = [ inputs.noctalia-shell.nixosModules.default ];
        
  services.noctalia-shell = {
    enable = true;
    target = "graphical-session.target"; # this is the default; use "hyprland-session.target" if you have something like that
  };
}
```
        
### Home Manager Module

#### Settings

>[!IMPORTANT]
> You **must** set all configuration options, since this overrides the *full* settings file.
> Its good to backup your current config - found in `~/.config/settings.json` before trying,
> and to use this file as a value here. We hope to fix this in a future PR; see https://github.com/noctalia-dev/noctalia-shell/issues/323

```nix
{
  home-manager.users.mrfoobar = {
    imports = [ inputs.noctalia-shell.homeModules.default ];
        
    programs.noctalia-shell = {
      enable = true;
      settings = {
        # put *all* settings here, see warning above
     };
    };
  };
}
```

#### Colors

You can configure your color theme like this:

>[!WARNING]
>This is experimental. We are not entirely sure how Mutagen behaves when you write this. In my own system so far, this has been ok.

```nix
{
   # ...        
    programs.noctalia-shell = {
      enable = true;
      colors = {
        # put *all* colors here, see warning above
     };
    };
  };
}
```

The home-manager module automatically restarts the systemd service when settings change. I've noticed a bug where rebuilding the system can hang, but after modifying the `onChange` hook and the systemd service restart settings, it seems fine.
