### PR TITLE
fix(osd): defer first show to prevent percentage text overflow

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -740,17 +740,24 @@ Variants {
           }
         }
 
+        // Delay showing the OSD to allow the layout to settle after activation.
+        // Without this, the percentage text renders outside the box on first
+        // show.
+        Timer {
+          id: showDelayTimer
+          interval: 30
+          onTriggered: {
+            osdItem.visible = true;
+            osdItem.opacity = 1;
+            osdItem.scale = 1.0;
+            hideTimer.start();
+          }
+        }
+
         function show() {
           hideTimer.stop();
           visibilityTimer.stop();
-          osdItem.visible = true;
-
-          Qt.callLater(() => {
-                         osdItem.opacity = 1;
-                         osdItem.scale = 1.0;
-                       });
-
-          hideTimer.start();
+          showDelayTimer.start();
         }
 
         function hide() {


### PR DESCRIPTION
# Pull Request

## Motivation

On first OSD display, the percentage text would render outside the bounding box because the layout hadn't finished positioning children.

Add a small delay 30ms delay before rendering the OSD, which seems to be enough time to allow for things to synchronize.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes https://github.com/noctalia-dev/noctalia-shell/issues/1425

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ x] Code follows project style guidelines
- [ x] Self-reviewed my code
- [ x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
