### PR TITLE
fix: adjust bar margin calculations for pixel-perfect alignment

### DIFF
--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -37,6 +37,7 @@ Item {
   readonly property string barPosition: Settings.data.bar.position || "top"
   readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
   readonly property bool barFloating: Settings.data.bar.floating || false
+  readonly property int barInset: Style.pixelAlignCenter(Style.barHeight, Style.capsuleHeight)
 
   // Fill the parent (the Loader)
   anchors.fill: parent
@@ -213,7 +214,7 @@ Item {
       ColumnLayout {
         x: Style.pixelAlignCenter(parent.width, width)
         anchors.top: parent.top
-        anchors.topMargin: Style.marginM
+        anchors.topMargin: root.barInset
         spacing: Style.marginS
 
         Repeater {
@@ -264,7 +265,7 @@ Item {
       ColumnLayout {
         x: Style.pixelAlignCenter(parent.width, width)
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Style.marginM
+        anchors.bottomMargin: root.barInset
         spacing: Style.marginS
 
         Repeater {
@@ -300,9 +301,9 @@ Item {
         id: leftSection
         objectName: "leftSection"
         anchors.left: parent.left
-        anchors.leftMargin: Style.marginS
+        anchors.leftMargin: root.barInset
         y: Style.pixelAlignCenter(parent.height, height)
-        spacing: Style.marginS
+        spacing: root.barInset
 
         Repeater {
           model: root.filterValidWidgets(Settings.data.bar.widgets.left)
@@ -329,7 +330,7 @@ Item {
         objectName: "centerSection"
         anchors.horizontalCenter: parent.horizontalCenter
         y: Style.pixelAlignCenter(parent.height, height)
-        spacing: Style.marginS
+        spacing: root.barInset
 
         Repeater {
           model: root.filterValidWidgets(Settings.data.bar.widgets.center)
@@ -355,9 +356,9 @@ Item {
         id: rightSection
         objectName: "rightSection"
         anchors.right: parent.right
-        anchors.rightMargin: Style.marginS
+        anchors.rightMargin: root.barInset
         y: Style.pixelAlignCenter(parent.height, height)
-        spacing: Style.marginS
+        spacing: root.barInset
 
         Repeater {
           model: root.filterValidWidgets(Settings.data.bar.widgets.right)

--- a/Modules/MainScreen/MainScreen.qml
+++ b/Modules/MainScreen/MainScreen.qml
@@ -317,8 +317,8 @@ PanelWindow {
       readonly property string barPosition: Settings.data.bar.position || "top"
       readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
       readonly property bool barFloating: Settings.data.bar.floating || false
-      readonly property real barMarginH: barFloating ? Math.floor(Settings.data.bar.marginHorizontal * Style.marginXL) : 0
-      readonly property real barMarginV: barFloating ? Math.floor(Settings.data.bar.marginVertical * Style.marginXL) : 0
+      readonly property real barMarginH: barFloating ? Math.ceil(Settings.data.bar.marginHorizontal * Style.marginXL) : 0
+      readonly property real barMarginV: barFloating ? Math.ceil(Settings.data.bar.marginVertical * Style.marginXL) : 0
 
       // Expose bar dimensions directly on this Item for BarBackground
       // Use screen dimensions directly


### PR DESCRIPTION
## Summary
- Fixes bar margin calculations to use pixel-aligned insets and `Math.ceil()` instead of `Math.floor()`
- Introduces `barInset` property for consistent pixel-aligned spacing
- Updates both horizontal and vertical bar margins for floating bars

## Changes Made
- **Bar.qml**: Added `barInset` property using `Style.pixelAlignCenter()` for consistent spacing
- Replaced hardcoded margins with `barInset` in all bar sections (top, bottom, left, center, right)
- **MainScreen.qml**: Changed margin calculations from `Math.floor()` to `Math.ceil()` for floating bars

## Visual Impact
This change ensures pixel-perfect alignment of bar widgets and margins. Before/after screenshots or videos should be added to demonstrate the visual improvements.

## Related Issues
Fixes spacing and alignment issues with bar widgets.

![comparison-slider](https://github.com/user-attachments/assets/4dd04b4d-ea20-48d2-b7bc-54c984a6c93b)

![comparison-slider](https://github.com/user-attachments/assets/875821f2-3d77-48b6-9d4f-a15dc02f9bd0)