### PR TITLE
fix(bar): Ensure SystemMonitor temperature is fully visible

### DIFF
--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -120,7 +120,7 @@ Rectangle {
         columnSpacing: Style.marginXXS * scaling
 
         NText {
-          text: isVertical ? `${SystemStatService.cpuTemp}°` : `${SystemStatService.cpuTemp}°C`
+          text: `${SystemStatService.cpuTemp}°C`
           font.family: Settings.data.ui.fontFixed
           font.pointSize: textSize
           font.weight: Style.fontWeightMedium
@@ -128,6 +128,7 @@ Rectangle {
           horizontalAlignment: Text.AlignHCenter
           verticalAlignment: Text.AlignVCenter
           color: Color.mPrimary
+          scale: isVertical ? Math.min(1.0, cpuTempContent.width / implicitWidth) : 1.0
           Layout.row: isVertical ? 0 : 0
           Layout.column: isVertical ? 0 : 1
         }


### PR DESCRIPTION
In the vertical bar layout, the temperature text in the SystemMonitor widget (e.g., "55°C") could be truncated due to the widget's fixed width.
  This commit resolves the issue by applying a dynamic scale
transformation to the text component.

<img width="38" height="105" alt="图片" src="https://github.com/user-attachments/assets/17d87745-0a97-41fa-b244-d5cf6d9fcd42" />
