### PR TITLE
CalendarPanel: toggle panel after date click

### DIFF
--- a/Modules/Bar/Calendar/CalendarPanel.qml
+++ b/Modules/Bar/Calendar/CalendarPanel.qml
@@ -737,6 +737,7 @@ NPanel {
               onClicked: {
                 const dateWithSlashes = `${model.month.toString().padStart(2, '0')}/${model.day.toString().padStart(2, '0')}/${model.year.toString().substring(2)}`
                 Quickshell.execDetached(["gnome-calendar", "--date", dateWithSlashes])
+                PanelService.getPanel("calendarPanel").toggle(null)
               }
 
               onExited: {


### PR DESCRIPTION
# Pull Request

## Motivation
Clicking on date in calendar panel opens gnome-calendar so it makes sense to toggle the panel so it's easier to interact with calendar

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: Niri
- [x] Tested with different bar positions and density settings

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors