### PR TITLE
feat(launcher): add complete vim navigation support to the launcher's grid view

### DIFF
--- a/Modules/MainScreen/MainScreen.qml
+++ b/Modules/MainScreen/MainScreen.qml
@@ -492,6 +492,12 @@ PanelWindow {
   }
 
   Shortcut {
+    sequence: "Ctrl+H"
+    enabled: root.isPanelOpen && (PanelService.openedPanel.onCtrlHPressed !== undefined)
+    onActivated: PanelService.openedPanel.onCtrlHPressed()
+  }
+
+  Shortcut {
     sequence: "Ctrl+J"
     enabled: root.isPanelOpen && (PanelService.openedPanel.onCtrlJPressed !== undefined)
     onActivated: PanelService.openedPanel.onCtrlJPressed()
@@ -501,6 +507,12 @@ PanelWindow {
     sequence: "Ctrl+K"
     enabled: root.isPanelOpen && (PanelService.openedPanel.onCtrlKPressed !== undefined)
     onActivated: PanelService.openedPanel.onCtrlKPressed()
+  }
+
+  Shortcut {
+    sequence: "Ctrl+L"
+    enabled: root.isPanelOpen && (PanelService.openedPanel.onCtrlLPressed !== undefined)
+    onActivated: PanelService.openedPanel.onCtrlLPressed()
   }
 
   Shortcut {

--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -318,12 +318,32 @@ SmartPanel {
     selectNextPage();
   }
 
+  function onCtrlHPressed() {
+    if (isGridView) {
+      selectPreviousWrapped();
+    }
+  }
+
   function onCtrlJPressed() {
-    selectNextWrapped();
+    if (isGridView) {
+      selectNextRow();
+    } else {
+      selectNextWrapped();
+    }
   }
 
   function onCtrlKPressed() {
-    selectPreviousWrapped();
+    if (isGridView) {
+      selectPreviousRow();
+    } else {
+      selectPreviousWrapped();
+    }
+  }
+
+  function onCtrlLPressed() {
+    if (isGridView) {
+      selectNextWrapped();
+    }
   }
 
   function onCtrlNPressed() {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Currently, the grid view supports moving the selection box left and right using the 'j' and 'k' keys. However, a more Vim-like approach would be to use 'h' and 'l' for left and right movement, and 'j' and 'k' for up and down.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/8d228372-e1cc-4069-b849-3d985e3177cc

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
