### PR TITLE
fix(brightness): handle DRM_connector format in ddcutil output

### DIFF
--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -104,7 +104,7 @@ Singleton {
                                              var ddcModelMatch = d.match(/(This monitor does not support DDC\/CI|Invalid display)/);
                                              var modelMatch = d.match(/Model:\s*(.*)/);
                                              var busMatch = d.match(/I2C bus:[ ]*\/dev\/i2c-([0-9]+)/);
-                                             var connectorMatch = d.match(/DRM connector:\s*card\d+-(.+)/);
+                                             var connectorMatch = d.match(/DRM[_ ]connector:\s*card\d+-(.+)/);
                                              var ddcModel = ddcModelMatch ? ddcModelMatch.length > 0 : false;
                                              var model = modelMatch ? modelMatch[1] : "Unknown";
                                              var bus = busMatch ? busMatch[1] : "Unknown";


### PR DESCRIPTION
## Summary
- Fixes regex to match both `DRM connector:` (space) and `DRM_connector:` (underscore) formats in ddcutil output
- This resolves #1427 where multiple identical monitors couldn't be distinguished

## Root Cause
The regex `/DRM connector:\s*card\d+-(.+)/` only matched the space variant, but newer ddcutil versions output `DRM_connector:` with an underscore. This caused the connector field to be empty for all DDC monitors.