### PR TITLE
fix(display): external display brightness slider fluidity

### DIFF
--- a/Modules/Panels/Settings/Tabs/Display/BrightnessSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Display/BrightnessSubTab.qml
@@ -23,6 +23,41 @@ ColumnLayout {
         color: Color.mSurface
 
         property var brightnessMonitor: BrightnessService.getMonitorForScreen(modelData)
+        property real localBrightness: 0.5
+        property bool localBrightnessChanging: false
+
+        onBrightnessMonitorChanged: {
+          if (brightnessMonitor && !localBrightnessChanging)
+            localBrightness = brightnessMonitor.brightness || 0.5;
+        }
+
+        Connections {
+          target: BrightnessService
+          function onMonitorBrightnessChanged(monitor, newBrightness) {
+            if (monitor === brightnessMonitor && !localBrightnessChanging) {
+              localBrightness = newBrightness;
+            }
+          }
+        }
+        Connections {
+          target: brightnessMonitor
+          ignoreUnknownSignals: true
+          function onBrightnessUpdated() {
+            if (brightnessMonitor && !localBrightnessChanging) {
+              localBrightness = brightnessMonitor.brightness || 0;
+            }
+          }
+        }
+        Timer {
+          id: debounceTimer
+          interval: 120
+          repeat: false
+          onTriggered: {
+            if (brightnessMonitor && brightnessMonitor.brightnessControlAvailable && Math.abs(localBrightness - brightnessMonitor.brightness) >= 0.005) {
+              brightnessMonitor.setBrightness(localBrightness);
+            }
+          }
+        }
 
         ColumnLayout {
           id: contentCol
@@ -80,24 +115,32 @@ ColumnLayout {
                 id: brightnessSlider
                 from: 0
                 to: 1
-                value: brightnessMonitor ? brightnessMonitor.brightness : 0.5
+                value: localBrightness
                 stepSize: 0.01
                 enabled: brightnessMonitor ? brightnessMonitor.brightnessControlAvailable : false
                 onMoved: value => {
                            if (brightnessMonitor && brightnessMonitor.brightnessControlAvailable) {
-                             brightnessMonitor.setBrightness(value);
+                             localBrightness = value;
+                             debounceTimer.restart();
                            }
                          }
                 onPressedChanged: (pressed, value) => {
+                                    localBrightnessChanging = pressed;
                                     if (brightnessMonitor && brightnessMonitor.brightnessControlAvailable) {
-                                      brightnessMonitor.setBrightness(value);
+                                      if (pressed) {
+                                        localBrightness = value;
+                                        debounceTimer.restart();
+                                      } else {
+                                        localBrightness = value;
+                                        debounceTimer.restart();
+                                      }
                                     }
                                   }
                 Layout.fillWidth: true
               }
 
               NText {
-                text: brightnessMonitor ? Math.round(brightnessSlider.value * 100) + "%" : "N/A"
+                text: brightnessMonitor ? Math.round(localBrightness * 100) + "%" : "N/A"
                 Layout.preferredWidth: 55
                 horizontalAlignment: Text.AlignRight
                 Layout.alignment: Qt.AlignVCenter

--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -371,8 +371,11 @@ Singleton {
         monitor.commandRunning = true;
         monitor.ignoreNextChange = true;
         var ddcValue = Math.round(value * monitor.maxBrightness);
-        setBrightnessProc.command = ["ddcutil", "-b", busNum, "--noverify", "--async", "--sleep-multiplier=0.05", "setvcp", "10", ddcValue];
-        setBrightnessProc.running = true;
+        var ddcBus = busNum;
+        Qt.callLater(() => {
+          setBrightnessProc.command = ["ddcutil", "-b", ddcBus, "--noverify", "--async", "--sleep-multiplier=0.05", "setvcp", "10", ddcValue];
+          setBrightnessProc.running = true;
+        });
       } else if (!isDdc) {
         monitor.commandRunning = true;
         monitor.ignoreNextChange = true;


### PR DESCRIPTION
# Pull Request

## Motivation
Makes the external display brightness slider smooth instead of janky.

## Type of Change
- [x] Bug fix
- [x] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before:

https://github.com/user-attachments/assets/ad8722ad-302b-4c41-a260-fdcf05d134d0

After:

https://github.com/user-attachments/assets/aade1ac1-0ade-48ca-87a1-19c448e59b84

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors

## Additional Notes
