### PR TITLE
feat(niri): adjust window sorting logic

### DIFF
--- a/Services/Compositor/NiriService.qml
+++ b/Services/Compositor/NiriService.qml
@@ -22,11 +22,15 @@ Item {
   signal windowListChanged
   signal displayScalesChanged
 
+  property var outputCache: ({})
+  property var workspaceCache: ({})
+
   function initialize() {
     niriEventStream.connected = true;
     niriCommandSocket.connected = true;
 
     startEventStream();
+    updateOutputs();
     updateWorkspaces();
     updateWindows();
     queryDisplayScales();
@@ -43,6 +47,10 @@ Item {
     sendSocketCommand(niriEventStream, "EventStream");
   }
 
+  function updateOutputs() {
+    sendSocketCommand(niriCommandSocket, "Outputs");
+  }
+
   function updateWorkspaces() {
     sendSocketCommand(niriCommandSocket, "Workspaces");
   }
@@ -57,6 +65,7 @@ Item {
 
   function recollectOutputs(outputsData) {
     const scales = {};
+    outputCache = {};
 
     for (const outputName in outputsData) {
       const output = outputsData[outputName];
@@ -66,7 +75,7 @@ Item {
         const modes = output.modes || [];
         const currentMode = modes[currentModeIdx] || {};
 
-        scales[output.name] = {
+        const outputData = {
           "name": output.name,
           "scale": logical.scale || 1.0,
           "width": logical.width || 0,
@@ -80,6 +89,9 @@ Item {
           "vrr_enabled": output.vrr_enabled || false,
           "transform": logical.transform || "Normal"
         };
+
+        scales[output.name] = outputData;
+        outputCache[output.name] = outputData;
       }
     }
 
@@ -90,18 +102,22 @@ Item {
 
   function recollectWorkspaces(workspacesData) {
     const workspacesList = [];
+    workspaceCache = {};
 
     for (const ws of workspacesData) {
-      workspacesList.push({
-                            "id": ws.id,
-                            "idx": ws.idx,
-                            "name": ws.name || "",
-                            "output": ws.output || "",
-                            "isFocused": ws.is_focused === true,
-                            "isActive": ws.is_active === true,
-                            "isUrgent": ws.is_urgent === true,
-                            "isOccupied": ws.active_window_id ? true : false
-                          });
+      const wsData = {
+        "id": ws.id,
+        "idx": ws.idx,
+        "name": ws.name || "",
+        "output": ws.output || "",
+        "isFocused": ws.is_focused === true,
+        "isActive": ws.is_active === true,
+        "isUrgent": ws.is_urgent === true,
+        "isOccupied": ws.active_window_id ? true : false
+      }
+
+      workspacesList.push(wsData);
+      workspaceCache[ws.id] = wsData;
     }
 
     workspacesList.sort((a, b) => {
@@ -226,14 +242,42 @@ Item {
     };
   }
 
-  function compareWindows(a, b) {
-    if (a.workspaceId !== b.workspaceId) {
-      return a.workspaceId - b.workspaceId;
-    }
-    if (a.position.x !== b.position.x) {
-      return a.position.x - b.position.x;
-    }
-    return a.position.y - b.position.y;
+  function toSortedWindowList(windowList) {
+    return windowList
+      .map(win => {
+        const workspace = workspaceCache[win.workspaceId];
+        const output = (workspace && workspace.output) ? outputCache[workspace.output] : null;
+
+        return {
+          window: win,
+          workspaceIdx: workspace ? workspace.idx : 0,
+          outputX: output ? output.x : 0,
+          outputY: output ? output.y : 0,
+        };
+      })
+      .sort((a, b) => {
+        // Sort by output position first
+        if (a.outputX !== b.outputX) {
+          return a.outputX - b.outputX;
+        }
+        if (a.outputY !== b.outputY) {
+          return a.outputY - b.outputY;
+        }
+        // Then by workspace index
+        if (a.workspaceIdx !== b.workspaceIdx) {
+          return a.workspaceIdx - b.workspaceIdx;
+        }
+        // Then by window position
+        if (a.window.position.x !== b.window.position.x) {
+          return a.window.position.x - b.window.position.x;
+        }
+        if (a.window.position.y !== b.window.position.y) {
+          return a.window.position.y - b.window.position.y;
+        }
+        // Finally by window ID to ensure consistent ordering
+        return a.window.id - b.window.id;
+      })
+      .map(info => info.window);
   }
 
   function recollectWindows(windowsData) {
@@ -241,8 +285,7 @@ Item {
     for (const win of windowsData) {
       windowsList.push(getWindowData(win));
     }
-    windowsList.sort(compareWindows);
-    windows = windowsList;
+    windows = toSortedWindowList(windowsList);
     windowListChanged();
 
     focusedWindowIndex = -1;
@@ -266,7 +309,7 @@ Item {
       } else {
         windows.push(newWindow);
       }
-      windows.sort(compareWindows);
+      windows = toSortedWindowList(windows);
 
       if (newWindow.isFocused) {
         const oldFocusedIndex = focusedWindowIndex;
@@ -353,7 +396,7 @@ Item {
         }
       }
 
-      windows.sort(compareWindows);
+      windows = toSortedWindowList(windows);
 
       windowListChanged();
     } catch (e) {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

This PR adjusts the window ordering logic under the Niri compositor to be more intuitive for users.

The specific sorting rules are as follows:

1. First, sort by monitor position
2. Next, sort by workspace order
3. Then, sort by window position
4. Finally, sort by window ID to ensure consistent ordering

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

Nope

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Nope

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

Nope
