### PR TITLE
Tiny pointless consistent naming fix.

### DIFF
--- a/Services/BarWidgetRegistry.qml
+++ b/Services/BarWidgetRegistry.qml
@@ -18,7 +18,7 @@ Singleton {
                            "Clock": clockComponent,
                            "ControlCenter": controlCenterComponent,
                            "CustomButton": customButtonComponent,
-                           "DarkMode": darkMode,
+                           "DarkMode": darkModeComponent,
                            "KeepAwake": keepAwakeComponent,
                            "KeyboardLayout": keyboardLayoutComponent,
                            "LockKeys": lockKeysComponent,
@@ -194,7 +194,7 @@ Singleton {
   property Component customButtonComponent: Component {
     CustomButton {}
   }
-  property Component darkMode: Component {
+  property Component darkModeComponent: Component {
     DarkMode {}
   }
   property Component keyboardLayoutComponent: Component {


### PR DESCRIPTION
# Pull Request

## Motivation
Because it annoyed me.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] None of the above

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] still works. Nothing really changed.

## Checklist
- [x] Code **NOW** follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
In BarWidgeRegistry. DarkMode was the only one not named with Component on the end. I discovered it when working on another widget, and decided to fix it separately instead of include it in an unrelated PR.
