### PR TITLE
VolumeSettings, MicrophoneSettings: Add middle click command

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -635,6 +635,7 @@
       "media-scrolling-title-description": "Enable continuous scrolling for long media titles.",
       "media-scrolling-title-label": "Scrolling title",
       "media-title": "Media players",
+      "on-middle-clicked-description": "Command to execute when the button is middle-clicked.",
       "panel-applications-empty": "No applications are currently playing audio",
       "title": "Audio",
       "visualizer-type-description": "Choose a visualization type for media playback.",

--- a/Modules/Bar/Widgets/Microphone.qml
+++ b/Modules/Bar/Widgets/Microphone.qml
@@ -34,6 +34,7 @@ Item {
 
   readonly property bool isBarVertical: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
   readonly property string displayMode: (widgetSettings.displayMode !== undefined) ? widgetSettings.displayMode : widgetMetadata.displayMode
+  readonly property string middleClickCommand: (widgetSettings.middleClickCommand !== undefined) ? widgetSettings.middleClickCommand : widgetMetadata.middleClickCommand
 
   // Used to avoid opening the pill on Quickshell startup
   property bool firstInputVolumeReceived: false
@@ -172,6 +173,8 @@ Item {
         contextMenu.openAtItem(pill, screen);
       }
     }
-    onMiddleClicked: root.openExternalMixer()
+    onMiddleClicked: {
+      Quickshell.execDetached(["sh", "-c", middleClickCommand]);
+    }
   }
 }

--- a/Modules/Bar/Widgets/Volume.qml
+++ b/Modules/Bar/Widgets/Volume.qml
@@ -33,6 +33,7 @@ Item {
 
   readonly property bool isBarVertical: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
   readonly property string displayMode: (widgetSettings.displayMode !== undefined) ? widgetSettings.displayMode : widgetMetadata.displayMode
+  readonly property string middleClickCommand: (widgetSettings.middleClickCommand !== undefined) ? widgetSettings.middleClickCommand : widgetMetadata.middleClickCommand
 
   // Used to avoid opening the pill on Quickshell startup
   property bool firstVolumeReceived: false
@@ -156,6 +157,8 @@ Item {
         contextMenu.openAtItem(pill, screen);
       }
     }
-    onMiddleClicked: root.openExternalMixer()
+    onMiddleClicked: {
+      Quickshell.execDetached(["sh", "-c", middleClickCommand]);
+    }
   }
 }

--- a/Modules/Panels/Settings/Bar/WidgetSettings/MicrophoneSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/MicrophoneSettings.qml
@@ -14,10 +14,12 @@ ColumnLayout {
 
   // Local state
   property string valueDisplayMode: widgetData.displayMode !== undefined ? widgetData.displayMode : widgetMetadata.displayMode
+  property string valueMiddleClickCommand: widgetData.middleClickCommand !== undefined ? widgetData.middleClickCommand : widgetMetadata.middleClickCommand
 
   function saveSettings() {
     var settings = Object.assign({}, widgetData || {});
     settings.displayMode = valueDisplayMode;
+    settings.middleClickCommand = valueMiddleClickCommand;
     return settings;
   }
 
@@ -41,5 +43,14 @@ ColumnLayout {
     ]
     currentKey: valueDisplayMode
     onSelected: key => valueDisplayMode = key
+  }
+
+  // Middle click command
+  NTextInput {
+    label: I18n.tr("panels.control-center.shortcuts-custom-button-on-middle-clicked-label")
+    description: I18n.tr("panels.audio.on-middle-clicked-description")
+    placeholderText: I18n.tr("panels.audio.external-mixer-placeholder")
+    text: valueMiddleClickCommand
+    onTextChanged: valueMiddleClickCommand = text
   }
 }

--- a/Modules/Panels/Settings/Bar/WidgetSettings/VolumeSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/VolumeSettings.qml
@@ -14,10 +14,12 @@ ColumnLayout {
 
   // Local state
   property string valueDisplayMode: widgetData.displayMode !== undefined ? widgetData.displayMode : widgetMetadata.displayMode
+  property string valueMiddleClickCommand: widgetData.middleClickCommand !== undefined ? widgetData.middleClickCommand : widgetMetadata.middleClickCommand
 
   function saveSettings() {
     var settings = Object.assign({}, widgetData || {});
     settings.displayMode = valueDisplayMode;
+    settings.middleClickCommand = valueMiddleClickCommand;
     return settings;
   }
 
@@ -41,5 +43,14 @@ ColumnLayout {
     ]
     currentKey: valueDisplayMode
     onSelected: key => valueDisplayMode = key
+  }
+
+  // Middle click command
+  NTextInput {
+    label: I18n.tr("panels.control-center.shortcuts-custom-button-on-middle-clicked-label")
+    description: I18n.tr("panels.audio.on-middle-clicked-description")
+    placeholderText: I18n.tr("panels.audio.external-mixer-placeholder")
+    text: valueMiddleClickCommand
+    onTextChanged: valueMiddleClickCommand = text
   }
 }

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -178,7 +178,8 @@ Singleton {
                                     "compactShowVisualizer": false
                                   },
                                   "Microphone": {
-                                    "displayMode": "onhover"
+                                    "displayMode": "onhover",
+                                    "middleClickCommand": "pwvucontrol || pavucontrol"
                                   },
                                   "NotificationHistory": {
                                     "showUnreadBadge": true,
@@ -246,7 +247,8 @@ Singleton {
                                     "iconScale": 0.8
                                   },
                                   "Volume": {
-                                    "displayMode": "onhover"
+                                    "displayMode": "onhover",
+                                    "middleClickCommand": "pwvucontrol || pavucontrol"
                                   }
                                 })
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
I have a custom script I would like to run to switch between speakers and headphones.
Middle click seemed to be a good target, since the external mixer can still be accessed through the right click context menu.
The existing default behavior of miidle click launching the external mixer is unchanged.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="507" height="279" alt="image" src="https://github.com/user-attachments/assets/f9ca3946-0f45-4813-9ddb-812dddb84d75" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
