### PR TITLE
I18n fix. Dock/Workspace/Taskbar menus had old values.

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -321,7 +321,7 @@ Rectangle {
       if (root.selectedWindowId) {
         // Focus item (for running apps)
         items.push({
-                     "label": I18n.tr("dock.menu.focus"),
+                     "label": I18n.tr("common.focus"),
                      "action": "focus",
                      "icon": "eye"
                    });
@@ -329,14 +329,14 @@ Rectangle {
         // Pin/Unpin item (always available when right-clicking an app)
         const isPinned = root.isAppPinned(root.selectedAppId);
         items.push({
-                     "label": !isPinned ? I18n.tr("dock.menu.pin") : I18n.tr("dock.menu.unpin"),
+                     "label": !isPinned ? I18n.tr("common.pin") : I18n.tr("common.unpin"),
                      "action": "pin",
                      "icon": !isPinned ? "pin" : "unpin"
                    });
 
         // Close item (for running apps)
         items.push({
-                     "label": I18n.tr("dock.menu.close"),
+                     "label": I18n.tr("common.close"),
                      "action": "close",
                      "icon": "x"
                    });
@@ -689,7 +689,7 @@ Rectangle {
     if (root.selectedWindowId) {
       // Focus item (for running apps)
       items.push({
-                   "label": I18n.tr("dock.menu.focus"),
+                   "label": I18n.tr("common.focus"),
                    "action": "focus",
                    "icon": "eye"
                  });
@@ -697,14 +697,14 @@ Rectangle {
       // Pin/Unpin item
       const isPinned = root.isAppPinned(root.selectedAppId);
       items.push({
-                   "label": !isPinned ? I18n.tr("dock.menu.pin") : I18n.tr("dock.menu.unpin"),
+                   "label": !isPinned ? I18n.tr("common.pin") : I18n.tr("common.unpin"),
                    "action": "pin",
                    "icon": !isPinned ? "pin" : "unpin"
                  });
 
       // Close item
       items.push({
-                   "label": I18n.tr("dock.menu.close"),
+                   "label": I18n.tr("common.close"),
                    "action": "close",
                    "icon": "x"
                  });

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -327,7 +327,7 @@ Item {
       if (root.selectedWindowId) {
         // Focus item
         items.push({
-                     "label": I18n.tr("dock.menu.focus"),
+                     "label": I18n.tr("common.focus"),
                      "action": "focus",
                      "icon": "eye"
                    });
@@ -335,14 +335,14 @@ Item {
         // Pin/Unpin item
         const isPinned = root.isAppPinned(root.selectedAppId);
         items.push({
-                     "label": !isPinned ? I18n.tr("dock.menu.pin") : I18n.tr("dock.menu.unpin"),
+                     "label": !isPinned ? I18n.tr("common.pin") : I18n.tr("common.unpin"),
                      "action": "pin",
                      "icon": !isPinned ? "pin" : "pinned-off"
                    });
 
         // Close item
         items.push({
-                     "label": I18n.tr("dock.menu.close"),
+                     "label": I18n.tr("common.close"),
                      "action": "close",
                      "icon": "x"
                    });

--- a/Modules/Dock/DockMenu.qml
+++ b/Modules/Dock/DockMenu.qml
@@ -82,7 +82,7 @@ PopupWindow {
       // Focus item
       next.push({
                   "icon": "eye",
-                  "text": I18n.tr("dock.menu.focus"),
+                  "text": I18n.tr("common.focus"),
                   "action": function () {
                     handleFocus();
                   }
@@ -92,7 +92,7 @@ PopupWindow {
     // Pin/Unpin item
     next.push({
                 "icon": !isPinned ? "pin" : "unpin",
-                "text": !isPinned ? I18n.tr("dock.menu.pin") : I18n.tr("dock.menu.unpin"),
+                "text": !isPinned ? I18n.tr("common.pin") : I18n.tr("common.unpin"),
                 "action": function () {
                   handlePin();
                 }
@@ -102,7 +102,7 @@ PopupWindow {
       // Close item
       next.push({
                   "icon": "close",
-                  "text": I18n.tr("dock.menu.close"),
+                  "text": I18n.tr("common.close"),
                   "action": function () {
                     handleClose();
                   }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Taskbar/Workspace/Dock right click menus had default values (i.e ## dock.menu.focus ##) from before the translation refactor. Updated to correct values.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
