### PR TITLE
fix(launcher): prevent image stretching in clipboard preview

### DIFF
--- a/Modules/Panels/Launcher/ClipboardPreview.qml
+++ b/Modules/Panels/Launcher/ClipboardPreview.qml
@@ -65,6 +65,12 @@ Item {
     }
   }
 
+  Image {
+    id: sizeHelper
+    source: imageDataUrl
+    visible: false
+  }
+
   Rectangle {
     anchors.fill: parent
     color: Color.mSurface || "#f5f5f5"
@@ -95,11 +101,32 @@ Item {
         }
 
         Item {
+          id: imageContainer
           anchors.fill: parent
           anchors.margins: Style.marginS
 
           NImageRounded {
-            anchors.fill: parent
+            id: imagePreview
+            anchors.centerIn: parent
+            
+            readonly property real imageAspect: (sizeHelper.sourceSize.height > 0) ? sizeHelper.sourceSize.width / sizeHelper.sourceSize.height : 1.0
+            readonly property real containerAspect: (imageContainer.height > 0) ? imageContainer.width / imageContainer.height : 1.0
+
+            width: {
+                if (imageAspect > containerAspect) {
+                    return imageContainer.width;
+                } else {
+                    return imageContainer.height * imageAspect;
+                }
+            }
+            height: {
+                if (imageAspect > containerAspect) {
+                    return imageContainer.width / imageAspect;
+                } else {
+                    return imageContainer.height;
+                }
+            }
+
             imagePath: imageDataUrl
             visible: isImageContent && !loadingFullContent && imageDataUrl !== ""
             radius: Style.radiusS


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
fix(launcher): prevent image stretching in clipboard preview

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
