### PR TITLE
Fix: password input not possible after leaving suspend w/ dual GPUs 

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -377,6 +377,18 @@ Loader {
           Item {
             anchors.fill: parent
 
+            // Mouse area to trigger focus on cursor movement (workaround for Hyprland focus issues)
+            MouseArea {
+              anchors.fill: parent
+              hoverEnabled: true
+              acceptedButtons: Qt.NoButton
+              onPositionChanged: {
+                if (passwordInput) {
+                  passwordInput.forceActiveFocus();
+                }
+              }
+            }
+
             // Time, Date, and User Profile Container
             Rectangle {
               width: Math.max(500, contentRow.implicitWidth + 32)


### PR DESCRIPTION
# Pull Request

## Motivation
Fixes password input losing focus on lock screen after suspend/resume in Hyprland, which seems to only affect dual GPU setups. 
- Added MouseArea with hover detection that automatically restores focus when cursor moves. 
- Based on end4's approach but simplified to use only the [mouse movement workaround](https://github.com/end-4/dots-hyprland/blob/80a7804adedf6f7bf6e3f14641d36461a379ba7b/dots/.config/quickshell/ii/modules/ii/lock/LockSurface.qml#L29-L36) (could make more robust by adding `hypridle` as a package dependancy and following [end4's method](https://github.com/end-4/dots-hyprland/blob/80a7804adedf6f7bf6e3f14641d36461a379ba7b/dots/.config/hypr/hypridle.conf#L8) more closely)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #917
- Closes #1029

## Testing
Tested on a laptop w/ dual GPU that previously had this issue

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway

## Screenshots / Videos
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
