### PR TITLE
fix: Bar outer corners automatically enabled when floating is off

### DIFF
--- a/Modules/Panels/Settings/Tabs/BarTab.qml
+++ b/Modules/Panels/Settings/Tabs/BarTab.qml
@@ -117,13 +117,6 @@ ColumnLayout {
     checked: Settings.data.bar.floating
     onToggled: checked => {
                  Settings.data.bar.floating = checked;
-                 if (checked) {
-                   // Disable outer corners when floating is enabled
-                   Settings.data.bar.outerCorners = false;
-                 } else {
-                   // Enable outer corners when floating is disabled
-                   Settings.data.bar.outerCorners = true;
-                 }
                }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation
fix: Bar outer corners automatically enabled when floating is off

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
