### PR TITLE
fix(slider): enable layer rendering for slider opacity animations

### DIFF
--- a/Widgets/NColorSlider.qml
+++ b/Widgets/NColorSlider.qml
@@ -174,4 +174,6 @@ Slider {
       }
     }
   }
+
+  layer.enabled: true
 }

--- a/Widgets/NSlider.qml
+++ b/Widgets/NSlider.qml
@@ -141,4 +141,6 @@ Slider {
       }
     }
   }
+
+  layer.enabled: true
 }


### PR DESCRIPTION
Adds layer.enabled: true to NColorSlider and NSlider to fix stacking opacity issues in the sliders.

Before:

https://github.com/user-attachments/assets/d72ebaa4-a716-4834-97bf-8e57e8be89b0

After

https://github.com/user-attachments/assets/f825ba93-a4c8-400e-9c92-1b9bf6325306

