### PR TITLE
Set chargingMode to disabled after success

### DIFF
--- a/Services/BatteryService.qml
+++ b/Services/BatteryService.qml
@@ -60,7 +60,6 @@ Singleton {
     if (enabled) {
       setChargingMode(BatteryService.ChargingMode.Full)
     } else {
-      BatteryService.chargingMode = BatteryService.ChargingMode.Disabled
       BatteryService.initialSetter = true
       ToastService.showNotice(I18n.tr("toast.battery-manager.title"), I18n.tr("toast.battery-manager.uninstall-setup"))
       PanelService.getPanel("batteryPanel")?.toggle(this)
@@ -194,6 +193,7 @@ Singleton {
         Logger.log("BatteryService", "Battery Manager uninstalled successfully")
         ToastService.showNotice(I18n.tr("toast.battery-manager.title"), I18n.tr("toast.battery-manager.uninstall-success"))
         Settings.data.battery.chargingMode = BatteryService.chargingMode
+        BatteryService.chargingMode = BatteryService.ChargingMode.Disabled
         cleanupProcess.running = true
       } else {
         ToastService.showError(I18n.tr("toast.battery-manager.title"), I18n.tr("toast.battery-manager.uninstall-failed"))


### PR DESCRIPTION
Currently, the battery panel behaves as if the battery manager was uninstalled even when uninstallation fails. This PR moves the BatteryService.chargingMode update to after successful uninstallation.