### PR TITLE
feat(launcher): added browser bookmarks provider

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -354,6 +354,7 @@
     "back": "Back",
     "battery": "Battery",
     "bluetooth": "Bluetooth",
+    "bookmarks": "Bookmarks",
     "brightness": "Brightness",
     "browse": "Browse",
     "calendar": "Calendar",
@@ -557,7 +558,12 @@
       "emoji-loading": "Loading emojis...",
       "emoji-loading-description": "Please wait",
       "emoji-no-recent": "No recent emojis yet",
-      "emoji-search-description": "Search and copy emojis"
+      "emoji-search-description": "Search and copy emojis",
+      "bookmarks": "Browser Bookmarks",
+      "bookmarks-search-description": "Search browser bookmarks",
+      "bookmarks-loading": "Loading bookmarks...",
+      "bookmarks-empty": "No bookmarks found",
+      "bookmarks-empty-description": "No browser bookmarks were detected"
     }
   },
   "lock-screen": {
@@ -1077,6 +1083,11 @@
       "settings-terminal-command-label": "Terminal command",
       "settings-use-app2unit-description": "Uses an alternative launch method to better manage app processes and prevent issues.",
       "settings-use-app2unit-label": "Use App2Unit to launch applications",
+      "settings-enable-bookmarks-label": "Enable browser bookmarks",
+      "settings-enable-bookmarks-description": "Access browser bookmarks from the launcher using the >bm command.",
+      "settings-bookmarks-browsers-label": "Browsers to index",
+      "settings-bookmarks-browsers-description": "Select which browsers to scan for bookmarks.",
+      "settings-bookmarks-hint": "Tip: Use >bm to search your browser bookmarks.",
       "title": "Launcher"
     },
     "location": {

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -191,7 +191,9 @@
     "showIconBackground": false,
     "enableSettingsSearch": true,
     "ignoreMouseInput": false,
-    "screenshotAnnotationTool": ""
+    "screenshotAnnotationTool": "",
+    "enableBookmarks": false,
+    "bookmarksBrowsers": ["chrome", "chromium", "brave", "edge", "vivaldi", "opera", "firefox", "firefox-dev", "librewolf", "zen"]
   },
   "controlCenter": {
     "position": "close_to_bar_button",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -397,6 +397,8 @@ Singleton {
       property bool enableSettingsSearch: true
       property bool ignoreMouseInput: false
       property string screenshotAnnotationTool: ""
+      property bool enableBookmarks: false
+      property list<string> bookmarksBrowsers: ["chrome", "chromium", "brave", "edge", "vivaldi", "opera", "firefox", "firefox-dev", "librewolf", "zen"]
     }
 
     // control center

--- a/Modules/Panels/Launcher/Launcher.qml
+++ b/Modules/Panels/Launcher/Launcher.qml
@@ -763,6 +763,16 @@ SmartPanel {
     }
   }
 
+  BookmarksProvider {
+    id: bookmarksProvider
+    Component.onCompleted: {
+      if (Settings.data.appLauncher.enableBookmarks) {
+        registerProvider(this);
+        Logger.d("Launcher", "Registered: BookmarksProvider");
+      }
+    }
+  }
+
   // ---------------------------------------------------
   panelContent: Rectangle {
     id: ui

--- a/Modules/Panels/Launcher/Providers/BookmarksProvider.qml
+++ b/Modules/Panels/Launcher/Providers/BookmarksProvider.qml
@@ -1,0 +1,591 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+
+Item {
+  id: root
+
+  // Provider metadata
+  property string name: I18n.tr("launcher.providers.bookmarks")
+  property var launcher: null
+  property string iconMode: Settings.data.appLauncher.iconMode
+  property bool handleSearch: false  // Only accessible via >bm command
+  property string supportedLayouts: "list"
+  property int preferredGridColumns: 5
+
+  // Internal state
+  property var bookmarks: []
+  property bool isLoading: false
+  property bool dataLoaded: false
+
+  // Home directory
+  readonly property string homeDir: Quickshell.env("HOME") || "/home"
+
+  // Chromium-based browser configurations
+  function getChromiumBrowserConfigs() {
+    return [
+      {
+        "name": "Google Chrome",
+        "id": "chrome",
+        "paths": [
+          homeDir + "/.config/google-chrome",
+          homeDir + "/.config/google-chrome-beta",
+          homeDir + "/.config/google-chrome-unstable"
+        ]
+      },
+      {
+        "name": "Chromium",
+        "id": "chromium",
+        "paths": [
+          homeDir + "/.config/chromium"
+        ]
+      },
+      {
+        "name": "Brave",
+        "id": "brave",
+        "paths": [
+          homeDir + "/.config/BraveSoftware/Brave-Browser",
+          homeDir + "/.config/BraveSoftware/Brave-Browser-Beta",
+          homeDir + "/.config/BraveSoftware/Brave-Browser-Nightly"
+        ]
+      },
+      {
+        "name": "Microsoft Edge",
+        "id": "edge",
+        "paths": [
+          homeDir + "/.config/microsoft-edge",
+          homeDir + "/.config/microsoft-edge-beta",
+          homeDir + "/.config/microsoft-edge-dev"
+        ]
+      },
+      {
+        "name": "Vivaldi",
+        "id": "vivaldi",
+        "paths": [
+          homeDir + "/.config/vivaldi",
+          homeDir + "/.config/vivaldi-snapshot"
+        ]
+      },
+      {
+        "name": "Opera",
+        "id": "opera",
+        "paths": [
+          homeDir + "/.config/opera",
+          homeDir + "/.config/opera-beta",
+          homeDir + "/.config/opera-developer"
+        ]
+      }
+    ];
+  }
+
+  // Firefox-based browser configurations
+  function getFirefoxBrowserConfigs() {
+    return [
+      {
+        "name": "Firefox",
+        "id": "firefox",
+        "paths": [
+          homeDir + "/.mozilla/firefox"
+        ]
+      },
+      {
+        "name": "Firefox Developer Edition",
+        "id": "firefox-dev",
+        "paths": [
+          homeDir + "/.mozilla/firefox-dev",
+          homeDir + "/.mozilla/firefox-developer-edition"
+        ]
+      },
+      {
+        "name": "LibreWolf",
+        "id": "librewolf",
+        "paths": [
+          homeDir + "/.librewolf"
+        ]
+      },
+      {
+        "name": "Zen Browser",
+        "id": "zen",
+        "paths": [
+          homeDir + "/.zen"
+        ]
+      }
+    ];
+  }
+
+  // Initialize provider
+  function init() {
+    Logger.d("BookmarksProvider", "Initialized");
+    loadBookmarks();
+  }
+
+  function onOpened() {
+    if (!dataLoaded) {
+      loadBookmarks();
+    }
+  }
+
+  // Check if this provider handles the command
+  function handleCommand(searchText) {
+    return searchText.startsWith(">bm");
+  }
+
+  // Return available commands when user types ">"
+  function commands() {
+    return [
+          {
+            "name": ">bm",
+            "description": I18n.tr("launcher.providers.bookmarks-search-description"),
+            "icon": "bookmarks",
+            "isTablerIcon": true,
+            "isImage": false,
+            "onActivate": function () {
+              launcher.setSearchText(">bm ");
+            }
+          }
+        ];
+  }
+
+  // Get search results
+  function getResults(searchText) {
+    if (!searchText.startsWith(">bm")) {
+      return [];
+    }
+
+    let query = searchText.slice(3).trim();
+
+    if (isLoading) {
+      return [
+            {
+              "name": I18n.tr("launcher.providers.bookmarks-loading"),
+              "description": I18n.tr("launcher.providers.emoji-loading-description"),
+              "icon": "refresh",
+              "isTablerIcon": true,
+              "isImage": false,
+              "onActivate": function () {}
+            }
+          ];
+    }
+
+    if (bookmarks.length === 0 && dataLoaded) {
+      return [
+            {
+              "name": I18n.tr("launcher.providers.bookmarks-empty"),
+              "description": I18n.tr("launcher.providers.bookmarks-empty-description"),
+              "icon": "bookmarks-off",
+              "isTablerIcon": true,
+              "isImage": false,
+              "onActivate": function () {}
+            }
+          ];
+    }
+
+    let filteredBookmarks = bookmarks;
+
+    if (query !== "") {
+      const searchTerm = query.toLowerCase();
+
+      if (typeof FuzzySort !== 'undefined') {
+        const fuzzyResults = FuzzySort.go(searchTerm, filteredBookmarks, {
+                                            "keys": ["name", "url", "folderPath"],
+                                            "limit": 50
+                                          });
+        return fuzzyResults.map(result => formatBookmarkEntry(result.obj, result.score));
+      } else {
+        // Fallback to simple search
+        filteredBookmarks = filteredBookmarks.filter(bm => {
+                                                       const name = (bm.name || "").toLowerCase();
+                                                       const url = (bm.url || "").toLowerCase();
+                                                       const folder = (bm.folderPath || "").toLowerCase();
+                                                       return name.includes(searchTerm) || url.includes(searchTerm) || folder.includes(searchTerm);
+                                                     });
+      }
+    }
+
+    // Sort alphabetically if no search query
+    if (query === "") {
+      filteredBookmarks = filteredBookmarks.slice().sort((a, b) => {
+                                                           return (a.name || "").toLowerCase().localeCompare((b.name || "").toLowerCase());
+                                                         });
+    }
+
+    // Limit results
+    return filteredBookmarks.slice(0, 100).map(bm => formatBookmarkEntry(bm, 0));
+  }
+
+  function formatBookmarkEntry(bookmark, score) {
+    // Format description with folder path and browser info
+    let description = bookmark.url || "";
+    if (description.length > 60) {
+      description = description.substring(0, 57) + "...";
+    }
+
+    let folderInfo = "";
+    if (bookmark.folderPath) {
+      folderInfo = bookmark.folderPath;
+    }
+    if (bookmark.browserName) {
+      folderInfo = folderInfo ? `${bookmark.browserName} • ${folderInfo}` : bookmark.browserName;
+    }
+
+    return {
+      "name": bookmark.name || bookmark.url || "Untitled",
+      "description": folderInfo ? `${folderInfo}\n${description}` : description,
+      "icon": "bookmark",
+      "isTablerIcon": true,
+      "isImage": false,
+      "_score": score || 0,
+      "provider": root,
+      "bookmarkUrl": bookmark.url,
+      "onActivate": function () {
+        openBookmark(bookmark.url);
+      }
+    };
+  }
+
+  function openBookmark(url) {
+    if (!url)
+      return;
+
+    launcher.closeImmediately();
+    Qt.callLater(() => {
+                   Logger.d("BookmarksProvider", `Opening bookmark: ${url}`);
+                   Quickshell.execDetached(["xdg-open", url]);
+                 });
+  }
+
+  // ============================================
+  // Bookmark Loading
+  // ============================================
+
+  property var _browserMap: ({})
+  property var _foundChromiumFiles: []
+  property var _firefoxProfiles: []
+  property int _currentFileIndex: 0
+  property int _pendingOperations: 0
+
+  function loadBookmarks() {
+    if (isLoading)
+      return;
+
+    isLoading = true;
+    bookmarks = [];
+    _foundChromiumFiles = [];
+    _firefoxProfiles = [];
+    _currentFileIndex = 0;
+    _pendingOperations = 0;
+
+    const enabledBrowsers = Settings.data.appLauncher.bookmarksBrowsers || [];
+
+    // Start Chromium bookmark search
+    loadChromiumBookmarks(enabledBrowsers);
+
+    // Start Firefox bookmark search
+    loadFirefoxBookmarks(enabledBrowsers);
+  }
+
+  // ============================================
+  // Chromium-based browsers
+  // ============================================
+
+  function loadChromiumBookmarks(enabledBrowsers) {
+    const chromiumConfigs = getChromiumBrowserConfigs();
+
+    let findPaths = [];
+    let browserMap = {};
+
+    for (const browser of chromiumConfigs) {
+      if (!enabledBrowsers.includes(browser.id))
+        continue;
+
+      for (const basePath of browser.paths) {
+        findPaths.push(basePath);
+        browserMap[basePath] = browser;
+      }
+    }
+
+    if (findPaths.length === 0) {
+      checkLoadingComplete();
+      return;
+    }
+
+    root._browserMap = browserMap;
+    _pendingOperations++;
+
+    let cmd = "find " + findPaths.map(p => `"${p}"`).join(" ") + " -name 'Bookmarks' -type f 2>/dev/null";
+    chromiumFinderProcess.command = ["sh", "-c", cmd];
+    chromiumFinderProcess.running = true;
+  }
+
+  Process {
+    id: chromiumFinderProcess
+    running: false
+
+    onExited: function (exitCode, exitStatus) {
+      const output = stdout.text.trim();
+      if (output !== "") {
+        root._foundChromiumFiles = output.split('\n').filter(f => f.length > 0);
+        Logger.d("BookmarksProvider", `Found ${root._foundChromiumFiles.length} Chromium bookmark files`);
+        root._currentFileIndex = 0;
+        root.readNextChromiumFile();
+      } else {
+        root._pendingOperations--;
+        root.checkLoadingComplete();
+      }
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  function readNextChromiumFile() {
+    if (_currentFileIndex >= _foundChromiumFiles.length) {
+      _pendingOperations--;
+      checkLoadingComplete();
+      return;
+    }
+
+    const filePath = _foundChromiumFiles[_currentFileIndex];
+    let browser = null;
+    for (const basePath in _browserMap) {
+      if (filePath.startsWith(basePath)) {
+        browser = _browserMap[basePath];
+        break;
+      }
+    }
+
+    chromiumReaderProcess._currentFilePath = filePath;
+    chromiumReaderProcess._currentBrowser = browser;
+    chromiumReaderProcess.command = ["cat", filePath];
+    chromiumReaderProcess.running = true;
+  }
+
+  Process {
+    id: chromiumReaderProcess
+    running: false
+
+    property string _currentFilePath: ""
+    property var _currentBrowser: null
+
+    onExited: function (exitCode, exitStatus) {
+      if (exitCode === 0) {
+        const content = stdout.text.trim();
+        if (content !== "") {
+          try {
+            const data = JSON.parse(content);
+            root.parseChromiumBookmarks(data, _currentBrowser);
+          } catch (e) {
+            Logger.d("BookmarksProvider", `Failed to parse ${_currentFilePath}: ${e}`);
+          }
+        }
+      }
+
+      root._currentFileIndex++;
+      Qt.callLater(root.readNextChromiumFile);
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  function parseChromiumBookmarks(data, browser) {
+    if (!data || !data.roots)
+      return;
+
+    const roots = data.roots;
+
+    if (roots.bookmark_bar && roots.bookmark_bar.children) {
+      parseChromiumFolder(roots.bookmark_bar.children, browser, "");
+    }
+
+    if (roots.other && roots.other.children) {
+      parseChromiumFolder(roots.other.children, browser, "");
+    }
+
+    if (roots.synced && roots.synced.children) {
+      parseChromiumFolder(roots.synced.children, browser, "");
+    }
+  }
+
+  function parseChromiumFolder(items, browser, parentPath) {
+    if (!Array.isArray(items))
+      return;
+
+    for (const item of items) {
+      if (item.type === "url" && item.url) {
+        bookmarks.push({
+                         "name": item.name || "",
+                         "url": item.url,
+                         "folderPath": parentPath,
+                         "browserName": browser ? browser.name : "Unknown"
+                       });
+      } else if (item.type === "folder" && item.children) {
+        const newPath = parentPath ? `${parentPath} / ${item.name}` : item.name;
+        parseChromiumFolder(item.children, browser, newPath);
+      }
+    }
+  }
+
+  // ============================================
+  // Firefox-based browsers
+  // ============================================
+
+  function loadFirefoxBookmarks(enabledBrowsers) {
+    const firefoxConfigs = getFirefoxBrowserConfigs();
+
+    let findPaths = [];
+    let browserMap = {};
+
+    for (const browser of firefoxConfigs) {
+      if (!enabledBrowsers.includes(browser.id))
+        continue;
+
+      for (const basePath of browser.paths) {
+        findPaths.push(basePath);
+        browserMap[basePath] = browser;
+      }
+    }
+
+    if (findPaths.length === 0) {
+      checkLoadingComplete();
+      return;
+    }
+
+    root._firefoxBrowserMap = browserMap;
+    _pendingOperations++;
+
+    let cmd = "find " + findPaths.map(p => `"${p}"`).join(" ") + " -name 'places.sqlite' -type f 2>/dev/null";
+    firefoxFinderProcess.command = ["sh", "-c", cmd];
+    firefoxFinderProcess.running = true;
+  }
+
+  property var _firefoxBrowserMap: ({})
+  property var _foundFirefoxFiles: []
+  property int _currentFirefoxIndex: 0
+
+  Process {
+    id: firefoxFinderProcess
+    running: false
+
+    onExited: function (exitCode, exitStatus) {
+      const output = stdout.text.trim();
+      if (output !== "") {
+        root._foundFirefoxFiles = output.split('\n').filter(f => f.length > 0);
+        Logger.d("BookmarksProvider", `Found ${root._foundFirefoxFiles.length} Firefox bookmark databases`);
+        root._currentFirefoxIndex = 0;
+        root.readNextFirefoxFile();
+      } else {
+        root._pendingOperations--;
+        root.checkLoadingComplete();
+      }
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  function readNextFirefoxFile() {
+    if (_currentFirefoxIndex >= _foundFirefoxFiles.length) {
+      _pendingOperations--;
+      checkLoadingComplete();
+      return;
+    }
+
+    const dbPath = _foundFirefoxFiles[_currentFirefoxIndex];
+
+    let browser = null;
+    for (const basePath in _firefoxBrowserMap) {
+      if (dbPath.startsWith(basePath)) {
+        browser = _firefoxBrowserMap[basePath];
+        break;
+      }
+    }
+
+    firefoxReaderProcess._currentBrowser = browser;
+    const query = "SELECT b.title, p.url FROM moz_bookmarks b JOIN moz_places p ON b.fk = p.id WHERE b.type = 1 AND p.url NOT LIKE 'place:%' AND p.url IS NOT NULL AND b.title IS NOT NULL";
+    firefoxReaderProcess.command = ["sh", "-c", `sqlite3 -separator '	' "file:${dbPath}?mode=ro&immutable=1" "${query}" 2>/dev/null || sqlite3 -separator '	' "${dbPath}" "${query}" 2>/dev/null`];
+    firefoxReaderProcess.running = true;
+  }
+
+  Process {
+    id: firefoxReaderProcess
+    running: false
+
+    property var _currentBrowser: null
+
+    onExited: function (exitCode, exitStatus) {
+      const output = stdout.text.trim();
+      if (output !== "") {
+        root.parseFirefoxOutput(output, _currentBrowser);
+      }
+
+      root._currentFirefoxIndex++;
+      Qt.callLater(root.readNextFirefoxFile);
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  function parseFirefoxOutput(output, browser) {
+    const lines = output.split('\n');
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      const parts = line.split('\t');
+      if (parts.length >= 2) {
+        const title = parts[0];
+        const url = parts[1];
+
+        if (url && !url.startsWith('place:')) {
+          bookmarks.push({
+                           "name": title || "",
+                           "url": url,
+                           "folderPath": "",
+                           "browserName": browser ? browser.name : "Firefox"
+                         });
+        }
+      }
+    }
+  }
+
+  // ============================================
+  // Loading completion
+  // ============================================
+
+  function checkLoadingComplete() {
+    if (_pendingOperations <= 0) {
+      isLoading = false;
+      dataLoaded = true;
+      Logger.d("BookmarksProvider", `Loaded ${bookmarks.length} bookmarks total`);
+      if (launcher) {
+        launcher.updateResults();
+      }
+    }
+  }
+
+  // Refresh bookmarks
+  function refresh() {
+    dataLoaded = false;
+    loadBookmarks();
+  }
+
+  // Item actions
+  function getItemActions(item) {
+    if (!item || !item.bookmarkUrl)
+      return [];
+
+    return [
+          {
+            "icon": "copy",
+            "tooltip": I18n.tr("common.copied-to-clipboard"),
+            "action": function () {
+              Quickshell.execDetached(["wl-copy", item.bookmarkUrl]);
+              if (launcher)
+                launcher.close();
+            }
+          }
+        ];
+  }
+}

--- a/Modules/Panels/Settings/Tabs/Launcher/BookmarksSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Launcher/BookmarksSubTab.qml
@@ -1,0 +1,116 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+ColumnLayout {
+  id: root
+  spacing: Style.marginL
+  Layout.fillWidth: true
+
+  NToggle {
+    label: I18n.tr("panels.launcher.settings-enable-bookmarks-label")
+    description: I18n.tr("panels.launcher.settings-enable-bookmarks-description")
+    checked: Settings.data.appLauncher.enableBookmarks
+    onToggled: checked => Settings.data.appLauncher.enableBookmarks = checked
+    defaultValue: Settings.getDefaultValue("appLauncher.enableBookmarks")
+  }
+
+  NDivider {
+    Layout.fillWidth: true
+  }
+
+  NLabel {
+    label: I18n.tr("panels.launcher.settings-bookmarks-browsers-label")
+    description: I18n.tr("panels.launcher.settings-bookmarks-browsers-description")
+    Layout.fillWidth: true
+  }
+
+  ColumnLayout {
+    spacing: Style.marginS
+    Layout.fillWidth: true
+    Layout.leftMargin: Style.marginL
+    enabled: Settings.data.appLauncher.enableBookmarks
+
+    NCheckbox {
+      label: "Google Chrome"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("chrome")
+      onToggled: function(checked) { toggleBrowser("chrome", checked) }
+    }
+
+    NCheckbox {
+      label: "Chromium"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("chromium")
+      onToggled: function(checked) { toggleBrowser("chromium", checked) }
+    }
+
+    NCheckbox {
+      label: "Brave"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("brave")
+      onToggled: function(checked) { toggleBrowser("brave", checked) }
+    }
+
+    NCheckbox {
+      label: "Microsoft Edge"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("edge")
+      onToggled: function(checked) { toggleBrowser("edge", checked) }
+    }
+
+    NCheckbox {
+      label: "Vivaldi"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("vivaldi")
+      onToggled: function(checked) { toggleBrowser("vivaldi", checked) }
+    }
+
+    NCheckbox {
+      label: "Opera"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("opera")
+      onToggled: function(checked) { toggleBrowser("opera", checked) }
+    }
+
+    NCheckbox {
+      label: "Firefox"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("firefox")
+      onToggled: function(checked) { toggleBrowser("firefox", checked) }
+    }
+
+    NCheckbox {
+      label: "Firefox Developer Edition"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("firefox-dev")
+      onToggled: function(checked) { toggleBrowser("firefox-dev", checked) }
+    }
+
+    NCheckbox {
+      label: "LibreWolf"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("librewolf")
+      onToggled: function(checked) { toggleBrowser("librewolf", checked) }
+    }
+
+    NCheckbox {
+      label: "Zen Browser"
+      checked: (Settings.data.appLauncher.bookmarksBrowsers || []).includes("zen")
+      onToggled: function(checked) { toggleBrowser("zen", checked) }
+    }
+  }
+
+  function toggleBrowser(browserId, enabled) {
+    let browsers = (Settings.data.appLauncher.bookmarksBrowsers || []).slice();
+    if (enabled && !browsers.includes(browserId)) {
+      browsers.push(browserId);
+    } else if (!enabled) {
+      browsers = browsers.filter(b => b !== browserId);
+    }
+    Settings.data.appLauncher.bookmarksBrowsers = browsers;
+  }
+
+  Item {
+    Layout.fillHeight: true
+  }
+
+  NLabel {
+    label: I18n.tr("panels.launcher.settings-bookmarks-hint")
+    opacity: 0.7
+    Layout.fillWidth: true
+  }
+}

--- a/Modules/Panels/Settings/Tabs/Launcher/LauncherTab.qml
+++ b/Modules/Panels/Settings/Tabs/Launcher/LauncherTab.qml
@@ -26,9 +26,14 @@ ColumnLayout {
       checked: subTabBar.currentIndex === 1
     }
     NTabButton {
-      text: I18n.tr("common.execute")
+      text: I18n.tr("common.bookmarks")
       tabIndex: 2
       checked: subTabBar.currentIndex === 2
+    }
+    NTabButton {
+      text: I18n.tr("common.execute")
+      tabIndex: 3
+      checked: subTabBar.currentIndex === 3
     }
   }
 
@@ -43,6 +48,7 @@ ColumnLayout {
 
     GeneralSubTab {}
     ClipboardSubTab {}
+    BookmarksSubTab {}
     ExecuteSubTab {}
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

I am not sure if anyone apart from me needs this, but this PR adds a new launcher provider that allows searching and opening browser bookmarks from the Noctalia launcher. 
You can quickly access bookmarks using the >bm command. Both Chromium-based browsers (Chrome, Chromium, Brave, Edge, Vivaldi, Opera) and Firefox-based browsers (Firefox, Firefox Developer Edition, LibreWolf, Zen Browser).

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/578daa8b-02a6-4ada-a302-368a8e6bc610

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
