### PR TITLE
Remove the code that creates `gui-settings.json` for NixOS users

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -136,24 +136,10 @@ Singleton {
         root.isFreshInstall = true;
         writeAdapter();
 
-        // Also write to fallback if set
-        if (Quickshell.env("NOCTALIA_SETTINGS_FALLBACK")) {
-          settingsFallbackFileView.writeAdapter();
-        }
-
         // We started without settings, we should open the setupWizard
         root.shouldOpenSetupWizard = true;
       }
     }
-  }
-
-  // Fallback FileView for writing settings to alternate location
-  FileView {
-    id: settingsFallbackFileView
-    path: Quickshell.env("NOCTALIA_SETTINGS_FALLBACK") || ""
-    adapter: Quickshell.env("NOCTALIA_SETTINGS_FALLBACK") ? adapter : null
-    printErrors: false
-    watchChanges: false
   }
 
   // FileView to load default settings for comparison
@@ -742,10 +728,6 @@ Singleton {
   // Public function to trigger immediate settings saving
   function saveImmediate() {
     settingsFileView.writeAdapter();
-    // Write to fallback location if set
-    if (Quickshell.env("NOCTALIA_SETTINGS_FALLBACK")) {
-      settingsFallbackFileView.writeAdapter();
-    }
     root.settingsSaved(); // Emit signal after saving
   }
 

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -22,15 +22,7 @@ in
   options.programs.noctalia-shell = {
     enable = lib.mkEnableOption "Noctalia shell configuration";
 
-    systemd = {
-      enable = lib.mkEnableOption "Noctalia shell systemd integration";
-
-      mutableRuntimeSettings = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether noctalia-shell creates a gui-settings.json to store setting changes made within the GUI at runtime.";
-      };
-    };
+    systemd.enable = lib.mkEnableOption "Noctalia shell systemd integration";
 
     package = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
@@ -223,9 +215,6 @@ in
         Service = {
           ExecStart = lib.getExe cfg.package;
           Restart = "on-failure";
-          Environment = lib.mkIf cfg.systemd.mutableRuntimeSettings [
-            "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
-          ];
         };
 
         Install.WantedBy = [ config.wayland.systemd.target ];

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -15,12 +15,6 @@ in
       description = "The noctalia-shell package to use";
     };
 
-    mutableRuntimeSettings = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Whether noctalia-shell creates a gui-settings.json to store setting changes made within the GUI at runtime.";
-    };
-
     target = lib.mkOption {
       type = lib.types.str;
       default = "graphical-session.target";
@@ -45,9 +39,6 @@ in
       serviceConfig = {
         ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";
-        Environment = lib.mkIf cfg.mutableRuntimeSettings [
-          "NOCTALIA_SETTINGS_FALLBACK=%h/.config/noctalia/gui-settings.json"
-        ];
       };
     };
 


### PR DESCRIPTION
For one, there's now the "Copy Settings" button. For another, having two settings is confusing for users.