### PR TITLE
Notification: delete from history on close button click

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -561,6 +561,7 @@ Variants {
               anchors.rightMargin: Style.marginM
 
               onClicked: {
+                NotificationService.removeFromHistory(model.id)
                 animateOut()
               }
             }


### PR DESCRIPTION
# Pull Request

## Motivation
Makes discarding a notification also delete it from history.

Previously, discarded notifications would remain in history. If someone clicked the close button, it's safe to assume they've read the notification and don't need it displayed in history or contributing to the unread indicator.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: Niri

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors