### PR TITLE
bug(hyprland): named workspaces break workspaces

### DIFF
--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -426,6 +426,10 @@ Item {
   // Public functions
   function switchToWorkspace(workspace) {
     try {
+      if (workspace.name) {
+        Hyprland.dispatch(`workspace ${workspace.name}`);
+        return;
+      }
       Hyprland.dispatch(`workspace ${workspace.idx}`);
     } catch (e) {
       Logger.e("HyprlandService", "Failed to switch workspace:", e);


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Named workspaces in Hyprland always have negative ids. They always appear before unnamed workspaces.
https://quickshell.org/docs/v0.2.1/types/Quickshell.Hyprland/Hyprland/

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1355 

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Need to dig a bit further to check if some things might not work because of the negative id of the workspace.
