### PR TITLE
Change visible condition for BluetoothPanel empty screen

### DIFF
--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -332,7 +332,7 @@ SmartPanel {
               }
 
               var availableCount = Bluetooth.devices.values.filter(dev => {
-                                                                     return dev && !dev.paired && !dev.pairing && !dev.blocked && (dev.signalStrength === undefined || dev.signalStrength > 0);
+                                                                     return dev && !dev.blocked && (dev.signalStrength === undefined || dev.signalStrength > 0);
                                                                    }).length;
               return (availableCount === 0);
             }


### PR DESCRIPTION
Paired devices obviously shouldn't be exempted, this was causing a double bottom space for me.