### PR TITLE
Do not persist wifiEnabled in settings

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -507,7 +507,6 @@ Singleton {
 
     // network
     property JsonObject network: JsonObject {
-      property bool wifiEnabled: true
       property bool bluetoothRssiPollingEnabled: false  // Opt-in Bluetooth RSSI polling (uses bluetoothctl)
       property int bluetoothRssiPollIntervalMs: 10000 // Polling interval in milliseconds for RSSI queries
       property string wifiDetailsViewMode: "grid"   // "grid" or "list"

--- a/Modules/Bar/Widgets/Network.qml
+++ b/Modules/Bar/Widgets/Network.qml
@@ -40,9 +40,9 @@ Item {
 
     model: [
       {
-        "label": Settings.data.network.wifiEnabled ? I18n.tr("actions.disable-wifi") : I18n.tr("actions.enable-wifi"),
+        "label": NetworkService.wifiEnabled ? I18n.tr("actions.disable-wifi") : I18n.tr("actions.enable-wifi"),
         "action": "toggle-wifi",
-        "icon": Settings.data.network.wifiEnabled ? "wifi-off" : "wifi"
+        "icon": NetworkService.wifiEnabled ? "wifi-off" : "wifi"
       },
       {
         "label": I18n.tr("actions.widget-settings"),
@@ -58,7 +58,7 @@ Item {
                    }
 
                    if (action === "toggle-wifi") {
-                     NetworkService.setWifiEnabled(!Settings.data.network.wifiEnabled);
+                     NetworkService.setWifiEnabled(!NetworkService.wifiEnabled);
                    } else if (action === "widget-settings") {
                      BarService.openWidgetSettings(screen, section, sectionWidgetIndex, widgetId, widgetSettings);
                    }

--- a/Modules/Panels/ControlCenter/Widgets/Network.qml
+++ b/Modules/Panels/ControlCenter/Widgets/Network.qml
@@ -52,5 +52,5 @@ NIconButtonHot {
     var panel = PanelService.getPanel("networkPanel", screen);
     panel?.toggle(this);
   }
-  onRightClicked: NetworkService.setWifiEnabled(!Settings.data.network.wifiEnabled)
+  onRightClicked: NetworkService.setWifiEnabled(!NetworkService.wifiEnabled)
 }

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -36,7 +36,7 @@ SmartPanel {
     expandedSsid = "";
     if (panelViewMode === "wifi") {
       ethernetInfoExpanded = false;
-      if (Settings.data.network.wifiEnabled && !NetworkService.scanning && Object.keys(NetworkService.networks).length === 0)
+      if (NetworkService.wifiEnabled && !NetworkService.scanning && Object.keys(NetworkService.networks).length === 0)
         NetworkService.scan();
     } else {
       if (NetworkService.ethernetConnected) {
@@ -49,7 +49,7 @@ SmartPanel {
 
   // Computed network lists
   readonly property var knownNetworks: {
-    if (!Settings.data.network.wifiEnabled)
+    if (!NetworkService.wifiEnabled)
       return [];
 
     var nets = Object.values(NetworkService.networks);
@@ -80,7 +80,7 @@ SmartPanel {
         panelViewMode = "wifi";
       }
     } else {
-      if (!Settings.data.network.wifiEnabled && NetworkService.hasEthernet())
+      if (!NetworkService.wifiEnabled && NetworkService.hasEthernet())
         panelViewMode = "ethernet";
       else
         panelViewMode = "wifi";
@@ -89,7 +89,7 @@ SmartPanel {
   }
 
   readonly property var availableNetworks: {
-    if (!Settings.data.network.wifiEnabled)
+    if (!NetworkService.wifiEnabled)
       return [];
 
     var nets = Object.values(NetworkService.networks);
@@ -114,7 +114,7 @@ SmartPanel {
   Connections {
     target: Settings.data.network
     function onWifiEnabledChanged() {
-      if (!Settings.data.network.wifiEnabled)
+      if (!NetworkService.wifiEnabled)
         root.hasHadNetworks = false;
     }
   }
@@ -143,9 +143,9 @@ SmartPanel {
           RowLayout {
             NIcon {
               id: modeIcon
-              icon: panelViewMode === "wifi" ? (Settings.data.network.wifiEnabled ? "wifi" : "wifi-off") : (NetworkService.hasEthernet() ? (NetworkService.ethernetConnected ? "ethernet" : "ethernet") : "ethernet-off")
+              icon: panelViewMode === "wifi" ? (NetworkService.wifiEnabled ? "wifi" : "wifi-off") : (NetworkService.hasEthernet() ? (NetworkService.ethernetConnected ? "ethernet" : "ethernet") : "ethernet-off")
               pointSize: Style.fontSizeXXL
-              color: panelViewMode === "wifi" ? (Settings.data.network.wifiEnabled ? Color.mPrimary : Color.mOnSurfaceVariant) : (NetworkService.ethernetConnected ? Color.mPrimary : Color.mOnSurfaceVariant)
+              color: panelViewMode === "wifi" ? (NetworkService.wifiEnabled ? Color.mPrimary : Color.mOnSurfaceVariant) : (NetworkService.ethernetConnected ? Color.mPrimary : Color.mOnSurfaceVariant)
               MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
@@ -176,7 +176,7 @@ SmartPanel {
             NToggle {
               id: wifiSwitch
               visible: panelViewMode === "wifi"
-              checked: Settings.data.network.wifiEnabled
+              checked: NetworkService.wifiEnabled
               onToggled: checked => NetworkService.setWifiEnabled(checked)
               baseSize: Style.baseWidgetSize * 0.65
             }
@@ -185,7 +185,7 @@ SmartPanel {
               icon: "refresh"
               tooltipText: I18n.tr("common.refresh")
               baseSize: Style.baseWidgetSize * 0.8
-              enabled: panelViewMode === "wifi" ? (Settings.data.network.wifiEnabled && !NetworkService.scanning) : true
+              enabled: panelViewMode === "wifi" ? (NetworkService.wifiEnabled && !NetworkService.scanning) : true
               onClicked: {
                 if (panelViewMode === "wifi")
                   NetworkService.scan();
@@ -294,7 +294,7 @@ SmartPanel {
             // Wi‑Fi disabled state
             NBox {
               id: disabledBox
-              visible: panelViewMode === "wifi" && !Settings.data.network.wifiEnabled
+              visible: panelViewMode === "wifi" && !NetworkService.wifiEnabled
               Layout.fillWidth: true
               Layout.preferredHeight: disabledColumn.implicitHeight + Style.marginXL
 
@@ -340,7 +340,7 @@ SmartPanel {
             // Scanning state (show when no networks and we haven't had any yet)
             NBox {
               id: scanningBox
-              visible: panelViewMode === "wifi" && Settings.data.network.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && !root.hasHadNetworks
+              visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && !root.hasHadNetworks
               Layout.fillWidth: true
               Layout.preferredHeight: scanningColumn.implicitHeight + Style.marginXL
 
@@ -377,7 +377,7 @@ SmartPanel {
             // Empty state when no networks (only show after we've had networks before, meaning a real empty result)
             NBox {
               id: emptyBox
-              visible: panelViewMode === "wifi" && Settings.data.network.wifiEnabled && !NetworkService.scanning && Object.keys(NetworkService.networks).length === 0 && root.hasHadNetworks
+              visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && !NetworkService.scanning && Object.keys(NetworkService.networks).length === 0 && root.hasHadNetworks
               Layout.fillWidth: true
               Layout.preferredHeight: emptyColumn.implicitHeight + Style.marginXL
 
@@ -421,7 +421,7 @@ SmartPanel {
             // Networks list container (Wi‑Fi)
             ColumnLayout {
               id: networksList
-              visible: panelViewMode === "wifi" && Settings.data.network.wifiEnabled && Object.keys(NetworkService.networks).length > 0
+              visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length > 0
               width: parent.width
               spacing: Style.marginM
 

--- a/Modules/Panels/Settings/Tabs/NetworkTab.qml
+++ b/Modules/Panels/Settings/Tabs/NetworkTab.qml
@@ -14,7 +14,7 @@ ColumnLayout {
   NToggle {
     label: I18n.tr("actions.enable-wifi")
     description: I18n.tr("panels.network.wifi-description")
-    checked: ProgramCheckerService.nmcliAvailable && Settings.data.network.wifiEnabled
+    checked: ProgramCheckerService.nmcliAvailable && NetworkService.wifiEnabled
     onToggled: checked => NetworkService.setWifiEnabled(checked)
     enabled: ProgramCheckerService.nmcliAvailable
   }

--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -377,7 +377,7 @@ Item {
   IpcHandler {
     target: "wifi"
     function toggle() {
-      NetworkService.setWifiEnabled(!Settings.data.network.wifiEnabled);
+      NetworkService.setWifiEnabled(!NetworkService.wifiEnabled);
     }
     function enable() {
       NetworkService.setWifiEnabled(true);


### PR DESCRIPTION
# Pull Request

## Motivation
I am using a laptop that is sometimes docked (wifi off), and sometimes not (wifi on). Now when I connect to or disconnect from the docking station, that triggers a change in my noctalia-shell config (persisting the current state of the wifi). This is not desirable, as I'm keeping the noctalia-shell config in a dotfiles repo with other configs, so there is constant noise of this bit of config being changed.

I also think the current situation of persisting `wifiEnabled` in the settings is inconsistent with similar other bits system state. Whether Bluetooth is on or off, which power profile is activated etc. Those are all part of the state of my system, which noctalia-shell can display and also mutate, but doesn't persist in its own settings to disk. I think having noctalia-shell not persist those (including `wifiEnabled`) is the correct choice.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This is my first attempt of contributing to noctalia-shell, so I might not be aware of some aspects of the coding style. I have read the guideline for contributing. Sorry about that - happy to make changes to comply. I guess this PR is also a request for comments, as to whether or not the main developers agree with the take that `wifiEnabled` shouldn't be persisted.
