### PR TITLE
HostService: add user display name and use it in UI

### DIFF
--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Services.Pam
 import qs.Commons
+import qs.Services.System
 
 Scope {
   id: root
@@ -40,7 +41,7 @@ Scope {
   PamContext {
     id: pam
     config: "login"
-    user: Quickshell.env("USER")
+    user: HostService.displayName
 
     onPamMessage: {
       Logger.i("LockContext", "PAM message:", message, "isError:", messageIsError, "responseRequired:", responseRequired)

--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -15,6 +15,7 @@ import qs.Services.Location
 import qs.Services.Media
 import qs.Services.Compositor
 import qs.Services.UI
+import qs.Services.System
 import qs.Widgets
 import qs.Widgets.AudioSpectrum
 
@@ -336,7 +337,7 @@ Loader {
 
                   // Welcome back + Username on one line
                   NText {
-                    text: I18n.tr("lock-screen.welcome-back") + " " + (Quickshell.env("USER").charAt(0).toUpperCase() + Quickshell.env("USER").slice(1)) + "!"
+                    text: I18n.tr("lock-screen.welcome-back") + " " + HostService.displayName + "!"
                     pointSize: Style.fontSizeXXL
                     font.weight: Font.Medium
                     color: Color.mOnSurface

--- a/Modules/Panels/ControlCenter/Cards/ProfileCard.qml
+++ b/Modules/Panels/ControlCenter/Cards/ProfileCard.qml
@@ -7,6 +7,7 @@ import Quickshell.Widgets
 import qs.Commons
 import qs.Modules.Panels.ControlCenter.Cards
 import qs.Modules.Panels.Settings
+import qs.Services.System
 import qs.Services.UI
 import qs.Widgets
 
@@ -37,7 +38,7 @@ NBox {
       Layout.fillWidth: true
       spacing: Style.marginXXS
       NText {
-        text: Quickshell.env("USER") || "user"
+        text: HostService.displayName
         font.weight: Style.fontWeightBold
         font.capitalization: Font.Capitalize
       }

--- a/Modules/Panels/Settings/Tabs/GeneralTab.qml
+++ b/Modules/Panels/Settings/Tabs/GeneralTab.qml
@@ -33,7 +33,7 @@ ColumnLayout {
 
     NTextInputButton {
       label: I18n.tr("settings.general.profile.picture.label", {
-                       "user": Quickshell.env("USER" || "User")
+                       "user": HostService.displayName
                      })
       description: I18n.tr("settings.general.profile.picture.description")
       text: Settings.data.general.avatarImage

--- a/Services/System/HostService.qml
+++ b/Services/System/HostService.qml
@@ -14,6 +14,28 @@ Singleton {
   property bool isNixOS: false
   property bool isReady: false
 
+  // User info
+  readonly property string username: (Quickshell.env("USER") || "")
+  readonly property string envRealName: (Quickshell.env("NOCTALIA_REALNAME") || "")
+  property string realName: ""
+
+  readonly property string displayName: {
+    // Explicit override
+    if (envRealName && envRealName.length > 0)
+      return envRealName
+
+    // Name from getent
+    if (realName && realName.length > 0)
+      return realName
+
+    // Fallback: capitalized $USER
+    if (username && username.length > 0)
+      return username.charAt(0).toUpperCase() + username.slice(1)
+
+    // Last resort: placeholder
+    return "User"
+  }
+
   function init() {
     Logger.i("HostService", "Service started")
   }
@@ -109,6 +131,24 @@ Singleton {
       }
     }
     stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  // Resolve GECOS real name once on startup
+  Process {
+    id: realNameProcess
+    command: ["sh", "-c", "getent passwd \"$USER\" | cut -d: -f5 | cut -d, -f1"]
+    running: true
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        const name = String(text || "").trim()
+        if (name.length > 0) {
+          root.realName = name
+          Logger.i("HostService", "resolved real name", name)
+        }
+      }
+    }
     stderr: StdioCollector {}
   }
 }


### PR DESCRIPTION
- Add username/envRealName/realName and displayName to HostService
- Resolve real name from `getent passwd "$USER"` with `NOCTALIA_REALNAME` override
- Use `HostService.displayName` on the lock screen and in the Control Center profile card

# Pull Request

## Motivation
The current lock screen and Control Center profile card display a capitalised `$USER` value, which is often not the user’s actual name. This PR introduces a single source of truth for the user’s display name in `HostService` and uses it across the UI.

The display name is resolved in the following order:
1. `NOCTALIA_REALNAME` environment variable (explicit override)
2. GECOS field from `getent passwd "$USER"` (real name)
3. Capitalised `$USER`
4. Final fallback: `"User"`

This improves the default experience on typical Linux setups while still allowing an explicit override via environment variable.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #717

## Testing
Describe how you tested your changes and mark the relevant items.

Manual testing:

- Default setup (no `NOCTALIA_REALNAME` set):
  - Lock screen shows `Welcome back <real name>!` using `getent`’s GECOS field.
  - Control Center profile card shows the same real name.
- With `NOCTALIA_REALNAME="Some Other Name"` set:
  - Lock screen greeting uses the override.
  - Control Center profile card uses the override.

Checklist:

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
If `getent` is unavailable or fails, `HostService.displayName` falls back to capitalised `$USER`, and finally to `"User"`, so behaviour remains sane even in minimal environments.
