### PR TITLE
SessionMenu: add single row layout

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -779,6 +779,10 @@
       "hover": "Scroll on hover",
       "never": "Never scroll"
     },
+    "session-menu-grid-layout": {
+      "grid": "Grid",
+      "single-row": "Single Row"
+    },
     "settings-panel-mode": {
       "attached": "Panel attached to bar",
       "centered": "Centered panel",
@@ -2357,6 +2361,10 @@
       "large-buttons-style": {
         "description": "Display the session menu with large buttons in a grid layout.",
         "label": "Large buttons style"
+      },
+      "large-buttons-layout": {
+        "description": "Choose how session menu buttons are displayed.",
+        "label": "Large buttons layout"
       },
       "position": {
         "description": "Choose where the session menu panel appears when opened.",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -529,6 +529,7 @@ Singleton {
       property string position: "center"
       property bool showHeader: true
       property bool largeButtonsStyle: false
+      property string largeButtonsLayout: "grid"
       property bool showNumberLabels: true
       property list<var> powerOptions: [
         {

--- a/Modules/Panels/SessionMenu/SessionMenu.qml
+++ b/Modules/Panels/SessionMenu/SessionMenu.qml
@@ -16,6 +16,7 @@ SmartPanel {
   id: root
 
   readonly property bool largeButtonsStyle: Settings.data.sessionMenu.largeButtonsStyle || false
+  readonly property bool largeButtonsLayout: Settings.data.sessionMenu.largeButtonsLayout || "grid"
 
   // Make panel background transparent for large buttons style
   panelBackgroundColor: largeButtonsStyle ? Color.transparent : Color.mSurface
@@ -293,8 +294,14 @@ SmartPanel {
   }
 
   function getGridInfo() {
-    const columns = Math.min(3, Math.ceil(Math.sqrt(powerOptions.length)));
-    const rows = Math.ceil(powerOptions.length / columns);
+    if (Settings.data.sessionMenu.largeButtonsLayout === "single-row") {
+      const columns = powerOptions.length;
+      const rows = 1;
+    } else {
+      const columns = Math.min(3, Math.ceil(Math.sqrt(powerOptions.length)));
+      const rows = Math.ceil(powerOptions.length / columns);
+    }
+
     return {
       columns,
       rows,
@@ -521,7 +528,7 @@ SmartPanel {
       GridLayout {
         id: largeButtonsGrid
         Layout.alignment: Qt.AlignHCenter
-        columns: Math.min(3, Math.ceil(Math.sqrt(powerOptions.length)))
+        columns: Settings.data.sessionMenu.largeButtonsLayout === "single-row" ?  powerOptions.length : Math.min(3, Math.ceil(Math.sqrt(powerOptions.length)))
         rowSpacing: Style.marginXL
         columnSpacing: Style.marginXL
         width: columns * 200 * Style.uiScaleRatio + (columns - 1) * Style.marginXL

--- a/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuTab.qml
+++ b/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuTab.qml
@@ -178,6 +178,27 @@ ColumnLayout {
     onToggled: checked => Settings.data.sessionMenu.largeButtonsStyle = checked
   }
 
+  NComboBox {
+    visible: Settings.data.sessionMenu.largeButtonsStyle
+    Layout.fillWidth: true
+    label: I18n.tr("settings.session-menu.large-buttons-layout.label")
+    description: I18n.tr("settings.session-menu.large-buttons-layout.description")
+    model: [
+      {
+        "key": "grid",
+        "name": I18n.tr("options.session-menu-grid-layout.grid")
+      },
+      {
+        "key": "single-row",
+        "name": I18n.tr("options.session-menu-grid-layout.single-row")
+      }
+    ]
+    currentKey: Settings.data.sessionMenu.largeButtonsLayout
+    isSettings: true
+    defaultValue: Settings.getDefaultValue("sessionMenu.largeButtonsLayout")
+    onSelected: key => Settings.data.sessionMenu.largeButtonsLayout = key
+  }
+
   NToggle {
     Layout.fillWidth: true
     label: I18n.tr("settings.session-menu.show-number-labels.label")


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

I find the look of having a single row of large icons to be more visually appealing. I've kept the current grid layout as the default.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

New layout selector dropdown in session menu settings:

<img width="565" height="757" alt="image" src="https://github.com/user-attachments/assets/67fe083f-5e2f-489b-8ffb-723e10fc1698" />

Left is the current session menu default, right is the new single row look.

![2025-12-30T22_16_39+08_00](https://github.com/user-attachments/assets/a2c57b28-a7f5-4ed1-9ea0-34ae8821ce4f)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I'm not sure how adding new translations are handled; I've only added the strings for English.