### PR TITLE
Add CavaVisualizer component to BarWidgetRegistry

### DIFF
--- a/Services/BarWidgetRegistry.qml
+++ b/Services/BarWidgetRegistry.qml
@@ -14,6 +14,7 @@ Singleton {
                            "Battery": batteryComponent,
                            "Bluetooth": bluetoothComponent,
                            "Brightness": brightnessComponent,
+                           "CavaVisualizer": cavaVisualizerComponent,
                            "Clock": clockComponent,
                            "ControlCenter": controlCenterComponent,
                            "CustomButton": customButtonComponent,
@@ -61,6 +62,17 @@ Singleton {
                                   "Brightness": {
                                     "allowUserSettings": true,
                                     "displayMode": "onhover"
+                                  },
+                                  "CavaVisualizer": {
+                                    "allowUserSettings": true,
+                                    "width": 300,
+                                    "minHeight": 12,
+                                    "maxHeight": 64,
+                                    "bars": 48,
+                                    "barWidth": 3,
+                                    "barSpacing": 1,
+                                    "framerate": 60,
+                                    "mono": true
                                   },
                                   "Clock": {
                                     "allowUserSettings": true,
@@ -167,6 +179,9 @@ Singleton {
   }
   property Component brightnessComponent: Component {
     Brightness {}
+  }
+  property Component cavaVisualizerComponent: Component { 
+    CavaVisualizer {} 
   }
   property Component clockComponent: Component {
     Clock {}


### PR DESCRIPTION
# Pull Request

## Motivation
This PR is for adding a CavaVisualizer to Noctalia-Shell. While the one that ships with Noctalia-Shell shows behind the mediaplayer and cannot be seen, this one can be added to the bar as a component. 

This is file 1 of 3.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ x ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [ x ] Tested on compositor: Hyperland 0.51.1
- [ x ] Tested with different bar positions and density settings
- [ x ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
![](https://i.imgur.com/DfxRyMi.png)

## Checklist
- [ x ] Code follows project style guidelines
- [ x ] Self-reviewed my code
- [ x ] No new warnings or errors
- [ x ] Documentation or comments updated (if relevant)

## Additional Notes
This is file 1 out of 3:
- **BarWidgetRegistry.qml** - Contents of the file go into `/Services/BarWidgetRegistry.qml`
- CavaVisualizerSettings - file gets added to `/Modules/Settings/Bar/WidgetSettings/`
- CavaVisualizer.qml - file gets added to `/Modules/Bar/Widgets/`