### PR TITLE
Hide gradient for solid color wallpaper

### DIFF
--- a/Modules/LockScreen/LockScreenBackground.qml
+++ b/Modules/LockScreen/LockScreenBackground.qml
@@ -119,6 +119,7 @@ Item {
   }
 
   Rectangle {
+    visible: !Settings.data.wallpaper.useSolidColor
     anchors.fill: parent
     gradient: Gradient {
       GradientStop {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
`LockScreenBackground` adds gradient on wallpaper which causes banding when wallpaper is solid color. Hide gradient.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

