### PR TITLE
Add yazi template

### DIFF
--- a/Assets/MatugenTemplates/yazi.toml
+++ b/Assets/MatugenTemplates/yazi.toml
@@ -1,0 +1,170 @@
+# : Manager [[[
+
+[mgr]
+cwd = { fg = "{{colors.on_surface.default.hex}}" }
+
+# Tab
+tab_active = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.primary.default.hex}}", bold = true }
+tab_inactive = { fg = "{{colors.primary_container.default.hex}}", bg = "{{colors.on_primary_container.default.hex}}" }
+tab_width = 1
+
+# Find
+find_keyword = { fg = "{{colors.error.default.hex}}", bold = true, italic = true, underline = true }
+find_position = { fg = "{{colors.error.default.hex}}", bold = true, italic = true }
+
+# Marker
+marker_copied = { fg = "{{colors.tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
+marker_cut = { fg = "{{colors.tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
+marker_marked = { fg = "{{colors.error.default.hex}}", bg = "{{colors.error.default.hex}}" }
+marker_selected = { fg = "{{colors.tertiary.default.hex}}", bg = "{{colors.tertiary.default.hex}}" }
+
+# Count
+count_copied = { fg = "{{colors.on_tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
+count_cut = { fg = "{{colors.on_tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
+count_selected = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.tertiary.default.hex}}" }
+
+# Border
+border_style  = { fg = "{{colors.primary.default.hex}}" }
+
+# : ]]]
+
+
+# : Status [[[
+
+[status]
+separator_style = { bg = "{{colors.on_primary.default.hex}}", fg = "#F4A261" }
+
+[mode]
+# Mode
+normal_main = { bg = "{{colors.primary.default.hex}}", fg = "{{colors.on_primary.default.hex}}", bold = true }
+normal_alt  = { bg = "{{colors.surface_variant.default.hex}}", fg = "{{colors.on_surface_variant.default.hex}}" }
+
+# Select mode
+select_main = { bg = "{{colors.secondary.default.hex}}", fg = "{{colors.on_secondary.default.hex}}", bold = true }
+select_alt  = { bg = "{{colors.surface_variant.default.hex}}", fg = "{{colors.on_surface_variant.default.hex}}" }
+
+# Unset mode
+unset_main = { bg = "{{colors.tertiary.default.hex}}", fg = "{{colors.on_tertiary.default.hex}}", bold = true }
+unset_alt  = { bg = "{{colors.surface_variant.default.hex}}", fg = "{{colors.on_surface_variant.default.hex}}" }
+
+# Progress
+progress_label = { bold = true }
+progress_normal = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.surface.default.hex}}" }
+progress_error = { fg = "{{colors.error.default.hex}}", bg = "{{colors.surface.default.hex}}" }
+
+# Permissions
+permissions_t = { fg = "{{colors.secondary.default.hex}}" }
+permissions_w = { fg = "{{colors.tertiary.default.hex}}" }
+permissions_x = { fg = "{{colors.error.default.hex}}" }
+permissions_r = { fg = "{{colors.tertiary_container.default.hex}}" }
+permissions_s = { fg = "{{colors.primary_container.default.hex}}" }
+
+# : ]]]
+
+
+# : Select [[[
+
+[select]
+border = { fg = "{{colors.primary.default.hex}}" }
+active = { fg = "{{colors.tertiary.default.hex}}", bold = true }
+
+# : ]]]
+
+
+# : Input [[[
+
+[input]
+border = { fg = "{{colors.primary.default.hex}}" }
+value = { fg = "{{colors.on_surface.default.hex}}" }
+
+# : ]]]
+
+# : Tabs [[[
+
+[tabs]
+active = { fg = "{{colors.primary.default.hex}}", bold = true, bg = "{{colors.surface.default.hex}}" }
+inactive = { fg = "{{colors.secondary.default.hex}}", bg = "{{colors.surface.default.hex}}" }
+sep_inner = { open = "[", close = "]" }
+
+# : ]]]
+
+
+# : Completion [[[
+
+[completion]
+border = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.on_primary.default.hex}}" }
+
+# : ]]]
+
+
+# : Tasks [[[
+
+[tasks]
+border = { fg = "{{colors.primary.default.hex}}" }
+title = {}
+hovered = { fg = "{{colors.tertiary_container.default.hex}}", underline = true }
+
+# : ]]]
+
+
+# : Which [[[
+
+[which]
+cols = 3
+mask = { bg = "{{colors.surface.default.hex}}" }
+cand = { fg = "{{colors.primary.default.hex}}" }
+rest = { fg = "{{colors.on_primary.default.hex}}" }
+desc = { fg = "{{colors.on_surface.default.hex}}" }
+separator = " ▶ "
+separator_style = { fg = "{{colors.on_surface.default.hex}}" }
+
+# : ]]]
+
+
+# : Help [[[
+
+[help]
+on = { fg = "{{colors.on_surface.default.hex}}" }
+run = { fg = "{{colors.on_surface.default.hex}}" }
+footer = { fg = "{{colors.on_secondary.default.hex}}", bg = "{{colors.secondary.default.hex}}" }
+
+# : ]]]
+
+
+# : Notify [[[
+
+[notify]
+title_info = { fg = "{{colors.tertiary.default.hex}}" }
+title_warn = { fg = "{{colors.primary.default.hex}}" }
+title_error = { fg = "{{colors.error.default.hex}}" }
+
+# : ]]]
+
+
+# : File-specific styles [[[
+
+[filetype]
+
+rules = [
+    # Images
+    { mime = "image/*", fg = "#94e2d5" },
+
+    # Media
+    { mime = "{audio,video}/*", fg = "#f9e2af" },
+
+    # Archives
+    { mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", fg = "#f5c2e7" },
+
+    # Documents
+    { mime = "application/{pdf,doc,rtf}", fg = "#a6e3a1" },
+
+    # Special files
+    { name = "*", is = "orphan", bg = "{{colors.error_container.default.hex}}" },
+    { name = "*", is = "exec", fg = "{{colors.on_error_container.default.hex}}" },
+
+    # Fallback
+    { name = "*", fg = "{{colors.on_surface.default.hex}}" },
+    { name = "*/", fg = "{{colors.primary.default.hex}}" },
+]
+
+# : ]]]

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1144,6 +1144,10 @@
             "description": "Write {filepath}",
             "description-missing": "Requires {app} to be installed"
           },
+          "yazi": {
+            "description": "Write {filepath}. Flavor needs to be activated manually.",
+            "description-missing": "Requires {app} to be installed"
+          },
           "code": {
             "description": "Write {filepath}. Hyprluna theme needs to be installed and activated manually",
             "description-missing": "No Code client detected. Install VSCode or VSCodium"

--- a/Assets/Translations/tr.json
+++ b/Assets/Translations/tr.json
@@ -1144,6 +1144,10 @@
             "description": "{filepath} dosyasına yaz.",
             "description-missing": "Kurulum için {app} gereklidir"
           },
+          "yazi": {
+            "description": "{filepath} dosyasına yaz. Temanın manuel etkinleştirilmesi gerekir.",
+            "description-missing": "Kurulum için {app} gereklidir"
+          },
           "code": {
             "description": "{filepath} dosyasına yaz. Hyprluna temasının kurulu ve manuel olarak etkinleştirilmiş olması gerekir.",
             "description-missing": "Code istemcisi tespit edilmedi. VSCode veya VSCodium kurun."

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -579,6 +579,7 @@ Singleton {
       property bool spicetify: false
       property bool telegram: false
       property bool cava: false
+      property bool yazi: false
       property bool emacs: false
       property bool niri: false
       property bool enableUserTemplates: false

--- a/Modules/Panels/Settings/Tabs/ColorScheme/ColorSchemeTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/ColorSchemeTab.qml
@@ -896,6 +896,24 @@ ColumnLayout {
       }
 
       NCheckbox {
+        label: "Yazi"
+        description: ProgramCheckerService.yaziAvailable ? I18n.tr("settings.color-scheme.templates.programs.yazi.description", {
+                                                                     "filepath": "~/.config/yazi/flavors/noctalia.yazi/flavor.toml"
+                                                                   }) : I18n.tr("settings.color-scheme.templates.programs.yazi.description-missing", {
+                                                                                  "app": "yazi"
+                                                                                })
+        checked: Settings.data.templates.yazi
+        enabled: ProgramCheckerService.yaziAvailable
+        opacity: ProgramCheckerService.yaziAvailable ? 1.0 : 0.6
+        onToggled: checked => {
+                     if (ProgramCheckerService.yaziAvailable) {
+                       Settings.data.templates.yazi = checked;
+                       AppThemeService.generate();
+                     }
+                   }
+      }
+
+      NCheckbox {
         label: "Emacs"
         description: ProgramCheckerService.emacsAvailable ? "Doom: ~/.config/doom/themes/noctalia.el\nStandard: ~/.emacs.d/themes/noctalia.el\n\nApply manually: (load-theme 'noctalia t)" : I18n.tr("settings.color-scheme.templates.programs.emacs.description-missing", {
                                                                                                                                                                                                        "app": "emacs"

--- a/Services/System/ProgramCheckerService.qml
+++ b/Services/System/ProgramCheckerService.qml
@@ -29,6 +29,7 @@ Singleton {
   property bool spicetifyAvailable: false
   property bool telegramAvailable: false
   property bool cavaAvailable: false
+  property bool yaziAvailable: false
   property bool emacsAvailable: false
   property bool niriAvailable: false
 
@@ -188,6 +189,7 @@ Singleton {
                                             "spicetifyAvailable": ["which", "spicetify"],
                                             "telegramAvailable": ["sh", "-c", "command -v telegram-desktop >/dev/null 2>&1 || command -v Telegram >/dev/null 2>&1 || (command -v flatpak >/dev/null 2>&1 && flatpak list --app | grep -q 'org.telegram.desktop')"],
                                             "cavaAvailable": ["which", "cava"],
+                                            "yaziAvailable": ["which", "yazi"],
                                             "emacsAvailable": ["sh", "-c", "test -d \"$HOME/.config/doom\" || test -d \"$HOME/.emacs.d\""],
                                             "niriAvailable": ["which", "niri"]
                                           })

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -233,6 +233,17 @@ Singleton {
       "postProcess": () => `${colorsApplyScript} cava`
     },
     {
+      "id": "yazi",
+      "name": "Yazi",
+      "category": "applications",
+      "input": "yazi.toml",
+      "outputs": [
+        {
+          "path": "~/.config/yazi/flavors/noctalia.yazi/flavor.toml"
+        }
+      ]
+    },
+    {
       "id": "emacs",
       "name": "Emacs",
       "category": "applications",


### PR DESCRIPTION
# Pull Request

## Motivation
Yazi is a good TUI file manager, I wanted to add it into the shell itself. I think it is needed and many people use it.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1036

## Testing
Tested with different colorschemes, works well. Haven't tested widely with light themes.

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/f928b88e-5957-4488-b9bc-82802b041a7b" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
- I added a Turkish translation for the description since I'm native Turkish speaker.

- I had to edit the default matugen yazi template which does not worked out of box.

- User needs to activate the theme manually from ``~/.config/yazi/theme.toml``, the theme does not override anything.

```toml
# ~/.config/yazi/theme.toml
[flavor]
dark = "noctalia"
```