### PR TITLE
[i18n/ja] Remove parenthesized romaji and replace 記憶 by メモリ

### DIFF
--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -235,7 +235,7 @@
         },
         "show-icon": {
           "description": "キーボードレイアウトのアイコンを表示します。",
-          "label": "アイコンを表示 (Aikona o hyōji)"
+          "label": "アイコンを表示"
         }
       },
       "launcher": {
@@ -351,7 +351,7 @@
         },
         "memory-percentage": {
           "description": "メモリ使用量を絶対値ではなくパーセンテージで表示します。",
-          "label": "メモリをパーセント表示"
+          "label": "メモリをパーセントで表示"
         },
         "memory-usage": {
           "description": "現在の RAM 使用量を表示します。",
@@ -506,7 +506,7 @@
       "disconnecting": "切断中...",
       "discoverable": "発見可能",
       "enable-message": "利用可能なデバイスを表示するには Bluetooth を有効にしてください。",
-      "info": "情報 (Jōhō)",
+      "info": "情報",
       "known-devices": "登録済みデバイス",
       "no-devices": "利用可能なデバイスはありません",
       "pair": "ペア",
@@ -516,7 +516,7 @@
       "pairing-mode": "デバイスがペアリングモードになっていることを確認してください。",
       "refresh-devices": "デバイスを更新",
       "scanning": "デバイスをスキャン中...",
-      "signal": "信号 (shingō)",
+      "signal": "信号",
       "signal-text": {
         "excellent": "信号: 良好",
         "fair": "合図：可",
@@ -596,7 +596,7 @@
     "close-app": "{app} を閉じる",
     "connect-vpn": "{name} に接続",
     "cycle-visualizer": "ビジュアライザーを切り替える",
-    "delete": "削除 (Sakujo)",
+    "delete": "削除",
     "disable-bluetooth": "Bluetooth を無効化",
     "disable-dnd": "おやすみモードを無効化",
     "disable-wifi": "Wi-Fi を無効化",
@@ -741,7 +741,7 @@
       }
     },
     "colors": {
-      "error": "エラー (Error)",
+      "error": "エラー",
       "none": "なし",
       "onSurface": "文字・アイコン (On Surface)",
       "primary": "メインカラー (Primary)",
@@ -2256,7 +2256,7 @@
       "settings-saved": "プラグイン設定を保存しました",
       "source": {
         "custom": "カスタムソース",
-        "official": "公式 (kōshiki)"
+        "official": "公式"
       },
       "sources": {
         "add-custom": "カスタムリポジトリを追加",
@@ -2715,10 +2715,10 @@
     "cpu-usage": "CPU使用率",
     "disk": "ディスク",
     "download": "ダウンロード",
-    "download-speed": "ダウンロード速度 (Daunrōdo sokudo)",
+    "download-speed": "ダウンロード速度",
     "gpu-temp": "GPU温度",
     "load-average": "負荷平均",
-    "memory": "記憶",
+    "memory": "メモリ",
     "title": "システムモニター",
     "upload": "アップロード",
     "upload-speed": "アップロード速度"
@@ -2970,7 +2970,7 @@
       },
       "search": "検索",
       "solid-color": {
-        "tooltip": "無地 (Muji)"
+        "tooltip": "無地"
       },
       "sorting": {
         "date_added": "追加日",
@@ -3118,7 +3118,7 @@
       "forgetting": "削除中...",
       "frequency": "周波数",
       "gateway": "ゲートウェイ",
-      "info": "情報 (Jōhō)",
+      "info": "情報",
       "internet": "インターネット",
       "internet-connected": "インターネット接続",
       "internet-limited": "インターネットなし",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

Rōmaji is Japanese transliteration in roman letters. Some labels included unnecessary transliterations in parentheses.

Additionally, this commit fixes a misuse of the word 記憶 (which refers to the memory in the brain) by the more appropriate メモリ (which refers to the memory in computers).

Finally, I also added a grammatical particle (で) in メモリをパーセント >で< 表示.


## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
None

## Testing
Not tested because this is a simple change in a few strings.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Showcase of problem:
<img width="279" height="137" alt="system monitor in Japanese" src="https://github.com/user-attachments/assets/9329d8c3-d54a-4fba-aea0-e71d1685733d" />


## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

