### PR TITLE
fix: Unset `PATH` that is auto-generated by Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -266,6 +266,10 @@
               wantedBy = [ cfg.target ];
               restartTriggers = [ cfg.package ];
 
+              environment = {
+                PATH = lib.mkForce null;
+              };
+
               unitConfig = {
                 StartLimitIntervalSec = 60;
                 StartLimitBurst = 3;
@@ -278,7 +282,6 @@
                 TimeoutStartSec = 10;
                 TimeoutStopSec = 5;
                 Environment = [
-                  "PATH=${config.system.path}/bin"
                   "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
                 ];
               };


### PR DESCRIPTION
This addresses a problem where the launcher is not able to actually launch any applications when it is started by a systemd unit generated by Nix.

The search path would typically be inherited by a systemd unit, but Nix's unit generator will assign a specific, minimal PATH that only includes the unit's runtime dependencies.

I ended up unsetting the autogenerated `PATH`, but it's possible that this may violate some expectation of `noctalia-shell`; the set of things on my path as a user is not guaranteed to overlap with the set of things required by derivation that generates the systemd unit.

Another option I considered was setting the `PATH` to effectively the same thing that it is set to when I read it from a terminal on my system. This is more or less the approach that `hyperland` uses to address what I think is the same problem: https://github.com/NixOS/nixpkgs/blob/7df7ff7d8e00218376575f0acdcc5d66741351ee/nixos/modules/programs/wayland/hyprland.nix#L69C1-L97

Ultimately, I decided that unsetting the `PATH` was the more robust solution because it accounts for cases where the inherited `PATH` is different for some reason. But, I'm open to taking any approach that makes sense to others here.