### PR TITLE
Fix/better radio button width

### DIFF
--- a/Widgets/NRadioButton.qml
+++ b/Widgets/NRadioButton.qml
@@ -45,7 +45,6 @@ RadioButton {
   contentItem: NText {
     text: root.text
     pointSize: root.pointSize
-    //implicitWidth: content.contentWidth
     anchors.verticalCenter: parent.verticalCenter
     anchors.left: outerCircle.right
     anchors.right: parent.right


### PR DESCRIPTION
# Pull Request
## Motivation
This improves the implicitWidth calculation of NRadioButton, so it's label is included. This is a quirk I found necessary for some upcoming PR. But I made sure it didn't affect the AudioSettings Tab (the only place I saw Radio Buttons currently in use)

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

