### PR TITLE
Hide scrollbar in NListView if it's not necessary

### DIFF
--- a/Modules/Panels/Settings/SettingsPanel.qml
+++ b/Modules/Panels/Settings/SettingsPanel.qml
@@ -411,7 +411,7 @@ SmartPanel {
             anchors.fill: parent
             anchors.margins: Style.marginS
             model: root.tabsModel
-            spacing: Style.marginXXS
+            spacing: Style.marginXS
             currentIndex: root.currentTabIndex
             verticalPolicy: ScrollBar.AsNeeded
 

--- a/Widgets/NListView.qml
+++ b/Widgets/NListView.qml
@@ -131,7 +131,7 @@ Item {
         implicitHeight: 100
         radius: root.handleRadius
         color: parent.pressed ? root.handlePressedColor : parent.hovered ? root.handleHoverColor : root.handleColor
-        opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 1.0 : 0.0
+        opacity: parent.policy === ScrollBar.AlwaysOn ? 1.0 : root.verticalScrollBarActive ? (parent.active ? 1.0 : 0.0) : 0.0
 
         Behavior on opacity {
           NumberAnimation {
@@ -150,7 +150,7 @@ Item {
         implicitWidth: root.handleWidth
         implicitHeight: 100
         color: root.trackColor
-        opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 0.3 : 0.0
+        opacity: parent.policy === ScrollBar.AlwaysOn ? 0.3 : root.verticalScrollBarActive ? (parent.active ? 0.3 : 0.0) : 0.0
         radius: root.handleRadius / 2
 
         Behavior on opacity {


### PR DESCRIPTION
In the sidebar of the settings panel there is now always a scrollbar visible when hovering over the right edge, even if there are not enough elements in the bar to make scrolling necessary. This PR hides the scrollbar in NListView completely if there are not enough elements a list.
I also reversed a recent change in the vertical spacing of the sidebar tabs, i think it looks to crowded this way.