### PR TITLE
GitHubService: do not print errors from githubDataFileView

### DIFF
--- a/Services/Noctalia/GitHubService.qml
+++ b/Services/Noctalia/GitHubService.qml
@@ -34,6 +34,7 @@ Singleton {
   FileView {
     id: githubDataFileView
     path: githubDataFile
+    printErrors: false
     watchChanges: false  // Disable to prevent reload on our own writes
     Component.onCompleted: {
       loadCacheMetadata();


### PR DESCRIPTION
```
WARN scene: QML FileView at @Services/Noctalia/GitHubService.qml[34:3]: Read of /home/kai/.cache/noctalia/github.json failed: File does not exist.
```