### PR TITLE
Fixed inconsistent font for Media OSD

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -785,6 +785,7 @@ Variants {
               text: root.getDisplayPercentage()
               color: Color.mOnSurface
               pointSize: Style.fontSizeXS
+              family: Settings.data.ui.fontFixed
               font.weight: Style.fontWeightRegular
               horizontalAlignment: Text.AlignLeft
               verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
# Pull Request

## Motivation
Fixed inconsistent font family and size of Media OSD
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
this was changed in https://github.com/noctalia-dev/noctalia-shell/commit/cd20b706e072042af863446e6ed356154e3e0854, but it makes it visually inconsistent with other OSD types