### PR TITLE
fix: clip overflowed weather entries

### DIFF
--- a/Modules/ControlCenter/Cards/WeatherCard.qml
+++ b/Modules/ControlCenter/Cards/WeatherCard.qml
@@ -18,6 +18,7 @@ NBox {
     anchors.top: parent.top
     anchors.margins: Style.marginM * scaling
     spacing: Style.marginM * scaling
+    clip: true
 
     RowLayout {
       spacing: Style.marginS * scaling


### PR DESCRIPTION
Fixes regression caused by 4ed16d795e73fafb4412cab8c27abcf870d76265 where the weather overflowing when using wider fonts

| Before | After |
|--------|--------|
| <img width="816" height="1211" alt="image" src="https://github.com/user-attachments/assets/38608e41-d07e-4204-99de-27f9e3270879" /> | <img width="728" height="1186" alt="image" src="https://github.com/user-attachments/assets/bd4f1156-d932-4477-9d78-7810a6007ec5" /> |
