### PR TITLE
fix(KeyboardLayoutService): incorrect language mapping for uk

### DIFF
--- a/Services/Keyboard/KeyboardLayoutService.qml
+++ b/Services/Keyboard/KeyboardLayoutService.qml
@@ -96,9 +96,8 @@ Singleton {
     "united states": "us",
     "us english": "us",
     "british": "gb",
-    "uk": "ua",
-    "united kingdom"// FIXED: Ukrainian language code should map to Ukraine
-    : "gb",
+    "uk": "gb",
+    "united kingdom": "gb",
     "english (uk)": "gb",
     "canadian": "ca",
     "canada": "ca",
@@ -175,7 +174,6 @@ Singleton {
     "slovak": "sk",
     "slovenčina": "sk",
     "slovakia": "sk",
-    "uk": "ua",
     "ukrainian"// Ukrainian language code
     : "ua",
     "українська": "ua",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This is just a minor fix of the `KeyboardLayoutService` which maps UK to UA.

Changes made:
- Removed the erroneous "uk": "ua" entry
- Removed the duplicate "uk": "ua" entry
- UK/United Kingdom is now correctly mapped only via "british": "gb", "united kingdom": "gb", and "english (uk)": "gb"

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any) - Not applicable.

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
