### PR TITLE
fix(launcher): intercept left/right key actions in grid view only

### DIFF
--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -871,10 +871,10 @@ SmartPanel {
                   } else if (event.key === Qt.Key_Backtab) {
                     root.onBackTabPressed();
                     event.accepted = true;
-                  } else if (event.key === Qt.Key_Left) {
+                  } else if (event.key === Qt.Key_Left && root.isGridView) {
                     root.onLeftPressed();
                     event.accepted = true;
-                  } else if (event.key === Qt.Key_Right) {
+                  } else if (event.key === Qt.Key_Right && root.isGridView) {
                     root.onRightPressed();
                     event.accepted = true;
                   } else if (event.key === Qt.Key_Up) {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
When in listview (vertical list), the left and right arrow keys are intercepted to move the focus up and down. This not only duplicates the function of the up and down arrow keys, but also prevents the cursor in input fields from moving left or right (which is even more problematic in calculator mode). Therefore, it makes sense to intercept the left and right arrow keys for horizontal movement only when in gridview.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1347 

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)