### PR TITLE
Feature/Dock pinned apps names changed from appId to appName

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -58,11 +58,12 @@ Loader {
         }
       }
 
-      // Refresh icons when DesktopEntries becomes available
+      // Refresh icons and names when DesktopEntries becomes available (or updates)
       Connections {
         target: DesktopEntries.applications
         function onValuesChanged() {
           root.iconRevision++;
+          updateDockApps();
         }
       }
 
@@ -333,8 +334,8 @@ Loader {
                                                              pushApp("pinned-running", toplevel, pinnedAppId, toplevel.title);
                                                            });
                                } else {
-                                 // App is pinned but not running - add once
-                                 pushApp("pinned", null, pinnedAppId, pinnedAppId);
+                                // App is pinned but not running - add once
+                                 pushApp("pinned", null, pinnedAppId, getAppNameFromDesktopEntry(pinnedAppId) || pinnedAppId);
                                }
                              });
         }


### PR DESCRIPTION
# Pull Request
## Motivation
Changed apps names in dock from appId to appName, that parsed with already existed function `getAppNameFromDesktopEntry`, also added `updateDockApps` to `onValuesChanged` 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1630

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
*Before:*

https://github.com/user-attachments/assets/4305c484-2256-417f-8638-6efbd2194692

*After:*

https://github.com/user-attachments/assets/1362cfa6-4756-460e-8390-27b5a6ba611e

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated

## Additional Notes
I don't added a option for turn on or turn off this feature, cause idk is it needed. Or it's okay that feature turned on by default, so if it's must be optional i will do this
