### PR TITLE
Custom button tooltip from command

### DIFF
--- a/Modules/Bar/Widgets/CustomButton.qml
+++ b/Modules/Bar/Widgets/CustomButton.qml
@@ -57,6 +57,8 @@ Item {
     tooltipText: {
       if (!hasExec) {
         return "Custom button, configure in settings."
+      } else if (_dynamicTooltip !== "") {
+        return _dynamicTooltip
       } else {
         var lines = []
         if (leftClickExec !== "") {
@@ -80,6 +82,7 @@ Item {
   // Internal state for dynamic text
   property string _dynamicText: ""
   property string _dynamicIcon: ""
+  property string _dynamicTooltip: ""
 
   // Periodically run the text command (if set)
   Timer {
@@ -135,11 +138,13 @@ Item {
         if (checkCollapse(text)) {
           _dynamicText = ""
           _dynamicIcon = ""
+          _dynamicTooltip = ""
           return
         }
 
         _dynamicText = text
         _dynamicIcon = parsed.icon || ""
+        _dynamicTooltip = parsed.tooltip || ""
         return
       } catch (e) {
 
@@ -150,11 +155,13 @@ Item {
     if (checkCollapse(contentStr)) {
       _dynamicText = ""
       _dynamicIcon = ""
+      _dynamicTooltip = ""
       return
     }
 
     _dynamicText = contentStr
     _dynamicIcon = ""
+    _dynamicTooltip = ""
   }
 
   function checkCollapse(text) {


### PR DESCRIPTION
# Pull Request

## Motivation

The custom button lacks the ability to present richer content than a single line of text (and now plus an icon). Ideally this richer content may be implemented as a panel that renders rich text like markdown. But it's more complex and I'm still learning how to implement that. For the time being, having a dynamic tooltip (potentially multi-line) may still be useful.

This PR is fully backward compatible. If there is no `tooltip` field specified in the output json, everything still works as before.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

None.

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: Niri
- [x] Tested with different bar positions and density settings
- [x] Tested with multiple monitors

## Screenshots / Videos

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes

None.