### PR TITLE
Nix: add `wget` dependency

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,6 +14,7 @@
   wlsunset,
   wl-clipboard,
   imagemagick,
+  wget,
   gpu-screen-recorder, # optional
 }: let
   src = lib.cleanSourceWith {
@@ -45,6 +46,7 @@
       wlsunset
       wl-clipboard
       imagemagick
+      wget
     ]
     ++ lib.optionals (stdenvNoCC.hostPlatform.system == "x86_64-linux") [
       gpu-screen-recorder


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Here curl does not work, only wget works
<img width="806" height="533" alt="图片" src="https://github.com/user-attachments/assets/9411cba2-96ee-416e-a018-63632478875a" />

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
