### PR TITLE
Vscode quote highlighting

### DIFF
--- a/Assets/MatugenTemplates/code.json
+++ b/Assets/MatugenTemplates/code.json
@@ -1984,4 +1984,4 @@
       "welcomePage.buttonHoverBackground": "{{colors.primary.default.hex}}20",
       "widget.shadow": "{{colors.background.default.hex}}5c"
     }
-  }
+}


### PR DESCRIPTION
# Pull Request

## Motivation
Implements a feature request from the discord server that improves quote contrast by differentiating the quotation marks from the quote contents with a different colour. Also applied a small indentation fix. 

## Type of Change
- [x] Bug fix
- [x] New feature

## Testing
Tested with multiple schemes in light and dark modes.

- [x] Tested on niri

## Screenshots / Videos
Before:
![before](https://media.discordapp.net/attachments/1456684572765851809/1457211183353434132/image.png?ex=695b2d2b&is=6959dbab&hm=57e75d8907d98e5bf39ed0d4d172e071c4c34d8f48b88dd63e4ee2b52031c8d3&=&format=webp&quality=lossless&width=1561&height=257)
After:
![after](https://cdn.discordapp.com/attachments/1456684572765851809/1457211271090012285/image.png?ex=695b2d40&is=6959dbc0&hm=9a91bfc52700e920cb2db7f98dd4669d723d2d7fc404f68c641d6d7c1a1489bd&)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors