### PR TITLE
Launcher: correct fix for custom launch prefix

### DIFF
--- a/Modules/Launcher/Plugins/ApplicationsPlugin.qml
+++ b/Modules/Launcher/Plugins/ApplicationsPlugin.qml
@@ -207,17 +207,10 @@ Item {
           const prefix = Settings.data.appLauncher.customLaunchPrefix.split(" ")
 
           if (app.runInTerminal) {
-            // For terminal apps, use the app command directly
-            const command = prefix.concat(app.command)
-            Quickshell.execDetached(command)
-          } else if (app.id) {
-            // For GUI apps, try to use the app name/executable name instead of desktop file
-            // This works better with commands like "niri msg action spawn --"
-            const appName = app.executableName || app.name.toLowerCase().replace(/\s+/g, '-')
-            const command = prefix.concat([appName])
+            const terminal = Settings.data.appLauncher.terminalCommand.split(" ")
+            const command = prefix.concat(terminal.concat(app.command))
             Quickshell.execDetached(command)
           } else {
-            // Fallback to direct command execution
             const command = prefix.concat(app.command)
             Quickshell.execDetached(command)
           }


### PR DESCRIPTION
# Pull Request

## Motivation
Pull Request #593 does not fully resolve the issue, as terminal applications still fail to launch. Moreover, directly using the .desktop files in the code is not a universal solution; after all, this is a custom prefix, not the runapp prefix.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
