### PR TITLE
Add clock font setting for customizable clock displays

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -272,6 +272,7 @@ Singleton {
     property JsonObject ui: JsonObject {
       property string fontDefault: "Roboto"
       property string fontFixed: "DejaVu Sans Mono"
+      property string clockFont: "Roboto"
       property real fontDefaultScale: 1.0
       property real fontFixedScale: 1.0
       property list<var> monitorsScaling: []

--- a/Modules/Bar/Widgets/Clock.qml
+++ b/Modules/Bar/Widgets/Clock.qml
@@ -65,7 +65,7 @@ Rectangle {
           NText {
             visible: text !== ""
             text: modelData
-            family: useMonospacedFont ? Settings.data.ui.fontFixed : Settings.data.ui.fontDefault
+            family: Settings.data.ui.clockFont || (useMonospacedFont ? Settings.data.ui.fontFixed : Settings.data.ui.fontDefault)
             pointSize: {
               if (repeater.model.length == 1) {
                 return Style.fontSizeS * scaling
@@ -95,7 +95,7 @@ Rectangle {
           delegate: NText {
             visible: text !== ""
             text: modelData
-            family: useMonospacedFont ? Settings.data.ui.fontFixed : Settings.data.ui.fontDefault
+            family: Settings.data.ui.clockFont || (useMonospacedFont ? Settings.data.ui.fontFixed : Settings.data.ui.fontDefault)
             pointSize: Style.fontSizeS * scaling
             font.weight: Style.fontWeightBold
             color: usePrimaryColor ? Color.mPrimary : Color.mOnSurface

--- a/Modules/Settings/Tabs/GeneralTab.qml
+++ b/Modules/Settings/Tabs/GeneralTab.qml
@@ -237,6 +237,20 @@ ColumnLayout {
         }
       }
 
+      NSearchableComboBox {
+        label: "Clock Font"
+        description: "Font used specifically for clock displays in the bar and widgets."
+        model: FontService.availableFonts
+        currentKey: Settings.data.ui.clockFont
+        placeholder: "Select clock font..."
+        searchPlaceholder: "Search fonts..."
+        popupHeight: 420 * scaling
+        minimumWidth: 300 * scaling
+        onSelected: function (key) {
+          Settings.data.ui.clockFont = key
+        }
+      }
+
       ColumnLayout {
         NLabel {
           label: I18n.tr("settings.general.fonts.default.scale.label")


### PR DESCRIPTION
This commit adds a new 'Clock Font' setting that allows users to customize the font used specifically for clock displays in the bar and widgets, independent of the default UI font.

Features:
- New clockFont property in Settings.data.ui (defaults to 'Roboto')
- Updated Bar Clock widget to use the custom font with fallback support
- Added searchable font dropdown in General Settings tab
- Backward compatible - uses default font if clockFont is not set
- Real-time updates - changes apply immediately

The font selection uses FontService.availableFonts and includes proper fallback logic that respects the existing monospaced font setting. Currently has only been tested on Niri, i'm still new to this all so i hope this is something atleast useable. It works for me currently...