### PR TITLE
Fix vertical centering and overflow of NSpinBox

### DIFF
--- a/Widgets/NSpinBox.qml
+++ b/Widgets/NSpinBox.qml
@@ -24,10 +24,56 @@ RowLayout {
   property alias minimum: root.from
   property alias maximum: root.to
 
+  // Properties for repeating
+  property int initialRepeatDelay: 400   // The "pause" after the first click (in ms)
+  property int repeatInterval: 80        // How often to step up after fist pause (ms)
+  property int rampFactor: 4             // How many ticks to wait before increasing the step multiplier
+  property int maxStepMultiplier: 10     // The max step (e.g., 10 * stepSize)
+  property int _holdTicks: 0             // Internal counter for hold duration
+  property int _repeatDirection: 0       // -1 for decrease, 1 for increase
+
   signal entered
   signal exited
 
   Layout.fillWidth: true
+
+  Timer {
+    id: repeatTimer
+    repeat: true
+    interval: root.initialRepeatDelay
+
+    onTriggered: {
+      if (repeatTimer.interval === root.initialRepeatDelay) {
+        repeatTimer.interval = root.repeatInterval;
+        root._holdTicks = 0;
+      }
+      root._holdTicks++;
+      var stepMultiplier = Math.min(root.maxStepMultiplier, 1 + Math.floor(root._holdTicks / root.rampFactor));
+      changeValue(root._repeatDirection, root.stepSize * stepMultiplier);
+    }
+  }
+
+  function changeValue(direction, step) {
+    var currentStep = step || root.stepSize;
+
+    if (direction === 1 && root.value < root.to) {
+      root.value = Math.min(root.to, root.value + currentStep);
+    } else if (direction === -1 && root.value > root.from) {
+      root.value = Math.max(root.from, root.value - currentStep);
+    } else {
+      return;
+    }
+
+    if (root.value === root.to || root.value === root.from) {
+      stopRepeat();
+    }
+  }
+
+  function stopRepeat() {
+    root._repeatDirection = 0;
+    repeatTimer.stop();
+    repeatTimer.interval = root.initialRepeatDelay;
+  }
 
   NLabel {
     label: root.label
@@ -82,7 +128,7 @@ RowLayout {
       anchors.top: parent.top
       anchors.bottom: parent.bottom
       anchors.left: parent.left
-      opacity: root.enabled && root.value > root.from ? 1.0 : 0.3
+      opacity: (root.enabled && root.value > root.from) || decreaseArea.containsMouse ? 1.0 : 0.3
       clip: true
 
       Item {
@@ -163,10 +209,13 @@ RowLayout {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         enabled: root.enabled && root.value > root.from
-        onClicked: {
-          let newValue = Math.max(root.from, root.value - root.stepSize);
-          root.value = newValue;
+        onPressed: {
+          root._repeatDirection = -1;
+          changeValue(root._repeatDirection, root.stepSize);
+          repeatTimer.start();
         }
+        onReleased: stopRepeat()
+        onExited:   stopRepeat()
       }
     }
 
@@ -178,7 +227,7 @@ RowLayout {
       anchors.top: parent.top
       anchors.bottom: parent.bottom
       anchors.right: parent.right
-      opacity: root.enabled && root.value < root.to ? 1.0 : 0.3
+      opacity: (root.enabled && root.value < root.to) || increaseArea.containsMouse ? 1.0 : 0.3
       clip: true
 
       Item {
@@ -259,10 +308,13 @@ RowLayout {
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         enabled: root.enabled && root.value < root.to
-        onClicked: {
-          let newValue = Math.min(root.to, root.value + root.stepSize);
-          root.value = newValue;
+        onPressed: {
+          root._repeatDirection = 1;
+          changeValue(root._repeatDirection, root.stepSize);
+          repeatTimer.start();
         }
+        onReleased: stopRepeat()
+        onExited:   stopRepeat()
       }
     }
 


### PR DESCRIPTION
# Pull Request

## Motivation
I've long been peeved at NSpinBox. It's my own doing. But there are a few minor issues with it that have been nagging at me every time I see them. The arrows arn't always vertically centered and so don't line up nice with the rounded circles endcaps. And the colored region when you hover over them, often overflows outisde the bounds of the pill shape. This PR should resolve both those issues.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Tested at different interface scaling as well.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [X] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before and After:
<img width="812" height="114" alt="image" src="https://github.com/user-attachments/assets/001b5c90-c16d-496b-9677-4da38317c219" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
