### PR TITLE
Fixed inconsistent icon styles for Media OSD

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -86,9 +86,9 @@ Variants {
         return "keyboard";
       case OSD.Type.Media:
         if (root.mediaAction === "pause")
-          return "media-pause";
+          return "player-pause";
         if (root.mediaAction === "play")
-          return "media-play";
+          return "player-play";
         return "music";
       default:
         return "";


### PR DESCRIPTION
# Pull Request

## Motivation
Made the icons for Media OSD consistent in style with other icons (changed from filled to unfilled)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Not sure how this bug came to be as my original PR for this feature used media-play/pause icons? maybe in the review process it was edited to be this way?