### PR TITLE
fix ClipboardPreview: add background color to text area for improved visibility

### DIFF
--- a/Modules/Panels/Launcher/ClipboardPreview.qml
+++ b/Modules/Panels/Launcher/ClipboardPreview.qml
@@ -118,6 +118,9 @@ Item {
               textFormat: TextArea.RichText // Enable HTML rendering
               font.pointSize: Style.fontSizeM // Adjust font size for readability
               color: Color.mOnSurface // Consistent text color
+              background: Rectangle {
+                color: Color.mSurfaceVariant || "#e0e0e0"
+              }
             }
           }
         }


### PR DESCRIPTION
# Pull Request

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Changes
- Added background color (`Color.mSurfaceVariant`) to the TextArea in ClipboardPreview
- Fallback color `#e0e0e0` for compatibility
- Improves text visibility and UI consistency