### PR TITLE
notifications: add IPC functions for action invocation

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -22,6 +22,20 @@ Item {
   // Screen detector passed from shell.qml
   required property CurrentScreenDetector screenDetector
 
+  // Helper for index-based notification lookups in IPC
+  function _getNotificationByIndex(index: string, funcName: string) {
+    var idx = index === "" ? 0 : parseInt(index);
+    if (isNaN(idx)) {
+      Logger.w("IPC", "Argument to ipc call '" + funcName + "' must be a number");
+      return null;
+    }
+    if (idx < 0 || idx >= NotificationService.activeList.count) {
+      Logger.w("IPC", "Notification index out of range: " + idx);
+      return null;
+    }
+    return NotificationService.activeList.get(idx);
+  }
+
   IpcHandler {
     target: "bar"
     function toggle() {
@@ -100,6 +114,47 @@ Item {
 
     function removeFromHistory(id: string): bool {
       return NotificationService.removeFromHistory(id);
+    }
+
+    function invokeDefault(index: string): bool {
+      var notif = root._getNotificationByIndex(index, "notifications invokeDefault");
+      if (!notif) return false;
+
+      var actions = JSON.parse(notif.actionsJson || "[]");
+      if (actions.length === 0) return false;
+
+      var actionId = actions.find(a => a.identifier === "default")?.identifier ?? actions[0].identifier;
+      return NotificationService.invokeAction(notif.id, actionId);
+    }
+
+    function invokeDefaultAndDismiss(index: string): bool {
+      var notif = root._getNotificationByIndex(index, "notifications invokeDefaultAndDismiss");
+      if (!notif) return false;
+
+      var actions = JSON.parse(notif.actionsJson || "[]");
+      if (actions.length === 0) {
+        NotificationService.dismissActiveNotification(notif.id);
+        return false;
+      }
+
+      var actionId = actions.find(a => a.identifier === "default")?.identifier ?? actions[0].identifier;
+      var result = NotificationService.invokeAction(notif.id, actionId);
+      NotificationService.dismissActiveNotification(notif.id);
+      return result;
+    }
+
+    function invokeAction(id: string, actionId: string): bool {
+      if (!id || !actionId) {
+        Logger.w("IPC", "Both 'id' and 'actionId' are required for 'notifications invokeAction'");
+        return false;
+      }
+      return NotificationService.invokeAction(id, actionId);
+    }
+
+    function getActions(index: string): string {
+      var notif = root._getNotificationByIndex(index, "notifications getActions");
+      if (!notif) return "[]";
+      return notif.actionsJson || "[]";
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation

Adds programmatic access to notification actions via IPC. This enables external tools and scripts (e.g., keyboard-driven workflows, automation, accessibility tools) to:

- Query what actions a notification supports
- Invoke the default action without GUI interaction
- Invoke specific actions by identifier

**Use case**: A user receives a notification with "Open" and "Dismiss" actions. Currently, the only way to invoke these is clicking in the GUI. With this PR, they can bind a keybind to:
```bash
qs -c noctalia-shell ipc call notifications invokeDefaultAndDismiss 0
```

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
None - this extends existing IPC infrastructure.

## Implementation

Adds four functions to the `notifications` IPC handler:

| Function | Args | Returns | Description |
|----------|------|---------|-------------|
| `getActions` | `index` | JSON array | Returns `[{identifier, text}, ...]` for notification at index |
| `invokeDefault` | `index` | bool | Invokes `default` action, or first action if no default |
| `invokeDefaultAndDismiss` | `index` | bool | Same as above, then dismisses notification |
| `invokeAction` | `id`, `actionId` | bool | Invokes specific action by notification ID and action identifier |

**Design decisions:**
- Index-based for `getActions`/`invokeDefault*` (matches `dismissOldest` pattern, intuitive for "act on most recent")
- ID-based for `invokeAction` (precise targeting when you know the notification ID)
- Consistent error handling with existing functions (Logger.w, graceful returns)
- Reuses existing `NotificationService.invokeAction()` and `dismissActiveNotification()`

## Testing

```bash
# Send notification with actions
notify-send -a "TestApp" "Test" "Body" --action="default=Open" --action="cancel=Cancel"

# Test each function
qs -c noctalia-shell ipc call notifications getActions 0
# → [{"text":"Open","identifier":"default"},{"text":"Cancel","identifier":"cancel"}]

qs -c noctalia-shell ipc call notifications invokeDefault 0
# → true

qs -c noctalia-shell ipc call notifications invokeDefaultAndDismiss 0
# → true (notification dismissed)

qs -c noctalia-shell ipc call notifications invokeAction <id> default
# → true
```

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
N/A - IPC-only change, no visual impact.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

The index defaults to `0` if omitted or empty string, allowing the shortest possible invocation:
```bash
qs -c noctalia-shell ipc call notifications invokeDefaultAndDismiss
# Acts on notification at index 0
```