### PR TITLE
Update NImageRounded.qml

### DIFF
--- a/Widgets/NImageRounded.qml
+++ b/Widgets/NImageRounded.qml
@@ -13,11 +13,11 @@ Item {
   property real fallbackIconSize: Style.fontSizeXXL
   property real borderWidth: 0
   property color borderColor: "transparent"
-  property int imageFillMode: Image.PreserveAspectCrop
+  property int imageFillMode: Image.PreserveAspectcrop
   readonly property bool showFallback: (fallbackIcon !== undefined && fallbackIcon !== "") && (imagePath === undefined || imagePath === "")
   readonly property int status: imageSource.status
 
-  Rectangle {
+   Rectangle {
     anchors.fill: parent
     radius: root.radius
     color: "transparent"
@@ -38,6 +38,9 @@ Item {
     }
 
     ShaderEffect {
+      anchors.fill: parent
+      anchors.margins: root.borderWidth
+      visible: !root.showFallback
       property variant source: imageSource
       property real itemWidth: width
       property real itemHeight: height
@@ -46,23 +49,30 @@ Item {
       property real cornerRadius: Math.max(0, root.radius - root.borderWidth)
       property real imageOpacity: 1.0
       property int fillMode: root.imageFillMode
-
+        ShaderEffect {
+            property variant source: imageSource
+            property real itemWidth: width
+            property real itemHeight: height
+            property real sourceWidth: imageSource.sourceSize.width
+            property real sourceHeight: imageSource.sourceSize.height
+            property real cornerRadius: Math.max(0, root.radius - root.borderWidth)
+            property real imageOpacity: 1
+            property int fillMode: root.imageFillMode
             anchors.fill: parent
             anchors.margins: root.borderWidth
             visible: !root.showFallback
+
       fragmentShader: Qt.resolvedUrl(Quickshell.shellDir + "/Shaders/qsb/rounded_image.frag.qsb")
       supportsAtlasTextures: false
       blending: true
-        }
-
-        NIcon {
-            anchors.fill: parent
-            anchors.margins: root.borderWidth
-            visible: root.showFallback
-            icon: root.fallbackIcon
-            pointSize: root.fallbackIconSize
-        }
-
     }
 
+    NIcon {
+      anchors.fill: parent
+      anchors.margins: root.borderWidth
+      visible: root.showFallback
+      icon: root.fallbackIcon
+      pointSize: root.fallbackIconSize
+    }
+  }
 }


### PR DESCRIPTION
# Pull Request

## Motivation
Currently, when utilizing `NImageRounded` for circular avatars or icons (e.g., in Settings or Notifications), rectangular source images are scaled to fit *inside* the container (`PreserveAspectFit`). This results in improper padding where the image doesn't fill the entire circular area. This PR changes the default behavior to `PreserveAspectCrop` to ensure images always fill their designated frames.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Tested on Hyprland by verifying that the profile picture in the Settings > General tab and icons in notification popups now correctly fill their circular containers without distortion or empty padding.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
BEFORE:
<img width="183" height="178" alt="image" src="https://github.com/user-attachments/assets/01c42d7f-24e7-4c14-ab93-0cd09e7f74de" />
AFTER:
<img width="176" height="161" alt="image" src="https://github.com/user-attachments/assets/9236527f-3e4d-4046-b51e-14f30f7f1555" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes