### PR TITLE
fix(ntabbar): add defensive checks for QML initialization timing

### DIFF
--- a/Widgets/NTabBar.qml
+++ b/Widgets/NTabBar.qml
@@ -20,6 +20,10 @@ Rectangle {
   Component.onCompleted: _applyDistribution()
 
   function _updateFirstLast() {
+    // Defensive check for QML initialization timing
+    if (!tabRow || !tabRow.children) {
+      return;
+    }
     var kids = tabRow.children;
     var len = kids.length;
     var firstVisible = -1;
@@ -43,6 +47,9 @@ Rectangle {
   }
 
   function _applyDistribution() {
+    if (!tabRow || !tabRow.children) {
+      return;
+    }
     if (!distributeEvenly) {
       for (var i = 0; i < tabRow.children.length; i++) {
         var child = tabRow.children[i];


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
```
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
  WARN scene: @Widgets/NTabBar.qml[23:-1]: TypeError: Cannot read property 'children' of null
```

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
