### PR TITLE
MediaPlayerPanel: improve the album artwork

### DIFF
--- a/Modules/Panels/Media/MediaPlayerPanel.qml
+++ b/Modules/Panels/Media/MediaPlayerPanel.qml
@@ -255,54 +255,22 @@ SmartPanel {
             Layout.alignment: Qt.AlignVCenter
             visible: root.showAlbumArt
 
-            Item {
+            NImageRounded {
               anchors.fill: parent
-              layer.enabled: true
-              layer.effect: MultiEffect {
-                maskEnabled: true
-                maskSource: ShaderEffectSource {
-                  sourceItem: maskRect
-                  hideSource: true
-                }
-              }
+              radius: root.compactMode ? Style.radiusM : Style.radiusL
+              imagePath: MediaService.trackArtUrl
+              imageFillMode: Image.PreserveAspectCrop
+              fallbackIcon: "disc"
+              fallbackIconSize: root.compactMode ? Style.fontSizeXXXL * 3 : Style.fontSizeXXXL * 6
+              borderWidth: 0
+            }
 
-              Rectangle {
-                id: maskRect
-                anchors.fill: parent
-                radius: root.compactMode ? Style.radiusM : Style.radiusL
-                color: "white"
-                visible: false
-              }
-
-              Rectangle {
-                anchors.fill: parent
-                color: Color.mSurfaceVariant
-              }
-
-              Image {
-                id: albumArt
-                anchors.fill: parent
-                source: MediaService.trackArtUrl
-                fillMode: Image.PreserveAspectCrop
-                asynchronous: true
-                visible: root.showAlbumArt && source != ""
-              }
-
-              NIcon {
-                anchors.centerIn: parent
-                icon: "disc"
-                pointSize: root.compactMode ? Style.fontSizeXXL : (Style.fontSizeXXXL * 2)
-                color: Color.mOnSurfaceVariant
-                visible: root.showAlbumArt && albumArt.status !== Image.Ready
-              }
-
-              Loader {
-                anchors.fill: parent
-                anchors.margins: Style.marginS
-                z: 2
-                active: !!(root.needsCava && root.showAlbumArt)
-                sourceComponent: visualizerSource
-              }
+            Loader {
+              anchors.fill: parent
+              anchors.margins: Style.marginS
+              z: 2
+              active: !!(root.needsCava && root.showAlbumArt)
+              sourceComponent: visualizerSource
             }
           }
 


### PR DESCRIPTION
## Motivation
- Smooth the jagged edges on the rounded corners.
- It's weird that when you switch songs, it goes album cover -> disc icon -> album cover.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
