### PR TITLE
Calendar: UTC-ify datetimes

### DIFF
--- a/Bin/calendar-events.py
+++ b/Bin/calendar-events.py
@@ -3,12 +3,13 @@ import gi
 
 gi.require_version('EDataServer', '1.2')
 gi.require_version('ECal', '2.0')
+gi.require_version('ICalGLib', "3.0")
 import json
 import sys
 import time
 from datetime import datetime, timezone
 
-from gi.repository import ECal, EDataServer
+from gi.repository import ECal, EDataServer, ICalGLib
 
 start_time = int(sys.argv[1])
 end_time = int(sys.argv[2])
@@ -23,6 +24,10 @@ def safe_get_time(ical_time):
         return None
 
     try:
+        # Later we use `tzinfo=timezone.utc`, so we set all calendar events to UTC
+        if not ical_time.is_utc():
+            ical_time = ical_time.convert_to_zone(ICalGLib.Timezone.get_utc_timezone())
+
         year = ical_time.get_year()
         month = ical_time.get_month()
         day = ical_time.get_day()


### PR DESCRIPTION
# Pull Request

## Motivation
While working on #714 I noticed that the calendar events were showing in the wrong times.

It seems to be what was happening was we were assuming `ical_time` was always UTC. This does not seem to be the case (both of my calendars, one Pacific time and one Amsterdam time) were showing incorrect.

If you try #714, you may see the times wrong. If you base this branch onto #714 you'll see those times fix.

Before (atop #714):
<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/58e2dfbf-33df-48d2-ad0c-c11546e05158" />

After (atop #714):
<img width="549" height="442" alt="image" src="https://github.com/user-attachments/assets/45107eb2-59a0-4880-8710-b28bdb65983b" />


## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- None

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
