### PR TITLE
Fix CustomButton ipc calls not working

### DIFF
--- a/Services/Control/CustomButtonIPCService.qml
+++ b/Services/Control/CustomButtonIPCService.qml
@@ -65,7 +65,7 @@ Item {
 
       // Trigger left click if configured
       if (button.leftClickExec || button.textCommand) {
-        button.onClicked();
+        button.clicked();
         Logger.i("CustomButtonIPCService", `Triggered left click on button '${identifier}'`);
       } else {
         Logger.w("CustomButtonIPCService", `Button '${identifier}' has no left click action configured`);
@@ -82,7 +82,7 @@ Item {
 
       // Trigger right click if configured
       if (button.rightClickExec) {
-        button.onRightClicked();
+        button.rightClicked();
         Logger.i("CustomButtonIPCService", `Triggered right click on button '${identifier}'`);
       } else {
         Logger.w("CustomButtonIPCService", `Button '${identifier}' has no right click action configured`);
@@ -116,7 +116,7 @@ Item {
 
       // Trigger wheel up if in separate mode and configured
       if (button.wheelMode === "separate" && button.wheelUpExec) {
-        button.onWheel(1);
+        button.wheeled(1);
         Logger.i("CustomButtonIPCService", `Triggered wheel up on button '${identifier}'`);
       } else {
         Logger.w("CustomButtonIPCService", `Button '${identifier}' has no separate wheel up action configured or is not in separate mode`);
@@ -133,7 +133,7 @@ Item {
 
       // Trigger wheel down if in separate mode and configured
       if (button.wheelMode === "separate" && button.wheelDownExec) {
-        button.onWheel(-1);
+        button.wheeled(-1);
         Logger.i("CustomButtonIPCService", `Triggered wheel down on button '${identifier}'`);
       } else {
         Logger.w("CustomButtonIPCService", `Button '${identifier}' has no separate wheel down action configured or is not in separate mode`);
@@ -150,7 +150,7 @@ Item {
 
       // Trigger unified wheel if in unified mode and configured
       if (button.wheelMode === "unified" && button.wheelExec) {
-        button.onWheel(1);
+        button.wheeled(1);
         Logger.i("CustomButtonIPCService", `Triggered wheel action on button '${identifier}'`);
       } else {
         Logger.w("CustomButtonIPCService", `Button '${identifier}' has no unified wheel action configured or is not in unified mode`);


### PR DESCRIPTION
# Pull Request


## Motivation
`CustomButtonIPCService.qml` was using `onClicked` signal handler as a function and `onWheel` instead of `wheeled`, which caused the ipc calls not to work.


## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- already closed, but fixes this one: https://github.com/noctalia-dev/noctalia-shell/issues/1420

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
