### PR TITLE
BluetoothPanel: dynamic battery icons for devices

### DIFF
--- a/Modules/Panels/Bluetooth/BluetoothDevicesList.qml
+++ b/Modules/Panels/Bluetooth/BluetoothDevicesList.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Bluetooth
 import Quickshell.Wayland
 import qs.Commons
+import qs.Services.Hardware
 import qs.Services.Networking
 import qs.Services.UI
 import qs.Widgets
@@ -161,7 +162,10 @@ NBox {
                 spacing: Style.marginXS
 
                 NIcon {
-                  icon: "battery"
+                  icon: {
+                    var b = BluetoothService.getBatteryPercent(modelData);
+                    return BatteryService.getIcon(b !== null ? b : 0, false, b !== null);
+                  }
                   pointSize: Style.fontSizeXS
                   color: getContentColor(Color.mOnSurface)
                 }
@@ -341,7 +345,10 @@ NBox {
                 Layout.preferredWidth: 1
                 spacing: Style.marginXS
                 NIcon {
-                  icon: "battery"
+                  icon: {
+                    var b = BluetoothService.getBatteryPercent(modelData);
+                    return BatteryService.getIcon(b !== null ? b : 0, false, b !== null);
+                  }
                   pointSize: Style.fontSizeXS
                   color: Color.mOnSurface
                   MouseArea {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
N/A

## Testing
Viewed, it works and ensured null value handled

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="802" height="325" alt="before" src="https://github.com/user-attachments/assets/fef0722c-67a0-458e-b665-770fa248a1fb" />

<img width="703" height="388" alt="after" src="https://github.com/user-attachments/assets/07ef32bc-0c86-45d5-a26d-b1fad56a0b98" />



## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Should i make DeviceName -- BatteryLevel on hover tooltip to show battery?
ex: NetworkName -- LinkSpeed