### PR TITLE
Calendar: add missing import

### DIFF
--- a/Modules/Panels/Calendar/CalendarPanel.qml
+++ b/Modules/Panels/Calendar/CalendarPanel.qml
@@ -7,6 +7,7 @@ import qs.Commons
 import qs.Modules.MainScreen
 import qs.Modules.Panels.ControlCenter.Cards
 import qs.Services.Location
+import qs.Services.System
 import qs.Services.UI
 import qs.Widgets
 


### PR DESCRIPTION
# Pull Request

## Motivation
```
Nov 12 20:04:09 .quickshell-wra[1937]:   WARN scene: @Modules/Panels/Calendar/CalendarPanel.qml[625:-1]: ReferenceError: ProgramCheckerService is not defined
```

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
