### PR TITLE
feat: sync DDC brightness on startup and panel open

### DIFF
--- a/Modules/Cards/BrightnessCard.qml
+++ b/Modules/Cards/BrightnessCard.qml
@@ -50,11 +50,12 @@ NBox {
     }
   }
 
-  // Timer to debounce brightness changes
+  // Timer to debounce brightness changes - only runs when user is changing slider
   Timer {
+    id: debounceTimer
     interval: 100
-    running: true
-    repeat: true
+    running: false
+    repeat: false
     onTriggered: {
       if (brightnessMonitor && Math.abs(localBrightness - brightnessMonitor.brightness) >= 0.01) {
         brightnessMonitor.setBrightness(localBrightness);
@@ -122,7 +123,10 @@ NBox {
         value: localBrightness
         stepSize: 0.01
         heightRatio: 0.5
-        onMoved: localBrightness = value
+        onMoved: {
+          localBrightness = value;
+          debounceTimer.restart();
+        }
         onPressedChanged: localBrightnessChanging = pressed
         tooltipText: `${Math.round(localBrightness * 100)}%`
         tooltipDirection: "bottom"
@@ -141,6 +145,7 @@ NBox {
                        const increment = delta > 0 ? step : -step;
                        const newValue = Math.max(0, Math.min(1, localBrightness + increment));
                        localBrightness = newValue;
+                       debounceTimer.restart();
                      }
                    }
         }

--- a/Modules/Panels/Brightness/BrightnessPanel.qml
+++ b/Modules/Panels/Brightness/BrightnessPanel.qml
@@ -15,6 +15,15 @@ SmartPanel {
   preferredWidth: Math.round(440 * Style.uiScaleRatio)
   preferredHeight: Math.round(420 * Style.uiScaleRatio)
 
+  onOpened: {
+    // Refresh DDC brightness from monitors (one-time on panel open)
+    BrightnessService.monitors.forEach(m => {
+      if (m.isDdc) {
+        m.refreshBrightnessFromSystem();
+      }
+    });
+  }
+
   panelContent: Item {
     id: panelContent
     property real contentPreferredHeight: mainColumn.implicitHeight + Style.marginL * 2

--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -196,8 +196,8 @@ Singleton {
             }
           }
 
-          // Update if we got a valid brightness value and it's different
-          if (!isNaN(newBrightness) && Math.abs(newBrightness - monitor.brightness) > 0.01) {
+          // Update if we got a valid brightness value
+          if (!isNaN(newBrightness) && (Math.abs(newBrightness - monitor.brightness) > 0.001 || monitor.brightness === 0)) {
             monitor.brightness = newBrightness;
             monitor.brightnessUpdated(monitor.brightness);
             root.monitorBrightnessChanged(monitor, monitor.brightness);
@@ -407,6 +407,7 @@ Singleton {
     }
 
     onBusNumChanged: initBrightness()
+    onIsDdcChanged: if (isDdc) initBrightness()
     Component.onCompleted: initBrightness()
   }
 }


### PR DESCRIPTION
## Summary

- Sync DDC monitor brightness on Quickshell startup
- Refresh DDC brightness when opening BrightnessPanel
- Fix BrightnessCard timer to not run continuously

## Changes

### BrightnessService.qml
- Added `onIsDdcChanged` handler - triggers `initBrightness()` when DDC is detected
- Fixed brightness update condition: `> 0.01` → `> 0.001 || brightness === 0` (fixes case when brightness is 0)

### BrightnessPanel.qml
- Added `onOpened` handler to refresh DDC brightness when panel opens

### BrightnessCard.qml
- Fixed debounce timer: was running continuously every 100ms, now only triggers on user interaction (slider drag or scroll)

## How it works

**On startup:**
1. `ddcProc` detects DDC monitors → sets `root.ddcMonitors`
2. `isDdc` property changes to `true` → `onIsDdcChanged` fires
3. `initBrightness()` runs `ddcutil getvcp 10` and sets brightness value

**On panel open:**
1. User opens BrightnessPanel
2. `onOpened` calls `refreshBrightnessFromSystem()` for each DDC monitor
3. Slider shows current monitor brightness
