### PR TITLE
fix: Music progress ring color not updating on theme change when paused

### DIFF
--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -397,6 +397,13 @@ Item {
               }
             }
 
+            // Property to track mPrimary color changes and trigger repaint
+            Item {
+              id: colorTrackerHorizontal
+              property color currentColor: Color.mPrimary
+              onCurrentColorChanged: progressCanvas.requestPaint()
+            }
+
             // Album art or icon - only show album art when enabled and player is active
             Item {
               anchors.fill: parent
@@ -673,6 +680,13 @@ Item {
         function onTrackLengthChanged() {
           progressCanvasVertical.requestPaint();
         }
+      }
+
+      // Property to track mPrimary color changes and trigger repaint for vertical canvas
+      Item {
+        id: colorTrackerVertical
+        property color currentColor: Color.mPrimary
+        onCurrentColorChanged: progressCanvasVertical.requestPaint()
       }
 
       // Mouse area for hover detection


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
[Provide a clear and concise explanation of what this PR does and why it is needed.](fix: Music progress ring color not updating on theme change when paused)

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
