### PR TITLE
BatteryWidget: charging status only if UPowerDeviceState.Charging

### DIFF
--- a/Modules/Bar/Widgets/Battery.qml
+++ b/Modules/Bar/Widgets/Battery.qml
@@ -134,11 +134,11 @@ Item {
   function chargingStatus(state) {
     switch (state) {
     case UPowerDeviceState.Charging: // 1
-    case UPowerDeviceState.FullyCharged: // 4
-    case UPowerDeviceState.PendingCharge: // 5
       return true;
     case UPowerDeviceState.Discharging: // 2
     case UPowerDeviceState.Empty: // 3
+    case UPowerDeviceState.FullyCharged: // 4
+    case UPowerDeviceState.PendingCharge: // 5
     case UPowerDeviceState.PendingDischarge: // 6
       return false;
     default:


### PR DESCRIPTION
The battery widget shows that it's charging when my laptop is connected to a charger but in idle state. `charging` should only be true in the case of UPowerDeviceState.Charging.