### PR TITLE
fix(plugin): Ensure button heights properly scale with UI scaling

### DIFF
--- a/Modules/Panels/Settings/Tabs/PluginsTab.qml
+++ b/Modules/Panels/Settings/Tabs/PluginsTab.qml
@@ -338,6 +338,7 @@ ColumnLayout {
           addSourceDialog.open();
         }
         Layout.fillWidth: true
+        Layout.maximumWidth: 490 * Style.uiScaleRatio
       }
     }
   }
@@ -373,6 +374,7 @@ ColumnLayout {
         text: I18n.tr("settings.plugins.filter.not-downloaded")
         Layout.fillWidth: true
         Layout.preferredWidth: 1
+        height: Style.baseWidgetSize * 1.2 * Style.uiScaleRatio
         backgroundColor: pluginFilter === "notDownloaded" ? Color.mPrimary : Color.mSurface
         textColor: pluginFilter === "notDownloaded" ? Color.mOnPrimary : Color.mOnSurfaceVariant
         onClicked: pluginFilter = "notDownloaded"
@@ -382,7 +384,7 @@ ColumnLayout {
     NIconButton {
       icon: "refresh"
       tooltipText: I18n.tr("settings.plugins.refresh.tooltip")
-      baseSize: Style.baseWidgetSize * 1.1
+      baseSize: Style.baseWidgetSize
       Layout.alignment: Qt.AlignVCenter
       onClicked: {
         PluginService.refreshAvailablePlugins();

--- a/Widgets/NButton.qml
+++ b/Widgets/NButton.qml
@@ -34,7 +34,7 @@ Rectangle {
 
   // Dimensions
   implicitWidth: contentRow.implicitWidth + (Style.marginL * 2)
-  implicitHeight: Math.max(Style.baseWidgetSize, contentRow.implicitHeight + (Style.marginM))
+  implicitHeight: Math.max(Style.baseWidgetSize * Style.uiScaleRatio, contentRow.implicitHeight + (Style.marginM))
 
   // Appearance
   radius: root.buttonRadius


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Ensure button heights properly scale with UI scaling

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="451" height="655" alt="图片" src="https://github.com/user-attachments/assets/4dee4537-07e5-4023-aae5-12f81d55155a" />

after
<img width="453" height="619" alt="图片" src="https://github.com/user-attachments/assets/2f57a92b-c24c-4351-8bdf-b19b60b95ea9" />


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
