### PR TITLE
Small fix to incorrect I18n string name

### DIFF
--- a/Modules/Settings/Bar/WidgetSettings/LockKeysSettings.qml
+++ b/Modules/Settings/Bar/WidgetSettings/LockKeysSettings.qml
@@ -51,7 +51,7 @@ ColumnLayout {
     }
 
     NButton {
-      text: I18n.tr("bar.widget-settings.lock-keys.browsedd")
+      text: I18n.tr("bar.widget-settings.lock-keys.browse")
       onClicked: capsPicker.open()
       enabled: valueShowCapsLock
     }


### PR DESCRIPTION
I'm not sure how this got in there. Must've accidentally fat fingered a couple letters after testing but before submitting my PR.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.
No Testing required.

## Screenshots / Videos
Fixes this:
<img width="640" height="330" alt="image" src="https://github.com/user-attachments/assets/60744514-7758-42c1-b1be-89232c65bddf" />


## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
My Bad!
