### PR TITLE
Control/search: fixup return handling.

### DIFF
--- a/Modules/Panels/Settings/SettingsContent.qml
+++ b/Modules/Panels/Settings/SettingsContent.qml
@@ -719,6 +719,10 @@ Item {
             }
 
             onTextChanged: root.searchText = text
+            onEditingFinished: {
+              if (root.searchText.trim() !== "")
+                root.searchActivate();
+            }
           }
 
           // Search button for collapsed sidebar

--- a/Modules/Panels/Settings/SettingsPanel.qml
+++ b/Modules/Panels/Settings/SettingsPanel.qml
@@ -219,12 +219,6 @@ SmartPanel {
     }
   }
 
-  function onReturnPressed() {
-    if (_settingsContent && _settingsContent.searchText.trim() !== "") {
-      _settingsContent.searchActivate();
-    }
-  }
-
   function onPageUpPressed() {
     scrollPageUp();
   }


### PR DESCRIPTION
# Pull Request

Commit 87f0c3aba611 introduces a regression where the input text boxes within the Control panel, such as Region (for weather setting), do not trigger their onEditingFinished handler as the onReturnPressed() function captures newline. This bug can be reproduced by entering a new location in the region input box, where nothing happens.

This patch removes onReturnPressed() and triggers search activation on onEditingFinished.

Fixes: 87f0c3aba611 ("settings-search: keyboard centric navigation")

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A (Didn't see a bug report yet...)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)