### PR TITLE
feat(theming): add hyprtoolkit support

### DIFF
--- a/Assets/MatugenTemplates/hyprtoolkit.conf
+++ b/Assets/MatugenTemplates/hyprtoolkit.conf
@@ -1,0 +1,7 @@
+background = rgba({{colors.background.default.hex_stripped}}ff)
+base = rgba({{colors.surface.default.hex_stripped}}ff)
+text = rgba({{colors.on_surface.default.hex_stripped}}ff)
+alternate_base = rgba({{colors.surface_variant.default.hex_stripped}}ff)
+bright_text = rgba({{colors.on_secondary.default.hex_stripped}}ff)
+accent = rgba({{colors.primary.default.hex_stripped}}ff)
+accent_secondary = rgba({{colors.secondary.default.hex_stripped}}ff)

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -333,6 +333,17 @@ Singleton {
       "postProcess": () => `${colorsApplyScript} hyprland`
     },
     {
+      "id": "hyprtoolkit",
+      "name": "Hyprtoolkit",
+      "category": "system",
+      "input": "hyprtoolkit.conf",
+      "outputs": [
+        {
+          "path": "~/.config/hypr/hyprtoolkit.conf"
+        }
+      ]
+    },
+    {
       "id": "mango",
       "name": "Mango",
       "category": "compositor",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Adds a new template for hyprtoolkit to apply the current colors of the noctalia shell to all hyprland applications that use hyprtoolkit.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1205

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Catppuccin color scheme applied to hyprpwcenter (some app from hyprland that uses the hyprtoolkit)
<img width="1750" height="1149" alt="image" src="https://github.com/user-attachments/assets/aa765c48-c74b-45b7-9aa3-8d37d34604fc" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
