### PR TITLE
Fixing Matugen Ghostty posthook

### DIFF
--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -21,7 +21,7 @@ Singleton {
       "name": "Ghostty",
       "matugenPath": "Terminal/ghostty",
       "outputPath": "~/.config/ghostty/themes/noctalia",
-      "postHook": "pgrep -x ghostty >/dev/null && pkill -SIGUSR2 ghostty; true"
+      "postHook": "bash -c 'pgrep -f ghostty >/dev/null && pkill -SIGUSR2 ghostty || true'"
     }, {
       "id": "kitty",
       "name": "Kitty",


### PR DESCRIPTION
Use pgrep -f instead of pgrep -x
The -f flag matches the entire command line, which ensures it catches variants like .ghostty-wrapped. On NixOS, my ghostty process runs as .ghostty-wrapped, so pgrep -x ghostty would fail to match and the postHook would not restart ghostty to apply color changes.

Run the command in Bash (bash -c)
Ensures compatibility for users running alternative shells (e.g., Nu shell), which otherwise fail to parse the command correctly.

# Pull Request

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.
- [x] Tested on compositor: (e.g., Hyprland, Sway, Niri)
- [x] Tested with different bar positions and density settings
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
