### PR TITLE
fix(taskbar): reorder title bar width form field

### DIFF
--- a/Modules/Panels/Settings/Bar/WidgetSettings/TaskbarSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/TaskbarSettings.qml
@@ -147,6 +147,17 @@ ColumnLayout {
     enabled: !isVerticalBar
   }
 
+  NTextInput {
+    id: titleWidthInput
+    visible: root.valueShowTitle && !isVerticalBar
+    Layout.fillWidth: true
+    label: I18n.tr("bar.taskbar.title-width-label")
+    description: I18n.tr("bar.taskbar.title-width-description")
+    text: widgetData.titleWidth || widgetMetadata.titleWidth
+    placeholderText: I18n.tr("placeholders.enter-width-pixels")
+    onEditingFinished: settingsChanged(saveSettings())
+  }
+
   NToggle {
     Layout.fillWidth: true
     visible: !isVerticalBar && root.valueShowTitle
@@ -173,16 +184,5 @@ ColumnLayout {
                settingsChanged(saveSettings());
              }
     text: Math.round(root.valueMaxTaskbarWidth) + "%"
-  }
-
-  NTextInput {
-    id: titleWidthInput
-    visible: root.valueShowTitle && !isVerticalBar && !root.valueSmartWidth
-    Layout.fillWidth: true
-    label: I18n.tr("bar.taskbar.title-width-label")
-    description: I18n.tr("bar.taskbar.title-width-description")
-    text: widgetData.titleWidth || widgetMetadata.titleWidth
-    placeholderText: I18n.tr("placeholders.enter-width-pixels")
-    onEditingFinished: settingsChanged(saveSettings())
   }
 }


### PR DESCRIPTION
# Pull Request

## Motivation
In PR #1062, I modified the "Title Width" form field in taskbar settings to always visible instead of only visible when smart width is disabled, and moved it before the "Smart Width" form field. This allows users to determine the title width first, and then enable the smart width feature as needed. I believe this order is more aligned with user logic.

However, commit 53b2e9d37b90a451f7902646cf0efd93e354ffcc mistakenly reverted this change, so I re-submitted this fix.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
