### PR TITLE
WallpaperService: add webp support

### DIFF
--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -465,7 +465,7 @@ Singleton {
       property string currentDirectory: root.getMonitorDirectory(screenName)
 
       folder: "file://" + currentDirectory
-      nameFilters: ["*.jpg", "*.jpeg", "*.png", "*.gif", "*.pnm", "*.bmp"]
+      nameFilters: ["*.jpg", "*.jpeg", "*.png", "*.gif", "*.pnm", "*.bmp", "*.webp"]
       showDirs: false
       sortField: FolderListModel.Name
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -63,6 +63,7 @@ stdenvNoCC.mkDerivation {
 
   buildInputs = [
     qt6.qtbase
+    qt6.qtimageformats
     qt6.qtmultimedia
   ];
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
All my wallpapers are in webp as in provides the best tradeoff between filesize and quality. It really does make a significant difference when there are thousands of them :) 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #982

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This adds support for webp in the wallpaper selector. I've added `qt6.qtimageformats` for the nix package for this to work. I don't see package builds for other distros, so I guess those are done elsewhere.