### PR TITLE
Calendar: Print times in Calendar

### DIFF
--- a/Modules/Panels/Calendar/CalendarPanel.qml
+++ b/Modules/Panels/Calendar/CalendarPanel.qml
@@ -608,9 +608,9 @@ SmartPanel {
                               return event.summary
                             } else {
                               const start = new Date(event.start * 1000)
-                              const startFormatted = I18n.locale.toString(start, "HH:mm").split("\\n")
+                              const startFormatted = start.toLocaleTimeString(I18n.locale, Locale.ShortFormat)
                               const end = new Date(event.end * 1000)
-                              const endFormatted = I18n.locale.toString(end, "HH:mm").split("\\n")
+                              const endFormatted = end.toLocaleTimeString(I18n.locale, Locale.ShortFormat)
                               return `${startFormatted}-${endFormatted} ${event.summary}`
                             }
                           }).join('\n')


### PR DESCRIPTION
# Pull Request

## Motivation
The calendar is great! It works with Evolution Data Server to create beautiful little dots to signal events.

When you hover over the date, it tells you what events are happening:
<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/0c1249a9-bf16-4f88-9844-0d53625df741" />

Even nicer, it highlights when something is all day:
<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/b647d4c8-5577-4cb7-affb-649dad477ceb" />


That's lovely, but it's not particularly useful without having an idea when the event is.

This change makes events show their time (if they're not all day events):
<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/70a933e5-5f4b-4fab-bf55-13f9044a7abe" />

<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/29ab9857-8f09-4dae-858d-07c1c93d53f2" />

While doing this, I was able to identify UTC problems (PR incoming).


## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- None

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
