### PR TITLE
Update es.json translation for 'play' to 'Reproducir'

### DIFF
--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -479,7 +479,7 @@
     "open-mixer": "Mezclador de audio",
     "open-settings": "Abrir ajustes",
     "pause": "Pausa",
-    "play": "Jugar",
+    "play": "Reproducir",
     "previous": "Anterior",
     "random-wallpaper": "Fondo de pantalla aleatorio",
     "toggle-mute": "Activar/desactivar silencio",


### PR DESCRIPTION
# Pull Request

<!-- spanish has a lot words for the same thing (in spanish (jugar) play it is used to play ...games (jugar juegos), but play music is "reproducir musica" -->

## Motivation
Correct a minor translation issue

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

