### PR TITLE
refactor(launcher): decouple preview logic from clipboard settings

### DIFF
--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -20,8 +20,7 @@ SmartPanel {
     var provider = activeProvider;
     if (!provider || !provider.hasPreview)
       return false;
-    if (!Settings.data.appLauncher.enableClipPreview)
-      return false;
+
     return selectedIndex >= 0 && results && !!results[selectedIndex];
   }
 

--- a/Modules/Panels/Launcher/Providers/ClipboardProvider.qml
+++ b/Modules/Panels/Launcher/Providers/ClipboardProvider.qml
@@ -17,7 +17,7 @@ Item {
   property bool handleSearch: false // Don't handle regular search
 
   // Preview support
-  property bool hasPreview: true
+  property bool hasPreview: Settings.data.appLauncher.enableClipPreview
   property string previewComponentPath: "./ClipboardPreview.qml"
 
   // Image handling - expose revision for reactive updates in delegates


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Currently, the preview panel in the launcher assumes that it only used by the clipboard, and the two are tightly coupled. This limits the launcher's extensibility and prevents other plugins from using the preview panel.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
