### PR TITLE
Fix: extra highlight and border

### DIFF
--- a/Modules/Panels/Wallpaper/WallpaperPanel.qml
+++ b/Modules/Panels/Wallpaper/WallpaperPanel.qml
@@ -502,9 +502,6 @@ SmartPanel {
                 if (isSelected) {
                   return Color.mSecondary
                 }
-                if (wallpaperGridView.currentIndex === index) {
-                  return Color.mHover
-                }
                 return Color.mSurface
               }
               border.width: Math.max(1, Style.borderL * 1.5)
@@ -533,7 +530,7 @@ SmartPanel {
             Rectangle {
               anchors.fill: parent
               color: Color.mSurface
-              opacity: (hoverHandler.hovered || isSelected || wallpaperGridView.currentIndex === index) ? 0 : 0.3
+              opacity: (hoverHandler.hovered || isSelected) ? 0 : 0.3
               radius: parent.radius
               Behavior on opacity {
                 NumberAnimation {


### PR DESCRIPTION
# Pull Request

## Motivation
Fixes #734 by removing the extra highlight and border that is always visible on the first image.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
#734

## Testing
Opened the wallpaper selector panel multiple times, tried different positions. Tried empty wallpaper directory.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
