### PR TITLE
feat: Auto-apply KDE color schemes with plasma-apply-colorscheme

### DIFF
--- a/Services/Theming/TemplateProcessor.qml
+++ b/Services/Theming/TemplateProcessor.qml
@@ -216,7 +216,8 @@ Singleton {
                                                                       lines.push(`input_path = "${Quickshell.shellDir}/Assets/MatugenTemplates/${inputFile}"`);
                                                                       const outputPath = output.path.replace("~", homeDir);
                                                                       lines.push(`output_path = "${outputPath}"`);
-                                                                      if (app.postProcess) {
+                                                                      // Add postProcess only on last output
+                                                                      if (app.postProcess && idx === app.outputs.length - 1) {
                                                                         const postHook = escapeTomlString(app.postProcess(mode));
                                                                         lines.push(`post_hook = "${postHook}"`);
                                                                       }

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -85,8 +85,26 @@ Singleton {
       "outputs": [
         {
           "path": "~/.local/share/color-schemes/noctalia.colors"
+        },
+        {
+          "path": "~/.local/share/color-schemes/noctalia-alt.colors"
         }
-      ]
+      ],
+      "postProcess": function(mode) {
+        // Apply KDE color scheme with workaround for plasma-apply-colorscheme bug
+        // KDE requires different name to trigger refresh, so we alternate between two files
+        const stateFile = "~/.cache/noctalia/kde-colorscheme-state";
+        return `if command -v plasma-apply-colorscheme >/dev/null 2>&1; then
+  mkdir -p ~/.cache/noctalia
+  if [ -f "${stateFile}" ] && [ "$(cat ${stateFile})" = "alt" ]; then
+    plasma-apply-colorscheme noctalia >/dev/null 2>&1
+    echo "main" > ${stateFile}
+  else
+    plasma-apply-colorscheme noctalia-alt >/dev/null 2>&1
+    echo "alt" > ${stateFile}
+  fi
+fi`;
+      }
     },
     {
       "id": "fuzzel",


### PR DESCRIPTION
# Pull Request

## Motivation

KDE apps don't automatically update their colors when Noctalia generates new color schemes from wallpapers or predefined themes. Users must manually apply the color scheme using System Settings or `plasma-apply-colorscheme` command.

This is reported in issue #1339 where users request integration similar to [kde-material-you-colors](https://github.com/luisbocanegra/kde-material-you-colors).

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1339

## Changes

### 1. Dual color scheme generation (KDE workaround)
KDE Plasma has a bug where `plasma-apply-colorscheme` doesn't refresh if the color scheme file has the same name. The workaround is to alternate between two different scheme names.

**Implementation:**
- Generate both `noctalia.colors` and `noctalia-alt.colors`
- Alternate between them on each color change
- Track state in `~/.cache/noctalia/kde-colorscheme-state`

### 2. Automatic application via postProcess hook
Added `postProcess` function to `kcolorscheme` template in TemplateRegistry.qml:
- Checks if `plasma-apply-colorscheme` is available
- Reads current state (main/alt)
- Applies opposite scheme to trigger KDE refresh
- Updates state for next iteration

```javascript
postProcess: function(mode) {
  const stateFile = "~/.cache/noctalia/kde-colorscheme-state";
  return `if command -v plasma-apply-colorscheme >/dev/null 2>&1; then
    mkdir -p ~/.cache/noctalia
    if [ -f "${stateFile}" ] && [ "$(cat ${stateFile})" = "alt" ]; then
      plasma-apply-colorscheme noctalia >/dev/null 2>&1
      echo "main" > ${stateFile}
    else
      plasma-apply-colorscheme noctalia-alt >/dev/null 2>&1
      echo "alt" > ${stateFile}
    fi
  fi`;
}
```

### 3. Fixed postProcess execution for multiple outputs
Modified TemplateProcessor.qml to execute postProcess only once when an app has multiple output files:
- Previously: called postProcess for every output (causing duplicates)
- Now: calls only on last output (`idx === app.outputs.length - 1`)
- This ensures KDE color scheme is applied once, not twice

## How It Works

**Color change flow:**
1. User changes wallpaper or selects different predefined scheme
2. Noctalia generates Material You colors via matugen
3. Both `noctalia.colors` and `noctalia-alt.colors` are created
4. postProcess hook checks which scheme is currently active
5. Applies the opposite scheme via `plasma-apply-colorscheme`
6. KDE detects "new" color scheme and updates all apps
7. State file is updated for next iteration

**Supported workflows:**
- ✅ Material You from wallpaper (automatic extraction)
- ✅ Predefined color schemes (manual selection)
- ✅ Works on all compositors (Hyprland, niri, sway, etc.)

## Compositor Compatibility

This feature is **compositor-agnostic**:
- Uses standard KDE Plasma tools (`plasma-apply-colorscheme`)
- No compositor-specific dependencies
- Works on any system with KDE apps + Plasma utilities installed
- Tested on Hyprland, but should work identically on other Wayland compositors

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

**Test Environment:**
- System: Arch Linux / Hyprland
- KDE apps: dolphin, kate, konsole, gwenview
- Plasma utilities: plasma-workspace (for plasma-apply-colorscheme)

**Test scenarios:**
1. ✅ Changed wallpaper with "Use Wallpaper Colors" enabled
2. ✅ Switched between predefined color schemes
3. ✅ Toggled dark/light mode
4. ✅ Verified KDE apps update immediately without restart
5. ✅ Confirmed no duplicate applications (postProcess called once)

**Before this PR:**
- Colors generated but not applied to KDE apps
- User must manually run `plasma-apply-colorscheme noctalia`
- KDE apps show outdated colors

**After this PR:**
- KDE apps automatically update colors
- No manual intervention required
- Seamless integration with Material You workflow

## Screenshots / Videos
**Expected behavior:**
- When wallpaper changes, KDE apps (dolphin, kate, konsole, etc.) immediately update their accent colors
- When switching predefined schemes, KDE apps reflect new color palette instantly

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes

### Comparison with kde-material-you-colors
This implementation follows the same workaround strategy as [kde-material-you-colors](https://github.com/luisbocanegra/kde-material-you-colors):
> "To update color with plasma-apply-colorscheme, the file must have a different name than the current one. This program creates two color scheme files with different names, then applies one after the other."

**Advantages of Noctalia's implementation:**
- ✅ Native integration (no separate Python service)
- ✅ Works with Noctalia's existing theming system
- ✅ Supports both wallpaper and predefined schemes
- ✅ Compositor-independent (not tied to Plasma Desktop)

### Dependencies
Optional runtime dependency:
- `plasma-workspace` (provides `plasma-apply-colorscheme` command)
- If not installed, feature is silently skipped (no errors)
- Works gracefully for users without KDE apps

### Performance
- Minimal overhead: single shell command per color change
- State file is tiny (4 bytes: "main" or "alt")
- No background services or polling