### PR TITLE
fix(qmlfmt): Add compatibility for qmlformat command

### DIFF
--- a/Bin/dev/qmlfmt.sh
+++ b/Bin/dev/qmlfmt.sh
@@ -5,9 +5,18 @@ set -euo pipefail
 # Uses: https://github.com/jesperhh/qmlfmt
 # Install: AUR package "qmlfmt-git" (requires qt6-5compat)
 
-command -v qmlfmt &>/dev/null || { echo "qmlfmt not found" >&2; exit 1; }
+# Find the available QML formatter command and define format_file accordingly
+if command -v qmlfmt &>/dev/null; then
+    echo "Using 'qmlfmt' for formatting."
+    format_file() { qmlfmt -e -b 360 -t 2 -i 2 -w "$1" || { echo "Failed: $1" >&2; return 1; }; }
+elif command -v qmlformat &>/dev/null; then
+    echo "Using 'qmlformat' for formatting."
+    format_file() { qmlformat -i --indent-width 2 --semicolon-rule essential "$1" || { echo "Failed: $1" >&2; return 1; }; }
+else
+    echo "Neither 'qmlfmt' nor 'qmlformat' found in PATH." >&2
+    exit 1
+fi
 
-format_file() { qmlfmt -e -b 360 -t 2 -i 2 -w "$1" || { echo "Failed: $1" >&2; return 1; }; }
 export -f format_file
 
 # Find all .qml files


### PR DESCRIPTION
- Modifies Bin/dev/qmlfmt.sh to check for both 'qmlfmt' and 'qmlformat' executables.
- Uses 'qmlfmt' with its original arguments if found.
- If 'qmlfmt' is not found, uses 'qmlformat' with arguments for 2-space indentation and essential semicolons.
- Exits with an error if neither command is available.
- This makes the QML formatting pre-commit hook more robust.

# Pull Request

## Motivation
I didn't find `qmlfmt` command support on `nixos`, so I used `qmlformat`

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
