### PR TITLE
fix: make sessionMenu grid navigation feel better

### DIFF
--- a/Modules/Panels/SessionMenu/SessionMenu.qml
+++ b/Modules/Panels/SessionMenu/SessionMenu.qml
@@ -480,15 +480,6 @@ SmartPanel {
       visible: largeButtonsStyle
       anchors.centerIn: parent
 
-      Rectangle {
-        id: gridBackground
-        anchors.fill: parent
-        color: Color.mSurface
-        // anchors.margins: Style.marginM
-        // spacing: Style.marginM
-        z: -1
-        radius: Style.marginXL
-      }
       // Large buttons style layout (grid)
       GridLayout {
         id: largeButtonsGrid


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
When set to grid mode, sessionMenu still follows the arrow key navigation of the vertical list. This PR fixes that behavior to be proper grid navigation.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
