### PR TITLE
Apply new notification drop shadow to toasts

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -179,7 +179,7 @@ Variants {
             readonly property int slideDistance: 300
 
             Layout.preferredWidth: notifWidth + notifWindow.shadowPadding * 2
-            Layout.preferredHeight: notificationContent.implicitHeight + Style.marginL * 2 + notifWindow.shadowPadding * 2
+            Layout.preferredHeight: notificationContent.implicitHeight + Style.marginM * 2 + notifWindow.shadowPadding * 2
             Layout.maximumHeight: Layout.preferredHeight
 
             // Animation properties

--- a/Modules/Toast/SimpleToast.qml
+++ b/Modules/Toast/SimpleToast.qml
@@ -16,11 +16,12 @@ Item {
 
   signal hidden
 
-  readonly property int notificationWidth: Math.round(400 * Style.uiScaleRatio)
+  readonly property int notificationWidth: Math.round(440 * Style.uiScaleRatio)
+  readonly property int shadowPadding: Style.shadowBlurMax + Style.marginL
 
   // Use exact notification width to match notifications precisely
   width: notificationWidth
-  height: Math.round(contentLayout.implicitHeight + Style.marginM * 3 * 2)
+  height: Math.round(contentLayout.implicitHeight + Style.marginM * 2 * 2 + shadowPadding * 2)
   visible: true
   opacity: 0
   scale: initialScale
@@ -29,7 +30,7 @@ Item {
   Rectangle {
     id: background
     anchors.fill: parent
-    anchors.margins: Style.marginM
+    anchors.margins: shadowPadding
     radius: Style.radiusL
     color: Qt.alpha(Color.mSurface, Settings.data.notifications.backgroundOpacity || 1.0)
 
@@ -95,13 +96,10 @@ Item {
 
   RowLayout {
     id: contentLayout
-    anchors.top: parent.top
+    anchors.fill: background
     anchors.topMargin: Style.marginM
-    anchors.bottom: parent.bottom
     anchors.bottomMargin: Style.marginM
-    anchors.left: parent.left
     anchors.leftMargin: Style.marginM * 3
-    anchors.right: parent.right
     anchors.rightMargin: Style.marginM * 3
     spacing: Style.marginL
 

--- a/Modules/Toast/ToastScreen.qml
+++ b/Modules/Toast/ToastScreen.qml
@@ -172,6 +172,8 @@ Item {
         const floatMarginH = isFloating ? Math.ceil(Settings.data.bar.marginHorizontal * Style.marginXL) : 0;
         return Style.barHeight + floatMarginH;
       }
+      
+      readonly property int shadowPadding: Style.shadowBlurMax + Style.marginL
 
       // Anchoring
       anchors.top: isTop
@@ -180,10 +182,10 @@ Item {
       anchors.right: isRight
 
       // Margins for PanelWindow - only apply bar offset for the specific edge where the bar is
-      margins.top: isTop ? barOffsetTop : 0
-      margins.bottom: isBottom ? barOffsetBottom : 0
-      margins.left: isLeft ? barOffsetLeft : 0
-      margins.right: isRight ? barOffsetRight : 0
+      margins.top: isTop ? barOffsetTop - shadowPadding + Style.marginM : 0
+      margins.bottom: isBottom ? barOffsetBottom - shadowPadding + Style.marginM : 0
+      margins.left: isLeft ? barOffsetLeft - shadowPadding + Style.marginM : 0
+      margins.right: isRight ? barOffsetRight - shadowPadding + Style.marginM : 0
 
       implicitWidth: Math.round(toastItem.width)
       implicitHeight: Math.round(toastItem.height)


### PR DESCRIPTION
I fixed the overflow problem (`anchors.fill: parent` to `anchors.fill: background`). Sorry, I changed this part before opening the PR without testing.