### PR TITLE
fix(MediaMini): make icon smaller when inside progress ring

### DIFF
--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -428,7 +428,7 @@ Item {
                 anchors.centerIn: parent
                 icon: hasActivePlayer ? (MediaService.isPlaying ? "media-pause" : "media-play") : "disc"
                 color: hasActivePlayer ? Color.mOnSurface : Color.mOnSurfaceVariant
-                pointSize: showAlbumArt ? 8 * scaling : 12 * scaling  // Smaller when inside album art circle, larger when alone
+                pointSize: (showAlbumArt || showProgressRing) ? 8 * scaling : 12 * scaling  // Smaller when inside album art circle or progress ring, larger when alone
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
                 visible: (!showAlbumArt && hasActivePlayer) && showProgressRing


### PR DESCRIPTION
# Pull Request

## Motivation
make icon smaller when inside progress ring (only change horizontal bar's mediamini widget icon size)

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="302" height="52" alt="image" src="https://github.com/user-attachments/assets/a3d61728-03de-48da-82a0-bb986076cbe9" />


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I'm not sure if other users have this problem. If it is an individual case, please ignore this pr
