### PR TITLE
SystemStatService: don't report efivarfs usage% to avoid stutters

### DIFF
--- a/Services/System/SystemStatService.qml
+++ b/Services/System/SystemStatService.qml
@@ -92,9 +92,10 @@ Singleton {
   // --------------------------------------------
   // Process to fetch disk usage in percent
   // Uses 'df' aka 'disk free'
+  // "-x efivarfs' skips efivarfs mountpoints, for which the `statfs` syscall may cause system-wide stuttering
   Process {
     id: dfProcess
-    command: ["df", "--output=target,pcent"]
+    command: ["df", "--output=target,pcent", "-x", "efivarfs"]
     running: false
     stdout: StdioCollector {
       onStreamFinished: {


### PR DESCRIPTION
# Pull Request

## Motivation
When updating filesystem usage stats, Noctalia uses`df`, which in turn uses the `statfs` syscall on each mounted filesystem. For efivarfs filesystems (which mainly contain EFI variables), this may trigger UEFI firmware function calls, which take a small but significant amount of time and can cause the system to temporarily hang. These hangs are in the order of milliseconds, which is sometimes enough to cause Pipewire to miss a deadline, causing audio stutters if the quantum values are low enough.

Here's the runtime of each `statfs` call executed by `df` on my system (last column, in seconds):
```
 I ~> strace -T -e trace=%statfs -e verbose=none df --output=target,pcent
statfs("/", 0x7fff41fc7780)                         = 0 <0.000013>
statfs("/run", 0x7fff41fc7780)                      = 0 <0.000012>
statfs("/sys/kernel/security", 0x7fff41fc7780)      = 0 <0.000012>
statfs("/sys/kernel/tracing", 0x7fff41fc7780)       = 0 <0.000012>
statfs("/sys/firmware/efi/efivars", 0x7fff41fc7780) = 0 <0.027975>
statfs("/sys/fs/cgroup", 0x7fff41fc7780)            = 0 <0.000081>
statfs("/dev", 0x7fff41fc7780)                      = 0 <0.000046>
statfs("/dev/shm", 0x7fff41fc7780)                  = 0 <0.000042>
statfs("/proc/sys/fs/binfmt_misc", 0x7fff41fc7780)  = 0 <0.000033>
statfs("/home", 0x7fff41fc7780)                     = 0 <0.000029>
Mounted on                Use%
/                          72%
/run                        1%
/sys/firmware/efi/efivars  97%
/dev                        0%
/dev/shm                    1%
/home                      72%
+++ exited with 0 +++
```

Since `df` is called periodically by Noctalia once the system status card is loaded, the stuttering continues until quickshell is killed.

This PR tells `df` to skip all efivarfs filesystems when reporting disk usage.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Launched Noctalia, launched `pw-top`, opened the control center (with the system status card enabled), verified that no stuttering occurred over a period of 15 minutes.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Here's a few screenshots showing the issue. For all these plots, my audio output is configured at 48kHz, quantum=128, so any spike above 128/48000 = 2.66ms is a stutter. Each graph captures around 60 seconds of data.

- Plot generated by `pw-profiler` before the fix (control center is opened and closed at ~5000 samples): 
<img width="600" height="480" alt="driver-timing" src="https://github.com/user-attachments/assets/265ac93f-0191-4b9b-b47b-3e359e3b1c93" />

- Plot generated by `pw-profiler` without Noctalia running, but with `watch -n 1 df --output=target,pcent` running in a terminal:
<img width="600" height="480" alt="driver-timing" src="https://github.com/user-attachments/assets/c06002e9-6091-4340-ac2d-7e21bd18277b" />

- Plot generated by `pw-profiler` after the fix (control center is opened and closed at ~5000 samples):
<img width="600" height="480" alt="driver-timing" src="https://github.com/user-attachments/assets/dc4a7eac-977f-4250-98db-1f90f01034c6" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes


