### PR TITLE
Add function to IPCService to query current visibility of bar

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -27,6 +27,9 @@ Item {
     function toggle() {
       BarService.isVisible = !BarService.isVisible;
     }
+    function isVisible(): bool {
+      return BarService.isVisible;
+    }
   }
 
   IpcHandler {


### PR DESCRIPTION
# Pull Request

## Motivation
This PR adds a function to IPCService which allows users to query the current visibility of the bar. This can be used in external scripts to specifically hide or show the bar instead of just a toggle or to do different behaviours depending on the current visibility of the bar.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
IPC docs need to be updated
