### PR TITLE
Launcher: fix some apps not launching with custom prefix

### DIFF
--- a/Modules/Launcher/Plugins/ApplicationsPlugin.qml
+++ b/Modules/Launcher/Plugins/ApplicationsPlugin.qml
@@ -203,22 +203,15 @@ Item {
         if (Settings.data.appLauncher.sortByMostUsed)
           recordUsage(app)
         if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix) {
-          // Use custom launch prefix
           const prefix = Settings.data.appLauncher.customLaunchPrefix.split(" ")
 
           if (app.runInTerminal) {
-            // For terminal apps, use the app command directly
-            const command = prefix.concat(app.command)
-            Quickshell.execDetached(command)
-          } else if (app.id) {
-            // For GUI apps, try to use the app name/executable name instead of desktop file
-            // This works better with commands like "niri msg action spawn --"
-            const appName = app.executableName || app.name.toLowerCase().replace(/\s+/g, '-')
-            const command = prefix.concat([appName])
+            const command = prefix.concat([app.id + ".desktop"])
+            Logger.d("ApplicationsPlugin", "Launching via custom prefix (with desktop id): " + command.join(" "))
             Quickshell.execDetached(command)
           } else {
-            // Fallback to direct command execution
             const command = prefix.concat(app.command)
+            Logger.d("ApplicationsPlugin", "Launching via custom prefix (with command): " + command.join(" "))
             Quickshell.execDetached(command)
           }
         } else if (Settings.data.appLauncher.useApp2Unit && app.id) {


### PR DESCRIPTION
# Pull Request

## Motivation
Some apps wouldn't launch with a custom prefix like `runapp` or `niri msg action spawn --`.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #587

## Testing
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

I attempted to launch `krita`, `equibop` and other apps and they successfully launched with the changes in the commit.

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I believe the logic is a mirror of app2unit launch prefix handling but adapted for custom launch prefix.
