### PR TITLE
Use workspace.num as index for sway

### DIFF
--- a/Services/SwayService.qml
+++ b/Services/SwayService.qml
@@ -71,7 +71,7 @@ Item {
 
         const wsData = {
           "id": i,
-          "idx": ws.id,
+          "idx": ws.num,
           "name": ws.name || "",
           "output": (ws.monitor && ws.monitor.name) ? ws.monitor.name : "",
           "isActive": ws.active === true,


### PR DESCRIPTION
Was incorrectly using the internal sway id of the workspace which is not the same as the user facing id

Fixes #442