### PR TITLE
Emacs matugen template: Add tab bar support ( background faces ) 

### DIFF
--- a/Assets/MatugenTemplates/emacs.el
+++ b/Assets/MatugenTemplates/emacs.el
@@ -315,6 +315,24 @@
    `(info-menu-header ((t (:foreground ,primary :weight bold))))
    `(info-menu-star ((t (:foreground ,primary))))
    `(info-node ((t (:foreground ,tertiary :weight bold))))
+
+   ;; Tabs
+   `(tab-bar ((t (:background ,surface-container :foreground ,on-surface :box nil))))
+   `(tab-bar-tab ((t (:background ,surface-container-high :foreground ,on-surface :weight bold :box nil))))
+   `(tab-bar-tab-inactive ((t (:background ,surface :foreground ,on-surface-variant :box nil))))
+
+   `(tab-line ((t (:background ,surface-container :foreground ,on-surface :box nil))))
+   `(tab-line-tab ((t (:background ,surface :foreground ,on-surface-variant :box nil))))
+   `(tab-line-tab-current ((t (:background ,surface-container-high :foreground ,on-surface :weight bold :box nil))))
+   `(tab-line-tab-inactive ((t (:background ,surface :foreground ,on-surface-variant :box nil))))
+   `(tab-line-highlight ((t (:background ,surface-container-highest :foreground ,on-surface))))
+
+   `(centaur-tabs-default ((t (:background ,surface-container :foreground ,on-surface))))
+   `(centaur-tabs-selected ((t (:background ,surface-container-high :foreground ,on-surface :weight bold))))
+   `(centaur-tabs-unselected ((t (:background ,surface :foreground ,on-surface-variant))))
+   `(centaur-tabs-selected-modified ((t (:background ,surface-container-high :foreground ,tertiary :weight bold))))
+   `(centaur-tabs-unselected-modified ((t (:background ,surface :foreground ,tertiary))))
+   `(centaur-tabs-active-bar-face ((t (:background ,primary))))
    
    ;; Fixed-pitch faces
    `(fixed-pitch ((t (:family "monospace"))))


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
