### PR TITLE
Ability to drag and drop windows in Taskbar to change the order

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -796,7 +796,11 @@ Rectangle {
             }
           }
 
-          function performSwap(from, to) {
+          // Helper function to reorder the combinedModel array and persist the custom order
+          function performSwap() {
+            var from = taskbarItem.index;
+            var to = taskbarItem.rootItem.dragOverIndex;
+
             if (from !== to && from >= 0 && to >= 0 && from < root.combinedModel.length && to < root.combinedModel.length) {
               taskbarItem.rootItem.reorderModel(from, to);
               taskbarItem.rootItem.saveCustomOrder();
@@ -807,10 +811,11 @@ Rectangle {
             dragTimer.stop();
 
             if (taskbarItem.held) {
+              // we were dragging the window - perform the swap
               taskbarItem.held = false;
               taskbarItem.Drag.drop();
 
-              performSwap(taskbarItem.index, taskbarItem.rootItem.dragOverIndex);
+              performSwap();
             } else if (!longPressTriggered && mouse.button === Qt.LeftButton) {
               // regular click behavior
               if (!modelData)


### PR DESCRIPTION
# Summary

This PR modifies the Taskbar widget for Bar module. 
It allows the user to hold the left mouse button on a window, then drag the mouse to a desired place on the Taskbar, then release the left mouse button to reorder the windows.

## Motivation
I got annoyed how windows on the taskbar are essentially stuck in place. The only way to change the order of the windows was to open them in a specific sequence; particularly inconvenient with programs that are set to auto-run on login.

Considering how many features noctalia-shell has, the inability to reorder the windows felt like a missing feature. I initially wanted to leave a feature request but an idea popped up in my mind, and it turned out to be way easier than I thought.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
I continuously dragged-and-dropped the windows in various ways, on various Bar positions (left, right, top, bottom), on various densities and scaling values, with labels turned on and off, with smart width on and off, with floating bar on and off, with various margin settings, with various Taskbar positionings. Pretty much all the settings available on the UI.

There is no multi-monitor support, dragging is possible only within a single Bar.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
[Kooha-2026-01-09-01-13-44.webm](https://github.com/user-attachments/assets/61b9e934-d005-4a54-b404-7299f8292c5c)

This video has an issue towards the end but that's been patched out now.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
