### PR TITLE
Remove minimum height from wifi & bluetooth panel

### DIFF
--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -21,8 +21,8 @@ SmartPanel {
     // Calculate content height based on header + devices list (or minimum for empty states)
     property real headerHeight: headerRow.implicitHeight + Style.marginM * 2
     property real devicesHeight: devicesList.implicitHeight
-    property real calculatedHeight: headerHeight + devicesHeight + Style.marginL * 2 + Style.marginM
-    property real contentPreferredHeight: (BluetoothService.adapter && BluetoothService.adapter.enabled) ? Math.min(root.preferredHeight, Math.max(280 * Style.uiScaleRatio, calculatedHeight)) : Math.min(root.preferredHeight, 280 * Style.uiScaleRatio)
+    property real calculatedHeight: (devicesHeight !== 0) ? (headerHeight + devicesHeight + Style.marginL * 2 + Style.marginM) : (280 * Style.uiScaleRatio)
+    property real contentPreferredHeight: (BluetoothService.adapter && BluetoothService.adapter.enabled) ? Math.min(root.preferredHeight, calculatedHeight) : Math.min(root.preferredHeight, 280 * Style.uiScaleRatio)
 
     ColumnLayout {
       id: mainColumn

--- a/Modules/Panels/WiFi/WiFiPanel.qml
+++ b/Modules/Panels/WiFi/WiFiPanel.qml
@@ -77,8 +77,8 @@ SmartPanel {
     // Calculate content height based on header + networks list (or minimum for empty states)
     property real headerHeight: headerRow.implicitHeight + Style.marginM * 2
     property real networksHeight: networksList.implicitHeight
-    property real calculatedHeight: headerHeight + networksHeight + Style.marginL * 2 + Style.marginM
-    property real contentPreferredHeight: Settings.data.network.wifiEnabled && Object.keys(NetworkService.networks).length > 0 ? Math.min(root.preferredHeight, Math.max(280 * Style.uiScaleRatio, calculatedHeight)) : Math.min(root.preferredHeight, 280 * Style.uiScaleRatio)
+    property real calculatedHeight: (networksHeight !== 0) ? (headerHeight + networksHeight + Style.marginL * 2 + Style.marginM) : (280 * Style.uiScaleRatio)
+    property real contentPreferredHeight: Settings.data.network.wifiEnabled && Object.keys(NetworkService.networks).length > 0 ? Math.min(root.preferredHeight, calculatedHeight) : Math.min(root.preferredHeight, 280 * Style.uiScaleRatio)
 
     ColumnLayout {
       id: mainColumn


### PR DESCRIPTION
This removes the empty space if there aren't enough devices to fill the the panel.

<img width="570" height="398" alt="Screenshot_20251124_17h27m11" src="https://github.com/user-attachments/assets/ff030ae8-123c-45e4-8b38-4064c9d6e3ea" />
