### PR TITLE
Bar Position Awareness In Widgets Ordering Menu

### DIFF
--- a/Modules/Panels/Settings/Bar/MonitorWidgetsConfig.qml
+++ b/Modules/Panels/Settings/Bar/MonitorWidgetsConfig.qml
@@ -14,6 +14,11 @@ NBox {
 
   required property var screen
   readonly property string screenName: screen?.name || ""
+  // Determine if the bar on a per screen basis is vertical
+  readonly property bool barIsVertical: {
+    var pos = Settings.getBarPositionForScreen(screenName);
+    return pos === "left" || pos === "right";
+  }
 
   color: Color.mSurfaceVariant
   Layout.fillWidth: true
@@ -153,7 +158,7 @@ NBox {
 
     // Left Section
     NSectionEditor {
-      sectionName: I18n.tr("positions.left")
+      sectionName: root.barIsVertical ? I18n.tr("positions.top") : I18n.tr("positions.left")
       sectionId: "left"
       screen: root.screen
       settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
@@ -187,7 +192,7 @@ NBox {
 
     // Right Section
     NSectionEditor {
-      sectionName: I18n.tr("positions.right")
+      sectionName: root.barIsVertical ? I18n.tr("positions.bottom") : I18n.tr("positions.right")
       sectionId: "right"
       screen: root.screen
       settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")

--- a/Modules/Panels/Settings/Tabs/Bar/WidgetsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/WidgetsSubTab.qml
@@ -19,6 +19,8 @@ ColumnLayout {
   property var moveWidgetBetweenSections
 
   signal openPluginSettings(var manifest)
+  // determine if the bar is vertical
+  readonly property bool barIsVertical: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
 
   function getSectionIcons() {
     return {
@@ -36,7 +38,7 @@ ColumnLayout {
 
   // Left Section
   NSectionEditor {
-    sectionName: I18n.tr("positions.left")
+    sectionName: root.barIsVertical ? I18n.tr("positions.top") : I18n.tr("positions.left")
     sectionId: "left"
     settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
     widgetRegistry: BarWidgetRegistry
@@ -70,7 +72,7 @@ ColumnLayout {
 
   // Right Section
   NSectionEditor {
-    sectionName: I18n.tr("positions.right")
+    sectionName: root.barIsVertical ? I18n.tr("positions.bottom") : I18n.tr("positions.right")
     sectionId: "right"
     settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
     widgetRegistry: BarWidgetRegistry


### PR DESCRIPTION
# Pull Request
Adds bar position awareness to the widgets order editing menu.

## Motivation
It annoyed me.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix

Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)