### PR TITLE
WallpaperPanel: add sort by random

### DIFF
--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -374,7 +374,7 @@ Singleton {
       property string wallhavenResolutionWidth: ""
 
       property string wallhavenResolutionHeight: ""
-      property string sortOrder: "name" // "name", "name_desc", "date", "date_desc"
+      property string sortOrder: "name" // "name", "name_desc", "date", "date_desc", "random"
     }
 
     // applauncher

--- a/Modules/Panels/Wallpaper/WallpaperPanel.qml
+++ b/Modules/Panels/Wallpaper/WallpaperPanel.qml
@@ -761,6 +761,8 @@ SmartPanel {
               return "history";
             if (sortOrder === "name_desc")
               return "sort-descending";
+            if (sortOrder === "random")
+              return "arrows-shuffle";
             return "sort-ascending";
           }
           tooltipText: {
@@ -770,6 +772,8 @@ SmartPanel {
               return "Sort: Oldest First";
             if (sortOrder === "name_desc")
               return "Sort: Name (Z-A)";
+            if (sortOrder === "random")
+              return "Sort: Random";
             return "Sort: Name (A-Z)";
           }
           baseSize: Style.baseWidgetSize * 0.8
@@ -779,7 +783,7 @@ SmartPanel {
               next = "date_desc";
             else if (sortOrder === "date_desc")
               next = "name"; // Toggle simpler: Name -> Newest -> Name
-            // Expanded cycle: Name -> Newest -> Oldest -> Z-A -> Name
+            // Expanded cycle: Name -> Newest -> Oldest -> Z-A -> Random -> Name
             // User just asked for "newest first", so let's make it easy to reach.
             // Let's do: Name (A-Z) -> Newest -> Oldest -> Name (Z-A) -> ...
 
@@ -789,6 +793,8 @@ SmartPanel {
               next = "date_asc";
             else if (sortOrder === "date_asc")
               next = "name_desc";
+            else if (sortOrder === "name_desc")
+              next = "random";
             else
               next = "name";
 

--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -767,17 +767,27 @@ Singleton {
         // Sort files based on settings
         var sortOrder = Settings.data.wallpaper.sortOrder || "name";
 
-        parsedFiles.sort(function (a, b) {
-          if (sortOrder === "date_desc") { // Newest first
-            return b.time - a.time;
-          } else if (sortOrder === "date_asc") { // Oldest first
-            return a.time - b.time;
-          } else if (sortOrder === "name_desc") {
-            return b.name.localeCompare(a.name);
-          } else { // name (asc)
-            return a.name.localeCompare(b.name);
-          }
-        });
+        // Fischer-Yates shuffle
+        if (sortOrder === "random") {
+            for (let i = parsedFiles.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                const temp = parsedFiles[i];
+                parsedFiles[i] = parsedFiles[j];
+                parsedFiles[j] = temp;
+            }
+        } else {
+          parsedFiles.sort(function (a, b) {
+            if (sortOrder === "date_desc") { // Newest first
+              return b.time - a.time;
+            } else if (sortOrder === "date_asc") { // Oldest first
+              return a.time - b.time;
+            } else if (sortOrder === "name_desc") {
+              return b.name.localeCompare(a.name);
+            } else { // name (asc)
+              return a.name.localeCompare(b.name);
+            }
+          });
+        }
 
         // Map back to string array
         files = parsedFiles.map(f => f.path);


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Added a Sort by: Random (shuffle) option to the WallpaperPanel. I opted to do a Fischer-Yates shuffle instead of a `Math.random() - 0.5` in sort for performance reasons and better randomness. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1872" height="1126" alt="image" src="https://github.com/user-attachments/assets/406bbc95-a2c1-4206-9e6c-74ff9e5eb7a7" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
