### PR TITLE
fix(tooltip): prevent orphaned tooltips when clicking during hover delay

### DIFF
--- a/Services/UI/TooltipService.qml
+++ b/Services/UI/TooltipService.qml
@@ -26,8 +26,8 @@ Singleton {
       return;
     }
 
-    // If we have a pending tooltip for a different target, cancel it
-    if (pendingTooltip && pendingTooltip.targetItem !== target) {
+    // Cancel any pending tooltip (same or different target)
+    if (pendingTooltip) {
       pendingTooltip.hideImmediately();
       pendingTooltip.destroy();
       pendingTooltip = null;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
I would like to have the possibility to update the tooltip when it's clicked. Currently, it's broken and causes the tooltip to freeze forever.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1317 

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Bug repro is listed in #1317 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)