### PR TITLE
discord: better hover readability - changed template color again

### DIFF
--- a/Assets/MatugenTemplates/vesktop.css
+++ b/Assets/MatugenTemplates/vesktop.css
@@ -88,7 +88,7 @@ body {
 --bg-2: {{colors.surface_container_low.default.hex}}; /* dark buttons */
 --bg-3: {{colors.surface_container.default.hex}}; /* spacing, secondary elements */
 --bg-4: {{colors.surface.default.hex}}; /* main background color */
---hover: {{colors.surface_variant.default.hex}}60; /* channels and buttons when hovered */
+--hover: {{colors.on_surface.default.hex}}15; /* channels and buttons when hovered */
 --active: {{colors.surface_container_highest.default.hex}}40; /* channels and buttons when clicked or selected */
 --active-2: {{colors.surface.default.hex}}30; /* extra state for transparent buttons */
 --message-hover: {{colors.surface_variant.default.hex}}40; /* messages when hovered */


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

Updated color choice based on feedback. Should be much more readable with better contrast on some elements, and look good in both Dark and Light mode as well as with Matugen generated color schemes and pre-defined color schemes.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

<img width="1824" height="109" alt="image" src="https://github.com/user-attachments/assets/d9cedad2-3593-4d27-9c13-83fd75616e9c" />
<img width="76" height="211" alt="image" src="https://github.com/user-attachments/assets/94ece8c8-46fe-4b41-b420-c1bab208ae21" />
<img width="69" height="201" alt="image" src="https://github.com/user-attachments/assets/4f851572-7648-4da2-9219-55161a848c3f" />

<img width="1816" height="102" alt="image" src="https://github.com/user-attachments/assets/2878a861-ca4c-4dcd-9229-8974a9bad860" />
<img width="67" height="208" alt="image" src="https://github.com/user-attachments/assets/c3cc3fae-54a7-482e-8a2e-aed177766e2f" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
