### PR TITLE
refactor(nix): devShells.(system).default init

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ We welcome contributions of any size - bug fixes, new features, documentation im
 - **Want to code?** Check out our [development guidelines](https://docs.noctalia.dev/development/guideline)
 - **Need help?** Join our [Discord](https://discord.noctalia.dev)
 
+### ✨ Nix DevShell (new)
+
+Nix users can use the flake's devShell to access a development environment. Run nix develop the repo root to enter the dev shell. In includes packages, utilities and environment variables needed to develop Noctalia.
+
 ---
 
 ## 💜 Credits

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,14 @@
 
     defaultPackage = eachSystem (system: self.packages.${system}.default);
 
+    devShells = eachSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        default = pkgs.callPackage ./shell.nix {};
+      }
+    );
+
     homeModules.default = {
       pkgs,
       lib,

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{
+  alejandra,
+  statix,
+  deadnix,
+  shfmt,
+  shellcheck,
+  jsonfmt,
+  lefthook,
+  kdePackages,
+  mkShellNoCC,
+}:
+mkShellNoCC {
+  #it's faster than mkDerivation / mkShell
+  packages = [
+    # nix
+    alejandra # formatter
+    statix # linter
+    deadnix # linter
+
+    # shell
+    shfmt # formatter
+    shellcheck # linter
+
+    # json
+    jsonfmt # formatter
+
+    # CoC
+    lefthook # githooks
+    kdePackages.qtdeclarative # qmlfmt, qmllint, qmlls and etc; Qt6
+  ];
+}


### PR DESCRIPTION
## Things done
- `devShells` inited! now you can `nix develop --command <your shell>` to enter isolated shell with formatters, linters and whole `qtdeclarative` stack for ease of development. also supports direnv, nix-output-monitor and devenv, if use them.
- not inited `qmlls` related stuff since i have no idea do we need one, or it's purely `quickshell` related stuff. 