### PR TITLE
Change button widths

### DIFF
--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -321,6 +321,7 @@ SmartPanel {
 
         NTabButton {
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
           text: I18n.tr("settings.audio.panel.tabs.volumes")
           tabIndex: 0
           checked: tabBar.currentIndex === 0
@@ -328,6 +329,7 @@ SmartPanel {
 
         NTabButton {
           Layout.fillWidth: true
+          Layout.preferredWidth: 0
           text: I18n.tr("settings.audio.panel.tabs.devices")
           tabIndex: 1
           checked: tabBar.currentIndex === 1

--- a/Modules/Panels/Settings/Tabs/PluginsTab.qml
+++ b/Modules/Panels/Settings/Tabs/PluginsTab.qml
@@ -395,12 +395,14 @@ ColumnLayout {
       }
 
       NTabButton {
+        Layout.fillWidth: true
         text: I18n.tr("settings.plugins.filter.all")
         tabIndex: 0
         checked: pluginFilter === "all"
       }
 
       NTabButton {
+        Layout.fillWidth: true
         text: I18n.tr("settings.plugins.filter.downloaded")
         tabIndex: 1
         checked: pluginFilter === "downloaded"


### PR DESCRIPTION
1. Make the volumes and devices buttons in the audio panel have the same width.
2. This change makes the buttons in the plugin tab have more similar horizontal margins (currently the "Not Downloaded" button has far to large margins).