### PR TITLE
feat: support Niri Alt-Tab in Matugen template

### DIFF
--- a/Assets/MatugenTemplates/niri.kdl
+++ b/Assets/MatugenTemplates/niri.kdl
@@ -26,3 +26,10 @@ layout {
         color "{{colors.primary.default.hex}}80"
     }
 }
+
+recent-windows {
+    highlight {
+        active-color "{{colors.primary.default.hex}}"
+        urgent-color "{{colors.error.default.hex}}"
+    }
+}


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Adds `recent-windows` support to the Matugen template. This enables dynamic theming for the new Niri Alt-Tab window switcher using the defined color palette.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/99f45ae2-cd2a-4f9d-b6e4-c551ffb1761d



## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
