### PR TITLE
fix(templates): correct color mapping in kitty.conf

### DIFF
--- a/Assets/MatugenTemplates/Terminal/kitty.conf
+++ b/Assets/MatugenTemplates/Terminal/kitty.conf
@@ -1,17 +1,17 @@
 color0 {{colors.surface.default.hex}}
 color1 {{colors.error.default.hex}}
-color2 {{colors.tertiary.default.hex}}
+color2 {{colors.primary.default.hex}}
 color3 {{colors.secondary.default.hex}}
-color4 {{colors.primary.default.hex}}
-color5 {{colors.tertiary_fixed_dim.default.hex}}
+color4 {{colors.tertiary.default.hex}}
+color5 {{colors.primary_fixed_dim.default.hex}}
 color6 {{colors.secondary_fixed_dim.default.hex}}
 color7 {{colors.on_surface.default.hex}}
 color8 {{colors.outline.default.hex}}
 color9 {{colors.error.default.hex}}
-color10 {{colors.tertiary.default.hex}}
+color10 {{colors.primary.default.hex}}
 color11 {{colors.secondary.default.hex}}
-color12 {{colors.primary.default.hex}}
-color13 {{colors.tertiary_fixed_dim.default.hex}}
+color12 {{colors.tertiary.default.hex}}
+color13 {{colors.primary_fixed_dim.default.hex}}
 color14 {{colors.secondary_fixed_dim.default.hex}}
 color15 {{colors.on_surface.default.hex}}
 


### PR DESCRIPTION
# Pull Request

## Motivation
This PR corrects the color mapping order in `Assets/MatugenTemplates/Terminal/kitty.conf`.

I noticed that the color scheme generated for **kitty** was inconsistent with **alacritty** and **foot** when using the same wallpaper/Matugen setup. Upon investigation, I found that the mappings for `colors.primary` and `colors.tertiary` (and their fixed dim variants) were incorrect in the kitty template.

This fix aligns the kitty configuration with the foot behavior, ensuring visual consistency across terminals.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A (Direct fix, no issue created)

## Testing
I have tested these changes with multiple wallpapers. I visually compared the result in **kitty** against **foot** and confirmed that the colors now match perfectly.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Specific mapping changes made:
- Swapped `color2`/`color10` to use `primary` (was tertiary).
- Swapped `color4`/`color12` to use `tertiary` (was primary).
- Adjusted `color5`/`color13` to use `primary_fixed_dim` (was tertiary_fixed_dim).