### PR TITLE
fix: never scroll media mini on pause

### DIFF
--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -208,7 +208,7 @@ Item {
           property bool isResetting: false
           property real textWidth: fullTitleMetrics.contentWidth
           property real containerWidth: 0
-          property bool needsScrolling: textWidth > containerWidth
+          property bool needsScrolling: textWidth > containerWidth && MediaService.isPlaying
 
           // Timer for "always" mode with delay
           Timer {


### PR DESCRIPTION
Media players almost never scroll the title when the media is paused