### PR TITLE
Add reverse scroll toggle to Volume and Brightness

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1080,6 +1080,8 @@
       "settings-copied": "Settings copied to clipboard",
       "tab-basics": "Basics",
       "tab-keybinds": "Keybinds"
+      "reverse-scrolling-description": "Reverse the interpreted scroll direction",
+      "reverse-scrolling-label": "Reverse scrolling"
     },
     "hooks": {
       "info-command-info-description": "• Commands are executed via shell (sh -lc)<br>• Commands run in background (detached)<br>• Test buttons execute with current values",

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -1076,6 +1076,8 @@
       "settings-copied": "Ajustes copiados al portapapeles",
       "tab-basics": "Conceptos Básicos",
       "tab-keybinds": "Atajos de Teclado"
+      "appearance-reverse-scrolling-description": "Invertir la dirección de trabajo al desplazarse.",
+      "appearance-reverse-scrolling-label": "Desplazamiento inverso"
     },
     "hooks": {
       "info-command-info-description": "• Los comandos se ejecutan a través de shell (sh -lc)<br>• Los comandos se ejecutan en segundo plano (desvinculados)<br>• Los botones de prueba se ejecutan con los valores actuales",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -124,6 +124,7 @@
         "Del"
       ]
     }
+    "reverseScroll": false,
   },
   "ui": {
     "fontDefault": "",

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -687,6 +687,14 @@
     "tabLabel": "common.general",
     "subTab": null
   },
+{
+    "labelKey": "panels.general.reverse-scrolling-label",
+    "descriptionKey": "panels.general.reverse-scrolling-description",
+    "widget": "NToggle",
+    "tab": 0,
+    "tabLabel": "common.general",
+    "subTab": null
+  },
   {
     "labelKey": "panels.hooks.system-hooks-enable-label",
     "descriptionKey": "panels.hooks.system-hooks-enable-description",

--- a/Assets/settings-widgets-default.json
+++ b/Assets/settings-widgets-default.json
@@ -216,7 +216,6 @@
       "occupiedColor": "secondary",
       "emptyColor": "secondary",
       "showBadge": true,
-      "reverseScroll": false,
       "pillSize": 0.6
     },
     "Volume": {

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -299,6 +299,7 @@ Singleton {
         property list<string> keyEscape: ["Esc"]
         property list<string> keyRemove: ["Del"]
       }
+      property bool reverseScroll: false
     }
 
     // ui

--- a/Modules/Bar/Widgets/Brightness.qml
+++ b/Modules/Bar/Widgets/Brightness.qml
@@ -37,6 +37,7 @@ Item {
   readonly property string displayMode: (widgetSettings.displayMode !== undefined) ? widgetSettings.displayMode : widgetMetadata.displayMode
   readonly property string iconColorKey: widgetSettings.iconColor !== undefined ? widgetSettings.iconColor : widgetMetadata.iconColor
   readonly property string textColorKey: widgetSettings.textColor !== undefined ? widgetSettings.textColor : widgetMetadata.textColor
+  readonly property bool reverseScroll: Settings.data.general.reverseScroll
 
   // Used to avoid opening the pill on Quickshell startup
   property bool firstBrightnessReceived: false
@@ -162,6 +163,9 @@ Item {
       var monitor = brightnessMonitor;
       if (!monitor || !monitor.brightnessControlAvailable)
         return;
+
+      if (root.reverseScroll)
+        angle *= -1;
 
       if (angle > 0) {
         monitor.increaseBrightness();

--- a/Modules/Bar/Widgets/Volume.qml
+++ b/Modules/Bar/Widgets/Volume.qml
@@ -39,6 +39,7 @@ Item {
   readonly property string middleClickCommand: (widgetSettings.middleClickCommand !== undefined) ? widgetSettings.middleClickCommand : widgetMetadata.middleClickCommand
   readonly property string iconColorKey: widgetSettings.iconColor !== undefined ? widgetSettings.iconColor : widgetMetadata.iconColor
   readonly property string textColorKey: widgetSettings.textColor !== undefined ? widgetSettings.textColor : widgetMetadata.textColor
+  readonly property bool reverseScroll: Settings.data.general.reverseScroll
 
   // Used to avoid opening the pill on Quickshell startup
   property bool firstVolumeReceived: false
@@ -136,6 +137,9 @@ Item {
     onWheel: function (delta) {
       // Hide tooltip as soon as the user starts scrolling to adjust volume
       TooltipService.hide();
+
+      if (root.reverseScroll)
+        delta *= -1;
 
       wheelAccumulator += delta;
       if (wheelAccumulator >= 120) {

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -61,7 +61,7 @@ Item {
   readonly property real unfocusedIconsOpacity: (widgetSettings.unfocusedIconsOpacity !== undefined) ? widgetSettings.unfocusedIconsOpacity : widgetMetadata.unfocusedIconsOpacity
   readonly property real groupedBorderOpacity: (widgetSettings.groupedBorderOpacity !== undefined) ? widgetSettings.groupedBorderOpacity : widgetMetadata.groupedBorderOpacity
   readonly property bool enableScrollWheel: (widgetSettings.enableScrollWheel !== undefined) ? widgetSettings.enableScrollWheel : widgetMetadata.enableScrollWheel
-  readonly property bool reverseScroll: (widgetSettings.reverseScroll !== undefined) ? widgetSettings.reverseScroll : (widgetMetadata.reverseScroll || false)
+  readonly property bool reverseScroll: Settings.data.general.reverseScroll
   readonly property real iconScale: (widgetSettings.iconScale !== undefined) ? widgetSettings.iconScale : widgetMetadata.iconScale
   readonly property string focusedColor: (widgetSettings.focusedColor !== undefined) ? widgetSettings.focusedColor : widgetMetadata.focusedColor
   readonly property string occupiedColor: (widgetSettings.occupiedColor !== undefined) ? widgetSettings.occupiedColor : widgetMetadata.occupiedColor

--- a/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
@@ -27,7 +27,6 @@ ColumnLayout {
   property real valueUnfocusedIconsOpacity: widgetData.unfocusedIconsOpacity !== undefined ? widgetData.unfocusedIconsOpacity : widgetMetadata.unfocusedIconsOpacity
   property real valueGroupedBorderOpacity: widgetData.groupedBorderOpacity !== undefined ? widgetData.groupedBorderOpacity : widgetMetadata.groupedBorderOpacity
   property bool valueEnableScrollWheel: widgetData.enableScrollWheel !== undefined ? widgetData.enableScrollWheel : widgetMetadata.enableScrollWheel
-  property bool valueReverseScroll: widgetData.reverseScroll !== undefined ? widgetData.reverseScroll : widgetMetadata.reverseScroll
   property real valueIconScale: widgetData.iconScale !== undefined ? widgetData.iconScale : widgetMetadata.iconScale
   property string valueFocusedColor: widgetData.focusedColor !== undefined ? widgetData.focusedColor : widgetMetadata.focusedColor
   property string valueOccupiedColor: widgetData.occupiedColor !== undefined ? widgetData.occupiedColor : widgetMetadata.occupiedColor
@@ -47,7 +46,6 @@ ColumnLayout {
     settings.unfocusedIconsOpacity = valueUnfocusedIconsOpacity;
     settings.groupedBorderOpacity = valueGroupedBorderOpacity;
     settings.enableScrollWheel = valueEnableScrollWheel;
-    settings.reverseScroll = valueReverseScroll;
     settings.iconScale = valueIconScale;
     settings.focusedColor = valueFocusedColor;
     settings.occupiedColor = valueOccupiedColor;
@@ -153,17 +151,6 @@ ColumnLayout {
                  valueEnableScrollWheel = checked;
                  saveSettings();
                }
-  }
-
-  NToggle {
-    label: I18n.tr("bar.workspace.reverse-scrolling-label")
-    description: I18n.tr("bar.workspace.reverse-scrolling-description")
-    checked: valueReverseScroll
-    onToggled: checked => {
-                 valueReverseScroll = checked;
-                 saveSettings();
-               }
-    visible: valueEnableScrollWheel
   }
 
   NDivider {

--- a/Modules/Panels/Settings/Tabs/GeneralTab.qml
+++ b/Modules/Panels/Settings/Tabs/GeneralTab.qml
@@ -37,10 +37,24 @@ ColumnLayout {
     Layout.preferredHeight: Style.marginL
   }
 
+  NToggle {
+    Layout.fillWidth: true
+    label: I18n.tr("panels.general.reverse-scrolling-label")
+    description: I18n.tr("panels.general.reverse-scrolling-description")
+    checked: Settings.data.general.reverseScroll
+    defaultValue: Settings.getDefaultValue("general.reverseScroll")
+    onToggled: checked => Settings.data.general.reverseScroll = checked
+  }
+
+  NDivider {
+    Layout.fillWidth: true
+    Layout.topMargin: Style.marginM
+    Layout.bottomMargin: Style.marginM
+  }
+
   NTabView {
     id: tabView
     currentIndex: subTabBar.currentIndex
-
     BasicsSubTab {}
     KeybindsSubTab {}
   }

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -292,7 +292,6 @@ Singleton {
                                     "occupiedColor": "secondary",
                                     "emptyColor": "secondary",
                                     "showBadge": true,
-                                    "reverseScroll": false,
                                     "pillSize": 0.6
                                   },
                                   "Volume": {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
I use noctalia on my laptop via trackpad and scrolling upward on widgets to decrease the volume, for example, is very unintuitive.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1640 

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested on sway
- [X] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="912" height="381" alt="image" src="https://github.com/user-attachments/assets/92fb5a68-5846-4090-bd8e-05a2f52dba83" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Implementation copied from the workspace module. Let me know if other widgets should be added as well, or if any specific documentation is required. 
