### PR TITLE
refactor(CurrentScreenDector): Use WM native methods when possible

### DIFF
--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -316,6 +316,14 @@ Singleton {
     return null;
   }
 
+  // Get focused screen from compositor
+  function getFocusedScreen() {
+    if (backend && backend.getFocusedScreen) {
+      return backend.getFocusedScreen();
+    }
+    return null;
+  }
+
   // Get focused window title
   function getFocusedWindowTitle() {
     if (focusedWindowIndex >= 0 && focusedWindowIndex < windows.count) {

--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -472,4 +472,17 @@ Item {
       Logger.e("HyprlandService", "Failed to cycle keyboard layout:", e);
     }
   }
+
+  function getFocusedScreen() {
+    const hyprMon = Hyprland.focusedMonitor;
+    if (hyprMon) {
+      const monitorName = hyprMon.name;
+      for (let i = 0; i < Quickshell.screens.length; i++) {
+        if (Quickshell.screens[i].name === monitorName) {
+          return Quickshell.screens[i];
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/Services/Compositor/LabwcService.qml
+++ b/Services/Compositor/LabwcService.qml
@@ -133,4 +133,12 @@ Item {
   function queryDisplayScales() {
     Logger.w("LabwcService", "Display scale queries not supported via ToplevelManager");
   }
+
+  function getFocusedScreen() {
+    const activeToplevel = ToplevelManager.activeToplevel;
+    if (activeToplevel && activeToplevel.screens && activeToplevel.screens.length > 0) {
+      return activeToplevel.screens[0];
+    }
+    return null;
+  }
 }

--- a/Services/Compositor/MangoService.qml
+++ b/Services/Compositor/MangoService.qml
@@ -677,4 +677,12 @@ Item {
   function cycleKeyboardLayout() {
     Logger.w("MangoService", "Keyboard layout cycling not supported");
   }
+
+  function getFocusedScreen() {
+    const activeToplevel = ToplevelManager.activeToplevel;
+    if (activeToplevel && activeToplevel.screens && activeToplevel.screens.length > 0) {
+      return activeToplevel.screens[0];
+    }
+    return null;
+  }
 }

--- a/Services/Compositor/NiriService.qml
+++ b/Services/Compositor/NiriService.qml
@@ -486,4 +486,12 @@ Item {
       Logger.e("NiriService", "Failed to cycle keyboard layout:", e);
     }
   }
+
+  function getFocusedScreen() {
+    const activeToplevel = ToplevelManager.activeToplevel;
+    if (activeToplevel && activeToplevel.screens && activeToplevel.screens.length > 0) {
+      return activeToplevel.screens[0];
+    }
+    return null;
+  }
 }

--- a/Services/Compositor/SwayService.qml
+++ b/Services/Compositor/SwayService.qml
@@ -385,4 +385,17 @@ Item {
       Logger.e("SwayService", "Failed to cycle keyboard layout:", e);
     }
   }
+
+  function getFocusedScreen() {
+    const i3Mon = I3.focusedMonitor;
+    if (i3Mon) {
+      const monitorName = i3Mon.name;
+      for (let i = 0; i < Quickshell.screens.length; i++) {
+        if (Quickshell.screens[i].name === monitorName) {
+          return Quickshell.screens[i];
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/Services/Control/CurrentScreenDetector.qml
+++ b/Services/Control/CurrentScreenDetector.qml
@@ -1,8 +1,6 @@
 import QtQuick
 import Quickshell
 import Quickshell.Wayland
-import Quickshell.Hyprland as Hyprland
-import Quickshell.I3 as I3
 import qs.Commons
 import qs.Services.Compositor
 
@@ -56,7 +54,7 @@ Item {
     }
 
     // Try compositor-specific focused monitor detection first
-    let screen = getCompositorFocusedScreen();
+    let screen = CompositorService.getFocusedScreen();
 
     if (screen) {
       // Apply the bar check if configured
@@ -76,51 +74,6 @@ Item {
     root.detectedScreen = null;
     root.pendingCallback = callback;
     screenDetectorLoader.active = true;
-  }
-
-  /**
-  * Helper function to get focused screen from compositor.
-  * Returns the ShellScreen where the focused window is, or null if unavailable.
-  */
-  function getCompositorFocusedScreen(): var {
-    let monitorName = null;
-
-    // Hyprland: use Hyprland.focusedMonitor
-    if (CompositorService.isHyprland) {
-      const hyprMon = Hyprland.Hyprland.focusedMonitor;
-      if (hyprMon) {
-        monitorName = hyprMon.name;
-        Logger.d("CurrentScreenDetector", "Hyprland focused monitor:", monitorName);
-      }
-    }
-    // Sway/i3: use I3.focusedMonitor
-    else if (CompositorService.isSway) {
-      const i3Mon = I3.I3.focusedMonitor;
-      if (i3Mon) {
-        monitorName = i3Mon.name;
-        Logger.d("CurrentScreenDetector", "Sway focused monitor:", monitorName);
-      }
-    }
-    // Niri, Labwc and other wlroots compositors: infer from active toplevel window
-    // (Niri supports wlr-foreign-toplevel-management since v0.1.1)
-    else if (CompositorService.isNiri || CompositorService.isLabwc || CompositorService.isMango) {
-      const activeToplevel = ToplevelManager.activeToplevel;
-      if (activeToplevel && activeToplevel.screens && activeToplevel.screens.length > 0) {
-        Logger.d("CurrentScreenDetector", "Toplevel-based screen:", activeToplevel.screens[0].name);
-        return activeToplevel.screens[0];  // Return ShellScreen directly
-      }
-    }
-
-    // Convert monitor name to ShellScreen
-    if (monitorName) {
-      for (let i = 0; i < Quickshell.screens.length; i++) {
-        if (Quickshell.screens[i].name === monitorName) {
-          return Quickshell.screens[i];
-        }
-      }
-    }
-
-    return null;  // Fall back to cursor-based detection
   }
 
   Timer {


### PR DESCRIPTION
# Pull Request
This PR refactors CurrentScreenDetector uses Quickshell's built in methods for supported WMs, and only falling back to the transparent panel method if no other method is available. This should give more consistent behavior across WMs. 

## Motivation
When using Noctalia on Hyprland with a 2 monitor setup. I noticed that my keybinds open shell panels and windows on my first display, and not the focused display, unless: 

1. There are no windows on the current workspace
2. I use the mouse to focus the bar before using a keybind

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Testing
I'm on an immutable/atomic system, so switching window managers is a pain. Hoping someone else can test on the other supported WMs

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
This is my first time working with QML and Quickshell, so pardon any mistakes or formatting issues I may have made.
