### PR TITLE
Add HDR Codec options to gpu-screen-recorder settings tab

### DIFF
--- a/Modules/Panels/Settings/Tabs/ScreenRecorderTab.qml
+++ b/Modules/Panels/Settings/Tabs/ScreenRecorderTab.qml
@@ -156,30 +156,41 @@ ColumnLayout {
     NComboBox {
       label: I18n.tr("settings.screen-recorder.video.video-codec.label")
       description: I18n.tr("settings.screen-recorder.video.video-codec.description")
-      model: [
-        {
-          "key": "h264",
-          "name": "H264"
-        },
-        {
-          "key": "hevc",
-          "name": "HEVC"
-        },
-        {
-          "key": "av1",
-          "name": "AV1"
-        },
-        {
-          "key": "vp8",
-          "name": "VP8"
-        },
-        {
-          "key": "vp9",
-          "name": "VP9"
+      model: {
+        let options = [
+          { "key": "h264", "name": "H264" },
+          { "key": "hevc", "name": "HEVC" },
+          { "key": "av1", "name": "AV1" },
+          { "key": "vp8", "name": "VP8" },
+          { "key": "vp9", "name": "VP9" }
+        ];
+        // Only add HDR options if source is 'screen'
+        if (Settings.data.screenRecorder.videoSource === "screen") {
+          options.push({ "key": "hevc_hdr", "name": "HEVC HDR" });
+          options.push({ "key": "av1_hdr", "name": "AV1 HDR" });
         }
-      ]
+        return options;
+      }
       currentKey: Settings.data.screenRecorder.videoCodec
-      onSelected: key => Settings.data.screenRecorder.videoCodec = key
+      onSelected: key => {
+          Settings.data.screenRecorder.videoCodec = key;
+          
+          // If an HDR codec is selected, change the colorRange to full
+          if (key.includes("_hdr")) {
+              Settings.data.screenRecorder.colorRange = "full";
+          }
+      }
+      // If user switches source to portal while an HDR codec is selected, reset to h264
+      Connections {
+        target: Settings.data.screenRecorder
+        function onVideoSourceChanged() {
+          let source = Settings.data.screenRecorder.videoSource;
+          let codec = Settings.data.screenRecorder.videoCodec;
+          if (source !== "screen" && (codec === "av1_hdr" || codec === "hevc_hdr")) {
+            Settings.data.screenRecorder.videoCodec = "h264";
+          }
+        }
+      }
     }
 
     // Color Range


### PR DESCRIPTION
# Pull Request

## Motivation
Adds HDR codecs to recording options. Makes sure they only show up when Screen is selected as a Video Source.

Also makes sure that if user switches to Portal while having an HDR codec selected, it will revert to H264 (default at the time of this PR) to avoid gpu-screen-recorder errors.

Finally, when an HDR codec is selected, it sets the Color Range to Full for self-explanatory reasons.


## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/155e0015-68f0-47fd-a8cc-8a2302cfc2c1

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This is my first time working with QML, so not sure if this is acceptable. Pardon my ignorance :(
