### PR TITLE
Fix German translation

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -746,7 +746,7 @@
           "label": "Widgets für Kurzbefehle"
         },
         "sectionLeft": "Links",
-        "sectionRight": "Richtig"
+        "sectionRight": "Rechts"
       }
     },
     "user-interface": {


### PR DESCRIPTION
Change "Richtig" to "Rechts" for control-center translation