### PR TITLE
Remove the muted/unmuted notification

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -1697,10 +1697,6 @@
       "changed": "Energieprofil geändert",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "Stummgeschaltet",
-      "unmuted": "Lautgeschaltet"
-    },
     "battery": {
       "low": "Niedriger Batteriestand",
       "low-desc": "Batterie ist bei {percent}%. Bitte schließen Sie das Ladegerät an."

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1657,10 +1657,6 @@
       "changed": "Power profile changed",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "Muted",
-      "unmuted": "Unmuted"
-    },
     "battery": {
       "low": "Low battery",
       "low-desc": "Battery is at {percent}%. Please connect the charger."

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -1657,10 +1657,6 @@
       "changed": "Perfil de energía cambiado",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "Silenciado",
-      "unmuted": "Sonido activado"
-    },
     "battery": {
       "low": "Batería baja",
       "low-desc": "La batería está al {percent}%. Por favor, conecta el cargador."

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -1657,10 +1657,6 @@
       "changed": "Profil d'alimentation changé",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "Son coupé",
-      "unmuted": "Son rétabli"
-    },
     "battery": {
       "low": "Batterie faible",
       "low-desc": "La batterie est à {percent}%. Veuillez brancher le chargeur."

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -1657,10 +1657,6 @@
       "changed": "Perfil de energia alterado",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "Silenciado",
-      "unmuted": "Som ativado"
-    },
     "battery": {
       "low": "Bateria Fraca",
       "low-desc": "A bateria está em {percent}%. Por favor, conecte o carregador."

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -1657,10 +1657,6 @@
       "changed": "电源模式已更改",
       "profile-name": "\"{profile}\""
     },
-    "audio": {
-      "muted": "已静音",
-      "unmuted": "已取消静音"
-    },
     "battery": {
       "low": "电量低",
       "low-desc": "电量为 {percent}%。请连接充电器。"

--- a/Services/AudioService.qml
+++ b/Services/AudioService.qml
@@ -62,7 +62,6 @@ Singleton {
     function onMutedChanged() {
       root._muted = (sink?.audio.muted ?? true)
       Logger.i("AudioService", "OnMuteChanged:", root._muted)
-      ToastService.showNotice(I18n.tr("settings.audio.devices.output-device.label"), root._muted ? I18n.tr("toast.audio.muted") : I18n.tr("toast.audio.unmuted"))
     }
   }
 
@@ -80,7 +79,6 @@ Singleton {
     function onMutedChanged() {
       root._inputMuted = (source?.audio.muted ?? true)
       Logger.i("AudioService", "OnInputMuteChanged:", root._inputMuted)
-      ToastService.showNotice(I18n.tr("settings.audio.devices.input-device.label"), root._inputMuted ? I18n.tr("toast.audio.muted") : I18n.tr("toast.audio.unmuted"))
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation
The notification for muting and unmuting of audio devices seems unnecessary to me. There is already the OSD popup (no need for 2 popups) and a change of the widget icon in the bar. This notification also shows up every time on start (I keep my mic usually muted).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
