### PR TITLE
Display month and year on calendar

### DIFF
--- a/Modules/Cards/CalendarMonthCard.qml
+++ b/Modules/Cards/CalendarMonthCard.qml
@@ -51,6 +51,18 @@ NBox {
       Layout.fillWidth: true
       spacing: Style.marginS
 
+
+      Item {
+        Layout.preferredWidth: Style.marginS
+      }
+
+      NText {
+        text: I18n.locale.monthName(root.calendarMonth, Locale.LongFormat).toUpperCase() + " " + root.calendarYear
+        pointSize: Style.fontSizeM
+        font.weight: Style.fontWeightBold
+        color: Color.white
+      }
+
       NDivider {
         Layout.fillWidth: true
       }


### PR DESCRIPTION
## Motivation
When viewing the calendar and switching months, you cannot see what month you are looking at.
This will display the month and year to the top left of the calendar.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
I have tested it on my machine while clicking around on the calendar controls.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="582" height="516" alt="image" src="https://github.com/user-attachments/assets/1c1810cd-eb9a-4711-b4f1-978de8df822e" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
