### PR TITLE
Nix: Matugen by default is fetch from nixpkgs but optionally can be downloaded from a flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,11 @@
       url = "git+https://git.outfoxxed.me/outfoxxed/quickshell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    matugen = {
+      url = "github:/InioX/Matugen";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -16,6 +21,7 @@
     nixpkgs,
     systems,
     quickshell,
+    matugen,
     ...
   }: let
     eachSystem = nixpkgs.lib.genAttrs (import systems);
@@ -32,6 +38,7 @@
             withX11 = false;
             withI3 = true;
           };
+          matugen = matugen.packages.${system}.default;
         };
       }
     );


### PR DESCRIPTION
# Pull Request

## Motivation
I was testing Noctalia on NixOS and matugen would throw an error when changing the predefined color scheme.
Thats because Noctalia would download and use Matugen v2.4.1 (from nixpkgs-unstable) instead of newer Matugen v3.0.0.
Also I wanted to contribute to open source :)

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [X] Breaking change (Only for NixOS users, see "Additional notes")
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [X] Tested on compositor: (Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
The video shows how before some errors are thrown and after updating matugen they are not present anymore.
https://github.com/user-attachments/assets/156eccea-3ced-49f3-ba8b-168471b032c1

This screenshot shows how nixpkgs unstable uses older version.
<img width="971" height="135" alt="image" src="https://github.com/user-attachments/assets/506ef2b8-5934-4f25-b70d-9634b093d747" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
1. My fix consists on using the latest Matugen from official flake https://github.com/InioX/matugen/.
2. NixOS users will have to add two line to theirs `flake.nix`:
```diff
{
  description = "NixOS configuration with Noctalia";

  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

    quickshell = {
      url = "github:outfoxxed/quickshell";
      inputs.nixpkgs.follows = "nixpkgs";
    };

+   matugen.url = "github:InioX/Matugen/v3.0.0"; # Idk but I set the version for safety

    noctalia = {
      url = "github:noctalia-dev/noctalia-shell";
      inputs.nixpkgs.follows = "nixpkgs";
      inputs.quickshell.follows = "quickshell";  # Use same quickshell version
+     inputs.matugen.follows = "matugen";
    };
  };

  outputs = inputs@{ self, nixpkgs, ... }: {
    nixosConfigurations.awesomebox = nixpkgs.lib.nixosSystem {
      modules = [
        # ... other modules
        ./noctalia.nix
      ];
    };
  };
}
```
3. If merged, the documentation of how to install in NixOS must be **updated** including these two lines.