### PR TITLE
AudioCard: make both sliders have the same width

### DIFF
--- a/Modules/ControlCenter/Cards/AudioCard.qml
+++ b/Modules/ControlCenter/Cards/AudioCard.qml
@@ -58,6 +58,7 @@ NBox {
     ColumnLayout {
       spacing: Style.marginXXS
       Layout.fillWidth: true
+      Layout.preferredWidth: 0
       opacity: AudioService.sink ? 1.0 : 0.5
       enabled: AudioService.sink
 
@@ -109,6 +110,7 @@ NBox {
     ColumnLayout {
       spacing: Style.marginXXS
       Layout.fillWidth: true
+      Layout.preferredWidth: 0
       opacity: AudioService.source ? 1.0 : 0.5
       enabled: AudioService.source
 


### PR DESCRIPTION
Enforce visual consistency by making both output and input sliders have the same width regardless of the devices names
