### PR TITLE
More Robust Vscode Theme Path Method

### DIFF
--- a/Modules/Panels/Settings/Tabs/ColorScheme/TemplatesSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/TemplatesSubTab.qml
@@ -56,11 +56,18 @@ ColumnLayout {
           if (app.id === "discord") {
             include = TemplateProcessor.isDiscordClientEnabled(client.name);
           } else if (app.id === "code") {
-            include = TemplateProcessor.isCodeClientEnabled(client.name);
+            // For code clients, resolve all theme paths dynamically (version-independent)
+            if (TemplateProcessor.isCodeClientEnabled(client.name)) {
+              var resolvedPaths = TemplateRegistry.resolvedCodeClientPaths(client.name);
+              for (var p = 0; p < resolvedPaths.length; p++) {
+                validClients.push(resolvedPaths[p]);
+              }
+            }
+            continue;
           }
 
           if (include) {
-            validClients.push(client.path);
+            if (client.path) validClients.push(client.path);
           }
         }
 

--- a/Scripts/python/src/theming/vscode-helper.py
+++ b/Scripts/python/src/theming/vscode-helper.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Finds all installed Noctalia theme extensions for VSCode/VSCodium.
+
+import sys
+from pathlib import Path
+
+
+def find_all_noctalia_themes(extensions_dir: Path, prefix: str) -> list[str]:
+    # Bail early if the extensions directory doesn't exist
+    if not extensions_dir.is_dir():
+        return []
+    # Collect all directories matching the extension prefix
+    candidates = [d for d in extensions_dir.iterdir() if d.is_dir() and d.name.startswith(prefix)]
+    # Return theme file paths for all matching extensions
+    return [str(d / "themes" / "NoctaliaTheme-color-theme.json") for d in candidates]
+
+
+if __name__ == "__main__":
+    # Resolve ~ in the provided extensions directory path
+    extensions_dir = Path(sys.argv[1]).expanduser()
+    prefix = sys.argv[2] if len(sys.argv) > 2 else "noctalia.noctaliatheme-"
+
+    # Print the resolved paths to stdout for the QML Process to capture
+    results = find_all_noctalia_themes(extensions_dir, prefix)
+    if results:
+        for path in results:
+            print(path)
+    else:
+        print(f"No matching extension found in {extensions_dir}", file=sys.stderr)
+        sys.exit(1)

--- a/Services/Theming/TemplateProcessor.qml
+++ b/Services/Theming/TemplateProcessor.qml
@@ -245,11 +245,14 @@ Singleton {
                                               if (isTemplateEnabled("code")) {
                                                 app.clients.forEach(client => {
                                                                       // Check if this specific client is detected
-                                                                      if (isCodeClientEnabled(client.name)) {
-                                                                        lines.push(`\n[templates.code_${client.name}]`);
-                                                                        lines.push(`input_path = "${Quickshell.shellDir}/Assets/Templates/${app.input}"`);
-                                                                        const expandedPath = client.path.replace("~", homeDir);
-                                                                        lines.push(`output_path = "${expandedPath}"`);
+                                                                      var resolvedPaths = TemplateRegistry.resolvedCodeClientPaths(client.name);
+                                                                      if (isCodeClientEnabled(client.name) && resolvedPaths.length > 0) {
+                                                                        resolvedPaths.forEach((resolvedPath, pathIndex) => {
+                                                                          var suffix = resolvedPaths.length > 1 ? `_${pathIndex}` : "";
+                                                                          lines.push(`\n[templates.code_${client.name}${suffix}]`);
+                                                                          lines.push(`input_path = "${Quickshell.shellDir}/Assets/Templates/${app.input}"`);
+                                                                          lines.push(`output_path = "${resolvedPath}"`);
+                                                                        });
                                                                       }
                                                                     });
                                               }

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -10,6 +10,11 @@ Singleton {
 
   readonly property string templateApplyScript: Quickshell.shellDir + '/Scripts/bash/template-apply.sh'
   readonly property string gtkRefreshScript: Quickshell.shellDir + '/Scripts/python/src/theming/gtk-refresh.py'
+  readonly property string vscodeHelperScript: Quickshell.shellDir + '/Scripts/python/src/theming/vscode-helper.py'
+
+  // Dynamically resolved VSCode extension theme paths (all matching noctalia extensions)
+  property var resolvedCodePaths: []
+  property var resolvedCodiumPaths: []
 
   // Terminal configurations (for wallpaper-based templates)
   // Each terminal must define a postHook that sets up config includes and triggers reload
@@ -398,6 +403,13 @@ Singleton {
     return clients;
   }
 
+  // Get resolved theme paths for a code client (returns array of all matching paths)
+  function resolvedCodeClientPaths(clientName) {
+    if (clientName === "code") return resolvedCodePaths;
+    if (clientName === "codium") return resolvedCodiumPaths;
+    return [];
+  }
+
   // Extract Code clients for ProgramCheckerService compatibility
   readonly property var codeClients: {
     var clients = [];
@@ -417,13 +429,41 @@ Singleton {
                                 clients.push({
                                                "name": client.name,
                                                "configPath": baseConfigDir,
-                                               "themePath": themePath
+                                               "themePath": "" // resolved dynamically via resolvedCodeClientPaths()
                                              });
                               });
     }
     return clients;
   }
 
+  // Resolve VSCode extension paths dynamically
+  Process {
+    id: codeResolverProcess
+    command: ["python3", vscodeHelperScript, "~/.vscode/extensions"]
+    running: true
+    property var paths: []
+    stdout: SplitParser {
+      onRead: data => {
+        var line = data.trim();
+        if (line) codeResolverProcess.paths.push(line);
+      }
+    }
+    onExited: { root.resolvedCodePaths = paths; }
+  }
+
+  Process {
+    id: codiumResolverProcess
+    command: ["python3", vscodeHelperScript, "~/.vscode-oss/extensions"]
+    running: true
+    property var paths: []
+    stdout: SplitParser {
+      onRead: data => {
+        var line = data.trim();
+        if (line) codiumResolverProcess.paths.push(line);
+      }
+    }
+    onExited: { root.resolvedCodiumPaths = paths; }
+  }
   // Build user templates TOML content
   function buildUserTemplatesToml() {
     var lines = [];


### PR DESCRIPTION
# Pull Request
Adds a python helper to find the file path of all the Noctalia VScode/Codium theme extensions installed. 

## Motivation
To replace the explicit targeting currently used with something more dynamic to enable easier extension updates in the future.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Tested with 2 versions of the vscode extension across both Code and Codium.

- [x] Tested on niri

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)