### PR TITLE
feat(taskbar): adjust smart title width calculation logic

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -61,19 +61,21 @@ Item {
   }
 
   readonly property int titleWidth: {
-    if (smartWidth && showTitle && !isVerticalBar && combinedModel.length > 0) {
-      var entriesCount = combinedModel.length;
-      var baseWidth = 140;
-      var calculatedWidth = baseWidth / Math.sqrt(entriesCount);
+    // First, use user-defined title width if set
+    var calculatedWidth = (widgetSettings.titleWidth !== undefined) ? widgetSettings.titleWidth : widgetMetadata.titleWidth;
 
+    // Second, shrink title width if it exceeds maxTaskbarWidth when smartWidth is enabled
+    if (smartWidth && combinedModel.length > 0) {
       if (maxTaskbarWidth > 0) {
+        var entriesCount = combinedModel.length;
         var maxWidthPerEntry = (maxTaskbarWidth / entriesCount) - itemSize - Style.marginS - Style.marginXL;
         calculatedWidth = Math.min(calculatedWidth, maxWidthPerEntry);
       }
 
-      return Math.max(Math.round(calculatedWidth), 20);
+      calculatedWidth = Math.max(Math.round(calculatedWidth), 20);
     }
-    return (widgetSettings.titleWidth !== undefined) ? widgetSettings.titleWidth : widgetMetadata.titleWidth;
+
+    return calculatedWidth;
   }
   readonly property bool showPinnedApps: (widgetSettings.showPinnedApps !== undefined) ? widgetSettings.showPinnedApps : widgetMetadata.showPinnedApps
 

--- a/Modules/Panels/Settings/Bar/WidgetSettings/TaskbarSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/TaskbarSettings.qml
@@ -124,6 +124,16 @@ ColumnLayout {
     enabled: !isVerticalBar
   }
 
+  NTextInput {
+    id: titleWidthInput
+    visible: root.valueShowTitle && !isVerticalBar
+    Layout.fillWidth: true
+    label: I18n.tr("bar.taskbar.title-width-label")
+    description: I18n.tr("bar.taskbar.title-width-description")
+    text: widgetData.titleWidth || widgetMetadata.titleWidth
+    placeholderText: I18n.tr("placeholders.enter-width-pixels")
+  }
+
   NToggle {
     Layout.fillWidth: true
     visible: !isVerticalBar && root.valueShowTitle
@@ -144,15 +154,5 @@ ColumnLayout {
     value: root.valueMaxTaskbarWidth
     onMoved: value => root.valueMaxTaskbarWidth = Math.round(value)
     text: Math.round(root.valueMaxTaskbarWidth) + "%"
-  }
-
-  NTextInput {
-    id: titleWidthInput
-    visible: root.valueShowTitle && !isVerticalBar && !root.valueSmartWidth
-    Layout.fillWidth: true
-    label: I18n.tr("bar.taskbar.title-width-label")
-    description: I18n.tr("bar.taskbar.title-width-description")
-    text: widgetData.titleWidth || widgetMetadata.titleWidth
-    placeholderText: I18n.tr("placeholders.enter-width-pixels")
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

This PR improves the smart title width feature by decoupling the title width setting from the smart width setting, allowing users to customize the title width while enabling smart width.

When smart width is disabled, the title width is used directly as a fixed width. When smart width is enabled, the title width serves as the base width and will be reduced when the taskbar exceeds the maximum width limit.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

Nope

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Nope

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

Nope