### PR TITLE
feat: spawn application process via compositor

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -395,9 +395,17 @@ Item {
           Logger.d("Taskbar", "Executing terminal app manually: " + app.name);
           const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
           const command = terminal.concat(app.command);
-          Quickshell.execDetached(command);
+          try {
+            CompositorService.spawn(command);
+          } catch (e) {
+            Quickshell.execDetached(command);
+          }
         } else if (app.command && app.command.length > 0) {
-          Quickshell.execDetached(app.command);
+          try {
+            CompositorService.spawn(app.command);
+          } catch (e) {
+            Quickshell.execDetached(app.command);
+          }
         } else if (app.execute) {
           app.execute();
         } else {

--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -6,6 +6,7 @@ import Quickshell
 import Quickshell.Wayland
 import Quickshell.Widgets
 import qs.Commons
+import qs.Services.Compositor
 import qs.Services.System
 import qs.Services.UI
 import qs.Widgets
@@ -1054,13 +1055,20 @@ Loader {
                               } else {
                                 // Fallback logic when app2unit is not used
                                 if (app.runInTerminal) {
-                                  // If app.execute() fails for terminal apps, we handle it manually.
                                   Logger.d("Dock", "Executing terminal app manually: " + app.name);
                                   const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
                                   const command = terminal.concat(app.command);
-                                  Quickshell.execDetached(command);
+                                  try {
+                                    CompositorService.spawn(command);
+                                  } catch (e) {
+                                    Quickshell.execDetached(command);
+                                  }
                                 } else if (app.command && app.command.length > 0) {
-                                  Quickshell.execDetached(app.command);
+                                  try {
+                                    CompositorService.spawn(app.command);
+                                  } catch (e) {
+                                    Quickshell.execDetached(app.command);
+                                  }
                                 } else if (app.execute) {
                                   app.execute();
                                 } else {

--- a/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
+++ b/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.Commons
+import qs.Services.Compositor
 import qs.Services.System
 
 Item {
@@ -580,13 +581,20 @@ Item {
                        } else {
                          // Fallback logic when app2unit is not used
                          if (app.runInTerminal) {
-                           // If app.execute() fails for terminal apps, we handle it manually.
                            Logger.d("ApplicationsProvider", "Executing terminal app manually: " + app.name);
                            const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
                            const command = terminal.concat(app.command);
-                           Quickshell.execDetached(command);
+                           try {
+                             CompositorService.spawn(command);
+                           } catch (e) {
+                             Quickshell.execDetached(command);
+                           }
                          } else if (app.command && app.command.length > 0) {
-                           Quickshell.execDetached(app.command);
+                           try {
+                             CompositorService.spawn(app.command);
+                           } catch (e) {
+                             Quickshell.execDetached(app.command);
+                           }
                          } else if (app.execute) {
                            app.execute();
                          } else {

--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -405,6 +405,15 @@ Singleton {
     }
   }
 
+  // Spawn command
+  function spawn(command) {
+    if (backend && backend.spawn) {
+      backend.spawn(command);
+    } else {
+      throw new Error("No backend available for spawn command");
+    }
+  }
+
   // Session management
   function logout() {
     if (backend && backend.logout) {

--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -485,4 +485,12 @@ Item {
     }
     return null;
   }
+
+  function spawn(command) {
+    try {
+      Quickshell.execDetached(["hyprctl", "dispatch", "--", "exec"].concat(command));
+    } catch (e) {
+      Logger.e("HyprlandService", "Failed to spawn command:", e);
+    }
+  }
 }

--- a/Services/Compositor/MangoService.qml
+++ b/Services/Compositor/MangoService.qml
@@ -688,4 +688,12 @@ Item {
     // }
     // return null;
   }
+
+  function spawn(command) {
+    try {
+      Quickshell.execDetached(["mmsg", "-d", "spawn", "--"].concat(command));
+    } catch (e) {
+      Logger.e("MangoService", "Failed to spawn command:", e);
+    }
+  }
 }

--- a/Services/Compositor/NiriService.qml
+++ b/Services/Compositor/NiriService.qml
@@ -498,4 +498,12 @@ Item {
     // }
     // return null;
   }
+
+  function spawn(command) {
+    try {
+      Quickshell.execDetached(["niri", "msg", "action", "spawn", "--"].concat(command));
+    } catch (e) {
+      Logger.e("NiriService", "Failed to spawn command:", e);
+    }
+  }
 }

--- a/Services/Compositor/SwayService.qml
+++ b/Services/Compositor/SwayService.qml
@@ -572,4 +572,12 @@ Item {
     // }
     // return null;
   }
+
+  function spawn(command) {
+    try {
+      Quickshell.execDetached(["swaymsg", "exec", "--"].concat(command));
+    } catch (e) {
+      Logger.e("SwayService", "Failed to spawn command:", e);
+    }
+  }
 }


### PR DESCRIPTION
## Motivation
When the systemd service restarts, all application processes directly started by quickshell will also terminate.

- https://discord.com/channels/1401598189823590460/1419664736957628559/threads/1462302923068276900
- https://github.com/AvengeMedia/DankMaterialShell/issues/218

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I only tested niri, as I don't use other compositors.