### PR TITLE
Nix: refactor & improve home-module

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -5,13 +5,14 @@
   ...
 }: let
   cfg = config.programs.noctalia-shell;
-  defaultSettings = builtins.fromJSON (builtins.readFile ../Assets/settings-default.json);
-  extractAttrs = x:
-    if builtins.isAttrs x
-    then x
-    else if builtins.isString x
-    then builtins.fromJson x
-    else builtins.fromJson (builtins.readFile x);
+  jsonFormat = pkgs.formats.json {};
+  generateJson = name: value:
+    if lib.isString value then
+      pkgs.writeText "noctalia-${name}.json" value
+    else if builtins.isPath value || lib.isStorePath value then
+      value
+    else
+      jsonFormat.generate "noctalia-${name}.json" value;
 in {
   options.programs.noctalia-shell = {
     enable = lib.mkEnableOption "Noctalia shell configuration";
@@ -26,12 +27,11 @@ in {
     settings = lib.mkOption {
       type = with lib.types;
         oneOf [
-          attrs
+          jsonFormat.type
           str
           path
         ];
       default = {};
-      apply = x: if x == {} then x else lib.recursiveUpdate defaultSettings (extractAttrs x);
       example = lib.literalExpression ''
         {
           bar = {
@@ -52,20 +52,17 @@ in {
       description = ''
         Noctalia shell configuration settings as an attribute set, string
         or filepath, to be written to ~/.config/noctalia/settings.json.
-        When provided as an attribute set, it will be deep-merged with
-        the default settings.
       '';
     };
 
     colors = lib.mkOption {
       type = with lib.types;
-        nullOr (oneOf [
-          attrs
+        oneOf [
+          jsonFormat.type
           str
           path
-        ]);
+        ];
       default = {};
-      apply = extractAttrs;
       example = lib.literalExpression ''
          {
            mError = "#dddddd";
@@ -112,8 +109,8 @@ in {
           PartOf = [ config.wayland.systemd.target ];
           After = [ config.wayland.systemd.target ];
           X-Restart-Triggers =
-            lib.optional (cfg.settings != {}) "${config.xdg.configFile."noctalia/settings.json".source}"
-            ++ lib.optional (cfg.colors != {}) "${config.xdg.configFile."noctalia/colors.json".source}";
+            lib.optional (cfg.settings != {}) config.xdg.configFile."noctalia/settings.json".source
+            ++ lib.optional (cfg.colors != {}) config.xdg.configFile."noctalia/colors.json".source;
         };
 
         Service = {
@@ -134,11 +131,11 @@ in {
       xdg.configFile = {
         "noctalia/settings.json" = lib.mkIf (cfg.settings != {}) {
           onChange = lib.mkIf (!cfg.systemd.enable) restart;
-          text = builtins.toJSON cfg.settings;
+          source = generateJson "settings" cfg.settings;
         };
         "noctalia/colors.json" = lib.mkIf (cfg.colors != {}) {
           onChange = lib.mkIf (!cfg.systemd.enable) restart;
-          text = builtins.toJSON cfg.colors;
+          source = generateJson "colors" cfg.colors;
         };
       };
 


### PR DESCRIPTION
# Pull Request

## Motivation
Clean up the code, improve implementation robustness, and align with standard practices. This PR contains no new features or breaking changes.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
First, I removed "deep-merged with the default settings" because removing it did not cause any issues. Then, I replaced `builtins.toJSON` with the type and generate functions provided by `pkgs.formats.json`, which is the standard practice in Home Manager. The difference caused by this:
- Before 
<img width="1912" height="1035" alt="图片" src="https://github.com/user-attachments/assets/bf9d1b9e-9531-437e-a2fe-be4d2bc7d1d4" />
- After 
<img width="1912" height="1035" alt="图片" src="https://github.com/user-attachments/assets/98dfe652-709a-48d8-abad-b6fc050c82b0" />

