### PR TITLE
Bluetooth: show connected icon in bar and Control Center

### DIFF
--- a/Modules/Bar/Widgets/Bluetooth.qml
+++ b/Modules/Bar/Widgets/Bluetooth.qml
@@ -71,7 +71,11 @@ Item {
     screen: root.screen
     density: Settings.data.bar.density
     oppositeDirection: BarService.getPillDirection(root)
-    icon: BluetoothService.enabled ? "bluetooth" : "bluetooth-off"
+    icon: !BluetoothService.enabled
+          ? "bluetooth-off"
+          : ((BluetoothService.connectedDevices && BluetoothService.connectedDevices.length > 0)
+              ? "bluetooth-connected"
+              : "bluetooth")
     text: {
       if (BluetoothService.connectedDevices && BluetoothService.connectedDevices.length > 0) {
         const firstDevice = BluetoothService.connectedDevices[0];

--- a/Modules/Panels/ControlCenter/Widgets/Bluetooth.qml
+++ b/Modules/Panels/ControlCenter/Widgets/Bluetooth.qml
@@ -8,7 +8,11 @@ import qs.Widgets
 NIconButtonHot {
   property ShellScreen screen
 
-  icon: BluetoothService.enabled ? "bluetooth" : "bluetooth-off"
+  icon: !BluetoothService.enabled
+        ? "bluetooth-off"
+        : ((BluetoothService.connectedDevices && BluetoothService.connectedDevices.length > 0)
+            ? "bluetooth-connected"
+            : "bluetooth")
   tooltipText: I18n.tr("quickSettings.bluetooth.tooltip.action")
   onClicked: PanelService.getPanel("bluetoothPanel", screen)?.toggle(this)
   onRightClicked: BluetoothService.setBluetoothEnabled(!BluetoothService.enabled)


### PR DESCRIPTION
# Pull Request

- Bar widget: updates icon binding in Bluetooth.qml to show bluetooth-connected when any device is connected, bluetooth when enabled without connections, and bluetooth-off when disabled.
- Control Center: mirrors the same logic in Bluetooth.qml.
- Icon source: bluetooth-connected is defined in IconsTabler.qml 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
bluetooth-on / bluetooth-connected / bluetooth-off
<img width="521" height="135" alt="image" src="https://github.com/user-attachments/assets/03ffb707-96ba-4df6-a3e2-00ad96177a96" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
