### PR TITLE
VSCode temmplate fix

### DIFF
--- a/Assets/MatugenTemplates/code.json
+++ b/Assets/MatugenTemplates/code.json
@@ -1787,6 +1787,7 @@
       "editorOverviewRuler.wordHighlightForeground": "{{colors.secondary.default.hex}}",
       "editorOverviewRuler.wordHighlightStrongForeground": "{{colors.secondary.default.hex}}",
       "editorRuler.foreground": "{{colors.outline_variant.default.hex}}",
+      "editorStickyScrollHover.background": "{{colors.surface_variant.default.hex}}", 
       "editorSuggestWidget.background": "{{colors.surface.default.hex}}",
       "editorSuggestWidget.border": "{{colors.outline.default.hex}}",
       "editorSuggestWidget.foreground": "{{colors.on_surface.default.hex}}",


### PR DESCRIPTION
# Pull Request

## Motivation
Fix for an issue raised in the Noctalia discord. There was just an unset element that hadn't been noticed until now due to the default value set by VS Code blending in pretty well with Noctalia's dark mode themes.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
tested with light and dark mode themes. Working as intended.

- [x] Tested on niri

## Screenshots / Videos
before:
![before](https://media.discordapp.net/attachments/1401607843123036162/1456768577612026018/image.png?ex=695990f6&is=69583f76&hm=0be7c2087e5f44f5256f43a5ff2501af0f34884c2b2b790102fdc72003e62851&=&format=webp&quality=lossless)

after:
![after](https://cdn.discordapp.com/attachments/1401607843123036162/1456768577922269194/image.png?ex=695990f6&is=69583f76&hm=0c7885c856782ab849c7be9e7e56e0ad6cb6fbb5c49f1265a549b4e3057facd8&)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
