### PR TITLE
BrightnessService: add minimum brightness to prevent backlight from t…

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "Helligkeits-Schrittgröße",
           "description": "Schrittgröße für Helligkeitsänderungen anpassen (Mausrad und Tastenkombinationen)."
+        },
+        "enforce-minimum": {
+          "label": "Mindesthelligkeit erzwingen (1%)",
+          "description": "Löst das Problem, dass die Hintergrundbeleuchtung auf einigen Displays bei 0% Helligkeit vollständig ausgeschaltet wird."
         }
       },
       "night-light": {

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "Brightness step size",
           "description": "Adjust the step size for brightness changes (scroll wheel and keyboard shortcuts)."
+        },
+        "enforce-minimum": {
+          "label": "Enforce minimum brightness (1%)",
+          "description": "Solves the problem of backlight completely turning off on some displays at 0% brightness."
         }
       },
       "night-light": {

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "Tamaño del paso de brillo",
           "description": "Ajusta el tamaño del paso para los cambios de brillo (rueda de desplazamiento y atajos de teclado)."
+        },
+        "enforce-minimum": {
+          "label": "Forzar brillo mínimo (1%)",
+          "description": "Resuelve el problema de la retroiluminación que se apaga completamente en algunas pantallas al 0% de brillo."
         }
       },
       "night-light": {

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "Incrément de luminosité",
           "description": "Ajustez l'incrément pour les changements de luminosité (molette de la souris et raccourcis clavier)."
+        },
+        "enforce-minimum": {
+          "label": "Imposer une luminosité minimale (1%)",
+          "description": "Résout le problème de l'extinction complète du rétroéclairage sur certains écrans à 0% de luminosité."
         }
       },
       "night-light": {

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "Tamanho do passo do brilho",
           "description": "Ajuste o tamanho do passo para alterações de brilho (roda do mouse e atalhos de teclado)."
+        },
+        "enforce-minimum": {
+          "label": "Forçar brilho mínimo (1%)",
+          "description": "Resolve o problema da retroiluminação apagar completamente em alguns monitores com brilho em 0%."
         }
       },
       "night-light": {

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -162,6 +162,10 @@
         "brightness-step": {
           "label": "亮度步长",
           "description": "调整亮度变化的步长（滚轮和键盘快捷键）。"
+        },
+        "enforce-minimum": {
+          "label": "限制最小亮度为 1%",
+          "description": "解决亮度为 0% 时部分显示器背光完全关闭的问题。"
         }
       },
       "night-light": {

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -352,6 +352,7 @@ Singleton {
     // brightness
     property JsonObject brightness: JsonObject {
       property int brightnessStep: 5
+      property bool enforceMinimum: true
     }
 
     property JsonObject colorSchemes: JsonObject {

--- a/Modules/Settings/Tabs/DisplayTab.qml
+++ b/Modules/Settings/Tabs/DisplayTab.qml
@@ -155,6 +155,14 @@ ColumnLayout {
       suffix: "%"
       onValueChanged: Settings.data.brightness.brightnessStep = value
     }
+
+      NToggle {
+        Layout.fillWidth: true
+        label: I18n.tr("settings.display.monitors.enforce-minimum.label")
+        description: I18n.tr("settings.display.monitors.enforce-minimum.description")
+        checked: Settings.data.brightness.enforceMinimum
+        onToggled: checked => Settings.data.brightness.enforceMinimum = checked
+      }
   }
 
   NDivider {

--- a/Services/BrightnessService.qml
+++ b/Services/BrightnessService.qml
@@ -233,7 +233,8 @@ Singleton {
       }
     }
 
-    readonly property real stepSize: Settings.data.brightness.brightnessStep / 100.0
+  readonly property real stepSize: Settings.data.brightness.brightnessStep / 100.0
+  readonly property real minBrightnessValue: (Settings.data.brightness.enforceMinimum ? 0.01 : 0.0)
 
     // Timer for debouncing rapid changes
     readonly property Timer timer: Timer {
@@ -253,9 +254,9 @@ Singleton {
 
     function increaseBrightness(): void {
       const value = !isNaN(monitor.queuedBrightness) ? monitor.queuedBrightness : monitor.brightness
-      // Set to step size if currently at minimum brightness
-      if (value <= 0.01) {
-        setBrightnessDebounced(Math.max(stepSize, 0.01))
+      // Enforce minimum brightness if enabled
+      if (Settings.data.brightness.enforceMinimum && value <= minBrightnessValue) {
+        setBrightnessDebounced(Math.max(stepSize, minBrightnessValue))
       } else {
         // Normal brightness increase
         setBrightnessDebounced(value + stepSize)
@@ -268,8 +269,7 @@ Singleton {
     }
 
     function setBrightness(value: real): void {
-      // Enforce a minimum brightness of 1% (0.01) to avoid completely turning off the backlight
-      value = Math.max(0.01, Math.min(1, value))
+      value = Math.max(minBrightnessValue, Math.min(1, value))
       var rounded = Math.round(value * 100)
 
       if (timer.running) {


### PR DESCRIPTION
## Changes

Add a minimum brightness value of 1% to prevent the display backlight from being completely turned off. And when increasing brightness from 1%, it will jump to minimum brightness step for consistency.

## Potential required changes

I'm not sure if all machines will completely turn off the backlight at 0% brightness. This is a workaround borrowed from other shell(illogical-impulse). Maybe we could add a setting option for the minimum brightness?

Let me know if changes are needed, thanks for reviewing!