### PR TITLE
nix: Add setting to toggle creation of gui-settings.json

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -22,7 +22,15 @@ in
   options.programs.noctalia-shell = {
     enable = lib.mkEnableOption "Noctalia shell configuration";
 
-    systemd.enable = lib.mkEnableOption "Noctalia shell systemd integration";
+    systemd = {
+      enable = lib.mkEnableOption "Noctalia shell systemd integration";
+
+      mutableRuntimeSettings = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether noctalia-shell creates a gui-settings.json to store setting changes made within the GUI at runtime.";
+      };
+    };
 
     package = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
@@ -155,7 +163,7 @@ in
         Service = {
           ExecStart = lib.getExe cfg.package;
           Restart = "on-failure";
-          Environment = [
+          Environment = lib.mkIf cfg.systemd.mutableRuntimeSettings [
             "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
           ];
         };

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -15,6 +15,12 @@ in
       description = "The noctalia-shell package to use";
     };
 
+    mutableRuntimeSettings = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether noctalia-shell creates a gui-settings.json to store setting changes made within the GUI at runtime.";
+    };
+
     target = lib.mkOption {
       type = lib.types.str;
       default = "graphical-session.target";
@@ -39,7 +45,7 @@ in
       serviceConfig = {
         ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";
-        Environment = [
+        Environment = lib.mkIf cfg.mutableRuntimeSettings [
           "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
         ];
       };


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Users might want to be able to use the systemd service, but not manage their noctalia settings with nix. They should be able to opt out. This PR introduces a `mutableRuntimeSettings` option for them to do so.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
