### PR TITLE
Fix empty space when hiding widgets

### DIFF
--- a/Modules/Bar/Widgets/AudioVisualizer.qml
+++ b/Modules/Bar/Widgets/AudioVisualizer.qml
@@ -58,6 +58,7 @@ Item {
   implicitWidth: !shouldShow ? 0 : isVerticalBar ? Style.capsuleHeight : visualizerWidth
   implicitHeight: !shouldShow ? 0 : isVerticalBar ? visualizerWidth : Style.capsuleHeight
   visible: shouldShow
+  opacity: shouldShow ? 1.0 : 0.0
 
   Behavior on implicitWidth {
     NumberAnimation {

--- a/Modules/Bar/Widgets/LockKeys.qml
+++ b/Modules/Bar/Widgets/LockKeys.qml
@@ -49,6 +49,8 @@ Rectangle {
 
   radius: Style.radiusM
   color: Style.capsuleColor
+  border.color: Style.capsuleBorderColor
+  border.width: Style.capsuleBorderWidth
 
   NPopupContextMenu {
     id: contextMenu

--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -406,7 +406,7 @@ Rectangle {
 
   // "visible": Always Visible, "hidden": Hide When Empty, "transparent": Transparent When Empty
   visible: hideMode !== "hidden" || hasWindow
-  opacity: (hideMode !== "transparent" || hasWindow) ? 1.0 : 0
+  opacity: ((hideMode !== "hidden" && hideMode !== "transparent") || hasWindow) ? 1.0 : 0.0
   Behavior on opacity {
     NumberAnimation {
       duration: Style.animationNormal

--- a/Modules/Bar/Widgets/Tray.qml
+++ b/Modules/Bar/Widgets/Tray.qml
@@ -267,13 +267,14 @@ Rectangle {
   Component.onCompleted: {
     root.updateFilteredItems(); // Initial update
   }
-  visible: filteredItems.length > 0 || dropdownItems.length > 0
   implicitWidth: isVertical ? Style.capsuleHeight : Math.round(trayFlow.implicitWidth)
   implicitHeight: isVertical ? Math.round(trayFlow.implicitHeight) : Style.capsuleHeight
   radius: Style.radiusM
   color: Style.capsuleColor
   border.color: Style.capsuleBorderColor
   border.width: Style.capsuleBorderWidth
+  visible: filteredItems.length > 0 || dropdownItems.length > 0
+  opacity: (filteredItems.length > 0 || dropdownItems.length > 0) ? 1.0 : 0.0
 
   Flow {
     id: trayFlow


### PR DESCRIPTION
The bar widgets AudioVisualizer, Taskbar and Tray don't hide properly (there is some empty space left behind) when the option "hide when empty" is selected since the opacity is not set to 0. This PR fixes this issue.
I also added the missing outline to the LockKeys widget.