### PR TITLE
Fix wrong day names in the weather forecast

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -818,7 +818,10 @@ Loader {
                         spacing: 3
 
                         NText {
-                          text: Qt.locale().toString(now, "ddd")
+                          text: {
+                            var weatherDate = new Date(LocationService.data.weather.daily.time[index].replace(/-/g, "/"))
+                            return Qt.locale().toString(weatherDate, "ddd")
+                          }
                           pointSize: Style.fontSizeM
                           color: Color.mOnSurfaceVariant
                           horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
The lock screen shows 3 times the current day name.
Copied the fix from CalendarPanel.qml