### PR TITLE
refactor(nix): migration to flake-parts

### DIFF
--- a/Assets/ColorScheme/Catppuccin/Catppuccin.json
+++ b/Assets/ColorScheme/Catppuccin/Catppuccin.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#cba6f7",
-        "mOnPrimary": "#11111b",
-        "mSecondary": "#fab387",
-        "mOnSecondary": "#11111b",
-        "mTertiary": "#94e2d5",
-        "mOnTertiary": "#11111b",
-        "mError": "#f38ba8",
-        "mOnError": "#11111b",
-        "mSurface": "#1e1e2e",
-        "mOnSurface": "#cdd6f4",
-        "mSurfaceVariant": "#313244",
-        "mOnSurfaceVariant": "#a3b4eb",
-        "mOutline": "#4c4f69",
-        "mShadow": "#11111b"
-    },
-    "light": {
-        "mPrimary": "#8839ef",
-        "mOnPrimary": "#eff1f5",
-        "mSecondary": "#fe640b",
-        "mOnSecondary": "#eff1f5",
-        "mTertiary": "#40a02b",
-        "mOnTertiary": "#eff1f5",
-        "mError": "#d20f39",
-        "mOnError": "#dce0e8",
-        "mSurface": "#eff1f5",
-        "mOnSurface": "#4c4f69",
-        "mSurfaceVariant": "#ccd0da",
-        "mOnSurfaceVariant": "#6c6f85",
-        "mOutline": "#a5adcb",
-        "mShadow": "#dce0e8"
-    }
+  "dark": {
+    "mPrimary": "#cba6f7",
+    "mOnPrimary": "#11111b",
+    "mSecondary": "#fab387",
+    "mOnSecondary": "#11111b",
+    "mTertiary": "#94e2d5",
+    "mOnTertiary": "#11111b",
+    "mError": "#f38ba8",
+    "mOnError": "#11111b",
+    "mSurface": "#1e1e2e",
+    "mOnSurface": "#cdd6f4",
+    "mSurfaceVariant": "#313244",
+    "mOnSurfaceVariant": "#a3b4eb",
+    "mOutline": "#4c4f69",
+    "mShadow": "#11111b"
+  },
+  "light": {
+    "mPrimary": "#8839ef",
+    "mOnPrimary": "#eff1f5",
+    "mSecondary": "#fe640b",
+    "mOnSecondary": "#eff1f5",
+    "mTertiary": "#40a02b",
+    "mOnTertiary": "#eff1f5",
+    "mError": "#d20f39",
+    "mOnError": "#dce0e8",
+    "mSurface": "#eff1f5",
+    "mOnSurface": "#4c4f69",
+    "mSurfaceVariant": "#ccd0da",
+    "mOnSurfaceVariant": "#6c6f85",
+    "mOutline": "#a5adcb",
+    "mShadow": "#dce0e8"
+  }
 }

--- a/Assets/ColorScheme/Dracula/Dracula.json
+++ b/Assets/ColorScheme/Dracula/Dracula.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#bd93f9",
-        "mOnPrimary": "#282A36",
-        "mSecondary": "#ff79c6",
-        "mOnSecondary": "#4e1d32",
-        "mTertiary": "#8be9fd",
-        "mOnTertiary": "#003543",
-        "mError": "#FF5555",
-        "mOnError": "#282A36",
-        "mSurface": "#282A36",
-        "mOnSurface": "#F8F8F2",
-        "mSurfaceVariant": "#44475A",
-        "mOnSurfaceVariant": "#d6d8e0",
-        "mOutline": "#5a5e77",
-        "mShadow": "#282A36"
-    },
-    "light": {
-        "mPrimary": "#8332f4",
-        "mOnPrimary": "#ffffff",
-        "mSecondary": "#ff1399",
-        "mOnSecondary": "#ffffff",
-        "mTertiary": "#0398b9",
-        "mOnTertiary": "#ffffff",
-        "mError": "#FF5555",
-        "mOnError": "#282A36",
-        "mSurface": "#f8f8f2",
-        "mOnSurface": "#282a36",
-        "mSurfaceVariant": "#e6e6ea",
-        "mOnSurfaceVariant": "#44475a",
-        "mOutline": "#cacad3",
-        "mShadow": "#d6d8e0"
-    }
+  "dark": {
+    "mPrimary": "#bd93f9",
+    "mOnPrimary": "#282A36",
+    "mSecondary": "#ff79c6",
+    "mOnSecondary": "#4e1d32",
+    "mTertiary": "#8be9fd",
+    "mOnTertiary": "#003543",
+    "mError": "#FF5555",
+    "mOnError": "#282A36",
+    "mSurface": "#282A36",
+    "mOnSurface": "#F8F8F2",
+    "mSurfaceVariant": "#44475A",
+    "mOnSurfaceVariant": "#d6d8e0",
+    "mOutline": "#5a5e77",
+    "mShadow": "#282A36"
+  },
+  "light": {
+    "mPrimary": "#8332f4",
+    "mOnPrimary": "#ffffff",
+    "mSecondary": "#ff1399",
+    "mOnSecondary": "#ffffff",
+    "mTertiary": "#0398b9",
+    "mOnTertiary": "#ffffff",
+    "mError": "#FF5555",
+    "mOnError": "#282A36",
+    "mSurface": "#f8f8f2",
+    "mOnSurface": "#282a36",
+    "mSurfaceVariant": "#e6e6ea",
+    "mOnSurfaceVariant": "#44475a",
+    "mOutline": "#cacad3",
+    "mShadow": "#d6d8e0"
+  }
 }

--- a/Assets/ColorScheme/Everforest/Everforest.json
+++ b/Assets/ColorScheme/Everforest/Everforest.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#D3C6AA",
-        "mOnPrimary": "#232A2E",
-        "mSecondary": "#D3C6AA",
-        "mOnSecondary": "#232A2E",
-        "mTertiary": "#9DA9A0",
-        "mOnTertiary": "#232A2E",
-        "mError": "#E67E80",
-        "mOnError": "#232A2E",
-        "mSurface": "#232A2E", 
-        "mOnSurface": "#859289",
-        "mSurfaceVariant": "#2D353B",
-        "mOnSurfaceVariant": "#D3C6AA",
-        "mOutline": "#D3C6AA",
-        "mShadow": "#475258"
-    },
-    "light": {
-        "mPrimary": "#434F55",
-        "mOnPrimary": "#D3C6AA",
-        "mSecondary": "#232a2e",
-        "mOnSecondary": "#D3C6AA",
-        "mTertiary": "#333c43",
-        "mOnTertiary": "#9DA9A0",
-        "mError": "#E66868",
-        "mOnError": "#9DA9A0",
-        "mSurface": "#9DA9A0",
-        "mOnSurface": "#232A2E",
-        "mSurfaceVariant": "#BEC5B2",
-        "mOnSurfaceVariant": "#333C43",
-        "mOutline": "#232A2E",
-        "mShadow": "#ECF5ED"
-    }
+  "dark": {
+    "mPrimary": "#D3C6AA",
+    "mOnPrimary": "#232A2E",
+    "mSecondary": "#D3C6AA",
+    "mOnSecondary": "#232A2E",
+    "mTertiary": "#9DA9A0",
+    "mOnTertiary": "#232A2E",
+    "mError": "#E67E80",
+    "mOnError": "#232A2E",
+    "mSurface": "#232A2E",
+    "mOnSurface": "#859289",
+    "mSurfaceVariant": "#2D353B",
+    "mOnSurfaceVariant": "#D3C6AA",
+    "mOutline": "#D3C6AA",
+    "mShadow": "#475258"
+  },
+  "light": {
+    "mPrimary": "#434F55",
+    "mOnPrimary": "#D3C6AA",
+    "mSecondary": "#232a2e",
+    "mOnSecondary": "#D3C6AA",
+    "mTertiary": "#333c43",
+    "mOnTertiary": "#9DA9A0",
+    "mError": "#E66868",
+    "mOnError": "#9DA9A0",
+    "mSurface": "#9DA9A0",
+    "mOnSurface": "#232A2E",
+    "mSurfaceVariant": "#BEC5B2",
+    "mOnSurfaceVariant": "#333C43",
+    "mOutline": "#232A2E",
+    "mShadow": "#ECF5ED"
+  }
 }

--- a/Assets/ColorScheme/Gruvbox/Gruvbox.json
+++ b/Assets/ColorScheme/Gruvbox/Gruvbox.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#b8bb26",
-        "mOnPrimary": "#282828",
-        "mSecondary": "#fabd2f",
-        "mOnSecondary": "#282828",
-        "mTertiary": "#83a598",
-        "mOnTertiary": "#282828",
-        "mError": "#fb4934",
-        "mOnError": "#282828",
-        "mSurface": "#282828",
-        "mOnSurface": "#fbf1c7",
-        "mSurfaceVariant": "#3c3836",
-        "mOnSurfaceVariant": "#ebdbb2",
-        "mOutline": "#57514e",
-        "mShadow": "#282828"
-    },
-    "light": {
-        "mPrimary": "#98971a",
-        "mOnPrimary": "#fbf1c7",
-        "mSecondary": "#d79921",
-        "mOnSecondary": "#fbf1c7",
-        "mTertiary": "#458588",
-        "mOnTertiary": "#fbf1c7",
-        "mError": "#cc241d",
-        "mOnError": "#fbf1c7",
-        "mSurface": "#fbf1c7",
-        "mOnSurface": "#3c3836",
-        "mSurfaceVariant": "#ebdbb2",
-        "mOnSurfaceVariant": "#7c6f64",
-        "mOutline": "#bdae93",
-        "mShadow": "#d5c4a1"
-    }
+  "dark": {
+    "mPrimary": "#b8bb26",
+    "mOnPrimary": "#282828",
+    "mSecondary": "#fabd2f",
+    "mOnSecondary": "#282828",
+    "mTertiary": "#83a598",
+    "mOnTertiary": "#282828",
+    "mError": "#fb4934",
+    "mOnError": "#282828",
+    "mSurface": "#282828",
+    "mOnSurface": "#fbf1c7",
+    "mSurfaceVariant": "#3c3836",
+    "mOnSurfaceVariant": "#ebdbb2",
+    "mOutline": "#57514e",
+    "mShadow": "#282828"
+  },
+  "light": {
+    "mPrimary": "#98971a",
+    "mOnPrimary": "#fbf1c7",
+    "mSecondary": "#d79921",
+    "mOnSecondary": "#fbf1c7",
+    "mTertiary": "#458588",
+    "mOnTertiary": "#fbf1c7",
+    "mError": "#cc241d",
+    "mOnError": "#fbf1c7",
+    "mSurface": "#fbf1c7",
+    "mOnSurface": "#3c3836",
+    "mSurfaceVariant": "#ebdbb2",
+    "mOnSurfaceVariant": "#7c6f64",
+    "mOutline": "#bdae93",
+    "mShadow": "#d5c4a1"
+  }
 }

--- a/Assets/ColorScheme/Kanagawa/Kanagawa.json
+++ b/Assets/ColorScheme/Kanagawa/Kanagawa.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#76946a",
-        "mOnPrimary": "#1f1f28",
-        "mSecondary": "#c0a36e",
-        "mOnSecondary": "#1f1f28",
-        "mTertiary": "#7e9cd8",
-        "mOnTertiary": "#1f1f28",
-        "mError": "#c34043",
-        "mOnError": "#1f1f28",
-        "mSurface": "#1f1f28",
-        "mOnSurface": "#c8c093",
-        "mSurfaceVariant": "#2a2a37",
-        "mOnSurfaceVariant": "#717c7c",
-        "mOutline": "#363646",
-        "mShadow": "#1f1f28"
-    },
-    "light": {
-        "mPrimary": "#6f894e",
-        "mOnPrimary": "#f2ecbc",
-        "mSecondary": "#77713f",
-        "mOnSecondary": "#f2ecbc",
-        "mTertiary": "#4d699b",
-        "mOnTertiary": "#f2ecbc",
-        "mError": "#c84053",
-        "mOnError": "#f2ecbc",
-        "mSurface": "#f2ecbc",
-        "mOnSurface": "#545464",
-        "mSurfaceVariant": "#e5ddb0",
-        "mOnSurfaceVariant": "#8a8980",
-        "mOutline": "#cfc49c",
-        "mShadow": "#f2ecbc"
-    }
+  "dark": {
+    "mPrimary": "#76946a",
+    "mOnPrimary": "#1f1f28",
+    "mSecondary": "#c0a36e",
+    "mOnSecondary": "#1f1f28",
+    "mTertiary": "#7e9cd8",
+    "mOnTertiary": "#1f1f28",
+    "mError": "#c34043",
+    "mOnError": "#1f1f28",
+    "mSurface": "#1f1f28",
+    "mOnSurface": "#c8c093",
+    "mSurfaceVariant": "#2a2a37",
+    "mOnSurfaceVariant": "#717c7c",
+    "mOutline": "#363646",
+    "mShadow": "#1f1f28"
+  },
+  "light": {
+    "mPrimary": "#6f894e",
+    "mOnPrimary": "#f2ecbc",
+    "mSecondary": "#77713f",
+    "mOnSecondary": "#f2ecbc",
+    "mTertiary": "#4d699b",
+    "mOnTertiary": "#f2ecbc",
+    "mError": "#c84053",
+    "mOnError": "#f2ecbc",
+    "mSurface": "#f2ecbc",
+    "mOnSurface": "#545464",
+    "mSurfaceVariant": "#e5ddb0",
+    "mOnSurfaceVariant": "#8a8980",
+    "mOutline": "#cfc49c",
+    "mShadow": "#f2ecbc"
+  }
 }

--- a/Assets/ColorScheme/Nord/Nord.json
+++ b/Assets/ColorScheme/Nord/Nord.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#8fbcbb",
-        "mOnPrimary": "#2e3440",
-        "mSecondary": "#88c0d0",
-        "mOnSecondary": "#2e3440",
-        "mTertiary": "#5e81ac",
-        "mOnTertiary": "#2e3440",
-        "mError": "#bf616a",
-        "mOnError": "#2e3440",
-        "mSurface": "#2e3440",
-        "mOnSurface": "#eceff4",
-        "mSurfaceVariant": "#3b4252",
-        "mOnSurfaceVariant": "#d8dee9",
-        "mOutline": "#505a70",
-        "mShadow": "#2e3440"
-    },
-    "light": {
-        "mPrimary": "#5e81ac",
-        "mOnPrimary": "#eceff4",
-        "mSecondary": "#64adc2",
-        "mOnSecondary": "#eceff4",
-        "mTertiary": "#6fa9a8",
-        "mOnTertiary": "#eceff4",
-        "mError": "#bf616a",
-        "mOnError": "#eceff4",
-        "mSurface": "#eceff4",
-        "mOnSurface": "#2e3440",
-        "mSurfaceVariant": "#e5e9f0",
-        "mOnSurfaceVariant": "#4c566a",
-        "mOutline": "#c5cedd",
-        "mShadow": "#d8dee9"
-    }
+  "dark": {
+    "mPrimary": "#8fbcbb",
+    "mOnPrimary": "#2e3440",
+    "mSecondary": "#88c0d0",
+    "mOnSecondary": "#2e3440",
+    "mTertiary": "#5e81ac",
+    "mOnTertiary": "#2e3440",
+    "mError": "#bf616a",
+    "mOnError": "#2e3440",
+    "mSurface": "#2e3440",
+    "mOnSurface": "#eceff4",
+    "mSurfaceVariant": "#3b4252",
+    "mOnSurfaceVariant": "#d8dee9",
+    "mOutline": "#505a70",
+    "mShadow": "#2e3440"
+  },
+  "light": {
+    "mPrimary": "#5e81ac",
+    "mOnPrimary": "#eceff4",
+    "mSecondary": "#64adc2",
+    "mOnSecondary": "#eceff4",
+    "mTertiary": "#6fa9a8",
+    "mOnTertiary": "#eceff4",
+    "mError": "#bf616a",
+    "mOnError": "#eceff4",
+    "mSurface": "#eceff4",
+    "mOnSurface": "#2e3440",
+    "mSurfaceVariant": "#e5e9f0",
+    "mOnSurfaceVariant": "#4c566a",
+    "mOutline": "#c5cedd",
+    "mShadow": "#d8dee9"
+  }
 }

--- a/Assets/ColorScheme/Rosepine/Rosepine.json
+++ b/Assets/ColorScheme/Rosepine/Rosepine.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#ebbcba",
-        "mOnPrimary": "#191724",
-        "mSecondary": "#9ccfd8",
-        "mOnSecondary": "#191724",
-        "mTertiary": "#524f67",
-        "mOnTertiary": "#e0def4",
-        "mError": "#eb6f92",
-        "mOnError": "#191724",
-        "mSurface": "#1f1d2e",
-        "mOnSurface": "#e0def4",
-        "mSurfaceVariant": "#26233a",
-        "mOnSurfaceVariant": "#908caa",
-        "mOutline": "#403d52",
-        "mShadow": "#191724"
-    },
-    "light": {
-        "mPrimary": "#d7827e",
-        "mOnPrimary": "#faf4ed",
-        "mSecondary": "#56949f",
-        "mOnSecondary": "#faf4ed",
-        "mTertiary": "#cecacd",
-        "mOnTertiary": "#575279",
-        "mError": "#b4637a",
-        "mOnError": "#faf4ed",
-        "mSurface": "#fffaf3",
-        "mOnSurface": "#575279",
-        "mSurfaceVariant": "#f2e9e1",
-        "mOnSurfaceVariant": "#797593",
-        "mOutline": "#dfdad9",
-        "mShadow": "#faf4ed"
-    }
+  "dark": {
+    "mPrimary": "#ebbcba",
+    "mOnPrimary": "#191724",
+    "mSecondary": "#9ccfd8",
+    "mOnSecondary": "#191724",
+    "mTertiary": "#524f67",
+    "mOnTertiary": "#e0def4",
+    "mError": "#eb6f92",
+    "mOnError": "#191724",
+    "mSurface": "#1f1d2e",
+    "mOnSurface": "#e0def4",
+    "mSurfaceVariant": "#26233a",
+    "mOnSurfaceVariant": "#908caa",
+    "mOutline": "#403d52",
+    "mShadow": "#191724"
+  },
+  "light": {
+    "mPrimary": "#d7827e",
+    "mOnPrimary": "#faf4ed",
+    "mSecondary": "#56949f",
+    "mOnSecondary": "#faf4ed",
+    "mTertiary": "#cecacd",
+    "mOnTertiary": "#575279",
+    "mError": "#b4637a",
+    "mOnError": "#faf4ed",
+    "mSurface": "#fffaf3",
+    "mOnSurface": "#575279",
+    "mSurfaceVariant": "#f2e9e1",
+    "mOnSurfaceVariant": "#797593",
+    "mOutline": "#dfdad9",
+    "mShadow": "#faf4ed"
+  }
 }

--- a/Assets/ColorScheme/Solarized/Solarized.json
+++ b/Assets/ColorScheme/Solarized/Solarized.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#b58900",
-        "mOnPrimary": "#002b36",
-        "mSecondary": "#d33682",
-        "mOnSecondary": "#002b36",
-        "mTertiary": "#cb4b16",
-        "mOnTertiary": "#002b36",
-        "mError": "#dc322f",
-        "mOnError": "#002b36",
-        "mSurface": "#002b36",
-        "mOnSurface": "#839496",
-        "mSurfaceVariant": "#073642",
-        "mOnSurfaceVariant": "#657b83",
-        "mOutline": "#0c5c70",
-        "mShadow": "#002b36"
-    },
-    "light": {
-        "mPrimary": "#b58900",
-        "mOnPrimary": "#fdf6e3",
-        "mSecondary": "#d33682",
-        "mOnSecondary": "#fdf6e3",
-        "mTertiary": "#cb4b16",
-        "mOnTertiary": "#fdf6e3",
-        "mError": "#dc322f",
-        "mOnError": "#fdf6e3",
-        "mSurface": "#fdf6e3",
-        "mOnSurface": "#657b83",
-        "mSurfaceVariant": "#eee8d5",
-        "mOnSurfaceVariant": "#839496",
-        "mOutline": "#dfd4b1",
-        "mShadow": "#eee8d5"
-    }
+  "dark": {
+    "mPrimary": "#b58900",
+    "mOnPrimary": "#002b36",
+    "mSecondary": "#d33682",
+    "mOnSecondary": "#002b36",
+    "mTertiary": "#cb4b16",
+    "mOnTertiary": "#002b36",
+    "mError": "#dc322f",
+    "mOnError": "#002b36",
+    "mSurface": "#002b36",
+    "mOnSurface": "#839496",
+    "mSurfaceVariant": "#073642",
+    "mOnSurfaceVariant": "#657b83",
+    "mOutline": "#0c5c70",
+    "mShadow": "#002b36"
+  },
+  "light": {
+    "mPrimary": "#b58900",
+    "mOnPrimary": "#fdf6e3",
+    "mSecondary": "#d33682",
+    "mOnSecondary": "#fdf6e3",
+    "mTertiary": "#cb4b16",
+    "mOnTertiary": "#fdf6e3",
+    "mError": "#dc322f",
+    "mOnError": "#fdf6e3",
+    "mSurface": "#fdf6e3",
+    "mOnSurface": "#657b83",
+    "mSurfaceVariant": "#eee8d5",
+    "mOnSurfaceVariant": "#839496",
+    "mOutline": "#dfd4b1",
+    "mShadow": "#eee8d5"
+  }
 }

--- a/Assets/ColorScheme/Tokyo-Night/Tokyo-Night.json
+++ b/Assets/ColorScheme/Tokyo-Night/Tokyo-Night.json
@@ -1,34 +1,34 @@
 {
-    "dark": {
-        "mPrimary": "#7aa2f7",
-        "mOnPrimary": "#16161e",
-        "mSecondary": "#bb9af7",
-        "mOnSecondary": "#16161e",
-        "mTertiary": "#9ece6a",
-        "mOnTertiary": "#16161e",
-        "mError": "#f7768e",
-        "mOnError": "#16161e",
-        "mSurface": "#1a1b26",
-        "mOnSurface": "#c0caf5",
-        "mSurfaceVariant": "#24283b",
-        "mOnSurfaceVariant": "#9aa5ce",
-        "mOutline": "#565f89",
-        "mShadow": "#15161e"
-    },
-    "light": {
-        "mPrimary": "#2e7de9",
-        "mOnPrimary": "#e1e2e7",
-        "mSecondary": "#9854f1",
-        "mOnSecondary": "#e1e2e7",
-        "mTertiary": "#587539",
-        "mOnTertiary": "#e1e2e7",
-        "mError": "#f52a65",
-        "mOnError": "#e1e2e7",
-        "mSurface": "#e1e2e7",
-        "mOnSurface": "#3760bf",
-        "mSurfaceVariant": "#d0d5e3",
-        "mOnSurfaceVariant": "#6172b0",
-        "mOutline": "#b4b5b9",
-        "mShadow": "#a8aecb"
-    }
+  "dark": {
+    "mPrimary": "#7aa2f7",
+    "mOnPrimary": "#16161e",
+    "mSecondary": "#bb9af7",
+    "mOnSecondary": "#16161e",
+    "mTertiary": "#9ece6a",
+    "mOnTertiary": "#16161e",
+    "mError": "#f7768e",
+    "mOnError": "#16161e",
+    "mSurface": "#1a1b26",
+    "mOnSurface": "#c0caf5",
+    "mSurfaceVariant": "#24283b",
+    "mOnSurfaceVariant": "#9aa5ce",
+    "mOutline": "#565f89",
+    "mShadow": "#15161e"
+  },
+  "light": {
+    "mPrimary": "#2e7de9",
+    "mOnPrimary": "#e1e2e7",
+    "mSecondary": "#9854f1",
+    "mOnSecondary": "#e1e2e7",
+    "mTertiary": "#587539",
+    "mOnTertiary": "#e1e2e7",
+    "mError": "#f52a65",
+    "mOnError": "#e1e2e7",
+    "mSurface": "#e1e2e7",
+    "mOnSurface": "#3760bf",
+    "mSurfaceVariant": "#d0d5e3",
+    "mOnSurfaceVariant": "#6172b0",
+    "mOutline": "#b4b5b9",
+    "mShadow": "#a8aecb"
+  }
 }

--- a/Assets/MatugenTemplates/noctalia.json
+++ b/Assets/MatugenTemplates/noctalia.json
@@ -1,22 +1,16 @@
 {
   "mPrimary": "{{colors.primary.default.hex}}",
   "mOnPrimary": "{{colors.on_primary.default.hex}}",
-
   "mSecondary": "{{colors.secondary.default.hex}}",
   "mOnSecondary": "{{colors.on_secondary.default.hex}}",
-
   "mTertiary": "{{colors.tertiary.default.hex}}",
   "mOnTertiary": "{{colors.on_tertiary.default.hex}}",
-
   "mError": "{{colors.error.default.hex}}",
   "mOnError": "{{colors.on_error.default.hex}}",
-
   "mSurface": "{{colors.surface.default.hex}}",
   "mOnSurface": "{{colors.on_surface.default.hex}}",
-
   "mSurfaceVariant": "{{colors.surface_container.default.hex}}",
   "mOnSurfaceVariant": "{{colors.on_surface_variant.default.hex}}",
-  
   "mOutline": "{{colors.outline_variant.default.hex}}",
   "mShadow": "{{colors.shadow.default.hex}}"
-} 
+}

--- a/Assets/MatugenTemplates/pywalfox.json
+++ b/Assets/MatugenTemplates/pywalfox.json
@@ -1,22 +1,22 @@
 {
-    "wallpaper": "{{image}}",
-    "alpha": "100",
-    "colors": {
-      "color0": "{{colors.background.default.hex}}",
-      "color1": "",
-      "color2": "",
-      "color3": "",
-      "color4": "",
-      "color5": "",
-      "color6": "",
-      "color7": "",
-      "color8": "",
-      "color9": "",
-      "color10": "{{colors.primary.default.hex}}",
-      "color11": "",
-      "color12": "",
-      "color13": "{{colors.surface_bright.default.hex}}",
-      "color14": "",
-      "color15": "{{colors.on_surface.default.hex}}"
-    }
+  "wallpaper": "{{image}}",
+  "alpha": "100",
+  "colors": {
+    "color0": "{{colors.background.default.hex}}",
+    "color1": "",
+    "color2": "",
+    "color3": "",
+    "color4": "",
+    "color5": "",
+    "color6": "",
+    "color7": "",
+    "color8": "",
+    "color9": "",
+    "color10": "{{colors.primary.default.hex}}",
+    "color11": "",
+    "color12": "",
+    "color13": "{{colors.surface_bright.default.hex}}",
+    "color14": "",
+    "color15": "{{colors.on_surface.default.hex}}"
   }
+}

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1233,7 +1233,6 @@
       "scan-again": "Scan again"
     }
   },
-
   "tooltips": {
     "refresh": "Refresh",
     "close": "Close",

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,73 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1760813311,
+        "narHash": "sha256-lbHQ7FXGzt6/IygWvJ1lCq+Txcut3xYYd6VIpF1ojkg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "4e627ac2e1b8f1de7f5090064242de9a259dbbc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1760809591,
+        "narHash": "sha256-OxGcFcQdfOK8veZkPdQuqXIotFYiy4sBQB58dMNLeHY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "870883ba11ba1c84f756c0c1f9fa74cdb2a16c1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1760284886,
+        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1756125398,
         "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
@@ -12,6 +79,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -38,23 +121,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_2",
         "quickshell": "quickshell",
-        "systems": "systems"
+        "treefmt-nix": "treefmt-nix"
       }
     },
-    "systems": {
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1760802554,
+        "narHash": "sha256-5YkOYOCF8/XNw89/ABKFB0c/P78U2EVuKRDGTql6+kA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "296ebf0c3668ebceb3b0bfee55298f112b4b5754",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    systems.url = "github:nix-systems/default";
+    home-manager.url = "github:nix-community/home-manager";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
 
     quickshell = {
       url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
@@ -11,51 +13,81 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    systems,
-    quickshell,
-    ...
-  }: let
-    eachSystem = nixpkgs.lib.genAttrs (import systems);
-  in {
-    formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.alejandra);
+  outputs = inputs @ {flake-parts, ...}:
+  # more elegant than `eachSystem f:`, way better than utils, and expandable
+    flake-parts.lib.mkFlake {
+      inherit
+        inputs
+        ;
+    } {
+      imports = [
+        # self.homeModules.default;
+        inputs.home-manager.flakeModules.home-manager
+        ./nix/home-module.nix
 
-    packages = eachSystem (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        default = pkgs.callPackage ./nix/package.nix {
-          version = self.rev or self.dirtyRev or "dirty";
-          quickshell = quickshell.packages.${system}.default.override {
-            withX11 = false;
-            withI3 = true;
+        # self.nixosModules.default;
+        ./nix/nixos-module.nix
+
+        # one-for-all formatter;
+        inputs.treefmt-nix.flakeModule
+        ./nix/treefmt.nix
+      ];
+
+      systems = [
+        # any other system could be added here
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      flake = {self', ...}: {
+        nixosModules.noctalia-shell = self'.nixosModules.default;
+        homeModules.noctalia-shell = self'.homeModules.default;
+      };
+
+      perSystem = {
+        self',
+        pkgs,
+        system,
+        ...
+      }: {
+        # in case of manual formatting / linitng
+        # or to extend things.
+        # devShell is a native development env,
+        # supported by direnv, devenv, and nix
+        # itself. just use `nix develop --command <shell>`
+        devShells = {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              # nix
+              alejandra # formatter
+              statix # linter
+              deadnix # linter
+
+              # shell
+              shfmt # formatter
+              shellcheck # linter
+
+              # json
+              jsonfmt # formatter
+
+              # CoC
+              lefthook # githooks
+              kdePackages.qtdeclarative # qmlfmt, qmllin and etc; Qt6
+            ];
           };
         };
-      }
-    );
 
-    defaultPackage = eachSystem (system: self.packages.${system}.default);
-
-    homeModules.default = {
-      pkgs,
-      lib,
-      ...
-    }: {
-      imports = [./nix/home-module.nix];
-      programs.noctalia-shell.app2unit.package =
-        lib.mkDefault
-        nixpkgs.legacyPackages.${pkgs.system}.app2unit;
+        # this way packages are wrapped, and extandable!
+        packages = {
+          noctalia-shell = self'.packages.default;
+          default = pkgs.callPackage ./nix/package.nix {
+            version = self'.rev or self'.dirtyRev or "dirty";
+            quickshell = inputs.quickshell.packages.${system}.default.override {
+              withX11 = false;
+              withI3 = true;
+            };
+          };
+        };
+      };
     };
-
-    nixosModules.default = {
-      pkgs,
-      lib,
-      ...
-    }: {
-      imports = [./nix/nixos-module.nix];
-      services.noctalia-shell.package = lib.mkDefault self.packages.${pkgs.system}.default;
-    };
-  };
 }

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,114 +1,116 @@
 {
-  config,
-  lib,
-  pkgs,
-  ...
-}: let
-  cfg = config.programs.noctalia-shell;
-  defaultSettings = builtins.fromJSON (builtins.readFile ../Assets/settings-default.json);
-  extractAttrs = x:
-    if builtins.isAttrs x
-    then x
-    else if builtins.isString x
-    then builtins.fromJson x
-    else builtins.fromJson (builtins.readFile x);
-in {
-  options.programs.noctalia-shell = {
-    enable = lib.mkEnableOption "Noctalia shell configuration";
+  flake.homeModules.default = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    cfg = config.programs.noctalia-shell;
+    defaultSettings = builtins.fromJSON (builtins.readFile ../Assets/settings-default.json);
+    extractAttrs = x:
+      if builtins.isAttrs x
+      then x
+      else if builtins.isString x
+      then builtins.fromJson x
+      else builtins.fromJson (builtins.readFile x);
+  in {
+    options.programs.noctalia-shell = {
+      enable = lib.mkEnableOption "Noctalia shell configuration";
 
-    settings = lib.mkOption {
-      type = with lib.types;
-        nullOr (oneOf [
-          attrs
-          str
-          path
-        ]);
-      default = {};
-      apply = x: lib.recursiveUpdate defaultSettings (extractAttrs x);
-      example = lib.literalExpression ''
-        {
-          bar = {
-            position = "bottom";
-            floating = true;
-            backgroundOpacity = 0.95;
-          };
-          general = {
-            animationSpeed = 1.5;
-            radiusRatio = 1.2;
-          };
-          colorSchemes = {
-            darkMode = true;
-            useWallpaperColors = true;
-          };
-        }
-      '';
-      description = ''
-        Noctalia shell configuration settings as an attribute set, string
-        or filepath, to be written to ~/.config/noctalia/settings.json.
-        When provided as an attribute set, it will be deep-merged with
-        the default settings.
-      '';
-    };
+      settings = lib.mkOption {
+        type = with lib.types;
+          nullOr (oneOf [
+            attrs
+            str
+            path
+          ]);
+        default = {};
+        apply = x: lib.recursiveUpdate defaultSettings (extractAttrs x);
+        example = lib.literalExpression ''
+          {
+            bar = {
+              position = "bottom";
+              floating = true;
+              backgroundOpacity = 0.95;
+            };
+            general = {
+              animationSpeed = 1.5;
+              radiusRatio = 1.2;
+            };
+            colorSchemes = {
+              darkMode = true;
+              useWallpaperColors = true;
+            };
+          }
+        '';
+        description = ''
+          Noctalia shell configuration settings as an attribute set, string
+          or filepath, to be written to ~/.config/noctalia/settings.json.
+          When provided as an attribute set, it will be deep-merged with
+          the default settings.
+        '';
+      };
 
-    colors = lib.mkOption {
-      type = with lib.types;
-        nullOr (oneOf [
-          attrs
-          str
-          path
-        ]);
-      default = {};
-      apply = extractAttrs;
-      example = lib.literalExpression ''
-         {
-           mError = "#dddddd";
-           mOnError = "#111111";
-           mOnPrimary = "#111111";
-           mOnSecondary = "#111111";
-           mOnSurface = "#828282";
-           mOnSurfaceVariant = "#5d5d5d";
-           mOnTertiary = "#111111";
-           mOutline = "#3c3c3c";
-           mPrimary = "#aaaaaa";
-           mSecondary = "#a7a7a7";
-           mShadow = "#000000";
-           mSurface = "#111111";
-           mSurfaceVariant = "#191919";
-           mTertiary = "#cccccc";
-        }
-      '';
-      description = ''
-        Noctalia shell color configuration as an attribute set, string
-        or filepath, to be written to ~/.config/noctalia/colors.json.
-      '';
-    };
+      colors = lib.mkOption {
+        type = with lib.types;
+          nullOr (oneOf [
+            attrs
+            str
+            path
+          ]);
+        default = {};
+        apply = extractAttrs;
+        example = lib.literalExpression ''
+           {
+             mError = "#dddddd";
+             mOnError = "#111111";
+             mOnPrimary = "#111111";
+             mOnSecondary = "#111111";
+             mOnSurface = "#828282";
+             mOnSurfaceVariant = "#5d5d5d";
+             mOnTertiary = "#111111";
+             mOutline = "#3c3c3c";
+             mPrimary = "#aaaaaa";
+             mSecondary = "#a7a7a7";
+             mShadow = "#000000";
+             mSurface = "#111111";
+             mSurfaceVariant = "#191919";
+             mTertiary = "#cccccc";
+          }
+        '';
+        description = ''
+          Noctalia shell color configuration as an attribute set, string
+          or filepath, to be written to ~/.config/noctalia/colors.json.
+        '';
+      };
 
-    app2unit.package = lib.mkOption {
-      type = lib.types.package;
-      description = ''
-        The app2unit package to use when appLauncher.useApp2Unit is enabled.
-      '';
-    };
-  };
-
-  config = let
-    restart = ''
-      ${pkgs.systemd}/bin/systemctl --user try-restart noctalia-shell.service 2>/dev/null || true
-    '';
-    useApp2Unit = cfg.settings.appLauncher.useApp2Unit or false;
-  in
-    lib.mkIf cfg.enable {
-      home.packages = lib.optional useApp2Unit cfg.app2unit.package;
-
-      xdg.configFile = {
-        "noctalia/settings.json" = {
-          onChange = restart;
-          text = builtins.toJSON cfg.settings;
-        };
-        "noctalia/colors.json" = lib.mkIf (cfg.colors != {}) {
-          onChange = restart;
-          text = builtins.toJSON cfg.colors;
-        };
+      app2unit.package = lib.mkOption {
+        type = lib.types.package;
+        description = ''
+          The app2unit package to use when appLauncher.useApp2Unit is enabled.
+        '';
       };
     };
+
+    config = let
+      restart = ''
+        ${pkgs.systemd}/bin/systemctl --user try-restart noctalia-shell.service 2>/dev/null || true
+      '';
+      useApp2Unit = cfg.settings.appLauncher.useApp2Unit or false;
+    in
+      lib.mkIf cfg.enable {
+        home.packages = lib.optional useApp2Unit cfg.app2unit.package;
+
+        xdg.configFile = {
+          "noctalia/settings.json" = {
+            onChange = restart;
+            text = builtins.toJSON cfg.settings;
+          };
+          "noctalia/colors.json" = lib.mkIf (cfg.colors != {}) {
+            onChange = restart;
+            text = builtins.toJSON cfg.colors;
+          };
+        };
+      };
+  };
 }

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,56 +1,58 @@
 {
-  config,
-  lib,
-  ...
-}: let
-  cfg = config.services.noctalia-shell;
-in {
-  options.services.noctalia-shell = {
-    enable = lib.mkEnableOption "Noctalia shell systemd service";
+  flake.nixosModules.default = {
+    config,
+    lib,
+    ...
+  }: let
+    cfg = config.services.noctalia-shell;
+  in {
+    options.services.noctalia-shell = {
+      enable = lib.mkEnableOption "Noctalia shell systemd service";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      description = "The noctalia-shell package to use";
-    };
-
-    target = lib.mkOption {
-      type = lib.types.str;
-      default = "graphical-session.target";
-      example = "hyprland-session.target";
-      description = "The systemd target for the noctalia-shell service.";
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    systemd.user.services.noctalia-shell = {
-      description = "Noctalia Shell - Wayland desktop shell";
-      documentation = ["https://github.com/noctalia-dev/noctalia-shell"];
-      after = [cfg.target];
-      partOf = [cfg.target];
-      wantedBy = [cfg.target];
-      restartTriggers = [cfg.package];
-
-      environment = {
-        PATH = lib.mkForce null;
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = "The noctalia-shell package to use";
       };
 
-      unitConfig = {
-        StartLimitIntervalSec = 60;
-        StartLimitBurst = 3;
-      };
-
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/noctalia-shell";
-        Restart = "on-failure";
-        RestartSec = 3;
-        TimeoutStartSec = 10;
-        TimeoutStopSec = 5;
-        Environment = [
-          "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
-        ];
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "hyprland-session.target";
+        description = "The systemd target for the noctalia-shell service.";
       };
     };
 
-    environment.systemPackages = [cfg.package];
+    config = lib.mkIf cfg.enable {
+      systemd.user.services.noctalia-shell = {
+        description = "Noctalia Shell - Wayland desktop shell";
+        documentation = ["https://github.com/noctalia-dev/noctalia-shell"];
+        after = [cfg.target];
+        partOf = [cfg.target];
+        wantedBy = [cfg.target];
+        restartTriggers = [cfg.package];
+
+        environment = {
+          PATH = lib.mkForce null;
+        };
+
+        unitConfig = {
+          StartLimitIntervalSec = 60;
+          StartLimitBurst = 3;
+        };
+
+        serviceConfig = {
+          ExecStart = "${cfg.package}/bin/noctalia-shell";
+          Restart = "on-failure";
+          RestartSec = 3;
+          TimeoutStartSec = 10;
+          TimeoutStopSec = 5;
+          Environment = [
+            "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
+          ];
+        };
+      };
+
+      environment.systemPackages = [cfg.package];
+    };
   };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -30,7 +30,7 @@
 }: let
   src = lib.cleanSourceWith {
     src = ../.;
-    filter = path: type:
+    filter = path: _type:
       !(builtins.any (prefix: lib.path.hasPrefix (../. + prefix) (/. + path)) [
         /.github
         /Assets/Screenshots
@@ -61,7 +61,7 @@
       wlsunset
       wl-clipboard
     ]
-    ++ lib.optionals (stdenv.hostPlatform.isx86_64) [gpu-screen-recorder];
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [gpu-screen-recorder];
 
   fontconfig = makeFontsConf {
     fontDirectories = [

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,81 @@
+{
+  perSystem = {
+    pkgs,
+    lib,
+    ...
+  }: {
+    treefmt = {
+      enableDefaultExcludes = true;
+      flakeCheck = true;
+      flakeFormatter = true;
+
+      programs = {
+        alejandra = {
+          enable = true;
+          priority = 3;
+          includes = [
+            "*.nix"
+          ];
+        };
+
+        deadnix = {
+          enable = true;
+          priority = 3;
+          includes = [
+            "*.nix"
+          ];
+        };
+
+        statix = {
+          enable = true;
+          priority = 3;
+          includes = [
+            "*.nix"
+          ];
+        };
+
+        shfmt = {
+          enable = true;
+          priority = 1;
+          indent_size = 3;
+          includes = [
+            "*.sh"
+          ];
+        };
+
+        shellcheck = {
+          enable = true;
+          priority = 1;
+          includes = [
+            "*.sh"
+          ];
+        };
+
+        jsonfmt = {
+          enable = true;
+          priority = 2;
+          includes = [
+            "*.json"
+            "*.jsonc"
+          ];
+        };
+      };
+
+      settings = {
+        global.excludes = [
+          "*.qmlls.ini"
+          ".zed/"
+        ];
+
+        formatter = {
+          "qmlfmt" = {
+            command = ''${lib.getExe' pkgs.kdePackages.qtdeclarative "qmlformat"}'';
+            includes = [
+              "*.qml"
+            ];
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Things Done
- (not intentional) formatted all `.json`, `.nix` via treefmt.
- complete rewrite of `flake.nix` with `flake-parts`:
- 1. added `devShell` with all formatters;
- 2. formatter changed to `treefmt`; `nix fmt` now can format and lint qml, json, shell, nix;
- 3. added `noctalia-shell` to `packages`, `nixosModules`, `homeModules`;

## Reasons
1. `flake-parts` are scalable: any new code could be added without annoying boilerplate;
2. `flake-parts` are modular: there are a lot of `flakeModules` that could extend and improve usability of standard flakes, for e.g. - `treefmt-nix`;
3. `flake-parts` are better than `flake-utils`; why? - https://ayats.org/blog/no-flake-utils