### PR TITLE
NetworkService: fix logic of resetting connectivityCheckProcess.failedChecks

### DIFF
--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -871,7 +871,9 @@ Singleton {
           return;
         }
         if (result === "full" || result === "none" || result === "unknown") {
-          connectivityCheckProcess.failedChecks = 0;
+          if (connectivityCheckProcess.failedChecks !== 0) {
+            connectivityCheckProcess.failedChecks = 0;
+          }
           if (result !== root.networkConnectivity) {
             root.networkConnectivity = result;
             root.scan();


### PR DESCRIPTION
I discovered that connectivityCheckProcess.failedChecks currently doesn't reset as it should if the network status is not "limited" or "portal".