### PR TITLE
Add more consistency for expression and interpunction & fix some errors

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -70,7 +70,7 @@
           "auto-detect": "Automatisch"
         }
       },
-      "launch-setup-wizard": "Starte den Setup-Assistenten"
+      "launch-setup-wizard": "Starten Sie den Setup-Assistenten"
     },
     "audio": {
       "title": "Audio",


### PR DESCRIPTION
It probably makes sense to don't mix between addressing the user as "Du" and "Sie".