### PR TITLE
MediaMini: handle empty media content with active player for rounded background

### DIFF
--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -120,6 +120,10 @@ Item {
     if (!hasActivePlayer) {
       return maxWidth
     }
+    // If there's an active player but no contenct, use a minimum height for rounded background
+    if (hasActivePlayer && fullTitleMetrics.contentWidth === 0) {
+      return Style.capsuleHeight + Style.marginS
+    }
     // Use content width but don't exceed user-set maximum width
     return Math.min(calculateContentWidth(), maxWidth)
   }


### PR DESCRIPTION
## Overview
<img width="510" height="95" alt="image" src="https://github.com/user-attachments/assets/757840e9-6da0-4f12-8a78-b65af4fb558d" />

## Changes

Add additional width judgement for active media player with no content, intended for some stubborn media events.

Not sure if it is better to hide the widget in this context, let me know if there are changes needed, thank you very much!