### PR TITLE
fix(settings): make color scheme grid layout responsive

### DIFF
--- a/Modules/Settings/Tabs/ColorSchemeTab.qml
+++ b/Modules/Settings/Tabs/ColorSchemeTab.qml
@@ -220,7 +220,7 @@ ColumnLayout {
 
     // Color Schemes Grid
     GridLayout {
-      columns: 3
+      columns: Math.max(1, Math.floor((root.width + columnSpacing) / (222 * scaling + columnSpacing)))
       rowSpacing: Style.marginM * scaling
       columnSpacing: Style.marginM * scaling
       Layout.fillWidth: true


### PR DESCRIPTION
The color scheme grid previously used a fixed number of columns, which caused cards to be partially clipped when the window width was narrow.

This change makes the number of columns dynamically calculated based on the available width. It ensures the grid layout gracefully adapts from 3 (or more) columns down to 1 column, preventing content overflow and clipping.

This fixes a UI bug where the right-side content of color scheme cards was not visible at certain window widths.

<img width="631" height="391" alt="图片" src="https://github.com/user-attachments/assets/182b8ee1-3f0e-456d-8011-bef85bb12766" />

