### PR TITLE
fix: zed formatting command

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,16 +5,7 @@
       "formatter": {
         "external": {
           "command": "qmlfmt",
-          "arguments": [
-            "-e",
-            "-b",
-            "360",
-            "-t",
-            "2",
-            "-i",
-            "2",
-            "{buffer_path}"
-          ]
+          "arguments": ["-e", "-b", "360", "-t", "2", "-i", "2"]
         }
       }
     }


### PR DESCRIPTION
fixes strange behavior, I should've RTFM'd about `buffer_path`