### PR TITLE
LockScreen: allow password unlock for fingerprint-enabled users

### DIFF
--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import Quickshell.Services.Pam
 import qs.Commons
 import qs.Services.System
@@ -59,6 +60,9 @@ Scope {
       infoMessage = "";
       showFailure = false;
       errorMessage = "";
+      occupyFingerprintSensorProc.running = true;
+    } else {
+      occupyFingerprintSensorProc.running = false;
     }
   }
 
@@ -87,6 +91,11 @@ Scope {
 
     Logger.i("LockContext", "Starting PAM authentication for user:", pam.user);
     pam.start();
+  }
+
+  Process {
+    id: occupyFingerprintSensorProc
+    command: [ "fprintd-verify" ]
   }
 
   PamContext {


### PR DESCRIPTION
A hacky way to fix the problem where users with fingerprint enabled can’t just unlock with their password.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1279
- Closes https://github.com/noctalia-dev/noctalia-shell/pull/1212

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/7bb31359-a303-41fa-b5bf-eaa55019b993

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
