### PR TITLE
fix: Fix the rich text display on the About page

### DIFF
--- a/Modules/Panels/Settings/Tabs/AboutTab.qml
+++ b/Modules/Panels/Settings/Tabs/AboutTab.qml
@@ -146,6 +146,7 @@ ColumnLayout {
                                                           }) : I18n.tr("settings.about.contributors.section.description_plural", {
                                                                          "count": root.contributors.length
                                                                        })
+    enableDescriptionRichText: true
   }
 
   GridView {

--- a/Widgets/NHeader.qml
+++ b/Widgets/NHeader.qml
@@ -7,6 +7,7 @@ ColumnLayout {
 
   property string label: ""
   property string description: ""
+  property bool enableDescriptionRichText: false
 
   spacing: Style.marginXXS
   Layout.fillWidth: true
@@ -27,5 +28,6 @@ ColumnLayout {
     wrapMode: Text.WordWrap
     Layout.fillWidth: true
     visible: root.description !== ""
+    richTextEnabled: root.enableDescriptionRichText
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
 Fix the rich text display on the About page

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
