### PR TITLE
add IPC calls to enable/disable Do Not Disturb

### DIFF
--- a/Services/IPCService.qml
+++ b/Services/IPCService.qml
@@ -57,6 +57,12 @@ Item {
     function toggleDND() {
       Settings.data.notifications.doNotDisturb = !Settings.data.notifications.doNotDisturb
     }
+    function enableDND() {
+      Settings.data.notifications.doNotDisturb = true
+    }
+    function disableDND() {
+      Settings.data.notifications.doNotDisturb = false
+    }
     function clear() {
       NotificationService.clearHistory()
     }


### PR DESCRIPTION
# Pull Request

## Motivation
Better support for daemons that enable or disable DND at specific times without user interaction. The existing IPC call to toggle DND is insufficient for this use case.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated: https://github.com/noctalia-dev/noctalia-docs/pull/28
