### PR TITLE
Added small margin, put theme colors on top

### DIFF
--- a/Widgets/NColorPickerDialog.qml
+++ b/Widgets/NColorPickerDialog.qml
@@ -620,43 +620,6 @@ Popup {
               columnSpacing: 6
               rowSpacing: 6
 
-              Repeater {
-                model: ColorList.colors
-
-                Rectangle {
-                  width: 24
-                  height: 24
-                  radius: Style.radiusXXS
-                  color: modelData.color
-                  border.color: root.selectedColor.toString() === modelData.color.toString() ? Color.mPrimary : Color.mOutline
-                  border.width: Math.max(1, root.selectedColor.toString() === modelData.color.toString() ? Style.borderM : Style.borderS)
-
-                  MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    hoverEnabled: true
-
-                    onEntered: {
-                      TooltipService.show(parent, modelData.name + "\n" + parent.color.toString().toUpperCase());
-                    }
-                    onExited: {
-                      TooltipService.hide();
-                    }
-                    onClicked: {
-                      root.selectedColor = modelData.color;
-                      TooltipService.hide();
-                    }
-                  }
-                }
-              }
-
-              NDivider {
-                Layout.columnSpan: 15
-                Layout.fillWidth: true
-                Layout.topMargin: Style.marginXS
-                Layout.bottomMargin: 0
-              }
-
               NLabel {
                 Layout.columnSpan: 15
                 Layout.fillWidth: true
@@ -698,6 +661,43 @@ Popup {
                 Rectangle {
                   width: 24
                   height: 24
+                  radius: Style.radiusXXS
+                  color: modelData.color
+                  border.color: root.selectedColor.toString() === modelData.color.toString() ? Color.mPrimary : Color.mOutline
+                  border.width: Math.max(1, root.selectedColor.toString() === modelData.color.toString() ? Style.borderM : Style.borderS)
+
+                  MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+
+                    onEntered: {
+                      TooltipService.show(parent, modelData.name + "\n" + parent.color.toString().toUpperCase());
+                    }
+                    onExited: {
+                      TooltipService.hide();
+                    }
+                    onClicked: {
+                      root.selectedColor = modelData.color;
+                      TooltipService.hide();
+                    }
+                  }
+                }
+              }
+
+              NDivider {
+                Layout.columnSpan: 15
+                Layout.fillWidth: true
+                Layout.topMargin: Style.marginXS
+                Layout.bottomMargin: 0
+              }
+
+              Repeater {
+                model: ColorList.colors
+
+                Rectangle {
+                  width: 24
+                  height: 24
                   radius: 4
                   color: modelData.color
                   border.color: root.selectedColor.toString() === modelData.color.toString() ? Color.mPrimary : Color.mOutline
@@ -728,8 +728,8 @@ Popup {
 
       RowLayout {
         Layout.fillWidth: true
-        //Layout.topMargin: 20
-        //Layout.bottomMargin: 20
+        Layout.topMargin: 1
+        Layout.bottomMargin: 1
         spacing: 10
 
         Item {


### PR DESCRIPTION
# Pull Request

## Motivation
I noticed a small rendering error with the bottom buttoms if you open and close the palette, the bottom edge of the buttons get a pixel shaved off. I add back in a much smaller margin to resolve it (and a top margin just so they look balanced.) I also put the theme colors on the top, but not outside the NCollapsible as I couldn't find a way that looked good without doing a lot more work to the NCollapsible widget than I had time for this week. 

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

