### PR TITLE
revert: 'Matugen/Discord: fix inbox alignment'

### DIFF
--- a/Assets/MatugenTemplates/vesktop.css
+++ b/Assets/MatugenTemplates/vesktop.css
@@ -254,7 +254,3 @@ div[class*="linkCalloutContainer"]:hover > span[data-text-variant*="semibold"] {
     color: var(--accent-1) !important;
     opacity: 1 !important;
 }
-
-div[aria-label="Inbox"].clickable_c99c29 {
-    top: 20px !important;
-}


### PR DESCRIPTION
# Pull Request

## Motivation
Reverts Vesktop override since the offset Inbox icon was fixed by (most likely) Discord.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Reverted locally and icon alignment was correct again.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before
<img width="208" height="93" alt="image" src="https://github.com/user-attachments/assets/83f49f6c-31b3-47b7-80cd-06f59df682cc" />

After
<img width="267" height="72" alt="image" src="https://github.com/user-attachments/assets/a12b0a88-6030-4ec6-9665-d1b360c6e7ab" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
