### PR TITLE
Refactor fastfetch command handling in VersionSubTab

### DIFF
--- a/Modules/Panels/Settings/Tabs/About/VersionSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/About/VersionSubTab.qml
@@ -223,27 +223,30 @@ ColumnLayout {
   }
 
   Process {
-    id: fastfetchProcess
-    command: ["fastfetch", "--format", "json"]
-    running: false
+      id: fastfetchProcess
 
-    onExited: function (exitCode) {
-      root.systemInfoLoading = false;
-      if (exitCode === 0) {
-        try {
-          root.systemInfo = JSON.parse(stdout.text);
-          root.systemInfoAvailable = true;
-        } catch (e) {
-          Logger.w("VersionSubTab", "Failed to parse fastfetch JSON: " + e);
-          root.systemInfoAvailable = false;
-        }
-      } else {
-        root.systemInfoAvailable = false;
+      command: root.fastfetchSupportsJsonFlag
+          ? ["fastfetch", "--json"]           // flag in newer versions
+          : ["fastfetch", "--format", "json"] // older flag for compatibility
+
+      stdout: StdioCollector {}
+      stderr: StdioCollector {}
+
+      onExited: function (exitCode) {
+          root.systemInfoLoading = false;
+
+          if (exitCode === 0) {
+              try {
+                  root.systemInfo = JSON.parse(stdout.text);
+                  root.systemInfoAvailable = true;
+              } catch (e) {
+                  Logger.w("VersionSubTab", "Failed to parse fastfetch JSON: " + e);
+                  root.systemInfoAvailable = false;
+              }
+          } else {
+              root.systemInfoAvailable = false;
+          }
       }
-    }
-
-    stdout: StdioCollector {}
-    stderr: StdioCollector {}
   }
 
   NHeader {


### PR DESCRIPTION
# Pull Request: Add Compatibility for --json and --format json Flags

## Motivation
This PR improves Fastfetch’s CLI compatibility by allowing both the legacy JSON output flag (--format json) and the newer shorthand flag (--json) to be used interchangeably. This resolves issues where external tools or panels expect one flag or the other depending on the installed Fastfetch version.

Fastfetch 2.x supports JSON output exclusively via: --format json
Later versions introduced: --json

When running against Fastfetch 2.x, this results in: Error: unknown option: --json & non‑zero exit codes (commonly 144)

This PR ensures Fastfetch remains backward‑compatible while supporting the newer syntax.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
