### PR TITLE
fix(dock): stop showTimer on peek area exit to prevent stuck visible …

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -312,6 +312,7 @@ Loader {
 
             onExited: {
               peekHovered = false;
+              showTimer.stop();
               if (!hidden && !dockHovered && !anyAppHovered && !menuHovered) {
                 hideTimer.restart();
               }


### PR DESCRIPTION
## Motivation

Fix dock not hiding after quickly hovering the peek area at the bottom of the screen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

When quickly moving the mouse in and out of the peek area, the dock could get stuck in a visible state. This happened because `showTimer` would trigger after the mouse already left, showing the dock without any mechanism to hide it again.

Fix: Stop `showTimer` when exiting the peek area to prevent this race condition.