### PR TITLE
Launcher: make numpad enter call ui.activate

### DIFF
--- a/Modules/Launcher/Launcher.qml
+++ b/Modules/Launcher/Launcher.qml
@@ -325,13 +325,17 @@ NPanel {
             // Override the TextField's default Home/End behavior
             searchInput.inputItem.Keys.priority = Keys.BeforeItem
             searchInput.inputItem.Keys.onPressed.connect(function (event) {
-              // Intercept Home and End BEFORE the TextField handles them
+              // Intercept Home, End, and Numpad Enter BEFORE the TextField handles them
               if (event.key === Qt.Key_Home) {
                 ui.selectFirst()
                 event.accepted = true
                 return
               } else if (event.key === Qt.Key_End) {
                 ui.selectLast()
+                event.accepted = true
+                return
+              } else if (event.key === Qt.Key_Enter) {
+                ui.activate()
                 event.accepted = true
                 return
               }


### PR DESCRIPTION
# Pull Request

## Motivation
Makes it so numpad enter can be used to accept a launcher entry.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
--

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: Hyprland
- [ ] Tested with different bar positions and density settings
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
--

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Not aware of this conflicting with anything, but please let me know if it does.
