### PR TITLE
NSearchableComboBox: fix infinite loop causing CPU spike

### DIFF
--- a/Widgets/NSearchableComboBox.qml
+++ b/Widgets/NSearchableComboBox.qml
@@ -29,6 +29,7 @@ RowLayout {
   // Filtered model for search results
   property ListModel filteredModel: ListModel {}
   property string searchText: ""
+  property bool isFiltering: false
 
   function findIndexByKey(key) {
     for (var i = 0; i < root.model.count; i++) {
@@ -49,10 +50,14 @@ RowLayout {
   }
 
   function filterModel() {
+    if (isFiltering) return;
+    isFiltering = true;
+
     filteredModel.clear();
 
     // Check if model exists and has items
     if (!root.model || root.model.count === undefined || root.model.count === 0) {
+      isFiltering = false;
       return;
     }
 
@@ -91,6 +96,8 @@ RowLayout {
         }
       }
     }
+    
+    isFiltering = false;
   }
 
   onSearchTextChanged: filterModel()


### PR DESCRIPTION
Added re-entrancy guard to filterModel() to prevent infinite recursion. The Connections block watching model.onCountChanged was triggering filterModel() which modified filteredModel.count, causing a feedback loop resulting in 100% CPU usage and system freeze.

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
