### PR TITLE
Prevent empty bar pills from expanding

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -381,7 +381,7 @@
     "plugged-in": "Angeschlossen.",
     "power-profile": "Energieprofil",
     "time-left": "Verbleibende Zeit: {time}.",
-    "time-until-full": "Zeit bis vollständig geladen: {time}."
+    "time-until-full": "Verbleibende Ladezeit: {time}."
   },
   "bluetooth": {
     "panel": {

--- a/Modules/Bar/Widgets/Bluetooth.qml
+++ b/Modules/Bar/Widgets/Bluetooth.qml
@@ -87,7 +87,7 @@ Item {
     }
     autoHide: false
     forceOpen: !isBarVertical && root.displayMode === "alwaysShow"
-    forceClose: isBarVertical || root.displayMode === "alwaysHide"
+    forceClose: isBarVertical || root.displayMode === "alwaysHide" || text == ""
     onClicked: PanelService.getPanel("bluetoothPanel", screen)?.toggle(this)
     onRightClicked: {
       var popupMenuWindow = PanelService.getPopupMenuWindow(screen);

--- a/Modules/Bar/Widgets/WiFi.qml
+++ b/Modules/Bar/Widgets/WiFi.qml
@@ -109,7 +109,7 @@ Item {
     }
     autoHide: false
     forceOpen: !isBarVertical && root.displayMode === "alwaysShow"
-    forceClose: isBarVertical || root.displayMode === "alwaysHide"
+    forceClose: isBarVertical || root.displayMode === "alwaysHide" || text == ""
     onClicked: PanelService.getPanel("wifiPanel", screen)?.toggle(this)
     onRightClicked: {
       var popupMenuWindow = PanelService.getPopupMenuWindow(screen);


### PR DESCRIPTION
This change is intended to prevent the wifi and bluetooth bar widget to expand when hovered but no networks/devices are connected (for horizontal bar positions).