### PR TITLE
IPC: add bar hide / show

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -27,6 +27,12 @@ Item {
     function toggle() {
       BarService.isVisible = !BarService.isVisible;
     }
+    function hide() {
+      BarService.isVisible = false;
+    }
+    function show() {
+      BarService.isVisible = true;
+    }
   }
 
   IpcHandler {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
I want to start with the bar hidden on my laptop with a smaller screen. I realize that running `bar toggle` at startup would achieve the same thing, but i think the separate IPC commands would be useful for keybinds as well. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
