### PR TITLE
Fix VSCode theming

### DIFF
--- a/Modules/Panels/Settings/Tabs/ColorScheme/ColorSchemeTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/ColorSchemeTab.qml
@@ -812,7 +812,7 @@ ColumnLayout {
               var clientName = client.name === "code" ? "VSCode" : "VSCodium";
               clientInfo.push(clientName);
             }
-            return "Detected: " + clientInfo.join(", ");
+            return "Applied to default profile. Detected: " + clientInfo.join(", ");
           }
         }
         Layout.fillWidth: true
@@ -823,6 +823,18 @@ ColumnLayout {
                      // Set unified code property
                      Settings.data.templates.code = checked;
                      if (ProgramCheckerService.availableCodeClients.length > 0) {
+                       if (!checked) {
+                         const homeDir = Quickshell.env("HOME");
+                         for (var i = 0; i < ProgramCheckerService.availableCodeClients.length; i++) {
+                           var client = ProgramCheckerService.availableCodeClients[i];
+                           var configDir = client.name === "code" ? "Code" : "VSCodium";
+                           var settingsPath = `${homeDir}/.config/${configDir}/User/settings.json`;
+
+                           // Reset to Visual Studio Dark before uninstalling
+                           Quickshell.execDetached(["sh", "-c", `sed -i 's/"workbench.colorTheme":[[:space:]]*"[^"]*"/"workbench.colorTheme": "Visual Studio Dark"/' "${settingsPath}"`]);
+                           Quickshell.execDetached([client.name, "--uninstall-extension", "undefined_publisher.noctaliatheme"]);
+                         }
+                       }
                        AppThemeService.generate();
                      }
                    }

--- a/Services/Theming/TemplateProcessor.qml
+++ b/Services/Theming/TemplateProcessor.qml
@@ -129,7 +129,7 @@ Singleton {
                                                                         var configDir = client.name === "code" ? "Code" : "VSCodium";
                                                                         var settingsPath = `${homeDir}/.config/${configDir}/User/settings.json`;
 
-                                                                        // Uninstall/reinstall with modified vsix forces theme reload
+                                                                        // Uninstall/reinstall with modified vsix to force theme reload
                                                                         var tmpDir = `/tmp/noctalia-vscode-${client.name}`;
                                                                         var modifiedVsix = `${tmpDir}/noctaliatheme.vsix`;
                                                                         var reinstallVsix = `if command -v ${client.name} >/dev/null 2>&1; then ${client.name} --uninstall-extension undefined_publisher.noctaliatheme 2>&1; rm -rf ${tmpDir} && mkdir -p ${tmpDir} && unzip -q '${Quickshell.shellDir}/Assets/MatugenTemplates/noctaliatheme-0.0.1.vsix' -d ${tmpDir} && cp '${expandedPath}' ${tmpDir}/extension/themes/NoctaliaTheme-color-theme.json && cd ${tmpDir} && zip -q -r ${modifiedVsix} . && ${client.name} --install-extension ${modifiedVsix} 2>&1 && rm -rf ${tmpDir}; fi`;
@@ -282,29 +282,29 @@ Singleton {
                               var tmpTheme = `${tmpDir}/theme.json`;
                               var modifiedVsix = `${tmpDir}/noctaliatheme.vsix`;
 
-                              script += `\n`;
-                              script += `if [ -d "${baseConfigDir}" ]; then\n`;
-                              script += `  if command -v ${client.name} >/dev/null 2>&1; then\n`;
-
                               // Generate theme, uninstall, modify vsix, reinstall
-                              script += `    rm -rf ${tmpDir} && mkdir -p ${tmpDir}\n`;
-                              script += `    cp '${templatePath}' '${tmpTheme}'\n`;
-                              script += `    ${replaceColorsInFile(tmpTheme, palette)}`;
-                              script += `    ${client.name} --uninstall-extension undefined_publisher.noctaliatheme 2>&1\n`;
-                              script += `    unzip -q '${Quickshell.shellDir}/Assets/MatugenTemplates/noctaliatheme-0.0.1.vsix' -d ${tmpDir}\n`;
-                              script += `    cp '${tmpTheme}' ${tmpDir}/extension/themes/NoctaliaTheme-color-theme.json\n`;
-                              script += `    cd ${tmpDir} && zip -q -r ${modifiedVsix} .\n`;
-                              script += `    ${client.name} --install-extension ${modifiedVsix} 2>&1\n`;
-                              script += `    rm -rf ${tmpDir}\n`;
-                              
-                              // Update settings.json
-                              script += `    if [ -f "${settingsPath}" ]; then\n`;
-                              script += `      sed -i 's/\\"workbench.colorTheme\\":[[:space:]]*\\"[^\\"]*/\\"workbench.colorTheme\\": \\"NoctaliaTheme/' "${settingsPath}"\n`;
-                              script += `    fi\n`;
-                              script += `  fi\n`;
-                              script += `else\n`;
-                              script += `  echo "Code client ${client.name} not found at ${baseConfigDir}, skipping"\n`;
-                              script += `fi\n`;
+                              script += `
+                                if [ -d "${baseConfigDir}" ]; then
+                                  if command -v ${client.name} >/dev/null 2>&1; then
+
+                                    rm -rf ${tmpDir} && mkdir -p ${tmpDir}
+                                    cp '${templatePath}' '${tmpTheme}'
+                                    ${replaceColorsInFile(tmpTheme, palette)}
+                                    ${client.name} --uninstall-extension undefined_publisher.noctaliatheme 2>&1
+                                    unzip -q '${Quickshell.shellDir}/Assets/MatugenTemplates/noctaliatheme-0.0.1.vsix' -d ${tmpDir}
+                                    cp '${tmpTheme}' ${tmpDir}/extension/themes/NoctaliaTheme-color-theme.json
+                                    cd ${tmpDir} && zip -q -r ${modifiedVsix} .
+                                    ${client.name} --install-extension ${modifiedVsix} 2>&1
+                                    rm -rf ${tmpDir}
+                                
+                                    if [ -f "${settingsPath}" ]; then
+                                      sed -i 's/\\"workbench.colorTheme\\":[[:space:]]*\\"[^\\"]*/\\"workbench.colorTheme\\": \\"NoctaliaTheme/' "${settingsPath}"
+                                    fi
+                                  fi
+                                else
+                                  echo "Code client ${client.name} not found at ${baseConfigDir}, skipping"
+                                fi
+                              `;
                             });
 
     return script;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

Fixes VSCode theme settings not being applied correctly + theme extension not installed in all cases

Also re-installs extension to force VSCode to load the new theme, feels slightly hacky to me but otherwise the new theme can't be previewed without manually reloading VSCode after every change

Previous (`sed` replacement was done incorrectly):
<img width="390" height="196" alt="image" src="https://github.com/user-attachments/assets/152ee555-799e-48e3-bebf-d047afbf6312" />

Fixed:
<img width="403" height="183" alt="image" src="https://github.com/user-attachments/assets/c347bf1d-084c-449a-9fd3-556377e557e8" />

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway

N/A:
~~Tested with different bar positions and density settings~~
~~Tested at different interface scaling values~~
~~Tested with multiple monitors (if applicable)~~

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
