### PR TITLE
fix: remove hardcoded placeholder from portuguese greeting in lock screen

### DIFF
--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -1480,7 +1480,7 @@
     "unknown-app": "Aplicativo desconhecido",
     "uptime": "Atividade: {uptime}",
     "user-requested": "Solicitado pelo usuário",
-    "welcome-back": "Bem-vindo(a) de volta, {user}!",
+    "welcome-back": "Bem-vindo(a) de volta,",
     "widget-settings-title": "Configurações de {widget}"
   },
   "system-monitor": {


### PR DESCRIPTION
# Pull Request

## Motivation
Removes the hardcoded placeholder from the portuguese greeting in lock screen.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="837" height="202" alt="image" src="https://github.com/user-attachments/assets/1543e840-8450-4304-8fdc-647257f7c9c0" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
