### PR TITLE
fix(lockscreen): retry pam when fingerprint not ready yet

### DIFF
--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -90,7 +90,7 @@
     "telemetryEnabled": false,
     "enableLockScreenCountdown": true,
     "lockScreenCountdownDuration": 10000,
-    "autoStartAuth": false
+    "autoStartAuth": false,
     "allowPasswordWithFprintd": false
   },
   "ui": {

--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -7,8 +7,6 @@ import qs.Services.System
 
 Scope {
   id: root
-  signal unlocked
-  signal failed
 
   property string currentText: ""
   property bool waitingForPassword: false
@@ -18,11 +16,24 @@ Scope {
   property string errorMessage: ""
   property string infoMessage: ""
 
+  // PAM detection (from upstream)
   readonly property string pamConfigDirectory: "/etc/pam.d"
   property string pamConfig: Quickshell.env("NOCTALIA_PAM_SERVICE") || "login"
   property bool pamReady: false
 
+  // Fingerprint retry logic (from your branch)
+  property bool fprintdAvailable: false
+  property int pamRetryCount: 0
+  readonly property int pamMaxRetries: 8
+
+  signal unlocked
+  signal failed
+
   Component.onCompleted: {
+    // Check if fprintd is available
+    checkFprintdProc.running = true;
+
+    // Detect PAM service
     if (Quickshell.env("NOCTALIA_PAM_SERVICE")) {
       Logger.i("LockContext", "NOCTALIA_PAM_SERVICE is set, using system PAM config: /etc/pam.d/" + pamConfig);
       pamReady = true;
@@ -78,13 +89,17 @@ Scope {
   onCurrentTextChanged: {
     if (currentText !== "") {
       showInfo = false;
+      infoMessage = "";
       showFailure = false;
-      if (!waitingForPassword) {
+      errorMessage = "";
+      pamRetryCount = 0;
+      pamRetryTimer.stop();
+      if (!waitingForPassword)
         pam.abort();
-      }
-      if (Settings.data.general.allowPasswordWithFprintd) {
+
+      // Occupy fingerprint sensor when typing (if available and enabled)
+      if (fprintdAvailable && Settings.data.general.allowPasswordWithFprintd)
         occupyFingerprintSensorProc.running = true;
-      }
     } else {
       occupyFingerprintSensorProc.running = false;
       if (pamReady && Settings.data.general.autoStartAuth) {
@@ -106,65 +121,111 @@ Scope {
       showInfo = false;
       return;
     }
-
+    errorMessage = "";
+    showFailure = false;
     Logger.i("LockContext", "Starting PAM authentication for user:", pam.user);
     pam.start();
   }
 
   Process {
+    id: checkFprintdProc
+
+    command: ["sh", "-c", "command -v fprintd-verify"]
+    onExited: function (exitCode) {
+      fprintdAvailable = (exitCode === 0);
+      Logger.i("LockContext", "fprintd available:", fprintdAvailable);
+    }
+  }
+
+  Process {
     id: occupyFingerprintSensorProc
+
     command: ["fprintd-verify"]
+  }
+
+  Timer {
+    id: pamRetryTimer
+
+    interval: 500
+    repeat: false
+    onTriggered: {
+      if (root.currentText === "" && root.pamRetryCount < root.pamMaxRetries) {
+        root.pamRetryCount++;
+        Logger.i("LockContext", "Retrying PAM authentication, attempt", root.pamRetryCount, "of", root.pamMaxRetries);
+        pam.start();
+      }
+    }
   }
 
   PamContext {
     id: pam
+
     configDirectory: root.pamConfigDirectory
     config: root.pamConfig
     user: HostService.username
-
     onPamMessage: {
       Logger.i("LockContext", "PAM message:", message, "isError:", messageIsError, "responseRequired:", responseRequired);
-
       if (this.responseRequired) {
         Logger.i("LockContext", "Responding to PAM with password");
         if (root.currentText !== "") {
           this.respond(root.currentText);
           unlockInProgress = true;
         } else {
-          root.waitingForPassword = true;
-          infoMessage = I18n.tr("lock-screen.password");
-          showInfo = true;
+          // Retry if password prompt came before fingerprint
+          if (root.pamRetryCount < root.pamMaxRetries && !root.waitingForPassword) {
+            Logger.i("LockContext", "Got password prompt early, aborting to retry fingerprint (attempt", root.pamRetryCount + 1, "of", root.pamMaxRetries + ")");
+            showInfo = false;
+            showFailure = false;
+            pam.abort();
+            pamRetryTimer.start();
+          } else {
+            root.waitingForPassword = true;
+            showFailure = false;
+            infoMessage = I18n.tr("lock-screen.password");
+            showInfo = true;
+          }
         }
       } else if (messageIsError) {
         errorMessage = message;
+        showInfo = false;
         showFailure = true;
       } else {
         infoMessage = message;
+        showFailure = false;
         showInfo = true;
       }
     }
-
     onCompleted: result => {
                    Logger.i("LockContext", "PAM completed with result:", result);
                    if (result === PamResult.Success) {
                      Logger.i("LockContext", "Authentication successful");
+                     root.pamRetryCount = 0;
                      root.unlocked();
                    } else {
                      Logger.i("LockContext", "Authentication failed");
-                     root.currentText = "";
-                     errorMessage = I18n.tr("authentication.failed");
-                     showFailure = true;
-                     root.failed();
+                     if (root.currentText === "" && !root.waitingForPassword && root.pamRetryCount < root.pamMaxRetries) {
+                       Logger.i("LockContext", "Will retry PAM (attempt", root.pamRetryCount + 1, "of", root.pamMaxRetries + ")");
+                       pamRetryTimer.start();
+                     } else {
+                       root.currentText = "";
+                       errorMessage = I18n.tr("authentication.failed");
+                       showFailure = true;
+                       root.failed();
+                     }
                    }
                    root.unlockInProgress = false;
                  }
-
     onError: {
       Logger.i("LockContext", "PAM error:", error, "message:", message);
-      errorMessage = message || "Authentication error";
-      showFailure = true;
+      if (root.currentText === "" && !root.waitingForPassword && root.pamRetryCount < root.pamMaxRetries) {
+        Logger.i("LockContext", "PAM error, will retry (attempt", root.pamRetryCount + 1, "of", root.pamMaxRetries + ")");
+        pamRetryTimer.start();
+      } else {
+        errorMessage = message || "Authentication error";
+        showFailure = true;
+        root.failed();
+      }
       root.unlockInProgress = false;
-      root.failed();
     }
   }
 }


### PR DESCRIPTION
## Motivation
  Fix fingerprint authentication timing issue on lock screen. Some fingerprint readers need time to wake up after sleep, causing
  PAM's password prompt to arrive before the sensor is ready. The lock screen now retries authentication (up to 8 times, 500ms
  interval) instead of immediately showing the password prompt.

  ## Type of Change
  - [x] Bug fix

  ## Related Issue
  - (none)

  ## Testing
  - [X] Tested on niri
  - [ ] Tested on Hyprland
  - [ ] Tested on sway

  ## Screenshots / Videos
  (not applicable - behaviour fix)

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my code
  - [x] No new warnings or errors

  ## Additional Notes
  - Adds `unlocked`/`failed` signals
  - Keeps upstream's `showInfo`/`showFailure` mutual exclusivity handlers
  - Retry parameters (count, interval) are hardcoded with sane defaults rather than exposed in settings to avoid unnecessary
  complexity for users