### PR TITLE
Bar/Widgets: hide volume tooltips while adjusting

### DIFF
--- a/Modules/Bar/Widgets/Microphone.qml
+++ b/Modules/Bar/Widgets/Microphone.qml
@@ -50,6 +50,9 @@ Item {
         // Ignore the first volume change
         firstInputVolumeReceived = true
       } else {
+        // If a tooltip is visible while we show the pill
+        // hide it so it doesn't overlap the volume slider.
+        TooltipService.hide()
         pill.show()
         externalHideTimer.restart()
       }
@@ -65,6 +68,7 @@ Item {
         // Ignore the first mute change
         firstInputVolumeReceived = true
       } else {
+        TooltipService.hide()
         pill.show()
         externalHideTimer.restart()
       }
@@ -96,6 +100,9 @@ Item {
                          })
 
     onWheel: function (delta) {
+      // As soon as we start scrolling to adjust volume, hide the tooltip
+      TooltipService.hide()
+
       wheelAccumulator += delta
       if (wheelAccumulator >= 120) {
         wheelAccumulator = 0

--- a/Modules/Bar/Widgets/Volume.qml
+++ b/Modules/Bar/Widgets/Volume.qml
@@ -50,6 +50,8 @@ Item {
         // Ignore the first volume change
         firstVolumeReceived = true
       } else {
+        // Hide any tooltip while the pill is visible / being updated
+        TooltipService.hide()
         pill.show()
         externalHideTimer.restart()
       }
@@ -81,6 +83,9 @@ Item {
                          })
 
     onWheel: function (delta) {
+      // Hide tooltip as soon as the user starts scrolling to adjust volume
+      TooltipService.hide()
+
       wheelAccumulator += delta
       if (wheelAccumulator >= 120) {
         wheelAccumulator = 0


### PR DESCRIPTION
# Pull Request

## Motivation
When changing the output volume or microphone level from the bar, the tooltip ("Volume at X%", "Microphone volume at X%") can overlap the pill/slider. This feels distracting and makes the slider harder to see while adjusting. It irritates the heck out of me. I know tooltips can be hidden but this small edit solves my ocd issue ;-)

This PR hides the tooltip whenever the user starts adjusting the volume/microphone from the bar (via scroll wheel), or when the pill is shown due to volume changes. Tooltips still work normally when simply hovering the icon while idle.

Perhaps this is not the best solution, I can imagine the system could use a global thing that says: when interacting with a widget, don't annoy the user with a tooltip. But that is something the repo ownser should decide.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

Manual testing on niri:

- Hovering volume/microphone in the bar still shows the tooltip as before.
- Scrolling on the volume pill to change volume:
  - Tooltip disappears immediately and does not overlap the slider.
  - Volume changes correctly in steps.
- Scrolling on the microphone pill behaves the same.
- Letting the pill auto-hide after a change:
  - The slider disappears without the tooltip flashing.
  - On a fresh hover, the tooltip appears again as normal.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
<img width="504" height="254" alt="Screenshot from 2025-11-14 04-59-07" src="https://github.com/user-attachments/assets/865c55ac-9226-4674-acc7-3776df5b8aac" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Changes are limited to:

- `Modules/Bar/Widgets/Volume.qml`
- `Modules/Bar/Widgets/Microphone.qml`

`BarPillHorizontal/Vertical` are left unchanged. The behaviour change is purely UX: tooltips no longer sit on top of the volume/mic pill while adjusting levels, but remain available on hover in idle state.
