### PR TITLE
fix: ghostty template apply

### DIFF
--- a/Scripts/bash/template-apply.sh
+++ b/Scripts/bash/template-apply.sh
@@ -38,7 +38,7 @@ ghostty)
             echo "theme = noctalia" >>"$CONFIG_FILE"
         fi
         # Only signal if ghostty is running
-        pgrep -x ghostty >/dev/null && pkill -SIGUSR2 ghostty || true
+        pgrep -f ghostty >/dev/null && pkill -SIGUSR2 ghostty || true
     else
         echo "Error: ghostty config file not found at $CONFIG_FILE" >&2
         exit 1


### PR DESCRIPTION
# Pull Request


## Motivation
pgrep -x looks for an exact process name match and fails on NixOS, where Ghostty runs as .ghostty-wrapped.
Switching to -f correctly detects the process.


## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
