### PR TITLE
MediaPlayer Widget persistent position for play/pause and animations.

### DIFF
--- a/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
+++ b/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
@@ -250,7 +250,13 @@ DraggableDesktopWidget {
       Layout.alignment: root.showAlbumArt ? Qt.AlignVCenter : Qt.AlignCenter
 
       NIconButton {
-        visible: showPrev
+        opacity: showPrev ? 1 : 0
+        Behavior on opacity {
+          NumberAnimation {
+            duration: Style.animationSlow
+            easing.type: Easing.InOutQuad
+          }
+        }
         baseSize: Math.round(32 * widgetScale)
         icon: "media-prev"
         enabled: hasPlayer && MediaService.canGoPrevious
@@ -280,7 +286,13 @@ DraggableDesktopWidget {
       }
 
       NIconButton {
-        visible: showNext
+        opacity: showNext ? 1 : 0
+        Behavior on opacity {
+          NumberAnimation {
+            duration: Style.animationSlow
+            easing.type: Easing.InOutQuad
+          }
+        }
         baseSize: Math.round(32 * widgetScale)
         icon: "media-next"
         enabled: hasPlayer && MediaService.canGoNext


### PR DESCRIPTION
# Pull Request


## Motivation
The current behavior of the media player controls is a bit rough. When switching from a single media item to a playlist, the next/previous buttons appear instantly and cause the play/pause button to shift. This makes the UI feel jarring and makes it harder to build muscle memory, since the play/pause button changes position.

## Type of Change
Mark the relevant option with an "x".
- [x] Minor improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue


## Testing
I have been using it for about a week on my own fork, everything has been working smoothly.
Doesn't seem to break anything, I've tried it with all different toggle settings and it works fine.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
I am uploading two videos to demonstrate the before and after behavior.

Here is the before

https://github.com/user-attachments/assets/987a0593-51eb-4af5-8d44-55bf01df0d58

Here is the after

https://github.com/user-attachments/assets/d2f899d0-8e49-4ff2-942e-152651280ca1


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I chose to hide the next/prev using opacity. This shouldn’t introduce any breaking changes, since when only a single media item is present, the buttons aren’t clickable anyway.
