### PR TITLE
i18n: fix syntax error in zh-CN.json

### DIFF
--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -1093,8 +1093,8 @@
           "description": "间隔时间（毫秒）。"
         },
         "text-stream": {
-          "label": "流"
-          "description": "来自命令的流式输出行将作为文本显示在按钮上。",
+          "label": "流",
+          "description": "来自命令的流式输出行将作为文本显示在按钮上。"
         },
         "collapse-condition": {
           "label": "折叠条件",


### PR DESCRIPTION
# Pull Request

## Motivation
Fix comma syntax error in zh-CN.json that prevents shell from starting.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: niri


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
