### PR TITLE
fix: Notifications don't scale with display scaling

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -16,7 +16,16 @@ Variants {
     id: root
 
     required property ShellScreen modelData
-    readonly property real scaling: ScalingService.getScreenScale(modelData)
+    property real scaling: ScalingService.getScreenScale(modelData)
+
+    Connections {
+      target: ScalingService
+      function onScaleChanged(screenName, newScale) {
+        if (modelData && screenName === modelData.name) {
+          scaling = newScale
+        }
+      }
+    }
 
     // Access the notification model from the service - UPDATED NAME
     property ListModel notificationModel: NotificationService.activeList


### PR DESCRIPTION
fixed: #329

This ensures that notification popups now correctly adapt their size and elements based on the current display scaling factor.