### PR TITLE
Settings: Show search while sidebar collapsed.

### DIFF
--- a/Modules/Panels/Settings/SettingsContent.qml
+++ b/Modules/Panels/Settings/SettingsContent.qml
@@ -86,6 +86,12 @@ Item {
       searchResults = [];
       return;
     }
+
+    // Auto-expand sidebar when searching
+    if (!root.sidebarExpanded) {
+      root.sidebarExpanded = true;
+    }
+
     if (searchIndex.length === 0)
       return;
 
@@ -265,6 +271,10 @@ Item {
   // Save sidebar state when it changes
   onSidebarExpandedChanged: {
     ShellState.setSettingsSidebarExpanded(sidebarExpanded);
+    if (!sidebarExpanded) {
+      root.searchText = "";
+      searchInput.text = "";
+    }
   }
 
   Component.onCompleted: {
@@ -670,6 +680,70 @@ Item {
             }
 
             onTextChanged: root.searchText = text
+          }
+
+          // Search button for collapsed sidebar
+          Item {
+            id: searchCollapsedContainer
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.round(searchCollapsedRow.implicitHeight + Style.marginS * 2)
+            visible: !root.sidebarExpanded
+            opacity: !root.sidebarExpanded ? 1.0 : 0.0
+
+            Behavior on opacity {
+              NumberAnimation {
+                duration: Style.animationFast
+                easing.type: Easing.InOutQuad
+              }
+            }
+
+            Rectangle {
+              id: searchCollapsedButton
+              width: Math.round(searchCollapsedRow.implicitWidth + Style.marginS * 2)
+              height: parent.height
+              anchors.left: parent.left
+              radius: Style.radiusS
+              color: searchCollapsedMouseArea.containsMouse ? Color.mHover : "transparent"
+
+              Behavior on color {
+                enabled: !Color.isTransitioning
+                ColorAnimation {
+                  duration: Style.animationFast
+                  easing.type: Easing.InOutQuad
+                }
+              }
+
+              RowLayout {
+                id: searchCollapsedRow
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.leftMargin: Style.marginS
+                spacing: 0
+
+                NIcon {
+                  icon: "search"
+                  color: searchCollapsedMouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
+                  pointSize: Style.fontSizeXL
+                }
+              }
+
+              MouseArea {
+                id: searchCollapsedMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                  root.sidebarExpanded = true;
+                  Qt.callLater(() => searchInput.inputItem.forceActiveFocus());
+                }
+                onEntered: {
+                  TooltipService.show(searchCollapsedButton, I18n.tr("common.search"));
+                }
+                onExited: {
+                  TooltipService.hide();
+                }
+              }
+            }
           }
 
           Item {


### PR DESCRIPTION
Writing anything auto expands sidebar.

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This completes what was missing.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
N/A yet

## Testing

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before:
<img width="1293" height="1600" alt="search_missing" src="https://github.com/user-attachments/assets/462252e8-7adb-4fb0-96e6-ecb6cd1136eb" />

After (On your left):
<img width="2560" height="1600" alt="search_Added" src="https://github.com/user-attachments/assets/df7af7df-6900-49d0-be60-78c95e26e3c9" />


## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
N/A
