### PR TITLE
Add helper packages for live development in NixOs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
     packages = eachSystem (
       system: {
         default = pkgsFor.${system}.noctalia-shell;
+        noctalia-live-devel = pkgsFor.${system}.callPackage ./nix/noctalia-live-devel.nix {pkgs = pkgsFor.${system};};
+        qs-noctalia = pkgsFor.${system}.callPackage ./nix/qs-noctalia.nix {pkgs = pkgsFor.${system};};
       }
     );
 

--- a/nix/noctalia-live-devel.nix
+++ b/nix/noctalia-live-devel.nix
@@ -1,0 +1,9 @@
+{pkgs, ...}:
+pkgs.writeShellScriptBin "noctalia-live-devel" ''
+  echo "Stopping noctalia-shell service and starting qs"
+  echo "Use qs-noctalia ipc to invoke the dev server or regular service"
+  [ -d ~/.config/quickshell/noctalia-shell ] || echo "error: noctalia-shell repo needs to be in ~/.config/quickshell"
+  systemctl stop --user noctalia-shell
+  trap 'systemctl start --user noctalia-shell; echo "Restarted noctalia-shell service"' EXIT
+  qs -p ~/.config/quickshell/noctalia-shell
+''

--- a/nix/qs-noctalia.nix
+++ b/nix/qs-noctalia.nix
@@ -1,0 +1,8 @@
+{pkgs, ...}:
+pkgs.writeShellScriptBin "qs-noctalia" ''
+  if qs list --all|grep /home/|grep noctalia-shell >/dev/null; then
+  qs -c noctalia-shell "$@"
+  else
+  noctalia-shell "$@"
+  fi
+''

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   quickshell,
   alejandra,
   statix,
@@ -30,5 +31,8 @@ mkShellNoCC {
     # CoC
     lefthook # githooks
     kdePackages.qtdeclarative # qmlfmt, qmllint, qmlls and etc; Qt6
+
+    (pkgs.callPackage ./noctalia-live-devel.nix {inherit pkgs;})
+    (pkgs.callPackage ./qs-noctalia.nix {inherit pkgs;})
   ];
 }


### PR DESCRIPTION
# Pull Request

## Motivation
I found using quickshell's live development capabilities in NixOs need some non-obvious setup. This adds two small helper scripts for easier live development under NixOs.

noctalia-live-devel will shutdown the systemd service for noctalia and start quickshell with the noctalia-shell linked into ~/.config/quickshell/noctalia-shell so live updates can take places. Once qs is exited using C-c the systemd service will be started, again.

qs-noctalia is a drop in replacement for noctalia-shell which detects whether the live server is running and will dispatch all commands to qs with the noctalia config or to noctalia-shell. I install this in NixOs and configure Niri to call qs-noctalia instead of noctalia-shell directly so shortcuts keep working with the live dev server.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Installed noctalia-shell in NixOs, linking my noctalia-shell repo into ~/.config/quickshell/noctalia-shell and editing a few things in noctala like the bar and lock screen and using this for while.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
