### PR TITLE
LocationSubTab: use a column layout for location

### DIFF
--- a/Modules/Panels/Settings/Tabs/Region/LocationSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Region/LocationSubTab.qml
@@ -47,11 +47,13 @@ ColumnLayout {
   }
 
   // Location
-  RowLayout {
+  ColumnLayout {
     Layout.fillWidth: true
-    spacing: Style.marginL
+    spacing: Style.marginS
 
     NTextInput {
+      Layout.maximumWidth: root.width / 2
+
       label: I18n.tr("panels.location.location-search-label")
       description: I18n.tr("panels.location.location-search-description")
       text: Settings.data.location.name || Settings.defaultLocation
@@ -79,10 +81,6 @@ ColumnLayout {
                     })
       pointSize: Style.fontSizeS
       color: Color.mOnSurfaceVariant
-      verticalAlignment: Text.AlignVCenter
-      horizontalAlignment: Text.AlignRight
-      Layout.alignment: Qt.AlignBottom
-      Layout.bottomMargin: Style.marginM
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation

For the location entry tab, a RowLayout is currently used. When a user
enters a new location, the search bar extends across the UI to fill up
the space while the location service evaluates the location text. It
then shrinks back once the location text is available. Which looks
glitchy.

This patch changes the layout to be a ColumnLayout, so the entries stack
vertically. Which avoids the jankyness of the case above.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Before:

<img width="1030" height="199" alt="image" src="https://github.com/user-attachments/assets/bc0fdc1c-8155-41b0-b446-708960f0cc58" />

Notice the bar length change.

<img width="1025" height="205" alt="image" src="https://github.com/user-attachments/assets/345f30d9-db34-43ce-8a8d-05c5f69acdb0" />

After:

<img width="569" height="228" alt="image" src="https://github.com/user-attachments/assets/fe6ee9d3-eea7-433e-826d-85369948d52f" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
