### PR TITLE
Added "All Wide" and "All Portrait" ratio options

### DIFF
--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -518,6 +518,14 @@ Popup {
             "key": "",
             "name": I18n.tr("wallpaper.panel.ratios-any")
           },
+		  {
+			"key": "landscape",
+			"name", "All Wide"
+		  },
+		  {
+			"key": "portrait",
+			"name": "All Portrait"
+		  },
           {
             "key": "16x9",
             "name": "16x9"


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Wallhaven search API allows for "All Wide" and "All Portrait" selections which includes sets of ratios:
- All Wide
  - 16x9
  - 16x10
  - 21x9
  - 32x9
  - 48x9
- All Portrait
  - 9x16
  - 10x16
  - 9x18

These increase your search results within broad ratio categories that might better fit your screen.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

These tests aren't really important because it's just a flag in the search settings of wallhaven.

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
<img width="664" height="686" alt="wallhaven-settings-menu" src="https://github.com/user-attachments/assets/a4e4c826-411a-434c-91c8-728485128704" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
