### PR TITLE
MediaMini: fix empty player not hiding

### DIFF
--- a/Services/Media/MediaService.qml
+++ b/Services/Media/MediaService.qml
@@ -146,7 +146,7 @@ Singleton {
     let controllablePlayers = [];
     for (var i = 0; i < finalPlayers.length; i++) {
       let player = finalPlayers[i];
-      if (player && player.canControl) {
+      if (player && player.canPlay) {
         controllablePlayers.push(player);
       }
     }


### PR DESCRIPTION
When i pause the Crunchyroll player, after a while the MediaMini widget goes empty but doesn't hide (the progress circle is still visible) as it should when hideWhenEmpty is selected. The reason is that the player goes into some idle state where it has to  be completely restarted, but in that state its still recognized as a player in has the `canControl` property.
This PR changes the availablePlayers filter to `canPlay` instead of `canControl` which fixes this issue and might apply to other players as well, although I don't know if there are any side effects.