### PR TITLE
fix: clip audio visualizer again on `DesktopMediaPlayer`

### DIFF
--- a/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
+++ b/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
@@ -108,6 +108,26 @@ DraggableDesktopWidget {
     z: 0
     clip: true
     active: shouldShowVisualizer
+    layer.enabled: true
+    layer.smooth: true
+    layer.samples: 4
+    layer.effect: MultiEffect {
+      maskEnabled: true
+      maskThresholdMin: 0.95
+      maskSpreadAtMin: 0.0
+      maskSource: ShaderEffectSource {
+        sourceItem: Rectangle {
+          width: root.width - Style.marginXS * 2
+          height: root.height - Style.marginXS * 2
+          radius: Math.max(0, Style.radiusL - Style.marginXS)
+          color: "white"
+          antialiasing: true
+          smooth: true
+        }
+        smooth: true
+        mipmap: true
+      }
+    }
 
     sourceComponent: {
       var visualizerType = (widgetData && widgetData.visualizerType) ? widgetData.visualizerType : "";


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Fixes the audio visualizer on the audio player desktop widget not clipping the background

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1129

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
