### PR TITLE
Launcher: make numpad enter call ui.activate again

### DIFF
--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -645,7 +645,10 @@ SmartPanel {
                 } else if (event.key === Qt.Key_Down) {
                   root.onDownPressed();
                   event.accepted = true;
-                }
+                } else if (event.key === Qt.Key_Enter) {
+                  root.activate();
+                  event.accepted = true;
+                }
               });
             }
           }


### PR DESCRIPTION
# Pull Request

## Motivation
Makes numpad enter activate launcher entries

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This was added back in 8065de8 but is now gone since the refactor.
