### PR TITLE
added logout for labwc and workspaces

### DIFF
--- a/Services/Compositor/LabwcService.qml
+++ b/Services/Compositor/LabwcService.qml
@@ -100,11 +100,28 @@ Item {
   }
 
   function switchToWorkspace(workspace) {
-    Logger.w("LabwcService", "Workspace switching not supported via ToplevelManager");
+    try {
+      const workspaceNum = workspace.idx || workspace.id || 1;
+      // LabWC does not support direct IPC for workspace switching.
+      // Workspace switching is done through keybindings configured in rc.xml.
+      // As a workaround, we simulate Super+[number] keypress using ydotool or wtype.
+      // This assumes the user has configured GoToDesktop keybindings like:
+      // <keybind key="W-1"><action name="GoToDesktop" to="1" /></keybind>
+      const keyCode = workspaceNum + 1; // ydotool: 2=1, 3=2, etc.
+      Quickshell.execDetached(["sh", "-c", `ydotool key 125:1 ${keyCode}:1 ${keyCode}:0 125:0 2>/dev/null || wtype -M logo -P ${workspaceNum} -m logo 2>/dev/null`]);
+    } catch (e) {
+      Logger.e("LabwcService", "Failed to switch workspace:", e);
+      Logger.w("LabwcService", "Workspace switching requires ydotool or wtype and configured keybindings in rc.xml");
+    }
   }
 
   function logout() {
-    Logger.w("LabwcService", "Logout not directly supported");
+    try {
+      // Exit labwc by sending SIGTERM to $LABWC_PID or using --exit flag
+      Quickshell.execDetached(["sh", "-c", "labwc --exit || kill -s SIGTERM $LABWC_PID"]);
+    } catch (e) {
+      Logger.e("LabwcService", "Failed to logout:", e);
+    }
   }
 
   function queryDisplayScales() {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

 Summary of What Changed

  Services/Compositor/LabwcService.qml - Lines 117-124:

  The logout function went from:
```
  function logout() {
    Logger.w("LabwcService", "Logout not directly supported");
  }
```
  To:
```
  function logout() {
    try {
      // Exit labwc by sending SIGTERM to $LABWC_PID or using --exit flag
      Quickshell.execDetached(["sh", "-c", "labwc --exit || kill -s SIGTERM $LABWC_PID"]);
    } catch (e) {
      Logger.e("LabwcService", "Failed to logout:", e);
    }
  }
```

  This matches the pattern used in the other compositor services
  (HyprlandService.qml:460-466, SwayService.qml:373-379, NiriService.qml:418-424,
  MangoService.qml:673-675).

workspaces needed one of two apps,  ydotool or wtype, and as such the code can be removed or the user can add in the install, the logout functionality is solid and tested - it uses labwc's official exit mechanism.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested on Labwc
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
i just updated my code is all, if you don't like adding in the additional needed dependency of ydotool or wtype, then feel free to remove the code after merge.  if my formatting is different from yours then i apologize. 
