### PR TITLE
add: Legcord as a consolidated discord client

### DIFF
--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -160,6 +160,11 @@ Singleton {
           "requiresThemesFolder": false
         },
         {
+          "name": "legcord",
+          "path": "~/.config/legcord",
+          "requiresThemesFolder": false
+        },
+        {
           "name": "equibop",
           "path": "~/.config/equibop",
           "requiresThemesFolder": false


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Adds [Legcord](https://github.com/legcord/legcord) (successor to Armcord) as a detected discord client.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Tested with the AUR Legcord package. I had to manually select the theme file from Vencord > Themes > Local Themes > Upload Theme.
