### PR TITLE
Nix: remove gpu-screen-recorder dependency

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -15,7 +15,6 @@
   wl-clipboard,
   imagemagick,
   wget,
-  gpu-screen-recorder, # optional
   # calendar support
   calendarSupport ? false,
   python3,
@@ -58,9 +57,6 @@ let
     wl-clipboard
     imagemagick
     wget
-  ]
-  ++ lib.optionals (stdenvNoCC.hostPlatform.system == "x86_64-linux") [
-    gpu-screen-recorder
   ]
   ++ lib.optional calendarSupport (python3.withPackages (pp: [ pp.pygobject3 ]));
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,6 @@
 {
   quickshell,
-  alejandra,
+  nixfmt,
   statix,
   deadnix,
   shfmt,
@@ -16,7 +16,7 @@ mkShellNoCC {
     quickshell
 
     # nix
-    alejandra # formatter
+    nixfmt # formatter
     statix # linter
     deadnix # linter
 


### PR DESCRIPTION
ScreenRecorder has been removed from core.