### PR TITLE
Display Pinned Apps in Dock option

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -900,6 +900,8 @@
       "appearance-icon-size-label": "Dock size",
       "appearance-inactive-indicators-description": "Display indicator pills for all apps, not just the currently active one.",
       "appearance-inactive-indicators-label": "Running Indicators",
+      "appearance-display-pinned-apps-description": "Display Pinned Apps in the dock.",
+      "appearance-display-pinned-apps-label": "Display Pinned Apps",
       "appearance-pinned-static-description": "Always push pinned app icons to the left in static order.",
       "appearance-pinned-static-label": "Static Pinned Apps",
       "enabled-description": "Show or hide the dock entirely.",

--- a/Assets/Translations/pl.json
+++ b/Assets/Translations/pl.json
@@ -898,6 +898,8 @@
       "appearance-hide-show-speed-label": "Prędkość ukrywania/pokazywania",
       "appearance-icon-size-description": "Dostosuj ogólny rozmiar doku.",
       "appearance-icon-size-label": "Rozmiar doku",
+      "appearance-display-pinned-apps-description": "Wyświetlaj Przypięte Aplikacje na doku.",
+      "appearance-display-pinned-apps-label": "Wyświetlaj przypięte aplikacje",
       "appearance-inactive-indicators-description": "Wyświetlaj wskaźniki dla wszystkich uruchomionych aplikacji, nie tylko dla aktywnej.",
       "appearance-inactive-indicators-label": "Wskaźniki uruchomionych",
       "appearance-pinned-static-description": "Zawsze spychaj przypięte aplikacje na lewo w stałej kolejności.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -289,6 +289,7 @@
     "size": 1,
     "onlySameOutput": true,
     "monitors": [],
+    "displayPinnedApps": true,
     "pinnedApps": [],
     "colorizeIcons": false,
     "pinnedStatic": false,

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -516,6 +516,7 @@ Singleton {
       property real size: 1
       property bool onlySameOutput: true
       property list<string> monitors: [] // holds dock visibility per monitor
+      property bool displayPinnedApps: true
       property list<string> pinnedApps: [] // Desktop entry IDs pinned to the dock (e.g., "org.kde.konsole", "firefox.desktop")
       property bool colorizeIcons: false
 

--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -42,6 +42,9 @@ Loader {
       // Update dock apps when pinned apps change
       Connections {
         target: Settings.data.dock
+        function onDisplayPinnedAppsChanged() {
+          updateDockApps();
+        }
         function onPinnedAppsChanged() {
           updateDockApps();
         }
@@ -153,7 +156,8 @@ Loader {
       // Function to update the combined dock apps model
       function updateDockApps() {
         const runningApps = ToplevelManager ? (ToplevelManager.toplevels.values || []) : [];
-        const pinnedApps = Settings.data.dock.pinnedApps || [];
+        // const pinnedApps = Settings.data.dock.pinnedApps || [];
+        const pinnedApps = Settings.data.dock.displayPinnedApps ? (Settings.data.dock.pinnedApps || []) : [];
         const combined = [];
         const processedToplevels = new Set();
         const processedPinnedAppIds = new Set();

--- a/Modules/Panels/Settings/Tabs/Dock/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Dock/AppearanceSubTab.qml
@@ -122,6 +122,14 @@ ColumnLayout {
     }
 
     NToggle {
+      label: I18n.tr("panels.dock.appearance-display-pinned-apps-label")
+      description: I18n.tr("panels.dock.appearance-display-pinned-apps-description")
+      checked: Settings.data.dock.displayPinnedApps
+      defaultValue: Settings.getDefaultValue("dock.displayPinnedApps")
+      onToggled: checked => Settings.data.dock.displayPinnedApps = checked
+    }
+
+    NToggle {
       label: I18n.tr("panels.dock.appearance-pinned-static-label")
       description: I18n.tr("panels.dock.appearance-pinned-static-description")
       checked: Settings.data.dock.pinnedStatic


### PR DESCRIPTION
# Pull Request

After trying out Noctalia I am amazed with its quality, but have noticed that pinning apps in the App Launcher, does the same for the Dock, which for some (me) can be an unintended result. I realize the UX is meant to probably act this way and to split the 2 would require bigger underlying changes (or could be simply not desired)
This PR adds a simple toggle to Display Pinned Apps (default On) or Hide them in the Dock.
Its basically my first PR to a project, so Im sorry if its patchy and needs more testing or work.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I have included the language translation for Polish since that is my native tongue.
