### PR TITLE
Custom button: add on-wheel command support

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -141,6 +141,11 @@
           "label": "Middle click",
           "update-text": "Update displayed text on middle-click"
         },
+        "wheel": {
+          "description": "Command to execute when the scroll wheel is used.\nUse $delta for the scroll wheel delta in the command",
+          "label": "Scroll wheel",
+          "update-text": "Update displayed text on scroll"
+        },
         "parse-json": {
           "description": "Parse the command output as a JSON object to dynamically set text and icon.",
           "label": "Parse output as JSON"

--- a/Modules/Bar/Widgets/CustomButton.qml
+++ b/Modules/Bar/Widgets/CustomButton.qml
@@ -39,13 +39,15 @@ Item {
   readonly property bool rightClickUpdateText: widgetSettings.rightClickUpdateText ?? widgetMetadata.rightClickUpdateText
   readonly property string middleClickExec: widgetSettings.middleClickExec || widgetMetadata.middleClickExec
   readonly property bool middleClickUpdateText: widgetSettings.middleClickUpdateText ?? widgetMetadata.middleClickUpdateText
+  readonly property string wheelExec: widgetSettings.wheelExec || widgetMetadata.wheelExec
+  readonly property bool wheelUpdateText: widgetSettings.wheelUpdateText ?? widgetMetadata.wheelUpdateText
   readonly property string textCommand: widgetSettings.textCommand !== undefined ? widgetSettings.textCommand : (widgetMetadata.textCommand || "")
   readonly property bool textStream: widgetSettings.textStream !== undefined ? widgetSettings.textStream : (widgetMetadata.textStream || false)
   readonly property int textIntervalMs: widgetSettings.textIntervalMs !== undefined ? widgetSettings.textIntervalMs : (widgetMetadata.textIntervalMs || 3000)
   readonly property string textCollapse: widgetSettings.textCollapse !== undefined ? widgetSettings.textCollapse : (widgetMetadata.textCollapse || "")
   readonly property bool parseJson: widgetSettings.parseJson !== undefined ? widgetSettings.parseJson : (widgetMetadata.parseJson || false)
   readonly property bool hideTextInVerticalBar: widgetSettings.hideTextInVerticalBar !== undefined ? widgetSettings.hideTextInVerticalBar : (widgetMetadata.hideTextInVerticalBar || false)
-  readonly property bool hasExec: (leftClickExec || rightClickExec || middleClickExec)
+  readonly property bool hasExec: (leftClickExec || rightClickExec || middleClickExec || wheelExec)
 
   readonly property bool shouldShowText: !isVerticalBar || !hideTextInVerticalBar
 
@@ -75,6 +77,9 @@ Item {
         if (middleClickExec !== "") {
           tooltipLines.push(`Middle click: ${middleClickExec}.`)
         }
+        if (wheelExec !== "") {
+          tooltipLines.push(`Wheel: ${wheelExec}.`)
+        }
       }
 
       if (_dynamicTooltip !== "") {
@@ -94,6 +99,7 @@ Item {
     onClicked: root.onClicked()
     onRightClicked: root.onRightClicked()
     onMiddleClicked: root.onMiddleClicked()
+    onWheel: delta => root.onWheel(delta)
   }
 
   // Internal state for dynamic text
@@ -240,6 +246,17 @@ Item {
       Logger.i("CustomButton", `Executing command: ${middleClickExec}`)
     }
     if (!textStream && middleClickUpdateText) {
+      runTextCommand()
+    }
+  }
+
+  function onWheel(delta) {
+    if (wheelExec) {
+      let command = wheelExec.replace(/\$delta/g, delta)
+      Quickshell.execDetached(["sh", "-c", command])
+      Logger.i("CustomButton", `Executing command: ${command}`)
+    }
+    if (!textStream && wheelUpdateText) {
       runTextCommand()
     }
   }

--- a/Modules/Panels/Settings/Bar/WidgetSettings/CustomButtonSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/CustomButtonSettings.qml
@@ -27,6 +27,8 @@ ColumnLayout {
     settings.rightClickUpdateText = rightClickUpdateText.checked
     settings.middleClickExec = middleClickExecInput.text
     settings.middleClickUpdateText = middleClickUpdateText.checked
+    settings.wheelExec = wheelExecInput.text
+    settings.wheelUpdateText = wheelUpdateText.checked
     settings.textCommand = textCommandInput.text
     settings.textCollapse = textCollapseInput.text
     settings.textStream = valueTextStream
@@ -133,6 +135,30 @@ ColumnLayout {
       onEntered: TooltipService.show(Screen, middleClickUpdateText, I18n.tr("bar.widget-settings.custom-button.middle-click.update-text"), "auto")
       onExited: TooltipService.hide()
       checked: widgetData?.middleClickUpdateText ?? widgetMetadata.middleClickUpdateText
+      onToggled: isChecked => checked = isChecked
+    }
+  }
+
+  RowLayout {
+    spacing: Style.marginM
+
+    NTextInput {
+      id: wheelExecInput
+      Layout.fillWidth: true
+      label: I18n.tr("bar.widget-settings.custom-button.wheel.label")
+      description: I18n.tr("bar.widget-settings.custom-button.wheel.description")
+      placeholderText: I18n.tr("placeholders.enter-command")
+      text: widgetData.wheelExec || widgetMetadata.wheelExec
+    }
+
+    NToggle {
+      id: wheelUpdateText
+      enabled: !valueTextStream
+      Layout.alignment: Qt.AlignRight | Qt.AlignBottom
+      Layout.bottomMargin: Style.marginS
+      onEntered: TooltipService.show(Screen, wheelUpdateText, I18n.tr("bar.widget-settings.custom-button.wheel.update-text"), "auto")
+      onExited: TooltipService.hide()
+      checked: widgetData?.wheelUpdateText ?? widgetMetadata.wheelUpdateText
       onToggled: isChecked => checked = isChecked
     }
   }

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -98,6 +98,8 @@ Singleton {
                                     "rightClickUpdateText": false,
                                     "middleClickExec": "",
                                     "middleClickUpdateText": false,
+                                    "wheelExec": "",
+                                    "wheelUpdateText": false,
                                     "textCommand": "",
                                     "textStream": false,
                                     "textIntervalMs": 3000,


### PR DESCRIPTION
# Pull Request

## Motivation
Handling wheel events with custom buttons is useful for stuff like being able to change song volume by scrolling on a custom button

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
