### PR TITLE
Fix: WallpaperSelector widget panel positioning

### DIFF
--- a/Modules/Bar/Widgets/WallpaperSelector.qml
+++ b/Modules/Bar/Widgets/WallpaperSelector.qml
@@ -20,5 +20,12 @@ NIconButton {
   colorFg: Color.mOnSurface
   colorBorder: Color.transparent
   colorBorderHover: Color.transparent
-  onClicked: PanelService.getPanel("wallpaperPanel", screen)?.toggle(this)
+    onClicked: {
+    var wallpaperPanel = PanelService.getPanel("wallpaperPanel", screen)
+    if (Settings.data.wallpaper.panelPosition === "follow_bar") {
+      wallpaperPanel?.toggle(this)
+    } else {
+      wallpaperPanel?.toggle()
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

## Motivation
When clicking the Wallpaper Selector button in the bar, it did not respect the users position choice. For example if set to bottom right, it would still follow bar position. This aims to fix this issue and ensures the same behavior as Contron Center / Launcher.
 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
I tested thoroughly all positions and seems to be working great.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
