### PR TITLE
Fixing desktop clock widget colorization

### DIFF
--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -83,7 +83,7 @@ Item {
     let rows = [];
 
     // CPU
-    rows.push([I18n.tr("system-monitor.cpu-usage"), `${Math.round(SystemStatService.cpuUsage)}% (${SystemStatService.cpuFreq})`]);
+    rows.push([I18n.tr("system-monitor.cpu-usage"), `${Math.round(SystemStatService.cpuUsage)}% (${SystemStatService.cpuFreq.replace(/[^0-9.]/g, "")} GHz)`]);
 
     if (SystemStatService.cpuTemp > 0) {
       rows.push([I18n.tr("system-monitor.cpu-temp"), `${Math.round(SystemStatService.cpuTemp)}°C`]);

--- a/Modules/DesktopWidgets/Widgets/DesktopClock.qml
+++ b/Modules/DesktopWidgets/Widgets/DesktopClock.qml
@@ -12,21 +12,11 @@ DraggableDesktopWidget {
   readonly property var now: Time.now
   readonly property var widgetMetadata: DesktopWidgetRegistry.widgetMetadata["Clock"]
 
-  readonly property color clockTextColor: {
-    if (usePrimaryColor) {
-      return Color.mPrimary;
-    }
-    var txtColor = widgetData && widgetData.textColor ? widgetData.textColor : "";
-    return (txtColor && txtColor !== "") ? txtColor : Color.mOnSurface;
-  }
-  readonly property real fontSize: {
-    var size = widgetData && widgetData.fontSize ? widgetData.fontSize : 0;
-    var baseSize = (size && size > 0) ? size : Style.fontSizeXXXL * 2.5;
-    return Math.round(baseSize * widgetScale);
-  }
+  readonly property color clockTextColor: Color.resolveColorKey(clockColor)
+  readonly property real fontSize: Math.round(Style.fontSizeXXXL * 2.5 * widgetScale)
   readonly property real widgetOpacity: (widgetData && widgetData.opacity !== undefined) ? widgetData.opacity : 1.0
   readonly property string clockStyle: (widgetData && widgetData.clockStyle !== undefined) ? widgetData.clockStyle : (widgetMetadata.clockStyle !== undefined ? widgetMetadata.clockStyle : "digital")
-  readonly property bool usePrimaryColor: (widgetData && widgetData.usePrimaryColor !== undefined) ? widgetData.usePrimaryColor : (widgetMetadata.usePrimaryColor !== undefined ? widgetMetadata.usePrimaryColor : false)
+  readonly property string clockColor: (widgetData && widgetData.clockColor !== undefined) ? widgetData.clockColor : (widgetMetadata.clockColor !== undefined ? widgetMetadata.clockColor : "none")
   readonly property bool useCustomFont: (widgetData && widgetData.useCustomFont !== undefined) ? widgetData.useCustomFont : (widgetMetadata.useCustomFont !== undefined ? widgetMetadata.useCustomFont : false)
   readonly property string customFont: (widgetData && widgetData.customFont !== undefined) ? widgetData.customFont : ""
   readonly property string format: (widgetData && widgetData.format !== undefined) ? widgetData.format : (widgetMetadata.format !== undefined ? widgetMetadata.format : "HH:mm\\nd MMMM yyyy")

--- a/Modules/Panels/Settings/DesktopWidgets/WidgetSettings/ClockSettings.qml
+++ b/Modules/Panels/Settings/DesktopWidgets/WidgetSettings/ClockSettings.qml
@@ -18,7 +18,7 @@ ColumnLayout {
   property bool valueShowBackground: widgetData.showBackground !== undefined ? widgetData.showBackground : widgetMetadata.showBackground
   property bool valueRoundedCorners: widgetData.roundedCorners !== undefined ? widgetData.roundedCorners : true
   property string valueClockStyle: widgetData.clockStyle !== undefined ? widgetData.clockStyle : widgetMetadata.clockStyle
-  property bool valueClockColor: widgetData.clockColor !== undefined ? widgetData.clockColor : widgetMetadata.clockColor
+  property string valueClockColor: widgetData.clockColor !== undefined ? widgetData.clockColor : widgetMetadata.clockColor
   property bool valueUseCustomFont: widgetData.useCustomFont !== undefined ? widgetData.useCustomFont : widgetMetadata.useCustomFont
   property string valueCustomFont: widgetData.customFont !== undefined ? widgetData.customFont : ""
   property string valueFormat: widgetData.format !== undefined ? widgetData.format : widgetMetadata.format
@@ -101,7 +101,7 @@ ColumnLayout {
 
   NComboBox {
     label: I18n.tr("common.select-color")
-    description: I18n.tr("bar.clock.select-color-description")
+    description: I18n.tr("common.select-color-description")
     model: [
       {
         "name": I18n.tr("common.none"),

--- a/Modules/Panels/SystemStats/SystemStatsPanel.qml
+++ b/Modules/Panels/SystemStats/SystemStatsPanel.qml
@@ -90,7 +90,7 @@ SmartPanel {
             }
 
             NText {
-              text: `${Math.round(SystemStatService.cpuUsage)}% ${SystemStatService.cpuFreq}`
+              text: `${Math.round(SystemStatService.cpuUsage)}% ${SystemStatService.cpuFreq.replace(/[^0-9.]/g, "")} GHz`
               pointSize: Style.fontSizeXS
               color: Color.mPrimary
               font.family: Settings.data.ui.fontFixed


### PR DESCRIPTION
I forgot to edit DesktopClock.qml in my previous PR, so the colorization doesn't work at the moment.
I've further added a space before the CPU frequency unit in the SystemMonitor to keep it in line with the other values.