### PR TITLE
LockScreen: add `allowPasswordWithFprintd` option

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1111,6 +1111,8 @@
       "weather-show-in-calendar-label": "Display weather in calendar"
     },
     "lock-screen": {
+      "allow-password-with-fprintd-description": "When fprintd (fingerprint authentication) is active, this option lets you still login using your password instead of a fingerprint",
+      "allow-password-with-fprintd-label": "Allow password login with fprintd",
       "auto-start-auth-description": "e.g., automatically starts fingerprint authentication without requiring a key press or button click.",
       "auto-start-auth-label": "Auto-start authentication",
       "compact-lockscreen-description": "Show only the login input and system controls, hiding weather and media widgets.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -91,6 +91,7 @@
     "enableLockScreenCountdown": true,
     "lockScreenCountdownDuration": 10000,
     "autoStartAuth": false
+    "allowPasswordWithFprintd": false
   },
   "ui": {
     "fontDefault": "",

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -846,6 +846,14 @@
     "subTab": null
   },
   {
+    "labelKey": "panels.lock-screen.allow-password-with-fprintd-label",
+    "descriptionKey": "panels.lock-screen.allow-password-with-fprintd-description",
+    "widget": "NToggle",
+    "tab": 11,
+    "tabLabel": "panels.lock-screen.title",
+    "subTab": null
+  },
+  {
     "labelKey": "panels.lock-screen.show-session-buttons-label",
     "descriptionKey": "panels.lock-screen.show-session-buttons-description",
     "widget": "NToggle",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -280,6 +280,7 @@ Singleton {
       property bool enableLockScreenCountdown: true
       property int lockScreenCountdownDuration: 10000
       property bool autoStartAuth: false
+      property bool allowPasswordWithFprintd: false
     }
 
     // ui

--- a/Modules/LockScreen/LockContext.qml
+++ b/Modules/LockScreen/LockContext.qml
@@ -17,15 +17,12 @@ Scope {
   property bool showInfo: false
   property string errorMessage: ""
   property string infoMessage: ""
-  property bool fprintdAvailable: false
 
   readonly property string pamConfigDirectory: "/etc/pam.d"
   property string pamConfig: Quickshell.env("NOCTALIA_PAM_SERVICE") || "login"
   property bool pamReady: false
 
   Component.onCompleted: {
-    checkFprintdProc.running = true;
-
     if (Quickshell.env("NOCTALIA_PAM_SERVICE")) {
       Logger.i("LockContext", "NOCTALIA_PAM_SERVICE is set, using system PAM config: /etc/pam.d/" + pamConfig);
       pamReady = true;
@@ -85,7 +82,7 @@ Scope {
       if (!waitingForPassword) {
         pam.abort();
       }
-      if (fprintdAvailable) {
+      if (Settings.data.general.allowPasswordWithFprintd) {
         occupyFingerprintSensorProc.running = true;
       }
     } else {
@@ -112,14 +109,6 @@ Scope {
 
     Logger.i("LockContext", "Starting PAM authentication for user:", pam.user);
     pam.start();
-  }
-
-  Process {
-    id: checkFprintdProc
-    command: ["sh", "-c", "command -v fprintd-verify"]
-    onExited: function (exitCode) {
-      fprintdAvailable = (exitCode === 0);
-    }
   }
 
   Process {

--- a/Modules/Panels/Settings/Tabs/LockScreenTab.qml
+++ b/Modules/Panels/Settings/Tabs/LockScreenTab.qml
@@ -34,6 +34,14 @@ ColumnLayout {
   }
 
   NToggle {
+    label: I18n.tr("panels.lock-screen.allow-password-with-fprintd-label")
+    description: I18n.tr("panels.lock-screen.allow-password-with-fprintd-description")
+    checked: Settings.data.general.allowPasswordWithFprintd
+    onToggled: checked => Settings.data.general.allowPasswordWithFprintd = checked
+    defaultValue: Settings.getDefaultValue("general.allowPasswordWithFprintd")
+  }
+
+  NToggle {
     label: I18n.tr("panels.lock-screen.show-session-buttons-label")
     description: I18n.tr("panels.lock-screen.show-session-buttons-description")
     checked: Settings.data.general.showSessionButtonsOnLockScreen


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
