### PR TITLE
Control Center: hide shortcuts box if empty

### DIFF
--- a/Modules/Panels/ControlCenter/Cards/ShortcutsCard.qml
+++ b/Modules/Panels/ControlCenter/Cards/ShortcutsCard.qml
@@ -14,6 +14,7 @@ RowLayout {
   NBox {
     Layout.fillWidth: true
     Layout.preferredHeight: root.shortcutsHeight
+    visible: Settings.datga.controlCenter.shortcuts.left.length > 0
 
     RowLayout {
       id: leftContent
@@ -53,6 +54,7 @@ RowLayout {
   NBox {
     Layout.fillWidth: true
     Layout.preferredHeight: root.shortcutsHeight
+    visible: Settings.data.controlCenter.shortcuts.right.length > 0
 
     RowLayout {
       id: rightContent


### PR DESCRIPTION
# Pull Request

## Motivation
Just thought it would be visually more appealing if we only rendered shortcut boxes with widgets in them

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Tested adding/removing shortcuts in both boxes

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="651" height="611" alt="screenshot-2025-11-26T20:09:38-05:00" src="https://github.com/user-attachments/assets/04c93b0f-a397-4996-9e54-2c1a6af07a8f" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
