### PR TITLE
Fix Brightness Control For Multi GPU/Backlight Devices

### DIFF
--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -269,7 +269,7 @@ Singleton {
               Logger.d("Brightness", "Internal brightness:", devices[0].current + "/" + devices[0].max + " =", monitor.brightness);
               Logger.d("Brightness", "Primary backlight device:", monitor.backlightDevice);
               if (devices.length > 1) {
-                Logger.i("Brightness", "Found", devices.length, "backlight devices, will control all of them");
+                Logger.d("Brightness", "Found", devices.length, "backlight devices, will control all of them");
               }
             }
           }


### PR DESCRIPTION
## Motivation
I use a laptop with both an nvidia dedicated gpu and integrated intel gpu. The brightness controls do not work at all for me because the current system takes the first backlight device it finds in `/sys/class/backlight/` and uses that for brightness control. Each GPU is treated as its own backlight device so when this isn't the gpu that is currently controlling my laptop display the brightness does not change.

The way this change works is just that it will take all internal backlight devices found in `/sys/class/backlight/` and set the brightness on all.
There is also a fallback in the case no device is detected.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #951 

## Testing
I tested it on my own machine and then also disabled one of the backlight devices on my machine to confirm it still works with a single one.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
