### PR TITLE
fix: A more robust implementation of NScrollText to fix misalignment issue caused by overly large Unicode characters

### DIFF
--- a/Widgets/NScrollText.qml
+++ b/Widgets/NScrollText.qml
@@ -126,16 +126,23 @@ Item {
     Loader {
       id: titleText
       sourceComponent: root.delegate
-      Layout.alignment: Qt.AlignVCenter
-      onLoaded: this.item.text = root.text
+      Layout.fillHeight: true
+      onLoaded: {
+        this.item.text = root.text;
+        // Bind height to container to enable vertical centering of overly high text
+        this.item.height = Qt.binding(() => titleText.height);
+      }
     }
 
     Loader {
       id: loopingText
       sourceComponent: root.delegate
-      Layout.alignment: Qt.AlignVCenter
+      Layout.fillHeight: true
       visible: root.state !== NScrollText.ScrollState.None
-      onLoaded: this.item.text = root.text
+      onLoaded: {
+        this.item.text = root.text;
+        this.item.height = Qt.binding(() => loopingText.height);
+      }
     }
 
     NumberAnimation on x {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
excessively tall characters prevent text alignment within NSCrollText. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1577 

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

##Screenshot
Before:
<img width="311" height="67" alt="image" src="https://github.com/user-attachments/assets/c3f59bab-5342-4b64-a2d5-7c8ce6221022" />

After:
<img width="314" height="70" alt="image" src="https://github.com/user-attachments/assets/a6ec9ca3-3103-46e2-9735-800e8996ab3b" />
