### PR TITLE
fix(notification): respect performance mode when playing notification sounds

### DIFF
--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -209,26 +209,16 @@ Singleton {
     playNotificationSound(data.urgency, notification.appName);
   }
 
-  // Function to play notification sound using existing SoundService
   function playNotificationSound(urgency, appName) {
-    // Rate limiting - prevent sound spam
-    const now = Date.now();
-    if (now - lastSoundTime < minSoundInterval) {
-      return;
-    }
-    lastSoundTime = now;
-
-    // Check if QtMultimedia is available
     if (!SoundService.multimediaAvailable) {
       return;
     }
-
-    // Check if notification sounds are enabled
     if (!Settings.data.notifications?.sounds?.enabled) {
       return;
     }
-
-    // Check if this app should be excluded
+    if (AudioService.muted) {
+      return;
+    }
     if (appName) {
       const excludedApps = Settings.data.notifications.sounds.excludedApps || "";
       if (excludedApps.trim() !== "") {
@@ -242,11 +232,6 @@ Singleton {
       }
     }
 
-    // Check if system is muted
-    if (AudioService.muted) {
-      return;
-    }
-
     // Get the sound file for this urgency level
     const soundFile = getNotificationSoundFile(urgency);
     if (!soundFile || soundFile.trim() === "") {
@@ -254,6 +239,13 @@ Singleton {
       Logger.i("NotificationService", `No sound file configured for urgency ${urgency}`);
       return;
     }
+
+    // Rate limiting - prevent sound spam
+    const now = Date.now();
+    if (now - lastSoundTime < minSoundInterval) {
+      return;
+    }
+    lastSoundTime = now;
 
     // Play sound using existing SoundService
     const volume = Settings.data.notifications?.sounds?.volume ?? 0.5;


### PR DESCRIPTION
### 🚀 Motivation and Context

Notification sounds were playing before checking the system's performance mode setting. This caused notification sounds to play even when performance mode was enabled.

The changes reorder the notification handling logic to respect the performance mode setting by:
- Moving the performance mode check to occur immediately after history tracking
- Ensuring no notification processing (including sound) occurs when performance mode is active
- Calling playNotificationSound() only after all validation checks pass
- Maintaining proper rate limiting and exclusion logic within the sound function

### 🔗 Related Topics

- #935

### 📋 Checklist for Reviewer

- [x] Tests passed locally.
- [x] Commit history is clean and descriptive.
- [x] Documentation updated (if applicable).
- [x] Code quality standards were met (e.g., linter passed).