### PR TITLE
fix(bar): consistent outer bar margin spacing

### DIFF
--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -267,7 +267,7 @@ Item {
       }
 
       // Calculate margin to center widgets vertically within the bar height
-      readonly property real verticalBarMargin: (root.barHeight - root.capsuleHeight) / 2
+      readonly property real verticalBarMargin: Math.round((root.barHeight - root.capsuleHeight) / 2)
 
       // Top section (left widgets)
       ColumnLayout {
@@ -374,7 +374,7 @@ Item {
       }
 
       // Calculate margin to center widgets horizontally within the bar height
-      readonly property real horizontalBarMargin: (root.barHeight - root.capsuleHeight) / 2
+      readonly property real horizontalBarMargin: Math.round((root.barHeight - root.capsuleHeight) / 2)
 
       // Left Section
       RowLayout {


### PR DESCRIPTION
## Summary
Center bar widgets properly by calculating margins dynamically based on `barHeight` and `capsuleHeight` instead of using fixed `Style.margin` values.

Widgets were positioned using fixed margins which didn't account for different bar densities, leading to inconsistent margins.

## Screenshots
*Before/after comparison showing proper widget centering*

Mini example
<img width="278" height="108" alt="image" src="https://github.com/user-attachments/assets/e169867b-7043-4bde-b9c1-934cec5fe6d2" />
<img width="274" height="108" alt="image" src="https://github.com/user-attachments/assets/2e765d7d-9331-46d0-8827-3d85ba83ab01" />

Spacious example
<img width="360" height="138" alt="image" src="https://github.com/user-attachments/assets/8d01cc6c-2922-4e8a-803d-4a7ade86b220" />
<img width="362" height="142" alt="image" src="https://github.com/user-attachments/assets/9e5a4878-ee87-4282-93bd-cbffe19e0e51" />

