### PR TITLE
BluetoothService: fix polling even when disabled

### DIFF
--- a/Services/Networking/BluetoothService.qml
+++ b/Services/Networking/BluetoothService.qml
@@ -223,7 +223,7 @@ QtObject {
   property Timer ctlPollTimer: Timer {
     interval: ctlPollMs
     repeat: true
-    running: true
+    running: root.enabled
     onTriggered: pollCtlState()
   }
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
bluetoothctl is still polled despite bluetooth being disabled, leading to hundreds of log messages such as 

```
Jan 04 09:35:11 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:12 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:14 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:15 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:17 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:18 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:20 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:21 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:23 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:24 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:26 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:27 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
Jan 04 09:35:29 desktop noctalia-shell[4148]:   WARN: Process failed to start, likely because the binary could not be found. Command: QList("bluetoothctl", "show")
```

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
