### PR TITLE
Replaced helix matugen template

### DIFF
--- a/Assets/MatugenTemplates/helix.toml
+++ b/Assets/MatugenTemplates/helix.toml
@@ -1,97 +1,159 @@
-"ui.background" = { bg = "{{colors.background.default.hex}}" }
-"ui.background.separator" = "{{colors.surface_container_lowest.default.hex}}"
-"ui.cursor" = { fg = "{{colors.background.default.hex}}", bg = "{{colors.on_background.default.hex}}" }
-"ui.cursor.insert" = { fg = "{{colors.background.default.hex}}", bg = "{{colors.primary.default.hex}}" }
-"ui.cursor.match" = { fg = "{{colors.background.default.hex}}", bg = "{{colors.tertiary.default.hex}}" }
-"ui.cursor.primary" = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.primary.default.hex}}" }
-"ui.cursorline" = { bg = "{{colors.surface_container_lowest.default.hex}}" }
-"ui.linenr" = "{{colors.outline_variant.default.hex}}"
-"ui.linenr.selected" = { fg = "{{colors.primary.default.hex}}", bg = "{{colors.surface_container_lowest.default.hex}}" }
-"ui.statusline" = { fg = "{{colors.on_surface.default.hex}}", bg = "{{colors.surface_container_low.default.hex}}" }
-"ui.statusline.inactive" = { fg = "{{colors.outline.default.hex}}", bg = "{{colors.surface_container_lowest.default.hex}}" }
-"ui.statusline.normal" = { fg = "{{colors.on_primary.default.hex}}", bg = "{{colors.primary_container.default.hex}}" }
-"ui.statusline.insert" = { fg = "{{colors.on_secondary.default.hex}}", bg = "{{colors.secondary_container.default.hex}}" }
-"ui.statusline.select" = { fg = "{{colors.on_tertiary.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
-"ui.popup" = { fg = "{{colors.on_surface.default.hex}}", bg = "{{colors.surface_container_highest.default.hex}}" }
-"ui.window" = { fg = "{{colors.outline.default.hex}}", bg = "{{colors.surface_container_highest.default.hex}}" }
-"ui.help" = { fg = "{{colors.on_surface.default.hex}}", bg = "{{colors.surface_container_highest.default.hex}}" }
-"ui.text" = "{{colors.on_background.default.hex}}"
-"ui.text.focus" = { fg = "{{colors.on_background.default.hex}}", bg = "{{colors.primary_container.default.hex}}" }
-"ui.virtual" = "{{colors.outline_variant.default.hex}}"
-"ui.virtual.ruler" = { bg = "{{colors.surface_container_lowest.default.hex}}" }
-"ui.virtual.whitespace" = "{{colors.outline_variant.default.hex}}"
-"ui.virtual.indent-guide" = "{{colors.outline_variant.default.hex}}"
-"ui.menu" = { fg = "{{colors.on_surface.default.hex}}", bg = "{{colors.surface_container_highest.default.hex}}" }
-"ui.menu.selected" = { fg = "{{colors.on_primary_container.default.hex}}", bg = "{{colors.primary_container.default.hex}}" }
-"ui.menu.scroll" = { fg = "{{colors.outline.default.hex}}", bg = "{{colors.surface_variant.default.hex}}" }
-"ui.selection" = { bg = "{{colors.primary_container.default.hex}}" }
-"ui.selection.primary" = { fg = "{{colors.on_primary_container.default.hex}}", bg = "{{colors.primary_container.default.hex}}" }
+# Syntax highlighting
+# -------------------
+"attribute" = "secondary"
 
-"attribute" = "{{colors.secondary.default.hex}}"
-"type" = "{{colors.primary.default.hex}}"
-"type.builtin" = "{{colors.primary.default.hex}}"
-"type.enum.variant" = "{{colors.tertiary.default.hex}}"
-"constructor" = "{{colors.primary.default.hex}}"
-"constant" = { fg = "{{colors.on_tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
-"constant.builtin" = "{{colors.secondary.default.hex}}"
-"constant.builtin.boolean" = "{{colors.primary.default.hex}}"
-"constant.character" = "{{colors.tertiary.default.hex}}"
-"constant.character.escape" = "{{colors.error.default.hex}}"
-"constant.numeric" = { fg = "{{colors.on_tertiary_container.default.hex}}", bg = "{{colors.tertiary_container.default.hex}}" }
-"string" = { fg = "{{colors.on_secondary_container.default.hex}}", bg = "{{colors.secondary_container.default.hex}}" }
-"string.regexp" = { fg = "{{colors.on_secondary_container.default.hex}}", bg = "{{colors.secondary_container.default.hex}}" }
-"string.special" = { fg = "{{colors.primary.default.hex}}", modifiers = ["underlined"] }
-"comment" = { fg = "{{colors.on_surface_variant.default.hex}}", bg = "{{colors.surface_container.default.hex}}" }
+"type" = "primary"
+"type.enum.variant" = "secondary"
 
-"variable" = "{{colors.on_background.default.hex}}"
-"variable.builtin" = { fg = "{{colors.secondary.default.hex}}", modifiers = ["underlined"] }
-"variable.parameter" = "{{colors.primary.default.hex}}"
-"variable.other.member" = "{{colors.tertiary.default.hex}}"
-"label" = "{{colors.primary.default.hex}}"
-"punctuation" = "{{colors.outline.default.hex}}"
-"punctuation.bracket" = "{{colors.outline.default.hex}}"
-"punctuation.delimiter" = "{{colors.outline.default.hex}}"
-"keyword" = "{{colors.primary.default.hex}}"
-"keyword.control" = "{{colors.primary.default.hex}}"
-"keyword.control.exception" = "{{colors.tertiary.default.hex}}"
-"keyword.directive" = "{{colors.secondary.default.hex}}"
-"operator" = "{{colors.tertiary.default.hex}}"
-"function" = "{{colors.primary.default.hex}}"
-"function.builtin" = "{{colors.secondary.default.hex}}"
-"function.macro" = "{{colors.secondary.default.hex}}"
-"function.special" = "{{colors.secondary.default.hex}}"
-"function.method" = "{{colors.primary.default.hex}}"
-"tag" = "{{colors.primary.default.hex}}"
-"special" = "{{colors.secondary.default.hex}}"
-"namespace" = "{{colors.tertiary.default.hex}}"
+"constructor" = "tertiary"
 
-"markup.bold" = { fg = "{{colors.on_background.default.hex}}", modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
-"markup.heading" = { fg = "{{colors.primary.default.hex}}", modifiers = ["bold"] }
-"markup.list" = "{{colors.secondary.default.hex}}"
-"markup.list.numbered" = "{{colors.primary.default.hex}}"
-"markup.list.unnumbered" = "{{colors.primary.default.hex}}"
-"markup.link.url" = { fg = "{{colors.secondary.default.hex}}", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "{{colors.primary.default.hex}}"
-"markup.link.label" = "{{colors.tertiary.default.hex}}"
-"markup.quote" = "{{colors.secondary.default.hex}}"
-"markup.raw" = "{{colors.secondary.default.hex}}"
-"markup.raw.inline" = "{{colors.primary.default.hex}}"
-"markup.raw.block" = "{{colors.secondary.default.hex}}"
+"constant" = "secondary"
+"constant.character" = "secondaryContainer"
+"constant.character.escape" = "tertiaryContainer"
 
-"diff.plus" = "{{colors.secondary.default.hex}}"
-"diff.minus" = "{{colors.error.default.hex}}"
-"diff.delta" = "{{colors.tertiary.default.hex}}"
+"string" = "tertiary"
+"string.regexp" = "tertiaryContainer"
+"string.special" = "tertiary"
+"string.special.symbol" = "tertiary"
 
-"hint" = "{{colors.primary.default.hex}}"
-"info" = "{{colors.secondary.default.hex}}"
-"warning" = "{{colors.tertiary.default.hex}}"
-"error" = "{{colors.error.default.hex}}"
+"comment" = { fg = "outline", modifiers = ["italic"] }
 
-"diagnostic.hint" = { underline = { color = "{{colors.primary.default.hex}}", style = "line" } }
-"diagnostic.info" = { underline = { color = "{{colors.secondary.default.hex}}", style = "line" } }
-"diagnostic.warning" = { underline = { color = "{{colors.tertiary.default.hex}}", style = "line" } }
-"diagnostic.error" = { underline = { color = "{{colors.error.default.hex}}", style = "line" } }
+"variable" = "onSurface"
+"variable.builtin" = "secondary"
+"variable.parameter" = { fg = "onSurfaceVariant", modifiers = ["italic"] }
+"variable.other.member" = "onSurface"
+
+"label" = "secondary"
+
+"punctuation" = "onBackground"
+"punctuation.special" = "onBackground"
+
+"keyword" = "primary"
+"keyword.control.conditional" = { fg = "tertiary", modifiers = ["italic"] }
+
+"operator" = "primary"
+
+"function" = "tertiary"
+"function.macro" = "tertiary"
+
+"tag" = "secondary"
+
+"namespace" = { fg = "secondary", modifiers = ["italic"] }
+
+"special" = "secondary"
+
+"markup.heading" = "primary"
+"markup.list" = "onSurface"
+"markup.bold" = { fg = "second", modifiers = ["bold"] }
+"markup.italic" = { fg = "secondary", modifiers = ["italic"] }
+"markup.link.url" = { fg = "secondary", modifiers = ["italic", "underlined"] }
+"markup.link.label" = "primary"
+"markup.raw" = "onSurface"
+"markup.quote" = "secondary"
+
+"diff.plus" = "plus"
+"diff.minus" = "error"
+"diff.delta" = "delta"
+
+# User Interface
+# --------------
+"ui.background" = "none"
+
+"ui.cursor" = { fg = "onSecondary", bg = "secondary" }
+"ui.cursor.match" = { fg = "onTertiary", bg = "tertiary", modifiers = ["bold"] }
+"ui.cursor.primary" = { fg = "onPrimary", bg = "primary" }
+
+"ui.linenr" = { fg = "onSurfaceVariant" }
+"ui.linenr.selected" = { fg = "primary" }
+
+"ui.statusline" = { fg = "onSurface", bg = "surfaceContainerLow" }
+"ui.statusline.inactive" = { fg = "onSurface", bg = "surfaceContainerLowest" }
+"ui.statusline.normal" = { fg = "onPrimary", bg = "primary", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "onTertiary", bg = "tertiary", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "onSecondary", bg = "secondary", modifiers = ["bold"] }
+
+"ui.bufferline" = { fg = "onSurface", bg = "surfaceContainerLowest" }
+"ui.bufferline.active" = { fg = "onSurface", bg = "surfaceContainer", underline = { color = "primary", style = "line" } }
+"ui.bufferline.background" = { bg = "surfaceContainerLowest" }
+
+"ui.popup" = { fg = "onSurface", bg = "surfaceContainerLow" }
+
+"ui.window" = { fg = "onSurface" }
+"ui.help" = { fg = "onSurface", bg = "surfaceContainerLow" }
+
+"ui.text" = { fg = "onBackground" }
+"ui.text.focus" = { fg = "onSurface", bg = "surfaceContainer", modifiers = ["bold"] }
+
+"ui.virtual" = "surfaceVariant"
+"ui.virtual.ruler" = { bg = "surfaceContainerLow" }
+"ui.virtual.indent-guide" = "surfaceVariant"
+"ui.virtual.inlay-hint" = { fg = "onSurfaceVariant", bg = "surfaceContainer", modifiers = ["dim"] }
+"ui.virtual.jump-label" = { fg = "primary", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "onSurface", bg = "surfaceContainer" }
+"ui.menu.selected" = { fg = "onPrimary", bg = "primary", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "surfaceContainerHigh" }
+
+"ui.highlight" = { bg = "primaryContainer", modifiers = ["bold"] }
+
+"ui.cursorline" = { bg = "surfaceContainerLowest" }
+"ui.cursorline.primary" = { bg = "surfaceContainerLow" }
+"ui.cursorline.secondary" = { bg = "surfaceContainerLow" }
+
+error = "error"
+warning = "warning"
+info = "info"
+hint = "hint"
+
+"diagnostic.hint" = { underline = { color = "hint", style = "curl" } }
+"diagnostic.info" = { underline = { color = "info", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "warning", style = "curl" } }
+"diagnostic.error" = { underline = { color = "error", style = "curl" } }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
-"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+[palette]
+# Constants to be used in syntax highlighting, not meant for matugen.
+warning = "#f9e2af"
+info = "#89dceb"
+hint = "#94e2d5"
+plus = "#a6e3a1"
+delta = "#89b4fa"
+
+# Matugen colors
+primary = "{{colors.primary.default.hex}}"
+surfaceTint = "{{colors.primary.default.hex}}"
+onPrimary = "{{colors.on_primary.default.hex}}"
+primaryContainer = "{{colors.primary_container.default.hex}}"
+onPrimaryContainer = "{{colors.on_primary_container.default.hex}}"
+
+secondary = "{{colors.secondary.default.hex}}"
+onSecondary = "{{colors.on_secondary.default.hex}}"
+secondaryContainer = "{{colors.secondary_container.default.hex}}"
+onSecondaryContainer = "{{colors.on_secondary_container.default.hex}}"
+
+tertiary = "{{colors.tertiary.default.hex}}"
+onTertiary = "{{colors.on_tertiary.default.hex}}"
+tertiaryContainer = "{{colors.tertiary_container.default.hex}}"
+onTertiaryContainer = "{{colors.on_tertiary_container.default.hex}}"
+
+error = "{{colors.error.default.hex}}"
+onError = "{{colors.on_error.default.hex}}"
+errorContainer = "{{colors.error_container.default.hex}}"
+onErrorContainer = "{{colors.on_error_container.default.hex}}"
+
+background = "{{colors.background.default.hex}}"
+onBackground = "{{colors.on_background.default.hex}}"
+surface = "{{colors.surface.default.hex}}"
+onSurface = "{{colors.on_surface.default.hex}}"
+surfaceVariant = "{{colors.surface_variant.default.hex}}"
+onSurfaceVariant = "{{colors.on_surface_variant.default.hex}}"
+
+outline = "{{colors.outline.default.hex}}"
+outlineVariant = "{{colors.outline_variant.default.hex}}"
+
+surfaceContainerLowest = "{{colors.surface_container_lowest.default.hex}}"
+surfaceContainerLow = "{{colors.surface_container_low.default.hex}}"
+surfaceContainer = "{{colors.surface_container.default.hex}}"
+surfaceContainerHigh = "{{colors.surface_container_high.default.hex}}"
+surfaceContainerHighest = "{{colors.surface_container_highest.default.hex}}"


### PR DESCRIPTION
# Pull Request
Replaced the existing `helix.toml` matugen template with my own, made for rust syntax highlighting, also works well with markdown. Should work well with any other language.
Original schema was based off of `catppuccin_mocha.toml` theme from the Helix repository

## Motivation
I personally did not like the previous helix config, I found it harder to read my code as alot of things shared the same color. The schema itself was also harder to read

The schema for my config is based off of `catppuccin_mocha` from the Helix repository, and was optimized for Rust as I have been coding in Helix with it for quite some time. It also works quite well with markdown and of course works with plain text. I have not tested other programming languages as I don't use any other nor have their LSP's

## Type of Change
- [ X ] Refactoring

## Testing
I generated templates for both my version and the previous version and switched themes between them while looking through my codebase. I found my own easier to read because of the different colored symbols (Constants, functions, types, modules)

Main differences:
- Symbols are colored differently, rather than being mostly one color
- Inlay hints have a solid color background with dimmer text, rather than having no background and dark text
- Warnings, Hints, and Info syntax highlighting are constant colors (errors keep matugen error color) to prevent confusion
- Better visibility for mode coloring if `color-modes` is set true in helix config
- Bufferline underlines and highlights the active buffer more clearly

## Screenshots / Videos
My config:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6c61a9a2-3647-41ec-9a0d-d0a707d5a781" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/33104663-3c44-4860-8f2a-875744d3bb3d" />

Previous config:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3624fd79-dee8-4793-ac0a-dad8cc5708c4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dd4cffe6-1516-4f1c-ae84-ba655252c2d1" />

## Checklist
- [ X ] Code follows project style guidelines
- [ X ] Self-reviewed my code
- [ X ] No new warnings or errors

## Additional Notes
I wasn't sure what I should mark down for the "Type of change", went with Refactoring as I only changed a previously existing template- even if it wasnt code.