### PR TITLE
LockScreen: Fix missing gap if hibernate is hidden

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -383,6 +383,7 @@ Loader {
                         "en": "dddd, MMMM d",
                         "es": "dddd, d 'de' MMMM",
                         "fr": "dddd d MMMM",
+                        "ja": "yyyy年M月d日 dddd",
                         "nl": "dddd d MMMM",
                         "pt": "dddd, d 'de' MMMM",
                         "zh": "yyyy年M月d日 dddd"


### PR DESCRIPTION
There is no gap between the suspend and restart buttons on the lock screen if hibernate is not shown.