### PR TITLE
MediaMini: fix empty player not hiding

### DIFF
--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -53,7 +53,7 @@ Item {
   readonly property int progressWidth: 2
 
   // State
-  readonly property bool hasPlayer: MediaService.currentPlayer !== null
+  readonly property bool hasPlayer: !MediaService.currentPlayer
   readonly property bool shouldHideIdle: (hideMode === "idle" || hideWhenIdle) && !MediaService.isPlaying
   readonly property bool shouldHideEmpty: !hasPlayer && hideMode === "hidden"
   readonly property bool isHidden: shouldHideIdle || shouldHideEmpty


### PR DESCRIPTION
When i pause a player, after a while the MediaMini widget goes empty but doesnt hide (the progress circle is still visible). The reason seems to be that the currentPlayer becomes an empty string, so I changed the condition for when there is a player.