### PR TITLE
feat: add folder organization to wallpaper selector

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2898,6 +2898,7 @@
     "widget-settings": "Widget settings"
   },
   "wallpaper": {
+    "all-folders": "All Folders",
     "configure-directory": "Configure your wallpaper directory with images.",
     "fill-modes": {
       "center": "Center",
@@ -2905,6 +2906,8 @@
       "fit": "Fit (Contain)",
       "stretch": "Stretch"
     },
+    "folder": "Folder",
+    "images": "images",
     "no-match": "No match found.",
     "no-wallpaper": "No wallpaper found.",
     "panel": {

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -2898,6 +2898,7 @@
     "widget-settings": "Configurações do widget"
   },
   "wallpaper": {
+    "all-folders": "Todas as Pastas",
     "configure-directory": "Configure seu diretório de papéis de parede com imagens.",
     "fill-modes": {
       "center": "Centralizar",
@@ -2905,6 +2906,8 @@
       "fit": "Ajustar (Conter)",
       "stretch": "Esticar"
     },
+    "folder": "Pasta",
+    "images": "imagens",
     "no-match": "Nenhuma correspondência encontrada.",
     "no-wallpaper": "Nenhum papel de parede encontrado.",
     "panel": {


### PR DESCRIPTION
## 📁 Description
This PR adds folder organization to the wallpaper selector panel, making it easier to browse wallpapers organized in subdirectories.

## ✨ Features
- Added folder selector dropdown to filter wallpapers by folder
- Automatically groups wallpapers by their parent directories
- Shows wallpaper count per folder
- "All Folders" option to show all wallpapers
- Maintains search functionality within selected folder
- Fully integrated with Noctalia's Matugen color scheme

## 📸 Screenshots

<img width="1703" height="495" alt="image" src="https://github.com/user-attachments/assets/68ed4e67-3528-4b0e-aa39-503543921c6c" />

<img width="1703" height="495" alt="image" src="https://github.com/user-attachments/assets/acedef07-7f51-4319-8c0a-8e55f4cb6df2" />


## 🧪 Testing
Tested with wallpapers organized in multiple subdirectories. The selector correctly:
- Lists all unique folders
- Filters wallpapers by selected folder
- Updates count dynamically
- Works with the existing search filter

## 🌐 Translations
Added translations for:
- `wallpaper.folder`
- `wallpaper.all-folders`
- `wallpaper.images`

Currently includes: English (en) and Portuguese (pt)