### PR TITLE
[i18n/ja]: Remove rōmaji and use a more fitting transl for ratios-any

### DIFF
--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -325,7 +325,7 @@
   },
   "colors": {
     "error": "エラー",
-    "on-surface": "表面上 (Hyōmenjō)",
+    "on-surface": "表面上",
     "primary": "主要",
     "secondary": "二次的",
     "tertiary": "第三紀"
@@ -718,7 +718,7 @@
       "monitor-reset-all": "すべてリセット",
       "monitor-widgets-title": "ウィジェット設定 - {monitor}",
       "monitors-desc": "バーを表示するディスプレイを選択します。未選択の場合は全てに表示されます。",
-      "monitors-desc-new": "どのモニターにBarを表示するかを設定し、モニターごとに設定をカスタマイズします。",
+      "monitors-desc-new": "どのモニターにバーを表示するかを設定し、モニターごとに設定をカスタマイズします。",
       "monitors-title": "表示するディスプレイ",
       "title": "バー",
       "tray-blacklist-description": "トレイから除外するルールを追加します。ワイルドカード (*) に対応しています。",
@@ -1229,7 +1229,7 @@
       "update-available": "新しいプラグインアップデートがあります",
       "update-available-plural": "新しいプラグインアップデートがあります（{count}個）",
       "update-error": "プラグインのアップデートに失敗しました: {plugin}: {error}。",
-      "update-pending": "v{current} → v{new} (Noctalia v{required} ga hitsuyou)",
+      "update-pending": "v{current} → v{new} (Noctalia v{required}が必要です)",
       "update-success": "{plugin} を v{version} にアップデートしました。",
       "update-version": "v{current} → v{new}",
       "updating": "更新中..."
@@ -1627,7 +1627,7 @@
       "purity-nsfw": "R-18",
       "purity-sfw": "全年齢",
       "purity-sketchy": "際どい",
-      "ratios-any": "どれか",
+      "ratios-any": "すべて",
       "ratios-label": "アスペクト比",
       "resolution-atleast": "以上",
       "resolution-exact": "完全一致",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

Rōmaji is Japanese transliteration in roman letters. Some labels included unnecessary transliterations in parentheses.

Additionally, this commit rewrites a Japanese sentence written in rōmaji instead of proper Japanese characters (ga hitsuyou -> が必要です) (I added a です/desu to end the sentence)

Finally, I also changed the translation of `ratios-any`. The original felt off the mark.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
N/A

## Testing


Not tested.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
None

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

Related PR: https://github.com/noctalia-dev/noctalia-shell/pull/1246