### PR TITLE
Add spaces to units in SystemMonitor

### DIFF
--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -74,27 +74,27 @@ Rectangle {
 
     // Load Average
     if (SystemStatService.loadAvg1 >= 0) {
-      lines.push(`${I18n.tr("system-monitor.load-average")}: ${SystemStatService.loadAvg1.toFixed(2)} ${SystemStatService.loadAvg5.toFixed(2)} ${SystemStatService.loadAvg15.toFixed(2)}`);
+      lines.push(`${I18n.tr("system-monitor.load-average")}: ${SystemStatService.loadAvg1.toFixed(2)} · ${SystemStatService.loadAvg5.toFixed(2)} · ${SystemStatService.loadAvg15.toFixed(2)}`);
     }
 
     // Memory
-    lines.push(`${I18n.tr("common.memory")}: ${Math.round(SystemStatService.memPercent)}% (${SystemStatService.formatMemoryGb(SystemStatService.memGb)})`);
+    lines.push(`${I18n.tr("common.memory")}: ${Math.round(SystemStatService.memPercent)}% (${SystemStatService.formatMemoryGb(SystemStatService.memGb).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")})`);
 
     // Swap (if available)
     if (SystemStatService.swapTotalGb > 0) {
-      lines.push(`${I18n.tr("bar.system-monitor.swap-usage-label")}: ${Math.round(SystemStatService.swapPercent)}% (${SystemStatService.formatMemoryGb(SystemStatService.swapGb)})`);
+      lines.push(`${I18n.tr("bar.system-monitor.swap-usage-label")}: ${Math.round(SystemStatService.swapPercent)}% (${SystemStatService.formatMemoryGb(SystemStatService.swapGb).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")})`);
     }
 
     // Network
-    lines.push(`${I18n.tr("system-monitor.download-speed")}: ${SystemStatService.formatSpeed(SystemStatService.rxSpeed)}`);
-    lines.push(`${I18n.tr("system-monitor.upload-speed")}: ${SystemStatService.formatSpeed(SystemStatService.txSpeed)}`);
+    lines.push(`${I18n.tr("system-monitor.download-speed")}: ${SystemStatService.formatSpeed(SystemStatService.rxSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")}`);
+    lines.push(`${I18n.tr("system-monitor.upload-speed")}: ${SystemStatService.formatSpeed(SystemStatService.txSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")}`);
 
     // Disk
     const diskPercent = SystemStatService.diskPercents[diskPath];
     if (diskPercent !== undefined) {
       const usedGb = SystemStatService.diskUsedGb[diskPath] || 0;
       const sizeGb = SystemStatService.diskSizeGb[diskPath] || 0;
-      lines.push(`${I18n.tr("system-monitor.disk")}: ${usedGb.toFixed(1)}G / ${sizeGb.toFixed(1)}G (${diskPercent}%)`);
+      lines.push(`${I18n.tr("system-monitor.disk")}: ${usedGb.toFixed(1)} G / ${sizeGb.toFixed(1)} G (${diskPercent}%)`);
     }
 
     return lines.join("\n");

--- a/Modules/Panels/SystemStats/SystemStatsPanel.qml
+++ b/Modules/Panels/SystemStats/SystemStatsPanel.qml
@@ -220,12 +220,12 @@ SmartPanel {
                   icon: "download-speed"
                   suffix: "%"
                   fillColor: Color.mPrimary
-                  tooltipText: I18n.tr("common.download") + `: ${SystemStatService.formatSpeed(SystemStatService.rxSpeed)}`
+                  tooltipText: I18n.tr("common.download") + `: ${SystemStatService.formatSpeed(SystemStatService.rxSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")}`
                   Layout.alignment: Qt.AlignHCenter
                 }
 
                 NText {
-                  text: SystemStatService.formatSpeed(SystemStatService.rxSpeed) + "/s"
+                  text: SystemStatService.formatSpeed(SystemStatService.rxSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2") + "/s"
                   pointSize: Style.fontSizeXXS
                   color: Color.mOnSurfaceVariant
                   Layout.alignment: Qt.AlignHCenter
@@ -248,12 +248,12 @@ SmartPanel {
                   icon: "upload-speed"
                   suffix: "%"
                   fillColor: Color.mPrimary
-                  tooltipText: I18n.tr("common.upload") + `: ${SystemStatService.formatSpeed(SystemStatService.txSpeed)}`
+                  tooltipText: I18n.tr("common.upload") + `: ${SystemStatService.formatSpeed(SystemStatService.txSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")}`
                   Layout.alignment: Qt.AlignHCenter
                 }
 
                 NText {
-                  text: SystemStatService.formatSpeed(SystemStatService.txSpeed) + "/s"
+                  text: SystemStatService.formatSpeed(SystemStatService.txSpeed).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2") + "/s"
                   pointSize: Style.fontSizeXXS
                   color: Color.mOnSurfaceVariant
                   Layout.alignment: Qt.AlignHCenter
@@ -317,7 +317,7 @@ SmartPanel {
                   }
 
                   NText {
-                    text: SystemStatService.formatMemoryGb(SystemStatService.memGb)
+                    text: SystemStatService.formatMemoryGb(SystemStatService.memGb).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")
                     pointSize: Style.fontSizeXS
                     color: Color.mOnSurface
                     Layout.fillWidth: true
@@ -344,7 +344,7 @@ SmartPanel {
                   }
 
                   NText {
-                    text: `${SystemStatService.formatMemoryGb(SystemStatService.swapGb)} / ${SystemStatService.formatMemoryGb(SystemStatService.swapTotalGb)}`
+                    text: `${SystemStatService.formatMemoryGb(SystemStatService.swapGb).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")} / ${SystemStatService.formatMemoryGb(SystemStatService.swapTotalGb).replace(/([0-9.]+)([A-Za-z]+)/, "$1 $2")}`
                     pointSize: Style.fontSizeXS
                     color: Color.mOnSurface
                     Layout.fillWidth: true
@@ -373,7 +373,7 @@ SmartPanel {
                     text: {
                       const usedGb = SystemStatService.diskUsedGb[panelContent.diskPath] || 0;
                       const sizeGb = SystemStatService.diskSizeGb[panelContent.diskPath] || 0;
-                      return `${usedGb.toFixed(1)}G / ${sizeGb.toFixed(1)}G`;
+                      return `${usedGb.toFixed(1)} G / ${sizeGb.toFixed(1)} G`;
                     }
                     pointSize: Style.fontSizeXS
                     color: Color.mOnSurface


### PR DESCRIPTION
This is a minor issue, but I think it would be more consistent with other tooltips if there would be spaces between numbers and units like "5 KB/s" instead of "5KB/s".