### PR TITLE
BatteryWidget: add option to hide if idle (solves #1464)

### DIFF
--- a/Assets/settings-widgets-default.json
+++ b/Assets/settings-widgets-default.json
@@ -19,7 +19,8 @@
       "deviceNativePath": "",
       "showPowerProfiles": false,
       "showNoctaliaPerformance": false,
-      "hideIfNotDetected": true
+      "hideIfNotDetected": true,
+      "hideIfIdle": false
     },
     "Bluetooth": {
       "displayMode": "onhover"

--- a/Modules/Bar/Widgets/Battery.qml
+++ b/Modules/Bar/Widgets/Battery.qml
@@ -37,11 +37,12 @@ Item {
   readonly property string displayMode: widgetSettings.displayMode !== undefined ? widgetSettings.displayMode : widgetMetadata.displayMode
   readonly property real warningThreshold: widgetSettings.warningThreshold !== undefined ? widgetSettings.warningThreshold : widgetMetadata.warningThreshold
   readonly property bool hideIfNotDetected: widgetSettings.hideIfNotDetected !== undefined ? widgetSettings.hideIfNotDetected : widgetMetadata.hideIfNotDetected
+  readonly property bool hideIfIdle: widgetSettings.hideIfIdle !== undefined ? widgetSettings.hideIfIdle : widgetMetadata.hideIfIdle
   // Only show low battery warning if device is ready (prevents false positive during initialization)
   readonly property bool isLowBattery: isReady && !charging && percent <= warningThreshold
 
   // Visibility: show if hideIfNotDetected is false, or if battery is ready (after initialization)
-  readonly property bool shouldShow: !hideIfNotDetected || isReady
+  readonly property bool shouldShow: !hideIfNotDetected || (isReady && (hideIfIdle ? (charging || battery.state === UPowerDeviceState.Discharging) : true))
   visible: shouldShow
   opacity: shouldShow ? 1.0 : 0.0
 

--- a/Modules/Panels/Settings/Bar/WidgetSettings/BatterySettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/BatterySettings.qml
@@ -20,6 +20,7 @@ ColumnLayout {
   property bool valueShowPowerProfiles: widgetData.showPowerProfiles !== undefined ? widgetData.showPowerProfiles : widgetMetadata.showPowerProfiles
   property bool valueShowNoctaliaPerformance: widgetData.showNoctaliaPerformance !== undefined ? widgetData.showNoctaliaPerformance : widgetMetadata.showNoctaliaPerformance
   property bool valueHideIfNotDetected: widgetData.hideIfNotDetected !== undefined ? widgetData.hideIfNotDetected : widgetMetadata.hideIfNotDetected
+  property bool valueHideIfIdle: widgetData.hideIfIdle !== undefined ? widgetData.hideIfIdle : widgetMetadata.hideIfIdle
 
   // Build model of available battery devices
   function buildDeviceModel() {
@@ -86,6 +87,7 @@ ColumnLayout {
     settings.showPowerProfiles = valueShowPowerProfiles;
     settings.showNoctaliaPerformance = valueShowNoctaliaPerformance;
     settings.hideIfNotDetected = valueHideIfNotDetected;
+    settings.hideIfIdle = valueHideIfIdle;
     if (valueDeviceNativePath && valueDeviceNativePath !== "") {
       settings.deviceNativePath = valueDeviceNativePath;
     } else {
@@ -174,7 +176,14 @@ ColumnLayout {
   NToggle {
     label: I18n.tr("bar.battery.hide-if-not-detected-label")
     description: I18n.tr("bar.battery.hide-if-not-detected-description")
-    checked: root.valueHideIfNotDetected
-    onToggled: checked => root.valueHideIfNotDetected = checked
+    checked: valueHideIfNotDetected
+    onToggled: checked => valueHideIfNotDetected = checked
+  }
+  
+  NToggle {
+    label: I18n.tr("bar.battery.hide-if-idle-label")
+    description: I18n.tr("bar.battery.hide-if-idle-description")
+    checked: valueHideIfIdle
+    onToggled: checked => valueHideIfIdle = checked
   }
 }

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -91,7 +91,8 @@ Singleton {
                                     "deviceNativePath": "",
                                     "showPowerProfiles": false,
                                     "showNoctaliaPerformance": false,
-                                    "hideIfNotDetected": true
+                                    "hideIfNotDetected": true,
+                                    "hideIfIdle": false
                                   },
                                   "Bluetooth": {
                                     "displayMode": "onhover"


### PR DESCRIPTION
This PR adds an option to hide the battery widget if not charging or discharging (as suggested in #1464).
I've added the translation keys directly to the website.