### PR TITLE
feat: clear password input on ctrl-c

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -276,6 +276,10 @@ Loader {
                   panelComponent.cancelTimer();
                   event.accepted = true;
                 }
+                if (event.modifiers & Qt.ControlModifier && event.key === Qt.Key_C) {
+                   lockContext.currentText = "";
+                   event.accepted = true;
+                }
               }
 
               Component.onCompleted: forceActiveFocus()


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This PR adds password clearing on ctrl-c. A key bind for this action currently doesn't exist and ctrl-c should be familiar to most linux users.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
