### PR TITLE
Add screen recording loading feedback

### DIFF
--- a/Modules/Bar/Widgets/ScreenRecorder.qml
+++ b/Modules/Bar/Widgets/ScreenRecorder.qml
@@ -1,3 +1,4 @@
+import QtQuick
 import Quickshell
 import qs.Commons
 import qs.Services.Media
@@ -11,7 +12,7 @@ NIconButton {
 
   property ShellScreen screen
 
-  icon: "camera-video"
+  icon: ScreenRecorderService.isPending ? "" : "camera-video"
   tooltipText: ScreenRecorderService.isRecording ? I18n.tr("tooltips.click-to-stop-recording") : I18n.tr("tooltips.click-to-start-recording")
   tooltipDirection: BarService.getTooltipDirection()
   density: Settings.data.bar.density
@@ -31,4 +32,32 @@ NIconButton {
   }
 
   onClicked: handleClick()
+
+  // Custom spinner shown only during pending start
+  NIcon {
+    id: pendingSpinner
+    icon: "loader-2"
+    visible: ScreenRecorderService.isPending
+    pointSize: {
+      switch (root.density) {
+      case "compact":
+        return Math.max(1, root.width * 0.65);
+      default:
+        return Math.max(1, root.width * 0.48);
+      }
+    }
+    applyUiScale: root.applyUiScale
+    color: root.enabled && root.hovering ? colorFgHover : colorFg
+    anchors.centerIn: parent
+    transformOrigin: Item.Center
+
+    RotationAnimation on rotation {
+      running: ScreenRecorderService.isPending
+      from: 0
+      to: 360
+      duration: Style.animationSlow
+      loops: Animation.Infinite
+      onStopped: pendingSpinner.rotation = 0
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Adds some much needed feedback to the screen recorder widget

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
1. Click screen recording widget
2. spinner displays
3. recording begins

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/69c3c89d-82b4-4f61-88ee-3b92b1fa35e8


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
