### PR TITLE
feat/fix: render label descriptions as styled text

### DIFF
--- a/Widgets/NLabel.qml
+++ b/Widgets/NLabel.qml
@@ -29,5 +29,7 @@ ColumnLayout {
     wrapMode: Text.WordWrap
     visible: description !== ""
     Layout.fillWidth: true
+    // allow HTML like <i>...</i> in labels/descriptions
+    textFormat: Text.StyledText
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
The Night Light "Automatic scheduling" description currently shows raw `<i>...</i>` tags around the location name instead of italicizing it. This leaks implementation detail into the UI and makes the toggle look broken.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="591" height="71" alt="unstyled" src="https://github.com/user-attachments/assets/e197f582-88a7-44fa-95c6-7707ada297d5" />
<img width="591" height="71" alt="styled" src="https://github.com/user-attachments/assets/d012f5fb-c4dd-4266-9ba9-d1da5669f7b4" />

## Checklist
- [x] Code follows project style guidelines

- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
