### PR TITLE
Add function to cycle power profiles in reverse order

### DIFF
--- a/Modules/Bar/Widgets/PowerProfile.qml
+++ b/Modules/Bar/Widgets/PowerProfile.qml
@@ -28,4 +28,5 @@ NIconButton {
   border.color: Style.capsuleBorderColor
   border.width: Style.capsuleBorderWidth
   onClicked: PowerProfileService.cycleProfile()
+  onRightClicked: PowerProfileService.cycleProfileReverse()
 }

--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -392,6 +392,10 @@ Item {
       PowerProfileService.cycleProfile();
     }
 
+    function cycleReverse() {
+      PowerProfileService.cycleProfileReverse();
+    }
+
     function set(mode: string) {
       switch (mode) {
       case "performance":

--- a/Services/Power/PowerProfileService.qml
+++ b/Services/Power/PowerProfileService.qml
@@ -78,6 +78,18 @@ Singleton {
       setProfile(PowerProfile.Balanced);
   }
 
+  function cycleProfileReverse() {
+    if (!available)
+      return;
+    const current = powerProfiles.profile;
+    if (current === PowerProfile.Performance)
+      setProfile(PowerProfile.Balanced);
+    else if (current === PowerProfile.Balanced)
+      setProfile(PowerProfile.PowerSaver);
+    else if (current === PowerProfile.PowerSaver)
+      setProfile(PowerProfile.Performance);
+    }
+
   function isDefault() {
     if (!available)
       return true;


### PR DESCRIPTION
# Pull Request

## Motivation
This PR adds a function and corresponding click functionality to let users cycle the power profiles in a reverse order by right clicking the bar widget or by IPC call.
## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
