### PR TITLE
BarWidgetLoader: Remove layout space left by hidden widgets

### DIFF
--- a/Modules/Bar/Extras/BarWidgetLoader.qml
+++ b/Modules/Bar/Extras/BarWidgetLoader.qml
@@ -21,6 +21,9 @@ Item {
   implicitWidth: getImplicitSize(loader.item, "implicitWidth")
   implicitHeight: getImplicitSize(loader.item, "implicitHeight")
 
+  // Remove layout space left by hidden widgets
+  visible: loader.item ? ((loader.item.opacity > 0.0) || (loader.item.hasOwnProperty("hideMode") && loader.item.hideMode === "transparent")) : false
+
   function getImplicitSize(item, prop) {
     return (item && item.visible) ? Math.round(item[prop]) : 0
   }


### PR DESCRIPTION
# Pull Request

## Motivation
Widgets that are able to hide (ActiveWindow, MediaMini) would left minor layout space because of the loader would not hide along with them, after this fix they can.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

- Before:
  - Space left by ActiveWindow:  <img width="204" height="36" alt="image" src="https://github.com/user-attachments/assets/9434f729-14b5-43c5-adf7-b0c41bef7097" />
  - Space left by MediaMini: <img width="204" height="36" alt="image" src="https://github.com/user-attachments/assets/2fa48b01-0079-459d-8535-06a2ad9dedc4" />

- After:
  - ActiveWindow hides: <img width="204" height="36" alt="image" src="https://github.com/user-attachments/assets/bfc8319f-53d5-49a4-aecf-8daf15e7b3a7" />
  - MediaMini hides: <img width="204" height="36" alt="image" src="https://github.com/user-attachments/assets/106bda5d-90f7-4c86-9a70-ef9996818bd1" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
On account of the gap is affect by the `visible` of the root item of `BarWidgetLoader.qml`, the removement of the gap is a bit of abrupt, but it's subtle, i currently can not figure solution.
