### PR TITLE
fix: Caps Off OSD color inconsistency with Num Off OSD

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -121,7 +121,14 @@ Variants {
       }
       // For lock keys, use a different color to indicate the lock state
       if (currentOSDType === OSD.Type.LockKey) {
-        return LockKeysService.capsLockOn || LockKeysService.numLockOn || LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        // Check the specific lock key that was changed
+        if (lastLockKeyChanged.startsWith("CAPS")) {
+          return LockKeysService.capsLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        } else if (lastLockKeyChanged.startsWith("NUM")) {
+          return LockKeysService.numLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        } else if (lastLockKeyChanged.startsWith("SCROLL")) {
+          return LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        }
       }
       return Color.mPrimary;
     }
@@ -132,7 +139,14 @@ Variants {
         return Color.mError;
 
       if (currentOSDType === OSD.Type.LockKey) {
-        return LockKeysService.capsLockOn || LockKeysService.numLockOn || LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        // Check the specific lock key that was changed
+        if (lastLockKeyChanged.startsWith("CAPS")) {
+          return LockKeysService.capsLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        } else if (lastLockKeyChanged.startsWith("NUM")) {
+          return LockKeysService.numLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        } else if (lastLockKeyChanged.startsWith("SCROLL")) {
+          return LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
+        }
       }
 
       return Color.mOnSurface;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Caps Off OSD color inconsistency with Num Off OSD

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
