### PR TITLE
Rounds the ends of NSliders to be more consistent with the look

### DIFF
--- a/Widgets/NSlider.qml
+++ b/Widgets/NSlider.qml
@@ -15,6 +15,8 @@ Slider {
   readonly property real trackHeight: knobDiameter * 0.4
   readonly property real cutoutExtra: Math.round(Style.baseWidgetSize * 0.1 * scaling)
 
+  padding: cutoutExtra / 2
+
   snapMode: snapAlways ? Slider.SnapAlways : Slider.SnapOnRelease
   implicitHeight: Math.max(trackHeight, knobDiameter)
 
@@ -90,14 +92,14 @@ Slider {
       }
     }
 
-  // Circular cutout
+    // Circular cutout
     Rectangle {
       id: knobCutout
       width: knobDiameter + cutoutExtra
       height: knobDiameter + cutoutExtra
       radius: width / 2
       color: root.cutoutColor !== undefined ? root.cutoutColor : Color.mSurface
-      x: root.leftPadding + root.visualPosition * (root.availableWidth - root.knobDiameter) - cutoutExtra / 2
+      x: root.leftPadding + Math.round(root.visualPosition * (root.availableWidth - root.knobDiameter) - cutoutExtra)
       anchors.verticalCenter: parent.verticalCenter
     }
   }


### PR DESCRIPTION
Admittedly a very very minor change. But just look at it!

<img width="714" height="162" alt="image" src="https://github.com/user-attachments/assets/1797339e-5999-46f9-8bc2-0ceef2da0a7e" />

I noticed Height/2 is used in the same file previously, and there might be some optimization possible by calculating it once and reusing it. But I wasn't certain if that was worth it since it would also (i guess) mean bytes of memory just being wasted all willy nilly.

~~If you want me to attempt that optimization, lemme know and I'll tweak the PR on my end.~~

Actually I think it wouldn't help after all, so this is likely fine as is.