### PR TITLE
refactor(wifi): Relocate entries in WiFi Info view

### DIFF
--- a/Modules/Panels/Network/WiFiNetworksList.qml
+++ b/Modules/Panels/Network/WiFiNetworksList.qml
@@ -354,10 +354,13 @@ NBox {
               }
 
               // Icons only; values have labels as tooltips on hover
-              // Row 1: Interface | Band
+              // --- Item 1: Interface ---
+              // Grid: Row 0, Col 0 | List: Row 0
               RowLayout {
                 Layout.fillWidth: true
                 Layout.preferredWidth: 1
+                Layout.row: 0
+                Layout.column: 0
                 spacing: Style.marginXS
                 NIcon {
                   icon: "network"
@@ -402,8 +405,12 @@ NBox {
                   }
                 }
               }
+              // --- Item 2: Frequency (Band) ---
+              // Grid: Row 1, Col 0 | List: Row 1
               RowLayout {
                 Layout.fillWidth: true
+                Layout.row: 1
+                Layout.column: 0
                 spacing: Style.marginXS
                 NIcon {
                   icon: "router"
@@ -429,9 +436,12 @@ NBox {
                 }
               }
 
-              // Row 2: Link Speed | Gateway
+              // --- Item 3: Link Speed ---
+              // Grid: Row 2, Col 0 | List: Row 2
               RowLayout {
                 Layout.fillWidth: true
+                Layout.row: 2
+                Layout.column: 0
                 spacing: Style.marginXS
                 NIcon {
                   icon: "gauge"
@@ -457,8 +467,13 @@ NBox {
                   clip: true
                 }
               }
+
+              // --- Item 4: Gateway ---
+              // Grid: Row 2, Col 1 | List: Row 5 (Last)
               RowLayout {
                 Layout.fillWidth: true
+                Layout.row: root.detailsGrid ? 2 : 5
+                Layout.column: root.detailsGrid ? 1 : 0
                 spacing: Style.marginXS
                 NIcon {
                   icon: "router"
@@ -484,10 +499,12 @@ NBox {
                   clip: true
                 }
               }
-
-              // Row 3: IPv4 | DNS
+              // --- Item 5: IPv4 ---
+              // Grid: Row 0, Col 1 | List: Row 3
               RowLayout {
                 Layout.fillWidth: true
+                Layout.row: root.detailsGrid ? 0 : 3
+                Layout.column: root.detailsGrid ? 1 : 0
                 spacing: Style.marginXS
                 NIcon {
                   // IPv4 address icon ("device-lan" doesn't exist in our font)
@@ -531,8 +548,12 @@ NBox {
                   }
                 }
               }
-              RowLayout {
+              // --- Item 6: DNS ---
+              // Grid: Row 1, Col 1 | List: Row 4
+            RowLayout {
                 Layout.fillWidth: true
+                Layout.row: root.detailsGrid ? 1 : 4
+                Layout.column: root.detailsGrid ? 1 : 0
                 spacing: Style.marginXS
                 // DNS: allow wrapping when selected
                 NIcon {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Visual grouping

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring

## Related Issue
N/A

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
**BEFORE**
<img width="652" height="439" alt="wifi-before" src="https://github.com/user-attachments/assets/d556f6e1-eec8-4a86-9b1b-8543b9222099" />
**AFTER**
<img width="633" height="426" alt="wifi-after" src="https://github.com/user-attachments/assets/956dcc61-500e-4676-93b1-2cff0195a5a8" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Same layout will be applied on ethernet side of things as well.

[network-wl-layout.txt](https://github.com/user-attachments/files/24692672/network-wl-layout.txt)
[network-eth-layout.txt](https://github.com/user-attachments/files/24692673/network-eth-layout.txt)
