### PR TITLE
Remove double bottom spacing in panels & hide scrollbar in NScrollView if not necessary

### DIFF
--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -241,10 +241,6 @@ SmartPanel {
               }
             }
           }
-
-          Item {
-            Layout.fillHeight: true
-          }
         }
       }
     }

--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -238,10 +238,6 @@ SmartPanel {
               }
             }
           }
-
-          Item {
-            Layout.fillHeight: true
-          }
         }
       }
     }

--- a/Modules/Panels/Calendar/CalendarPanel.qml
+++ b/Modules/Panels/Calendar/CalendarPanel.qml
@@ -650,6 +650,7 @@ SmartPanel {
       Loader {
         id: weatherLoader
         active: Settings.data.location.weatherEnabled && Settings.data.location.showCalendarWeather
+        visible: active
         Layout.fillWidth: true
 
         sourceComponent: WeatherCard {

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -17,6 +17,8 @@ T.ScrollView {
   property bool preventHorizontalScroll: horizontalPolicy === ScrollBar.AlwaysOff
   property int boundsBehavior: Flickable.StopAtBounds
   property int flickableDirection: Flickable.VerticalFlick
+  readonly property bool verticalScrollable: contentItem.contentHeight > contentItem.height
+  readonly property bool horizontalScrollable: contentItem.contentWidth > contentItem.width
 
   implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset, contentWidth + leftPadding + rightPadding)
   implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset, contentHeight + topPadding + bottomPadding)
@@ -65,7 +67,7 @@ T.ScrollView {
       implicitHeight: 100
       radius: root.handleRadius
       color: parent.pressed ? root.handlePressedColor : parent.hovered ? root.handleHoverColor : root.handleColor
-      opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 1.0 : 0.0
+      opacity: parent.policy === ScrollBar.AlwaysOn ? 1.0 : root.verticalScrollable ? (parent.active ? 1.0 : 0.0) : 0.0
 
       Behavior on opacity {
         NumberAnimation {
@@ -84,7 +86,7 @@ T.ScrollView {
       implicitWidth: root.handleWidth
       implicitHeight: 100
       color: root.trackColor
-      opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 0.3 : 0.0
+      opacity: parent.policy === ScrollBar.AlwaysOn ? 0.3 : root.verticalScrollable ? (parent.active ? 0.3 : 0.0) : 0.0
       radius: root.handleRadius / 2
 
       Behavior on opacity {
@@ -108,7 +110,7 @@ T.ScrollView {
       implicitHeight: root.handleWidth
       radius: root.handleRadius
       color: parent.pressed ? root.handlePressedColor : parent.hovered ? root.handleHoverColor : root.handleColor
-      opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 1.0 : 0.0
+      opacity: parent.policy === ScrollBar.AlwaysOn ? 1.0 : root.horizontalScrollable ? (parent.active ? 1.0 : 0.0) : 0.0
 
       Behavior on opacity {
         NumberAnimation {
@@ -127,7 +129,7 @@ T.ScrollView {
       implicitWidth: 100
       implicitHeight: root.handleWidth
       color: root.trackColor
-      opacity: parent.policy === ScrollBar.AlwaysOn || parent.active ? 0.3 : 0.0
+      opacity: parent.policy === ScrollBar.AlwaysOn ? 0.3 : root.horizontalScrollable ? (parent.active ? 0.3 : 0.0) : 0.0
       radius: root.handleRadius / 2
 
       Behavior on opacity {


### PR DESCRIPTION
# Pull Request

## Motivation
Some panels (audio, bluetooth & calendar if weather is off) show a double spacing at the bottom caused by empty elements. I fixed this and also made the same changes to NScrollView that I made to NListView in commit [ef1b7cf](https://github.com/noctalia-dev/noctalia-shell/pull/770/commits/ef1b7cfd893792340da3272a2890eeff92664fc3) (hiding the scrollbar if it is not needed, as it currently appears when hovering over the right edge in the audio and bluetooth panel).

## Screenshots / Videos
<img width="528" height="235" alt="Screenshot_20251118_10h13m31" src="https://github.com/user-attachments/assets/2d8d6b95-c6be-4412-9ec3-94bebf6daca8" />
