### PR TITLE
Reload hyprland after applying noctalia theme

### DIFF
--- a/Bin/colors-apply.sh
+++ b/Bin/colors-apply.sh
@@ -307,6 +307,10 @@ hyprland)
             echo "✅ Added noctalia theme include to config."
         fi
     fi
+
+    # Reload hyprland
+    echo "✅ Reloading hyprland"
+    hyprctl reload
     ;;
 
 mango)


### PR DESCRIPTION
# Pull Request

## Motivation
Hyprland shows an error after changing the colorscheme. Basically adding ``hyprctl reload`` to ``colors-appy.sh`` fixes it. Probably because of the latest Hyprland update, it wasn't happening before.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
### Before change

https://github.com/user-attachments/assets/0e56342f-95ff-4ed2-9bd8-2a8aec8ac86d

### After change

https://github.com/user-attachments/assets/be20ff98-246d-492a-85a7-46df8fe58129

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
