### PR TITLE
Hue Slider Rainbow Mode Fix

### DIFF
--- a/Widgets/NColorPickerDialog.qml
+++ b/Widgets/NColorPickerDialog.qml
@@ -396,7 +396,7 @@ Popup {
             NColorSlider {
               id: selectedSlider
               Layout.fillHeight: true
-              rainbowMode: root.editMode === "h"
+              rainbowMode: root.editMode === NColorPickerDialog.EditMode.H
               topColor: {
                 if (rainbowMode)
                   return "transparent";
@@ -758,8 +758,8 @@ Popup {
           root.colorSelected(root.selectedColor);
           // Delay close to prevent click propagation to elements behind the dialog
           Qt.callLater(() => {
-                         root.close();
-                       });
+            root.close();
+          });
         }
       }
     }


### PR DESCRIPTION
# Pull Request

## Motivation
The Hue Slider was erroneously stopped using RainbowMode because a pror cleanup did not use Enum correctly.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Shouldn't be affected my anything, simple fix.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="601" height="472" alt="image" src="https://github.com/user-attachments/assets/72f995d4-d3e8-445f-af4d-5fee49391cf9" />

This is what it's supposed to look like with the HUE slider, so you can visually see where the different HUEs are. And not just if you're 'hight or low' values.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
QML enums are weird.
