### PR TITLE
Nix: Sync Flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,15 +23,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1761821581,
-        "narHash": "sha256-nLuc6jA7z+H/6bHPEBSOYPbz7RtvNCZiTKmYItJuBmM=",
+        "lastModified": 1760228179,
+        "narHash": "sha256-4Z6k7lv3Zcgk3K+4h60LpqB9wCkR+utkYERU735U068=",
         "ref": "refs/heads/master",
-        "rev": "db1777c20b936a86528c1095cbcb1ebd92801402",
-        "revCount": 699,
+        "rev": "c9d3ffb6043c5bf3f3009202bad7e0e5132c4a25",
+        "revCount": 693,
         "type": "git",
         "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
       },
       "original": {
+        "rev": "c9d3ffb6043c5bf3f3009202bad7e0e5132c4a25",
         "type": "git",
         "url": "https://git.outfoxxed.me/outfoxxed/quickshell"
       }


### PR DESCRIPTION
# Pull Request

## Motivation
Currently the `flake.lock` missmatches the input information in `flake.nix`.
This results in nix trying to update it when fetching the inputs, which is not possible if noctalia is accessed via a nix command or as a flake input itself, due to the readonly nature of the nix store:
```
> nix shell github:noctalia-dev/noctalia-shell?ref=1a38c6d66525c29ff40d8fbc88e9be7d7222a153`
[...]
error:
       … while updating the lock file of flake 'github:noctalia-dev/noctalia-shell/1a38c6d66525c29ff40d8fbc88e9be7d7222a153?narHash=sha256-nOHTjQFxBRhg99Hllcj1/tHis3leu/HVXUNW/d0ub/c%3D'

       error: cannot write modified lock file of flake 'github:noctalia-dev/noctalia-shell/1a38c6d66525c29ff40d8fbc88e9be7d7222a153' (use '--no-write-lock-file' to ignore)
```

This pull request fixes that.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

Run `nix develop`

- [x] Works

## Screenshots / Videos
N/A

## Checklist
- N/A: Code follows project style guidelines
- N/A: Self-reviewed my code
- [x] No new warnings or errors
- N/A: Documentation or comments updated (if relevant)

## Additional Notes
Updated by simply running `nix develop`, which, to be frank, should have been done by the person pushing the faulty commit (`1a38c6d66525c29ff40d8fbc88e9be7d7222a153`). At least test your stuff before pushing to `main` man..
