### PR TITLE
Fixed inconsistent colors for Media OSD

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -173,10 +173,6 @@ Variants {
           return LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
         }
       }
-      // For media, use primary color
-      if (currentOSDType === OSD.Type.Media) {
-        return Color.mPrimary;
-      }
       return Color.mPrimary;
     }
 
@@ -194,10 +190,6 @@ Variants {
         } else if (lastLockKeyChanged.startsWith("SCROLL")) {
           return LockKeysService.scrollLockOn ? Color.mPrimary : Color.mOnSurfaceVariant;
         }
-      }
-
-      if (currentOSDType === OSD.Type.Media) {
-        return Color.mPrimary;
       }
 
       return Color.mOnSurface;


### PR DESCRIPTION
# Pull Request

## Motivation
Changes colors for Media OSD to be same as for volume and brightness

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

