### PR TITLE
Dock: make border radius configurable

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1216,6 +1216,10 @@
           "description": "Adjust the dock's background opacity.",
           "label": "Background opacity"
         },
+        "border-radius": {
+          "description": "Adjust the dock's border radius.",
+          "label": "Border radius"
+        },
         "colorize-icons": {
           "description": "Apply theme colors to dock app icons (non-focused apps only).",
           "label": "Colorize Icons"

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -385,6 +385,7 @@ Singleton {
       property bool enabled: true
       property string displayMode: "always_visible" // "always_visible", "auto_hide", "exclusive"
       property real backgroundOpacity: 1.0
+      property real radiusRatio: 0.1
       property real floatingRatio: 1.0
       property real size: 1
       property bool onlySameOutput: true

--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -299,7 +299,7 @@ Loader {
               height: Math.round(iconSize * 1.5)
               color: Qt.alpha(Color.mSurface, Settings.data.dock.backgroundOpacity)
               anchors.centerIn: parent
-              radius: Style.radiusL
+              radius: height * 0.5 * Settings.data.dock.radiusRatio
               border.width: Style.borderS
               border.color: Qt.alpha(Color.mOutline, Settings.data.dock.backgroundOpacity)
 

--- a/Modules/Panels/Settings/Tabs/DockTab.qml
+++ b/Modules/Panels/Settings/Tabs/DockTab.qml
@@ -85,6 +85,25 @@ ColumnLayout {
     visible: Settings.data.dock.enabled
     spacing: Style.marginXXS
     Layout.fillWidth: true
+    NLabel {
+      label: I18n.tr("settings.dock.appearance.border-radius.label")
+      description: I18n.tr("settings.dock.appearance.border-radius.description")
+    }
+    NValueSlider {
+      Layout.fillWidth: true
+      from: 0
+      to: 1
+      stepSize: 0.01
+      value: Settings.data.dock.radiusRatio
+      onMoved: value => Settings.data.dock.radiusRatio = value
+      text: Math.floor(Settings.data.dock.radiusRatio * 100) + "%"
+    }
+  }
+
+  ColumnLayout {
+    visible: Settings.data.dock.enabled
+    spacing: Style.marginXXS
+    Layout.fillWidth: true
 
     NLabel {
       label: I18n.tr("settings.dock.appearance.floating-distance.label")


### PR DESCRIPTION
# Pull Request

## Motivation
Just thought people might want to be able to configure the dock's border radius

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Tested the value at all percentages including changing the dock size to make sure the radius calculated properly against the dock's height

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1170" height="1303" alt="screenshot-2025-11-21T07:47:49-05:00" src="https://github.com/user-attachments/assets/522fa4f0-e989-4001-b1d3-e1cf7cf8e3ba" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)