### PR TITLE
NetworkService: re-add improved internet connectivity check

### DIFF
--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -302,7 +302,7 @@ Singleton {
   Process {
     id: connectivityCheckProcess
     running: false
-    command: ["sh", "-c", "ping -c1 -W1 ping.archlinux.org >/dev/null 2>&1 || ping -c1 -W1 1.1.1.1 >/dev/null 2>&1 || curl -fsI --max-time 3 https://cloudflare.com/cdn-cgi/trace 2>&1"]
+    command: ["sh", "-c", "ping -c1 -W1 ping.archlinux.org >/dev/null 2>&1 || ping -c1 -W1 1.1.1.1 >/dev/null 2>&1 || curl -fsI --max-time 3 https://cloudflare.com/cdn-cgi/trace >/dev/null 2>&1"]
     
     property int failedChecks: 0
     


### PR DESCRIPTION
I've seen this has been removed for too many false positives. I have changed how the connectivity is tested and added a redundancy check, it should now work as intended.
The main reason for this process is actually not the internet connectivity warning, but to keep the bar icon updated if a wifi network gets connected/disconnected without having the wifi panel open.