### PR TITLE
SettingsPanel: Remove duplicated SessionMenu tab

### DIFF
--- a/Modules/Panels/Settings/SettingsPanel.qml
+++ b/Modules/Panels/Settings/SettingsPanel.qml
@@ -259,11 +259,6 @@ SmartPanel {
                      "label": "settings.screen-recorder.title",
                      "icon": "settings-screen-recorder",
                      "source": screenRecorderTab
-                   }, {
-                     "id": SettingsPanel.Tab.SessionMenu,
-                     "label": "settings.session-menu.title",
-                     "icon": "settings-session-menu",
-                     "source": sessionMenuTab
                    }, //  {
                    //    "id": SettingsPanel.Tab.SystemMonitor,
                    //    "label": "settings.system-monitor.title",


### PR DESCRIPTION
# Pull Request

## Motivation
There were two SessionMenu tabs in the settings.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
