### PR TITLE
fix: Media player auto-switching in Control Center

### DIFF
--- a/Modules/ControlCenter/Cards/MediaCard.qml
+++ b/Modules/ControlCenter/Cards/MediaCard.qml
@@ -179,8 +179,7 @@ NBox {
       onTriggered: function (action) {
         var index = parseInt(action)
         if (!isNaN(index)) {
-          MediaService.selectedPlayerIndex = index
-          MediaService.updateCurrentPlayer()
+          MediaService.switchToPlayer(index)
         }
       }
     }

--- a/Modules/ControlCenter/ControlCenterPanel.qml
+++ b/Modules/ControlCenter/ControlCenterPanel.qml
@@ -63,6 +63,14 @@ NPanel {
   readonly property int weatherHeight: Math.round(190 * Style.uiScaleRatio)
   readonly property int mediaSysMonHeight: Math.round(260 * Style.uiScaleRatio)
 
+  onOpened: {
+    MediaService.autoSwitchingPaused = true
+  }
+
+  onClosed: {
+    MediaService.autoSwitchingPaused = false
+  }
+
   panelContent: Item {
     id: content
 

--- a/Services/MediaService.qml
+++ b/Services/MediaService.qml
@@ -171,6 +171,21 @@ Singleton {
     }
   }
 
+  property bool autoSwitchingPaused: false
+
+  function switchToPlayer(index) {
+    let availablePlayers = getAvailablePlayers()
+    if (index >= 0 && index < availablePlayers.length) {
+      let newPlayer = availablePlayers[index]
+      if (newPlayer !== currentPlayer) {
+        currentPlayer = newPlayer
+        selectedPlayerIndex = index
+        currentPosition = currentPlayer ? currentPlayer.position : 0
+        Logger.d("Media", "Manually switched to player " + currentPlayer.identity)
+      }
+    }
+  }
+
   // Switch to the most recently active player
   function updateCurrentPlayer() {
     let newPlayer = findActivePlayer()
@@ -289,6 +304,8 @@ Singleton {
     repeat: true
     running: true
     onTriggered: {
+      Logger.d("MediaService", "playerStateMonitor triggered. autoSwitchingPaused: " + root.autoSwitchingPaused)
+      if (autoSwitchingPaused) return
       // Only update if we don't have a playing player or if current player is paused
       if (!currentPlayer || !currentPlayer.isPlaying || currentPlayer.playbackState !== MprisPlaybackState.Playing) {
         updateCurrentPlayer()


### PR DESCRIPTION
Detailed Explanation:
  Addresses an issue where the media player would automatically switch,overriding user's manual selections when the Control Center was open.

  The core problem was that the automatic player detection logic was too aggressive and didn't respect explicit user choices. Previous attempts to pause auto-switching based on UI visibility were unreliable due to incorrect event handling for the custom NPanel component.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
