### PR TITLE
fix(bin): reload theme even if kitty.conf is read-only

### DIFF
--- a/Bin/colors-apply.sh
+++ b/Bin/colors-apply.sh
@@ -14,7 +14,12 @@ APP_NAME="$1"
 case "$APP_NAME" in
 kitty)
     echo "🎨 Applying 'noctalia' theme to kitty..."
-    kitty +kitten themes --reload-in=all noctalia
+    KITTY_CONF="$HOME/.config/kitty/kitty.conf"
+    if [ -w "$KITTY_CONF" ]; then
+        kitty +kitten themes --reload-in=all noctalia
+    else
+        kitty +runpy "from kitty.utils import *; reload_conf_in_all_kitties()"
+    fi
     ;;
 
 ghostty)
@@ -302,41 +307,41 @@ mango)
     else
         # First-time setup: backup and remove legacy color definitions
         echo "Setting up noctalia theme for the first time..."
-        
+
         # Scan all .conf files in config directory for legacy color variables
         FOUND_LEGACY=false
         for conf_file in "$CONFIG_DIR"/*.conf; do
             # Skip if no .conf files exist or if it's the theme file itself
             [ -e "$conf_file" ] || continue
             [ "$conf_file" = "$THEME_FILE" ] && continue
-            
+
             # Check if this file contains any color variable definitions
             if grep -qE "^($COLOR_VARS)\s*=" "$conf_file"; then
                 FOUND_LEGACY=true
                 echo "Found legacy colors in $(basename "$conf_file"), backing up..."
-                
+
                 # Extract and append color definitions to backup file
-                grep -E "^($COLOR_VARS)\s*=" "$conf_file" >> "$BACKUP_FILE"
-                
+                grep -E "^($COLOR_VARS)\s*=" "$conf_file" >>"$BACKUP_FILE"
+
                 # Remove color definitions from original file
                 sed -i -E "/^($COLOR_VARS)\s*=/d" "$conf_file"
             fi
         done
-        
+
         if [ "$FOUND_LEGACY" = true ]; then
             echo "✅ Legacy color definitions backed up to $(basename "$BACKUP_FILE")"
         fi
-        
-         # Add source line to main config
-         if [ -f "$MAIN_CONFIG" ]; then
-             echo "" >> "$MAIN_CONFIG"
-             echo "# This sources the noctalia theme" >> "$MAIN_CONFIG"
-             echo "$SOURCE_LINE" >> "$MAIN_CONFIG"
-         else
-             echo "# This sources the noctalia theme" > "$MAIN_CONFIG"
-             echo "$SOURCE_LINE" >> "$MAIN_CONFIG"
-         fi
-        
+
+        # Add source line to main config
+        if [ -f "$MAIN_CONFIG" ]; then
+            echo "" >>"$MAIN_CONFIG"
+            echo "# This sources the noctalia theme" >>"$MAIN_CONFIG"
+            echo "$SOURCE_LINE" >>"$MAIN_CONFIG"
+        else
+            echo "# This sources the noctalia theme" >"$MAIN_CONFIG"
+            echo "$SOURCE_LINE" >>"$MAIN_CONFIG"
+        fi
+
         echo "✅ Added noctalia theme to config."
     fi
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
this PR ensures that the Kitty theme is correctly applied even when kitty.conf is read-only. Previously, the +kitten themes --reload-in=all command failed to update the theme in such cases. Now, the PR introduces a fallback using reload_conf_in_all_kitties() via Kitty's Python API, guaranteeing that the theme is applied in all running Kitty instances.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
https://github.com/kovidgoyal/kitty/pull/5858#issuecomment-1373829286
