### PR TITLE
update lastSeenTs in notifications toggleHistory ipc call

### DIFF
--- a/Modules/Bar/Widgets/NotificationHistory.qml
+++ b/Modules/Bar/Widgets/NotificationHistory.qml
@@ -61,7 +61,6 @@ NIconButton {
   onClicked: {
     var panel = PanelService.getPanel("notificationHistoryPanel")
     panel?.toggle(this)
-    Settings.data.notifications.lastSeenTs = Time.timestamp * 1000
   }
 
   onRightClicked: Settings.data.notifications.doNotDisturb = !Settings.data.notifications.doNotDisturb

--- a/Modules/Notification/NotificationHistoryPanel.qml
+++ b/Modules/Notification/NotificationHistoryPanel.qml
@@ -16,6 +16,10 @@ NPanel {
   preferredHeight: 480
   panelKeyboardFocus: true
 
+  onOpened: function() {
+    Settings.data.notifications.lastSeenTs = Time.timestamp * 1000
+  }
+
   panelContent: Rectangle {
     id: notificationRect
     color: Color.transparent

--- a/Services/IPCService.qml
+++ b/Services/IPCService.qml
@@ -36,7 +36,6 @@ Item {
     function toggleHistory() {
       // Will attempt to open the panel next to the bar button if any.
       notificationHistoryPanel.toggle(null, "NotificationHistory")
-      Settings.data.notifications.lastSeenTs = Time.timestamp * 1000
     }
     function toggleDND() {
       Settings.data.notifications.doNotDisturb = !Settings.data.notifications.doNotDisturb

--- a/Services/IPCService.qml
+++ b/Services/IPCService.qml
@@ -36,6 +36,7 @@ Item {
     function toggleHistory() {
       // Will attempt to open the panel next to the bar button if any.
       notificationHistoryPanel.toggle(null, "NotificationHistory")
+      Settings.data.notifications.lastSeenTs = Time.timestamp * 1000
     }
     function toggleDND() {
       Settings.data.notifications.doNotDisturb = !Settings.data.notifications.doNotDisturb


### PR DESCRIPTION
Currently only clicking on the notification icon will update timestamp and mark all notifications as read, with this change it will be possible when opening with `qs -c noctalia-shell ipc call notifications toggleHistory`. This enables marking notifications as read programmatically via IPC.