### PR TITLE
feat: Add IPC command to toggle dock visibility

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -223,6 +223,13 @@ Item {
     }
   }
 
+  IpcHandler {
+    target: "dock"
+    function toggle() {
+      Settings.data.dock.enabled = !Settings.data.dock.enabled;
+    }
+  }
+
   // Wallpaper IPC: trigger a new random wallpaper
   IpcHandler {
     target: "wallpaper"


### PR DESCRIPTION
# Pull Request

## Motivation
Add the IPC command to toggle the display of the dock. fixed #766 

The documentation for https://github.com/noctalia-dev/noctalia-docs/pull/32 has been updated.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
