### PR TITLE
feat: Add Wallhaven API key support for NSFW content and update purity settings

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2750,7 +2750,13 @@
         "all": "All",
         "label": "Content filter",
         "sfw": "SFW",
-        "sketchy": "Sketchy"
+        "sketchy": "Sketchy",
+        "nsfw": "NSFW"
+      },
+      "apikey": {
+        "label": "API Key",
+        "placeholder": "Enter your Wallhaven API Key",
+        "help": "An API key is required to access NSFW content."
       },
       "ratios": {
         "any": "Any",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -164,6 +164,7 @@
     "wallhavenCategories": "111",
     "wallhavenPurity": "100",
     "wallhavenRatios": "",
+    "wallhavenApiKey": "",
     "wallhavenResolutionMode": "atleast",
     "wallhavenResolutionWidth": "",
     "wallhavenResolutionHeight": ""

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -367,6 +367,7 @@ Singleton {
       property string wallhavenCategories: "111" // general,anime,people
       property string wallhavenPurity: "100" // sfw only
       property string wallhavenRatios: ""
+      property string wallhavenApiKey: ""
       property string wallhavenResolutionMode: "atleast" // "atleast" or "exact"
       property string wallhavenResolutionWidth: ""
       property string wallhavenResolutionHeight: ""

--- a/Services/UI/WallhavenService.qml
+++ b/Services/UI/WallhavenService.qml
@@ -28,6 +28,7 @@ Singleton {
   property string resolutions: "" // e.g., "1920x1080,1920x1200"
   property string ratios: "" // e.g., "16x9,16x10"
   property string colors: "" // Color hex codes
+  property string apiKey: "" // User API key for NSFW access
 
   // Signals
   signal searchCompleted(var results, var meta)
@@ -88,6 +89,10 @@ Singleton {
     if (colors) {
       params.push("colors=" + colors);
     }
+    
+    if (apiKey) {
+      params.push("apikey=" + apiKey);
+    }
 
     params.push("page=" + currentPage);
 
@@ -130,6 +135,11 @@ Singleton {
           var errorMsg = "Rate limit exceeded (45 requests/minute)";
           lastError = errorMsg;
           Logger.w("Wallhaven", errorMsg);
+          searchFailed(errorMsg);
+        } else if (xhr.status === 401) {
+          var errorMsg = "Invalid API Key. Please check your settings.";
+          lastError = errorMsg;
+          Logger.e("Wallhaven", errorMsg);
           searchFailed(errorMsg);
         } else {
           var errorMsg = "API error: " + xhr.status;


### PR DESCRIPTION
# Pull Request

## Motivation
Adds support for Wallhaven API keys to enable NSFW categories.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="444" height="498" alt="image" src="https://github.com/user-attachments/assets/37327b89-63b0-4746-ba8e-c68c00a2d4c5" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
The NSFW checkbox only appears once an API key is entered and applied.