### PR TITLE
WidgetSettings: ensure minimal width for NComboBox

### DIFF
--- a/Modules/Panels/Settings/Bar/WidgetSettings/BluetoothSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/BluetoothSettings.qml
@@ -25,7 +25,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/BrightnessSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/BrightnessSettings.qml
@@ -26,7 +26,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
@@ -29,7 +29,7 @@ ColumnLayout {
     visible: valueShowIcon // Hide display mode setting when icon is disabled
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/MicrophoneSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/MicrophoneSettings.qml
@@ -28,7 +28,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/NetworkSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/NetworkSettings.qml
@@ -25,7 +25,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/VPNSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/VPNSettings.qml
@@ -23,7 +23,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Modules/Panels/Settings/Bar/WidgetSettings/VolumeSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/VolumeSettings.qml
@@ -28,7 +28,7 @@ ColumnLayout {
   NComboBox {
     label: I18n.tr("bar.volume.display-mode-label")
     description: I18n.tr("bar.volume.display-mode-description")
-    minimumWidth: 134
+    minimumWidth: 200
     model: [
       {
         "key": "onhover",

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -57,6 +57,7 @@ Singleton {
                                      "LockKeys": "WidgetSettings/LockKeysSettings.qml",
                                      "MediaMini": "WidgetSettings/MediaMiniSettings.qml",
                                      "Microphone": "WidgetSettings/MicrophoneSettings.qml",
+                                     "Network": "WidgetSettings/NetworkSettings.qml",
                                      "NotificationHistory": "WidgetSettings/NotificationHistorySettings.qml",
                                      "SessionMenu": "WidgetSettings/SessionMenuSettings.qml",
                                      "Spacer": "WidgetSettings/SpacerSettings.qml",
@@ -65,9 +66,6 @@ Singleton {
                                      "Tray": "WidgetSettings/TraySettings.qml",
                                      "Volume": "WidgetSettings/VolumeSettings.qml",
                                      "VPN": "WidgetSettings/VPNSettings.qml",
-                                     // Reuse the same settings UI for renamed widget
-                                     "WiFi": "WidgetSettings/WiFiSettings.qml",
-                                     "Network": "WidgetSettings/WiFiSettings.qml",
                                      "Workspace": "WidgetSettings/WorkspaceSettings.qml"
                                    })
 


### PR DESCRIPTION
This box is too small in some widgets for many languages. I also renamed WifiSettings to NetworkSettings.