### PR TITLE
Add proper cursor icon for system Monitor widget when hovering.

### DIFF
--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -142,6 +142,7 @@ Rectangle {
   MouseArea {
     id: tooltipArea
     anchors.fill: parent
+    cursorShape: Qt.PointingHandCursor
     acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
     hoverEnabled: true
     onClicked: mouse => {


### PR DESCRIPTION
Adds the correct mouse icon when hovering over the SystemMonitor widget in the Bar. Given that there is an actual press action, I feel like the cursor icon should reflect that. I didn't create an issue because this seemed to just be such a trivial bug.

Tested on Niri.

Video showing change:

https://github.com/user-attachments/assets/2d543275-314c-4910-a484-225916425c59


