### PR TITLE
preview font in own typeface

### DIFF
--- a/Modules/Panels/Settings/Tabs/GeneralTab.qml
+++ b/Modules/Panels/Settings/Tabs/GeneralTab.qml
@@ -83,6 +83,7 @@ ColumnLayout {
         popupHeight: 420
         defaultValue: Settings.getDefaultValue("ui.fontDefault")
         settingsPath: "ui.fontDefault"
+        useFontPreview: true
         onSelected: key => Settings.data.ui.fontDefault = key
       }
 
@@ -96,6 +97,7 @@ ColumnLayout {
         popupHeight: 320
         defaultValue: Settings.getDefaultValue("ui.fontFixed")
         settingsPath: "ui.fontFixed"
+        useFontPreview: true
         onSelected: key => Settings.data.ui.fontFixed = key
       }
 

--- a/Widgets/NSearchableComboBox.qml
+++ b/Widgets/NSearchableComboBox.qml
@@ -19,6 +19,7 @@ RowLayout {
   property Component delegate: null
   property var defaultValue: undefined
   property string settingsPath: ""
+  property bool useFontPreview: false
 
   readonly property real preferredHeight: Math.round(Style.baseWidgetSize * 1.1)
 
@@ -278,6 +279,7 @@ RowLayout {
 
                 NText {
                   text: name
+                  font.family: root.useFontPreview ? name : undefined
                   pointSize: Style.fontSizeM
                   color: highlighted ? Color.mOnHover : Color.mOnSurface
                   verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
for the font picker, this shows the font in its own typeface. this is usually common in font pickers in editors etc and helps in remembering what each font looks like

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="615" height="677" alt="default_font" src="https://github.com/user-attachments/assets/ff6f4ed0-e78c-417f-9bc0-14fffc372307" />
<img width="615" height="677" alt="monospace_font" src="https://github.com/user-attachments/assets/90184201-1bec-4679-bd48-6955e372bebb" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
