### PR TITLE
Fix/less math

### DIFF
--- a/Modules/Bar/Extras/BarPillVertical.qml
+++ b/Modules/Bar/Extras/BarPillVertical.qml
@@ -42,8 +42,8 @@ Item {
   readonly property int buttonSize: Style.capsuleHeight
   readonly property int pillHeight: buttonSize
   readonly property int pillOverlap: Math.round(buttonSize * 0.5)
-  readonly property int maxPillWidth: rotateText ? Math.max(buttonSize, Math.round(textItem.implicitHeight + Style.marginM * 2)) : buttonSize
-  readonly property int maxPillHeight: rotateText ? Math.max(1, Math.round(textItem.implicitWidth + Style.marginM * 2 + Math.round(iconCircle.height / 4))) : Math.max(1, Math.round(textItem.implicitHeight + Style.marginM * 2))
+  readonly property int maxPillWidth: rotateText ? Math.max(buttonSize, Math.round(textItem.implicitHeight + Style.marginXL)) : buttonSize
+  readonly property int maxPillHeight: rotateText ? Math.max(1, Math.round(textItem.implicitWidth + Style.marginXL + Math.round(iconCircle.height / 4))) : Math.max(1, Math.round(textItem.implicitHeight + Style.marginXL))
 
   // Determine pill direction based on section position
   readonly property bool openDownward: oppositeDirection

--- a/Modules/Bar/Extras/TrayMenu.qml
+++ b/Modules/Bar/Extras/TrayMenu.qml
@@ -254,7 +254,7 @@ PopupWindow {
 
           NDivider {
             anchors.centerIn: parent
-            width: parent.width - (Style.marginM * 2)
+            width: parent.width - (Style.marginXL)
             visible: modelData?.isSeparator ?? false
           }
 

--- a/Modules/Bar/Widgets/ActiveWindow.qml
+++ b/Modules/Bar/Widgets/ActiveWindow.qml
@@ -93,7 +93,7 @@ Item {
     contentWidth += titleContainer.measuredWidth;
 
     // Additional small margin for text
-    contentWidth += Style.marginXXS * 2;
+    contentWidth += Style.marginXS;
 
     // Add container margins
     contentWidth += margins;
@@ -249,7 +249,7 @@ Item {
           maxWidth: {
             // Calculate available width based on other elements
             var iconWidth = (showIcon && windowIcon.visible ? (iconSize + Style.marginS) : 0);
-            var totalMargins = Style.marginXXS * 2;
+            var totalMargins = Style.marginXS;
             var availableWidth = mainContainer.width - iconWidth - totalMargins;
             return Math.max(20, availableWidth);
           }
@@ -273,8 +273,8 @@ Item {
       // Vertical layout for left/right bars - icon only
       Item {
         id: verticalLayout
-        width: parent.width - Style.marginM * 2
-        height: parent.height - Style.marginM * 2
+        width: parent.width - Style.marginXL
+        height: parent.height - Style.marginXL
         x: Style.pixelAlignCenter(parent.width, width)
         y: Style.pixelAlignCenter(parent.height, height)
         visible: isVerticalBar

--- a/Modules/Bar/Widgets/Clock.qml
+++ b/Modules/Bar/Widgets/Clock.qml
@@ -41,7 +41,7 @@ Rectangle {
   readonly property string formatVertical: widgetSettings.formatVertical !== undefined ? widgetSettings.formatVertical : widgetMetadata.formatVertical
   readonly property string tooltipFormat: widgetSettings.tooltipFormat !== undefined ? widgetSettings.tooltipFormat : widgetMetadata.tooltipFormat
 
-  implicitWidth: isBarVertical ? Style.capsuleHeight : Math.round((isBarVertical ? verticalLoader.implicitWidth : horizontalLoader.implicitWidth) + Style.marginM * 2)
+  implicitWidth: isBarVertical ? Style.capsuleHeight : Math.round((isBarVertical ? verticalLoader.implicitWidth : horizontalLoader.implicitWidth) + Style.marginXL)
 
   implicitHeight: isBarVertical ? Math.round(verticalLoader.implicitHeight + Style.marginS * 2) : Style.capsuleHeight
 

--- a/Modules/Bar/Widgets/LockKeys.qml
+++ b/Modules/Bar/Widgets/LockKeys.qml
@@ -44,8 +44,8 @@ Rectangle {
 
   readonly property bool hideWhenOff: (widgetSettings.hideWhenOff !== undefined) ? widgetSettings.hideWhenOff : (widgetMetadata.hideWhenOff !== undefined ? widgetMetadata.hideWhenOff : false)
 
-  implicitWidth: isVertical ? Style.capsuleHeight : Math.round(layout.implicitWidth + Style.marginM * 2)
-  implicitHeight: isVertical ? Math.round(layout.implicitHeight + Style.marginM * 2) : Style.capsuleHeight
+  implicitWidth: isVertical ? Style.capsuleHeight : Math.round(layout.implicitWidth + Style.marginXL)
+  implicitHeight: isVertical ? Math.round(layout.implicitHeight + Style.marginXL) : Style.capsuleHeight
 
   Layout.alignment: Qt.AlignVCenter
 

--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -121,7 +121,7 @@ Item {
     var textWidth = 0;
     if (titleContainer.measuredWidth > 0) {
       margins += Style.marginS;
-      textWidth = titleContainer.measuredWidth + Style.marginXXS * 2;
+      textWidth = titleContainer.measuredWidth + Style.marginXS;
     }
 
     var total = iconWidth + textWidth + margins;

--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -109,8 +109,8 @@ Rectangle {
   readonly property bool diskCritical: showDiskUsage && SystemStatService.isDiskCritical(diskPath)
 
   anchors.centerIn: parent
-  implicitWidth: isVertical ? Style.capsuleHeight : Math.round(mainGrid.implicitWidth + Style.marginM * 2)
-  implicitHeight: isVertical ? Math.round(mainGrid.implicitHeight + Style.marginM * 2) : Style.capsuleHeight
+  implicitWidth: isVertical ? Style.capsuleHeight : Math.round(mainGrid.implicitWidth + Style.marginXL)
+  implicitHeight: isVertical ? Math.round(mainGrid.implicitHeight + Style.marginXL) : Style.capsuleHeight
   radius: Style.radiusM
   color: Style.capsuleColor
   border.color: Style.capsuleBorderColor

--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -61,7 +61,7 @@ Rectangle {
       var calculatedWidth = baseWidth / Math.sqrt(entriesCount);
 
       if (maxTaskbarWidth > 0) {
-        var maxWidthPerEntry = (maxTaskbarWidth / entriesCount) - itemSize - Style.marginS - Style.marginM * 2;
+        var maxWidthPerEntry = (maxTaskbarWidth / entriesCount) - itemSize - Style.marginS - Style.marginXL;
         calculatedWidth = Math.min(calculatedWidth, maxWidthPerEntry);
       }
 
@@ -501,7 +501,7 @@ Rectangle {
     if (isVerticalBar)
       return Style.capsuleHeight;
 
-    var calculatedWidth = showTitle ? taskbarLayout.implicitWidth : taskbarLayout.implicitWidth + Style.marginM * 2;
+    var calculatedWidth = showTitle ? taskbarLayout.implicitWidth : taskbarLayout.implicitWidth + Style.marginXL;
 
     // Apply maximum width constraint when smartWidth is enabled
     if (smartWidth && maxTaskbarWidth > 0) {
@@ -510,7 +510,7 @@ Rectangle {
 
     return Math.round(calculatedWidth);
   }
-  implicitHeight: visible ? (isVerticalBar ? Math.round(taskbarLayout.implicitHeight + Style.marginM * 2) : Style.capsuleHeight) : 0
+  implicitHeight: visible ? (isVerticalBar ? Math.round(taskbarLayout.implicitHeight + Style.marginXL) : Style.capsuleHeight) : 0
   radius: Style.radiusM
   color: Style.capsuleColor
   border.color: Style.capsuleBorderColor
@@ -551,7 +551,7 @@ Rectangle {
         readonly property color titleBgColor: (isHovered || isFocused) ? Color.mHover : Style.capsuleColor
         readonly property color titleFgColor: (isHovered || isFocused) ? Color.mOnHover : Color.mOnSurface
 
-        Layout.preferredWidth: root.showTitle ? Math.round(contentWidth + Style.marginM * 2) : Math.round(contentWidth) // Add margins for both pinned and running apps
+        Layout.preferredWidth: root.showTitle ? Math.round(contentWidth + Style.marginXL) : Math.round(contentWidth) // Add margins for both pinned and running apps
         Layout.preferredHeight: root.itemSize
         Layout.alignment: Qt.AlignCenter
 

--- a/Modules/Cards/CalendarHeaderCard.qml
+++ b/Modules/Cards/CalendarHeaderCard.qml
@@ -10,9 +10,9 @@ import qs.Widgets
 Rectangle {
   id: root
   Layout.fillWidth: true
-  Layout.minimumHeight: (60 * Style.uiScaleRatio) + (Style.marginM * 2)
-  Layout.preferredHeight: (60 * Style.uiScaleRatio) + (Style.marginM * 2)
-  implicitHeight: (60 * Style.uiScaleRatio) + (Style.marginM * 2)
+  Layout.minimumHeight: (60 * Style.uiScaleRatio) + (Style.marginXL)
+  Layout.preferredHeight: (60 * Style.uiScaleRatio) + (Style.marginXL)
+  implicitHeight: (60 * Style.uiScaleRatio) + (Style.marginXL)
   radius: Style.radiusL
   color: Color.mPrimary
 

--- a/Modules/Cards/CalendarMonthCard.qml
+++ b/Modules/Cards/CalendarMonthCard.qml
@@ -12,7 +12,7 @@ import qs.Widgets
 NBox {
   id: root
   Layout.fillWidth: true
-  implicitHeight: calendarContent.implicitHeight + Style.marginM * 2
+  implicitHeight: calendarContent.implicitHeight + Style.marginXL
 
   // Internal state - independent from header
   readonly property var now: Time.now

--- a/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
+++ b/Modules/DesktopWidgets/Widgets/DesktopMediaPlayer.qml
@@ -58,7 +58,7 @@ DraggableDesktopWidget {
   readonly property int visibleButtonCount: root.showButtons ? (1 + (showPrev ? 1 : 0) + (showNext ? 1 : 0)) : 0
 
   implicitWidth: Math.round(400 * widgetScale)
-  implicitHeight: Math.round(64 * widgetScale + Style.marginM * widgetScale * 2)
+  implicitHeight: Math.round(64 * widgetScale + Style.marginXL * widgetScale)
   width: implicitWidth
   height: implicitHeight
 

--- a/Modules/DesktopWidgets/Widgets/DesktopWeather.qml
+++ b/Modules/DesktopWidgets/Widgets/DesktopWeather.qml
@@ -44,8 +44,8 @@ DraggableDesktopWidget {
     return chunks[0];
   }
 
-  implicitWidth: Math.round(Math.max(240 * widgetScale, contentLayout.implicitWidth + Style.marginM * widgetScale * 2))
-  implicitHeight: Math.round(64 * widgetScale + Style.marginM * widgetScale * 2)
+  implicitWidth: Math.round(Math.max(240 * widgetScale, contentLayout.implicitWidth + Style.marginXL * widgetScale))
+  implicitHeight: Math.round(64 * widgetScale + Style.marginXL * widgetScale)
   width: implicitWidth
   height: implicitHeight
 

--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -444,8 +444,8 @@ Loader {
             Rectangle {
               id: dockContainer
               // For vertical dock, swap width and height logic
-              width: isVertical ? Math.round(iconSize * 1.5) : dockLayout.implicitWidth + Style.marginM * 2
-              height: isVertical ? dockLayout.implicitHeight + Style.marginM * 2 : Math.round(iconSize * 1.5)
+              width: isVertical ? Math.round(iconSize * 1.5) : dockLayout.implicitWidth + Style.marginXL
+              height: isVertical ? dockLayout.implicitHeight + Style.marginXL : Math.round(iconSize * 1.5)
               color: Qt.alpha(Color.mSurface, Settings.data.dock.backgroundOpacity)
 
               // Anchor based on padding to achieve centering shift
@@ -494,8 +494,8 @@ Loader {
               Item {
                 id: dock
                 // Swap dimensions based on orientation
-                width: isVertical ? parent.width - (Style.marginM * 2) : dockLayout.implicitWidth
-                height: isVertical ? dockLayout.implicitHeight : parent.height - (Style.marginM * 2)
+                width: isVertical ? parent.width - (Style.marginXL) : dockLayout.implicitWidth
+                height: isVertical ? dockLayout.implicitHeight : parent.height - (Style.marginXL)
                 anchors.centerIn: parent
 
                 function getAppIcon(appData): string {

--- a/Modules/Dock/DockMenu.qml
+++ b/Modules/Dock/DockMenu.qml
@@ -26,8 +26,8 @@ PopupWindow {
 
   property real menuContentWidth: 160
 
-  implicitWidth: menuContentWidth + (Style.marginM * 2)
-  implicitHeight: contextMenuColumn.implicitHeight + (Style.marginM * 2)
+  implicitWidth: menuContentWidth + (Style.marginXL)
+  implicitHeight: contextMenuColumn.implicitHeight + (Style.marginXL)
   color: "transparent"
   visible: false
 

--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -197,7 +197,7 @@ Variants {
             readonly property int slideDistance: 300
 
             Layout.preferredWidth: notifWidth + notifWindow.shadowPadding * 2
-            Layout.preferredHeight: notificationContent.implicitHeight + Style.marginM * 2 + notifWindow.shadowPadding * 2
+            Layout.preferredHeight: notificationContent.implicitHeight + Style.marginXL + notifWindow.shadowPadding * 2
             Layout.maximumHeight: Layout.preferredHeight
 
             // Animation properties

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -282,7 +282,7 @@ SmartPanel {
       // HEADER
       NBox {
         Layout.fillWidth: true
-        implicitHeight: header.implicitHeight + (Style.marginM * 2)
+        implicitHeight: header.implicitHeight + (Style.marginXL)
 
         ColumnLayout {
           id: header
@@ -360,7 +360,7 @@ SmartPanel {
             // Output Volume
             NBox {
               Layout.fillWidth: true
-              Layout.preferredHeight: outputVolumeColumn.implicitHeight + (Style.marginM * 2)
+              Layout.preferredHeight: outputVolumeColumn.implicitHeight + (Style.marginXL)
 
               RowLayout {
                 id: outputVolumeColumn
@@ -425,7 +425,7 @@ SmartPanel {
             // Input Volume
             NBox {
               Layout.fillWidth: true
-              Layout.preferredHeight: inputVolumeColumn.implicitHeight + (Style.marginM * 2)
+              Layout.preferredHeight: inputVolumeColumn.implicitHeight + (Style.marginXL)
 
               RowLayout {
                 id: inputVolumeColumn
@@ -500,7 +500,7 @@ SmartPanel {
                 id: appBox
                 required property PwNode modelData
                 Layout.fillWidth: true
-                Layout.preferredHeight: appRow.implicitHeight + (Style.marginM * 2)
+                Layout.preferredHeight: appRow.implicitHeight + (Style.marginXL)
                 visible: !isCaptureStream
 
                 // Track individual node to ensure properties are bound
@@ -802,7 +802,7 @@ SmartPanel {
 
             NBox {
               Layout.fillWidth: true
-              Layout.preferredHeight: outputColumn.implicitHeight + (Style.marginM * 2)
+              Layout.preferredHeight: outputColumn.implicitHeight + (Style.marginXL)
 
               ColumnLayout {
                 id: outputColumn
@@ -844,7 +844,7 @@ SmartPanel {
 
             NBox {
               Layout.fillWidth: true
-              Layout.preferredHeight: inputColumn.implicitHeight + (Style.marginM * 2)
+              Layout.preferredHeight: inputColumn.implicitHeight + (Style.marginXL)
 
               ColumnLayout {
                 id: inputColumn

--- a/Modules/Panels/Battery/BatteryPanel.qml
+++ b/Modules/Panels/Battery/BatteryPanel.qml
@@ -205,7 +205,7 @@ SmartPanel {
       // HEADER
       NBox {
         Layout.fillWidth: true
-        implicitHeight: headerRow.implicitHeight + (Style.marginM * 2)
+        implicitHeight: headerRow.implicitHeight + (Style.marginXL)
 
         RowLayout {
           id: headerRow

--- a/Modules/Panels/Bluetooth/BluetoothDevicesList.qml
+++ b/Modules/Panels/Bluetooth/BluetoothDevicesList.qml
@@ -25,7 +25,7 @@ NBox {
   property bool detailsGrid: (Settings.data && Settings.data.ui && Settings.data.network.bluetoothDetailsViewMode !== undefined) ? (Settings.data.network.bluetoothDetailsViewMode === "grid") : true
 
   Layout.fillWidth: true
-  Layout.preferredHeight: column.implicitHeight + Style.marginM * 2
+  Layout.preferredHeight: column.implicitHeight + Style.marginXL
 
   ColumnLayout {
     id: column
@@ -89,7 +89,7 @@ NBox {
         }
 
         Layout.fillWidth: true
-        Layout.preferredHeight: deviceColumn.implicitHeight + (Style.marginM * 2)
+        Layout.preferredHeight: deviceColumn.implicitHeight + (Style.marginXL)
         radius: Style.radiusM
         clip: true
 

--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -30,7 +30,7 @@ SmartPanel {
       // Header
       NBox {
         Layout.fillWidth: true
-        Layout.preferredHeight: headerRow.implicitHeight + Style.marginM * 2
+        Layout.preferredHeight: headerRow.implicitHeight + Style.marginXL
 
         RowLayout {
           id: headerRow
@@ -94,7 +94,7 @@ SmartPanel {
         id: disabledBox
         visible: !(BluetoothService.adapter && BluetoothService.adapter.enabled)
         Layout.fillWidth: true
-        Layout.preferredHeight: disabledColumn.implicitHeight + Style.marginM * 2
+        Layout.preferredHeight: disabledColumn.implicitHeight + Style.marginXL
 
         // Center the content within this rectangle
         ColumnLayout {
@@ -275,7 +275,7 @@ SmartPanel {
               return (availableCount === 0);
             }
             Layout.fillWidth: true
-            Layout.preferredHeight: emptyColumn.implicitHeight + Style.marginM * 2
+            Layout.preferredHeight: emptyColumn.implicitHeight + Style.marginXL
 
             ColumnLayout {
               id: emptyColumn
@@ -319,7 +319,7 @@ SmartPanel {
           // Fallback - No devices, scanning
           NBox {
             Layout.fillWidth: true
-            Layout.preferredHeight: scanningColumn.implicitHeight + Style.marginM * 2
+            Layout.preferredHeight: scanningColumn.implicitHeight + Style.marginXL
             visible: {
               if (!(BluetoothService.adapter && BluetoothService.adapter.devices) || !BluetoothService.scanningActive) {
                 return false;

--- a/Modules/Panels/Brightness/BrightnessPanel.qml
+++ b/Modules/Panels/Brightness/BrightnessPanel.qml
@@ -32,7 +32,7 @@ SmartPanel {
       // HEADER
       NBox {
         Layout.fillWidth: true
-        implicitHeight: headerRow.implicitHeight + (Style.marginM * 2)
+        implicitHeight: headerRow.implicitHeight + (Style.marginXL)
 
         RowLayout {
           id: headerRow
@@ -82,7 +82,7 @@ SmartPanel {
             model: Quickshell.screens || []
             delegate: NBox {
               Layout.fillWidth: true
-              Layout.preferredHeight: outputColumn.implicitHeight + (Style.marginM * 2)
+              Layout.preferredHeight: outputColumn.implicitHeight + (Style.marginXL)
 
               property var brightnessMonitor: BrightnessService.getMonitorForScreen(modelData)
 

--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -86,7 +86,7 @@ SmartPanel {
   readonly property var currentProvider: activeProvider || defaultProvider
 
   readonly property int badgeSize: Math.round(Style.baseWidgetSize * 1.6 * Style.uiScaleRatio)
-  readonly property int entryHeight: Math.round(badgeSize + Style.marginM * 2)
+  readonly property int entryHeight: Math.round(badgeSize + Style.marginXL)
   // Whether current provider is showing categorized view (vs filtered search results)
   readonly property bool providerShowsCategories: {
     return currentProvider.showsCategories === true;
@@ -1123,7 +1123,7 @@ SmartPanel {
                       anchors.bottom: parent.bottom
                       anchors.right: parent.right
                       anchors.margins: 2
-                      width: formatLabel.width + Style.marginXXS * 2
+                      width: formatLabel.width + Style.marginXS
                       height: formatLabel.height + Style.marginXXS
                       color: Color.mSurfaceVariant
                       radius: Style.radiusXXS

--- a/Modules/Panels/Media/MediaPlayerPanel.qml
+++ b/Modules/Panels/Media/MediaPlayerPanel.qml
@@ -101,7 +101,7 @@ SmartPanel {
 
       NBox {
         Layout.fillWidth: true
-        Layout.preferredHeight: headerRow.implicitHeight + Style.marginM * 2
+        Layout.preferredHeight: headerRow.implicitHeight + Style.marginXL
 
         RowLayout {
           id: headerRow

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -133,7 +133,7 @@ SmartPanel {
       // Header
       NBox {
         Layout.fillWidth: true
-        Layout.preferredHeight: header.implicitHeight + Style.marginM * 2
+        Layout.preferredHeight: header.implicitHeight + Style.marginXL
 
         ColumnLayout {
           id: header
@@ -243,7 +243,7 @@ SmartPanel {
         Rectangle {
           visible: panelViewMode === "wifi" && NetworkService.lastError.length > 0
           Layout.fillWidth: true
-          Layout.preferredHeight: errorRow.implicitHeight + (Style.marginM * 2)
+          Layout.preferredHeight: errorRow.implicitHeight + (Style.marginXL)
           color: Qt.alpha(Color.mError, 0.1)
           radius: Style.radiusS
           border.width: Style.borderS
@@ -296,7 +296,7 @@ SmartPanel {
               id: disabledBox
               visible: panelViewMode === "wifi" && !Settings.data.network.wifiEnabled
               Layout.fillWidth: true
-              Layout.preferredHeight: disabledColumn.implicitHeight + Style.marginM * 2
+              Layout.preferredHeight: disabledColumn.implicitHeight + Style.marginXL
 
               ColumnLayout {
                 id: disabledColumn
@@ -342,7 +342,7 @@ SmartPanel {
               id: scanningBox
               visible: panelViewMode === "wifi" && Settings.data.network.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && !root.hasHadNetworks
               Layout.fillWidth: true
-              Layout.preferredHeight: scanningColumn.implicitHeight + Style.marginM * 2
+              Layout.preferredHeight: scanningColumn.implicitHeight + Style.marginXL
 
               ColumnLayout {
                 id: scanningColumn
@@ -379,7 +379,7 @@ SmartPanel {
               id: emptyBox
               visible: panelViewMode === "wifi" && Settings.data.network.wifiEnabled && !NetworkService.scanning && Object.keys(NetworkService.networks).length === 0 && root.hasHadNetworks
               Layout.fillWidth: true
-              Layout.preferredHeight: emptyColumn.implicitHeight + Style.marginM * 2
+              Layout.preferredHeight: emptyColumn.implicitHeight + Style.marginXL
 
               ColumnLayout {
                 id: emptyColumn
@@ -488,7 +488,7 @@ SmartPanel {
               NBox {
                 visible: !(NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
                 Layout.fillWidth: true
-                Layout.preferredHeight: emptyEthColumn.implicitHeight + Style.marginM * 2
+                Layout.preferredHeight: emptyEthColumn.implicitHeight + Style.marginXL
 
                 ColumnLayout {
                   id: emptyEthColumn
@@ -535,7 +535,7 @@ SmartPanel {
                     Layout.fillWidth: true
                     Layout.leftMargin: Style.marginXS
                     Layout.rightMargin: Style.marginXS
-                    implicitHeight: ethItemColumn.implicitHeight + (Style.marginM * 2)
+                    implicitHeight: ethItemColumn.implicitHeight + (Style.marginXL)
                     radius: Style.radiusM
                     border.width: Style.borderS
                     border.color: modelData.connected ? Color.mPrimary : Color.mOutline
@@ -543,7 +543,7 @@ SmartPanel {
 
                     ColumnLayout {
                       id: ethItemColumn
-                      width: parent.width - (Style.marginM * 2)
+                      width: parent.width - (Style.marginXL)
                       x: Style.marginM
                       y: Style.marginM
                       spacing: Style.marginS
@@ -585,7 +585,7 @@ SmartPanel {
                               color: Color.mPrimary
                               radius: height * 0.5
                               width: ethConnectedText.implicitWidth + (Style.marginS * 2)
-                              height: ethConnectedText.implicitHeight + (Style.marginXXS * 2)
+                              height: ethConnectedText.implicitHeight + (Style.marginXS)
 
                               NText {
                                 id: ethConnectedText

--- a/Modules/Panels/Network/WiFiNetworksList.qml
+++ b/Modules/Panels/Network/WiFiNetworksList.qml
@@ -48,7 +48,7 @@ NBox {
   }
 
   Layout.fillWidth: true
-  Layout.preferredHeight: column.implicitHeight + Style.marginM * 2
+  Layout.preferredHeight: column.implicitHeight + Style.marginXL
   visible: root.model.length > 0
 
   ColumnLayout {
@@ -81,7 +81,7 @@ NBox {
         Layout.fillWidth: true
         Layout.leftMargin: Style.marginXS
         Layout.rightMargin: Style.marginXS
-        implicitHeight: netColumn.implicitHeight + (Style.marginM * 2)
+        implicitHeight: netColumn.implicitHeight + (Style.marginXL)
 
         opacity: (NetworkService.disconnectingFrom === modelData.ssid || NetworkService.forgettingNetwork === modelData.ssid) ? 0.6 : 1.0
 
@@ -95,7 +95,7 @@ NBox {
 
         ColumnLayout {
           id: netColumn
-          width: parent.width - (Style.marginM * 2)
+          width: parent.width - (Style.marginXL)
           x: Style.marginM
           y: Style.marginM
           spacing: Style.marginS
@@ -158,7 +158,7 @@ NBox {
                   color: NetworkService.internetConnectivity ? Color.mPrimary : Color.mError
                   radius: height * 0.5
                   width: connectedText.implicitWidth + (Style.marginS * 2)
-                  height: connectedText.implicitHeight + (Style.marginXXS * 2)
+                  height: connectedText.implicitHeight + (Style.marginXS)
 
                   NText {
                     id: connectedText
@@ -188,7 +188,7 @@ NBox {
                   color: Color.mError
                   radius: height * 0.5
                   width: disconnectingText.implicitWidth + (Style.marginS * 2)
-                  height: disconnectingText.implicitHeight + (Style.marginXXS * 2)
+                  height: disconnectingText.implicitHeight + (Style.marginXS)
 
                   NText {
                     id: disconnectingText
@@ -204,7 +204,7 @@ NBox {
                   color: Color.mError
                   radius: height * 0.5
                   width: forgettingText.implicitWidth + (Style.marginS * 2)
-                  height: forgettingText.implicitHeight + (Style.marginXXS * 2)
+                  height: forgettingText.implicitHeight + (Style.marginXS)
 
                   NText {
                     id: forgettingText
@@ -222,7 +222,7 @@ NBox {
                   border.width: Style.borderS
                   radius: height * 0.5
                   width: savedText.implicitWidth + (Style.marginS * 2)
-                  height: savedText.implicitHeight + (Style.marginXXS * 2)
+                  height: savedText.implicitHeight + (Style.marginXS)
 
                   NText {
                     id: savedText

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -142,7 +142,7 @@ SmartPanel {
       totalHeight = visibleCount * avgNotificationHeight + (visibleCount - 1) * Style.marginM;
       return totalHeight;
     }
-    property real calculatedHeight: headerHeight + tabsHeight + contentHeight + (Style.marginL * 2) + (Style.marginM * 2)
+    property real calculatedHeight: headerHeight + tabsHeight + contentHeight + (Style.marginL * 2) + (Style.marginXL)
     property real contentPreferredHeight: {
       if (NotificationService.historyList.count === 0) {
         // Empty state: smaller height
@@ -162,7 +162,7 @@ SmartPanel {
       NBox {
         id: headerBox
         Layout.fillWidth: true
-        implicitHeight: header.implicitHeight + (Style.marginM * 2)
+        implicitHeight: header.implicitHeight + (Style.marginXL)
 
         ColumnLayout {
           id: header
@@ -328,7 +328,7 @@ SmartPanel {
                 id: notificationDelegate
                 width: parent.width
                 visible: panelContent.isInCurrentRange(model.timestamp)
-                height: visible ? contentColumn.height + (Style.marginM * 2) : 0
+                height: visible ? contentColumn.height + (Style.marginXL) : 0
 
                 property string notificationId: model.id
                 property bool isExpanded: scrollView.expandedId === notificationId

--- a/Modules/Panels/SessionMenu/SessionMenu.qml
+++ b/Modules/Panels/SessionMenu/SessionMenu.qml
@@ -650,7 +650,7 @@ SmartPanel {
         anchors.left: countdownText.visible ? countdownText.right : parent.left
         anchors.leftMargin: countdownText.visible ? Style.marginXS : 0
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.marginM * 2
+        width: Style.marginXL
         height: width
         radius: Math.min(Style.radiusM, height / 2)
         color: (buttonRoot.isSelected || mouseArea.containsMouse) ? Color.mPrimary : Qt.alpha(Color.mSurfaceVariant, 0.5)
@@ -774,7 +774,7 @@ SmartPanel {
         id: numberIndicator
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        width: Style.marginM * 2
+        width: Style.marginXL
         height: width
         radius: Math.min(Style.radiusM, height / 2)
         color: Qt.alpha(Color.mSurfaceVariant, 0.5)

--- a/Modules/Panels/Settings/SettingsContent.qml
+++ b/Modules/Panels/Settings/SettingsContent.qml
@@ -351,7 +351,7 @@ Item {
         readonly property bool panelVeryTransparent: Settings.data.ui.panelBackgroundOpacity <= 0.75
 
         clip: true
-        Layout.preferredWidth: Math.round(root.sidebarExpanded ? 200 * Style.uiScaleRatio : sidebarToggle.width + (panelVeryTransparent ? Style.marginM * 2 : 0) + (sidebarList.verticalScrollBarActive ? Style.marginM : 0))
+        Layout.preferredWidth: Math.round(root.sidebarExpanded ? 200 * Style.uiScaleRatio : sidebarToggle.width + (panelVeryTransparent ? Style.marginXL : 0) + (sidebarList.verticalScrollBarActive ? Style.marginM : 0))
         Layout.fillHeight: true
         Layout.alignment: Qt.AlignTop
 

--- a/Modules/Panels/Settings/Tabs/About/ContributorsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/About/ContributorsSubTab.qml
@@ -207,7 +207,7 @@ ColumnLayout {
       model: Math.max(0, root.contributors.length - root.topContributorsCount)
 
       delegate: Rectangle {
-        width: nameText.implicitWidth + Style.marginM * 2
+        width: nameText.implicitWidth + Style.marginXL
         height: nameText.implicitHeight + Style.marginS * 2
         radius: Style.radiusS
         color: nameArea.containsMouse ? Color.mHover : "transparent"

--- a/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
+++ b/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
@@ -122,7 +122,7 @@ Popup {
         // Default command display
         Rectangle {
           Layout.fillWidth: true
-          Layout.preferredHeight: defaultCommandText.implicitHeight + Style.marginM * 2
+          Layout.preferredHeight: defaultCommandText.implicitHeight + Style.marginXL
           radius: Style.radiusM
           color: Color.mSurfaceVariant
           border.color: Color.mOutline

--- a/Modules/Panels/SetupWizard/SetupAppearanceStep.qml
+++ b/Modules/Panels/SetupWizard/SetupAppearanceStep.qml
@@ -406,7 +406,7 @@ ColumnLayout {
         // Predefined schemes Grid (matches ColorSchemeTab)
         GridLayout {
           id: schemesGrid
-          columns: Math.max(2, Math.floor((parent.width - Style.marginM * 2) / 180))
+          columns: Math.max(2, Math.floor((parent.width - Style.marginXL) / 180))
           rowSpacing: Style.marginM
           columnSpacing: Style.marginM
           Layout.fillWidth: true

--- a/Modules/Panels/SetupWizard/SetupWizard.qml
+++ b/Modules/Panels/SetupWizard/SetupWizard.qml
@@ -231,7 +231,7 @@ SmartPanel {
                 Rectangle {
                   Layout.fillWidth: true
                   Layout.topMargin: Style.marginL
-                  Layout.preferredHeight: childrenRect.height + Style.marginM * 2
+                  Layout.preferredHeight: childrenRect.height + Style.marginXL
                   color: Color.mSurfaceVariant
                   radius: Style.radiusL
                   opacity: 0.4

--- a/Modules/Panels/SystemStats/SystemStatsPanel.qml
+++ b/Modules/Panels/SystemStats/SystemStatsPanel.qml
@@ -36,7 +36,7 @@ SmartPanel {
       // HEADER
       NBox {
         Layout.fillWidth: true
-        implicitHeight: headerRow.implicitHeight + (Style.marginM * 2)
+        implicitHeight: headerRow.implicitHeight + (Style.marginXL)
 
         RowLayout {
           id: headerRow
@@ -72,7 +72,7 @@ SmartPanel {
       // Stats Grid + Bottom section
       NBox {
         Layout.fillWidth: true
-        Layout.preferredHeight: statsContainer.implicitHeight + (Style.marginM * 2)
+        Layout.preferredHeight: statsContainer.implicitHeight + (Style.marginXL)
 
         ColumnLayout {
           id: statsContainer

--- a/Modules/Toast/SimpleToast.qml
+++ b/Modules/Toast/SimpleToast.qml
@@ -22,7 +22,7 @@ Item {
   readonly property int shadowPadding: Style.shadowBlurMax + Style.marginL
 
   width: notificationWidth + shadowPadding * 2
-  height: Math.round(contentLayout.implicitHeight + Style.marginM * 2 * 2 + shadowPadding * 2)
+  height: Math.round(contentLayout.implicitHeight + Style.marginXL * 2 + shadowPadding * 2)
   visible: true
   opacity: 0
   scale: initialScale
@@ -111,8 +111,8 @@ Item {
     anchors.fill: background
     anchors.topMargin: Style.marginM
     anchors.bottomMargin: Style.marginM
-    anchors.leftMargin: Style.marginM * 2
-    anchors.rightMargin: Style.marginM * 2
+    anchors.leftMargin: Style.marginXL
+    anchors.rightMargin: Style.marginXL
     spacing: Style.marginL
 
     // Icon

--- a/Widgets/NCollapsible.qml
+++ b/Widgets/NCollapsible.qml
@@ -23,7 +23,7 @@ ColumnLayout {
   Rectangle {
     id: headerContainer
     Layout.fillWidth: true
-    Layout.preferredHeight: headerContent.implicitHeight + (Style.marginM * 2)
+    Layout.preferredHeight: headerContent.implicitHeight + (Style.marginXL)
     color: root.expanded ? Color.mSecondary : Color.mPrimary
     radius: Style.iRadiusM
     border.color: root.expanded ? Color.mOnSecondary : Color.mOutline

--- a/Widgets/NComboBox.qml
+++ b/Widgets/NComboBox.qml
@@ -187,7 +187,7 @@ RowLayout {
     popup: Popup {
       y: combo.height
       implicitWidth: combo.width - Style.marginM
-      implicitHeight: Math.min(Math.round(root.popupHeight * Style.uiScaleRatio), listView.contentHeight + Style.marginM * 2)
+      implicitHeight: Math.min(Math.round(root.popupHeight * Style.uiScaleRatio), listView.contentHeight + Style.marginXL)
       padding: Style.marginM
 
       contentItem: ListView {

--- a/Widgets/NPopupContextMenu.qml
+++ b/Widgets/NPopupContextMenu.qml
@@ -67,7 +67,7 @@ PopupWindow {
             itemWidth += iconMeasure.width + Style.marginS;
           }
 
-          itemWidth += Style.marginM * 2;
+          itemWidth += Style.marginXL;
 
           if (itemWidth > maxWidth) {
             maxWidth = itemWidth;

--- a/Widgets/NTabButton.qml
+++ b/Widgets/NTabButton.qml
@@ -22,7 +22,7 @@ Rectangle {
 
   // Sizing
   Layout.fillHeight: true
-  implicitWidth: tabText.implicitWidth + Style.marginM * 2
+  implicitWidth: tabText.implicitWidth + Style.marginXL
 
   topLeftRadius: isFirst ? Style.iRadiusM : Style.iRadiusXXXS
   bottomLeftRadius: isFirst ? Style.iRadiusM : Style.iRadiusXXXS


### PR DESCRIPTION
# Pull Request

## Motivation
Reduces unneeded math since a lot of style values*2 etc. equal other style values. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

I'll be honest, not tested thoroughly. I've not seen any issue though. Since widgets were affected, and this was done in bulk, I could've affected something, somewhere theoretically. But the math *should* all work out precisely the same.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
In some cases a marginM might be * 2 so it accounts for both sides. So it could be argued changing that to marginXL would be less clear, since we're accounting for 2 marginMs. I think the less math the better though, even if these are marginal performance gains. 