### PR TITLE
feat: add aspect ratio filter to Wallhaven wallpaper settings

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2730,6 +2730,10 @@
         "sfw": "SFW",
         "sketchy": "Sketchy"
       },
+      "ratios": {
+        "any": "Any",
+        "label": "Aspect Ratio"
+      },
       "resolution": {
         "atleast": "At least",
         "exact": "Exact",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -163,6 +163,7 @@
     "wallhavenOrder": "desc",
     "wallhavenCategories": "111",
     "wallhavenPurity": "100",
+    "wallhavenRatios": "",
     "wallhavenResolutionMode": "atleast",
     "wallhavenResolutionWidth": "",
     "wallhavenResolutionHeight": ""

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -342,6 +342,7 @@ Singleton {
       property string wallhavenOrder: "desc"
       property string wallhavenCategories: "111" // general,anime,people
       property string wallhavenPurity: "100" // sfw only
+      property string wallhavenRatios: ""
       property string wallhavenResolutionMode: "atleast" // "atleast" or "exact"
       property string wallhavenResolutionWidth: ""
       property string wallhavenResolutionHeight: ""

--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -270,6 +270,48 @@ Popup {
       }
     }
 
+    // Aspect Ratio
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.marginM
+
+      NText {
+        text: I18n.tr("wallpaper.panel.ratios.label")
+        color: Color.mOnSurface
+        pointSize: Style.fontSizeM
+        Layout.preferredWidth: implicitWidth
+      }
+
+      NComboBox {
+        id: ratioComboBox
+        Layout.fillWidth: true
+        Layout.minimumWidth: 200
+        model: [
+          { "key": "", "name": I18n.tr("wallpaper.panel.ratios.any") },
+          { "key": "16x9", "name": "16x9" },
+          { "key": "16x10", "name": "16x10" },
+          { "key": "21x9", "name": "21x9" },
+          { "key": "32x9", "name": "32x9" },
+          { "key": "48x9", "name": "48x9" },
+          { "key": "9x16", "name": "9x16" },
+          { "key": "10x16", "name": "10x16" },
+          { "key": "9x18", "name": "9x18" },
+          { "key": "1x1", "name": "1x1" },
+          { "key": "3x2", "name": "3x2" },
+          { "key": "4x3", "name": "4x3" },
+          { "key": "5x4", "name": "5x4" }
+        ]
+        currentKey: Settings.data.wallpaper.wallhavenRatios || ""
+        onSelected: key => {
+                      Settings.data.wallpaper.wallhavenRatios = key;
+                      if (typeof WallhavenService !== "undefined") {
+                        WallhavenService.ratios = key;
+                        WallhavenService.search(Settings.data.wallpaper.wallhavenQuery || "", 1);
+                      }
+                    }
+      }
+    }
+
     // Categories
     RowLayout {
       Layout.fillWidth: true
@@ -657,6 +699,7 @@ Popup {
           WallhavenService.purity = Settings.data.wallpaper.wallhavenPurity;
           WallhavenService.sorting = Settings.data.wallpaper.wallhavenSorting;
           WallhavenService.order = Settings.data.wallpaper.wallhavenOrder;
+          WallhavenService.ratios = Settings.data.wallpaper.wallhavenRatios;
 
           // Update resolution settings (without triggering search)
           updateResolution(false);


### PR DESCRIPTION
# Pull Request

## Motivation
I wanted to add the ability to choose from any of the available aspect ratios in Wallhaven searches since different wallpaper scaling and fill types make that worth having.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="454" height="463" alt="image" src="https://github.com/user-attachments/assets/56fdf4b7-098a-42ca-9b35-d77f61c75ed6" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
