### PR TITLE
feat: Add IPC command to set color scheme

### DIFF
--- a/Services/ColorSchemeService.qml
+++ b/Services/ColorSchemeService.qml
@@ -91,6 +91,31 @@ Singleton {
     schemeReader.path = filePath
   }
 
+  function setPredefinedScheme(schemeName) {
+    Logger.i("ColorScheme", "Attempting to set predefined scheme to:", schemeName)
+
+    var resolvedPath = resolveSchemePath(schemeName)
+    var basename = getBasename(schemeName)
+
+    // Check if the scheme actually exists in the loaded schemes list
+    var schemeExists = false
+    for (var i = 0; i < schemes.length; i++) {
+      if (getBasename(schemes[i]) === basename) {
+        schemeExists = true
+        break
+      }
+    }
+
+    if (schemeExists) {
+      Settings.data.colorSchemes.predefinedScheme = basename
+      applyScheme(schemeName)
+      ToastService.showNotice("Color Scheme", `Set to ${basename}`)
+    } else {
+      Logger.e("ColorScheme", "Scheme not found:", schemeName)
+      ToastService.showError("Color Scheme", `Scheme '${basename}' not found!`)
+    }
+  }
+
   Process {
     id: findProcess
     running: false

--- a/Services/IPCService.qml
+++ b/Services/IPCService.qml
@@ -127,6 +127,13 @@ Item {
   }
 
   IpcHandler {
+    target: "colorScheme"
+    function set(schemeName: string) {
+      ColorSchemeService.setPredefinedScheme(schemeName)
+    }
+  }
+
+  IpcHandler {
     target: "volume"
     function increase() {
       AudioService.increaseVolume()


### PR DESCRIPTION
# Pull Request

## Motivation
I’ve got a script that switches themes, and I wanted noctalia-shell themes to integrate with it, so I added an IPC command for setting preset themes.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
