### PR TITLE
Workspace: label follows old radius behavior

### DIFF
--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -911,7 +911,7 @@ Item {
           id: groupedWorkspaceNumberBackground
 
           anchors.fill: parent
-          radius: width / 2
+          radius: Math.min(Style.radiusL, width / 2)
 
           color: {
             if (groupedContainer.workspaceModel.isFocused)


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Changes groupedWorkspaceNumberBackground radius to match what originally TaskbarGrouped had

When using something 0% radius, it looks out of place as everything else doesn't have any roundedness

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
I looked at it

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
TaskbarGrouped (v3.6.2):
<img width="179" height="28" alt="Screenshot from 2025-12-26 01-26-23" src="https://github.com/user-attachments/assets/e3395734-19a4-483c-a53c-46bd45681921" />
Before:
<img width="179" height="28" alt="Screenshot from 2025-12-26 01-24-56" src="https://github.com/user-attachments/assets/8af49393-cf38-4eb3-826e-5d8598c145e3" />
After:
<img width="179" height="28" alt="Screenshot from 2025-12-26 01-22-04" src="https://github.com/user-attachments/assets/9249da76-4bfa-4e51-a987-d54e6ab8b619" />


## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I don't know why this was removed when TaskbarGrouped is now consolidated in the Workspace widget, so please let me know, also i didn't really thoroughly look at all issues or pull requests so apologies if this is a duplicate.
