### PR TITLE
Increase OSD initTimer interval to 500ms

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -347,7 +347,7 @@ Variants {
     // Timer to initialize volume/mute flags after services are ready
     Timer {
       id: initTimer
-      interval: 100 // 100ms delay to allow services to initialize
+      interval: 500
       running: true
       onTriggered: {
         volumeInitialized = true


### PR DESCRIPTION
The volume osd window started to appear again during startup, so the delay time was increased 🙃