### PR TITLE
fix(matugen): foot template & sh implementation

### DIFF
--- a/Assets/MatugenTemplates/Terminal/foot
+++ b/Assets/MatugenTemplates/Terminal/foot
@@ -1,30 +1,24 @@
 [colors]
-background={{ colors.background.default.hex_stripped }}
-foreground={{ colors.on_surface.default.hex_stripped }}
-regular0={{ colors.surface.default.hex_stripped }}
-regular1={{ colors.error.default.hex_stripped }}
-regular2={{ colors.primary.default.hex_stripped }}
-regular3={{ colors.tertiary.default.hex_stripped }}
-regular4={{ colors.on_primary_container.default.hex_stripped }}
-regular5={{ colors.on_secondary_container.default.hex_stripped }}
-regular6={{ colors.secondary.default.hex_stripped }}
-regular7={{ colors.on_surface.default.hex_stripped }}
-bright0={{ colors.surface_bright.default.hex_stripped }}
-bright1={{ colors.error.default.hex_stripped }}
-bright2={{ colors.primary.default.hex_stripped }}
-bright3={{ colors.tertiary.default.hex_stripped }}
-bright4={{ colors.on_primary_container.default.hex_stripped }}
-bright5={{ colors.on_secondary_container.default.hex_stripped }}
-bright6={{ colors.secondary.default.hex_stripped }}
-bright7={{ colors.on_surface.default.hex_stripped }}
-dim0=45475A
-dim1=F38BA8
-dim2=A6E3A1
-dim3=F9E2AF
-dim4=89B4FA
-dim5=F5C2E7
-dim6=94E2D5
-dim7=BAC2DE
-selection-foreground={{ colors.primary.default.hex_stripped }}
-selection-background={{ colors.on_primary.default.hex_stripped }}
-cursor={{ colors.surface_variant.default.hex_stripped }} {{ colors.on_surface.default.hex_stripped }}
+background = {{colors.surface.default.hex_stripped}}
+foreground = {{colors.on_surface.default.hex_stripped}}
+
+selection-background = {{colors.tertiary.default.hex_stripped}}
+selection-foreground = {{colors.on_tertiary.default.hex_stripped}}
+
+regular0 = {{colors.surface_variant.default.hex_stripped}}
+regular1 = {{colors.error.default.hex_stripped}}
+regular2 = {{colors.primary.default.hex_stripped}}
+regular3 = {{colors.secondary.default.hex_stripped}}
+regular4 = {{colors.tertiary.default.hex_stripped}}
+regular5 = {{colors.primary_fixed_dim.default.hex_stripped}}
+regular6 = {{colors.secondary_fixed_dim.default.hex_stripped}}
+regular7 = {{colors.on_surface.default.hex_stripped}}
+
+bright0  = {{colors.on_surface_variant.default.hex_stripped}}
+bright1  = {{colors.error.default.hex_stripped}}
+bright2  = {{colors.primary.default.hex_stripped}}
+bright3  = {{colors.secondary.default.hex_stripped}}
+bright4  = {{colors.tertiary.default.hex_stripped}}
+bright5  = {{colors.primary_fixed_dim.default.hex_stripped}}
+bright6  = {{colors.secondary_fixed_dim.default.hex_stripped}}
+bright7  = {{colors.on_surface.default.hex_stripped}}

--- a/Bin/colors-apply.sh
+++ b/Bin/colors-apply.sh
@@ -55,7 +55,7 @@ EOF
         echo "Created new config file with noctalia theme."
     else
         # Check if theme is already set to noctalia
-        if grep -q "include=~/.config/foot/themes/noctalia" "$CONFIG_FILE"; then
+        if grep -q "include.*noctalia" "$CONFIG_FILE"; then
             echo "Theme already set to noctalia, skipping modification."
         else
             # Remove any existing theme include line to prevent duplicates.


### PR DESCRIPTION
## Motivation

- Foot template are really wrong, taked from here https://github.com/Abhra00/Matuprland/blob/main/matugen/templates/matugen-foot.ini
- colors-apply.sh changes foot.ini despite having the line, which constantly hinders rebuilding in nixos, throwing errors because the linked file in the store has been modified.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
**Foot Term in the left | Ghostty Term in the right**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5a6e098c-8e14-4815-9394-df6a145d681b" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)