### PR TITLE
devex: precommit hook to run qmlfmt, parallelize `qmlfmt.sh`

### DIFF
--- a/Bin/dev/qmlfmt.sh
+++ b/Bin/dev/qmlfmt.sh
@@ -4,4 +4,6 @@
 # Can be installed from AUR "qmlfmt-git"
 # Requires qt6-5compat
 
-find . -name "*.qml" -print -exec qmlfmt -e -b 360 -t 2 -i 2 -w {} \;
+cd "$(git rev-parse --show-toplevel)"
+echo "Formatting $(find . -name "*.qml" | wc -l) files..."
+find . -name "*.qml" -print0 | xargs -0 -P "$(nproc)" -I {} qmlfmt -e -b 360 -t 2 -i 2 -w {}

--- a/Services/HyprlandService.qml
+++ b/Services/HyprlandService.qml
@@ -275,8 +275,9 @@ Item {
       appId = toplevel.wayland.appId
       console.lo
       if (appId)
-          return appId
+        return appId
     } catch (e) {
+
     }
 
     // Try direct properties
@@ -299,6 +300,7 @@ Item {
         return String(ipcData.class || ipcData.initialClass || ipcData.appId || ipcData.wm_class || "")
       }
     } catch (e) {
+
     }
 
     return ""

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  jobs:
+    - name: format qml
+      run: ./Bin/dev/qmlfmt.sh && git update-index --again


### PR DESCRIPTION
- `lefthook` is used for pre-commit hook 
- `qmlfmt.sh` now checks if `qmlfmt` is installed & runs `qmlfmt` in parallel via `xargs`