### PR TITLE
[NixOS] feat/temp settings

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -71,7 +71,13 @@ Singleton {
     id: saveTimer
     running: false
     interval: 1000
-    onTriggered: settingsFileView.writeAdapter()
+    onTriggered: {
+      settingsFileView.writeAdapter()
+      // Write to fallback location if set
+      if (Quickshell.env("NOCTALIA_SETTINGS_FALLBACK")) {
+        settingsFallbackFileView.writeAdapter()
+      }
+    }
   }
 
   FileView {
@@ -101,10 +107,24 @@ Singleton {
       }
     }
     onLoadFailed: function (error) {
-      if (error.toString().includes("No such file") || error === 2)
+      if (error.toString().includes("No such file") || error === 2) {
         // File doesn't exist, create it with default values
         writeAdapter()
+        // Also write to fallback if set
+        if (Quickshell.env("NOCTALIA_SETTINGS_FALLBACK")) {
+          settingsFallbackFileView.writeAdapter()
+        }
+      }
     }
+  }
+
+  // Fallback FileView for writing settings to alternate location
+  FileView {
+    id: settingsFallbackFileView
+    path: Quickshell.env("NOCTALIA_SETTINGS_FALLBACK") || ""
+    adapter: Quickshell.env("NOCTALIA_SETTINGS_FALLBACK") ? adapter : null
+    printErrors: false
+    watchChanges: false
   }
   JsonAdapter {
     id: adapter

--- a/flake.nix
+++ b/flake.nix
@@ -277,7 +277,10 @@
                 RestartSec = 3;
                 TimeoutStartSec = 10;
                 TimeoutStopSec = 5;
-                Environment = [ "PATH=${config.system.path}/bin" ];
+                Environment = [
+                  "PATH=${config.system.path}/bin"
+                  "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
+                ];
               };
             };
 


### PR DESCRIPTION
If you use the new flake option to declaratively configure Noctalia, `~/.config/settings.json` becomes a symlink to the Nix store, and is managed by Nix.

Therefore, edits in the GUI settings panel succeed in memory, but silently fail to write the `settings.json` file, with a `PERMISSION DENIED` error.

This isn't really a problem for using Noctalia as-such; the settings _should_ befined by the user's Nix dotfiles in this case. However, NixOS users using the settings option have a challenge: how to figure out the available configuration options?

I added the _defaults_ to the documentation; but this obviously doesn't reveal _all_ the options. In an ideal world, all options would be meticulously documented somehow. But I think doing this would be too much work to maintain, at least at the moment.

This adds a fallback write path, configurable with `NOCTALIA_SETTINGS_FALLBACK`. When provided, it writes the config there in addition to the default location. The flake then sets it in the systemd service.