### PR TITLE
ControlCenterPanel: sync DDC brightness on Quick Settings open

### DIFF
--- a/Modules/Panels/ControlCenter/ControlCenterPanel.qml
+++ b/Modules/Panels/ControlCenter/ControlCenterPanel.qml
@@ -5,6 +5,7 @@ import Quickshell
 import qs.Commons
 import qs.Modules.Cards
 import qs.Modules.MainScreen
+import qs.Services.Hardware
 import qs.Services.Media
 import qs.Services.UI
 import qs.Widgets
@@ -80,6 +81,12 @@ SmartPanel {
 
   onOpened: {
     MediaService.autoSwitchingPaused = true;
+    // Refresh DDC brightness from monitors (one-time on QS open)
+    BrightnessService.monitors.forEach(m => {
+      if (m.isDdc) {
+        m.refreshBrightnessFromSystem();
+      }
+    });
   }
 
   onClosed: {


### PR DESCRIPTION
## Summary

- Refresh DDC monitor brightness values when Control Center (Quick Settings) opens
- Ensures the brightness slider displays the actual monitor brightness value

## Problem

Previously, DDC brightness was only read once at Quickshell startup. If the user changed monitor brightness externally (e.g., via monitor OSD buttons or another application), the brightness slider in Quick Settings would show an outdated value.

## Solution

Added a one-time brightness refresh in the `onOpened` handler of `ControlCenterPanel.qml`:

```qml
onOpened: {
  MediaService.autoSwitchingPaused = true;
  // Refresh DDC brightness from monitors (one-time on QS open)
  BrightnessService.monitors.forEach(m => {
    if (m.isDdc) {
      m.refreshBrightnessFromSystem();
    }
  });
}
```

**How it works:**
1. When Control Center opens, iterate over all monitors in `BrightnessService`
2. For each DDC-capable monitor (`isDdc === true`), call `refreshBrightnessFromSystem()`
3. This executes `ddcutil -b <busNum> getvcp 10 --brief` to read current brightness
4. The result updates the monitor's `brightness` property
5. `BrightnessCard` receives the `monitorBrightnessChanged` signal and updates the slider