### PR TITLE
LockScreen: Add fingerprint authentication support

### DIFF
--- a/Services/Hardware/FingerprintService.qml
+++ b/Services/Hardware/FingerprintService.qml
@@ -1,0 +1,112 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services.System
+
+Singleton {
+  id: root
+
+  // Detection state
+  property bool available: false // fprintd command available
+  property bool hasDevice: false // physical sensor present
+  property bool hasEnrolledFingers: false // user has fingerprints enrolled
+  readonly property bool ready: hasDevice && hasEnrolledFingers
+
+  // Re-check detection (e.g., after user enrolls fingerprints)
+  function refresh() {
+    detectProc.retryCount = 0;
+    detectProc.running = true;
+  }
+
+  Component.onCompleted: {
+    Logger.i("Fingerprint", "Service starting, detecting fingerprint reader...");
+    detectProc.running = true;
+  }
+
+  // Retry timer for transient failures
+  Timer {
+    id: retryTimer
+    interval: 1000 // 1 second between retries
+    repeat: false
+    onTriggered: detectProc.running = true
+  }
+
+  // Detection via fprintd-list
+  // Output format:
+  //   "found 1 device" -> hasDevice = true
+  //   "Device at /net/reactivated/Fprint/Device/0" (device path)
+  //   "Fingerprints for user <username>:" followed by finger names -> hasEnrolledFingers = true
+  //   "no fingerprints enrolled" -> hasEnrolledFingers = false
+  //   Command fails or "No devices available" -> hasDevice = false
+  Process {
+    id: detectProc
+    command: ["fprintd-list", HostService.username]
+
+    property int retryCount: 0
+    property int maxRetries: 3
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var output = text.trim();
+        if (output.length > 10000) {
+          Logger.w("Fingerprint", "fprintd-list output unexpectedly large, truncating");
+          output = output.substring(0, 10000);
+        }
+        Logger.d("Fingerprint", "fprintd-list output:", output);
+
+        // Check for device
+        root.hasDevice = output.includes("found") && output.includes("device");
+
+        if (!root.hasDevice) {
+          Logger.i("Fingerprint", "No fingerprint device found");
+          root.available = false;
+          root.hasEnrolledFingers = false;
+          return;
+        }
+
+        root.available = true;
+        detectProc.retryCount = 0; // Reset on success
+
+        // Check for enrolled fingerprints - more flexible pattern
+        // Look for finger entries like "- #0:" which indicates enrolled fingers
+        var hasFingers = output.includes("Fingerprints for user") &&
+                         !output.includes("no fingerprints enrolled") &&
+                         /- #\d+:/.test(output);
+
+        root.hasEnrolledFingers = hasFingers;
+
+        if (root.hasEnrolledFingers) {
+          Logger.i("Fingerprint", "Device found with enrolled fingerprints - fingerprint auth ready");
+        } else {
+          Logger.i("Fingerprint", "Device found but no fingerprints enrolled");
+        }
+      }
+    }
+
+    stderr: StdioCollector {
+      onStreamFinished: {
+        if (text.trim() !== "") {
+          Logger.w("Fingerprint", "fprintd-list stderr:", text.trim());
+        }
+      }
+    }
+
+    onExited: (exitCode, exitStatus) => {
+      if (exitCode !== 0) {
+        if (retryCount < maxRetries) {
+          retryCount++;
+          Logger.i("Fingerprint", "fprintd-list failed, retry", retryCount, "of", maxRetries);
+          retryTimer.start();
+        } else {
+          Logger.i("Fingerprint", "fprintd-list failed after", maxRetries, "retries - fingerprint auth unavailable");
+          root.available = false;
+          root.hasDevice = false;
+          root.hasEnrolledFingers = false;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What Changed

**Before**: Lock screen only supported password authentication. User must type password and press Enter to unlock.

**After**: Lock screen supports fingerprint OR password authentication with seamless switching.

## Summary

Enable fingerprint unlocking without requiring Enter key press first.

- Auto-detect fingerprint sensor and enrolled fingerprints via fprintd
- Start PAM authentication automatically when lock screen becomes visible
- Show pulsating fingerprint indicator during scanning (icon only, no text)
- Allow typing password while fingerprint scans (user chooses which to use)
- Switch to password-only PAM when Enter is pressed (cancels fingerprint)
- Continuous detection handles fprintd initialization after suspend/resume
- Infinite timeout (`timeout=0`) with instant abort via Enter key - no 30s wait

## Key Features

### Dual Authentication Methods
- **Fingerprint**: Touch sensor anytime → instant unlock
- **Password**: Type password + Enter → aborts fingerprint and switches to password-only mode
- Both methods available simultaneously - user decides which to use

### Smart Detection
- Detects sensor and enrollment at startup via `fprintd-list`
- Continuous polling after lock activation handles resume-from-suspend scenarios
- Automatically starts PAM when fprintd becomes ready
- Gracefully degrades if no sensor or no enrolled fingerprints

### No Timeout Frustration
- `timeout=0` on pam_fprintd means no 30s wait for fingerprint timeout
- User can press Enter instantly to switch to password
- Works in other contexts too (sudo supports Ctrl+C to cancel fingerprint)
- Safe: `max-tries=1` limits attempts, abort mechanism provides escape path

### Resume Reliability
- Lock screen starts continuous detection when activated
- Polls fprintd every 1s until ready (handles slow initialization after suspend)
- Stops polling on unlock to save resources
- Adapts to variable fprintd timing instead of fixed delays

## Implementation

### New Files
- **Services/Hardware/FingerprintService.qml**: Singleton that detects sensor via `fprintd-list`
  - Retry mechanism with stderr capture for robust detection
  - Continuous detection mode for post-resume scenarios
  - Reactive `ready` property triggers PAM start

### Modified Files
- **Modules/LockScreen/LockContext.qml**: PAM flow management
  - Fingerprint mode properties and state tracking
  - Password-only mode switching with PAM abort handling (500ms timeout)
  - Smart config selection (NixOS uses `/etc/pam.d/login`, others use generated config)
  
- **Modules/LockScreen/LockScreen.qml**: UI integration
  - Pulsating fingerprint indicator (visible during scan, hidden during password mode)
  - Connections handler reacts to FingerprintService.ready state
  - Continuous detection lifecycle (start on lock, stop on unlock)

- **Commons/Settings.qml**: PAM configuration
  - Generates `password.conf` with `pam_fprintd.so timeout=0` + `pam_unix.so`
  - Generates `password-only.conf` with just `pam_unix.so` for fast password fallback
  - Secure permissions (chmod 600 on files, 700 on directory)

## Platform Support

- **Non-NixOS**: Uses generated PAM config in `~/.config/quickshell/pam/`
- **NixOS**: Uses system PAM config `/etc/pam.d/login`
  - Note: NixOS users should add `timeout=0` to their fprintd PAM config for infinite timeout
  - Example: `security.pam.services.login.rules.auth.fprintd.args = [ "timeout=0" ];`

## Test Plan

Tested on NixOS with:
- Framework Laptop 13 (AMD) with built-in fingerprint sensor
- Hyprland compositor
- fprintd 1.94.2
- Custom PAM config with lid-check rule

**Scenarios verified:**
- [x] Lock screen shows fingerprint indicator when sensor enrolled
- [x] Touching sensor unlocks immediately
- [x] Typing password and pressing Enter switches to password-only mode
- [x] Can type password while fingerprint scans, then choose either method
- [x] Resume from suspend: continuous detection enables fingerprint when fprintd ready
- [x] No sensor/enrollment: gracefully shows password-only mode

**Still needs testing:**
- [ ] Non-NixOS systems (generated PAM config)
- [ ] Different compositors (Niri, Sway, labwc)
- [ ] Multiple monitors

## Notes

- Fingerprint indicator is icon-only (no text) for clean UI
- Works with existing PAM customizations (e.g., lid-check rules)
- No translation keys needed (icon-only UI)
- Abort timeout (500ms) provides fallback if PAM abort hangs