### PR TITLE
make lockscreen animations optional

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1178,6 +1178,8 @@
       "clock-style-label": "Clock style",
       "compact-lockscreen-description": "Show only the login input and system controls, hiding weather and media widgets.",
       "compact-lockscreen-label": "Compact lock screen",
+      "lock-screen-animations-label": "Lockscreen animations",
+      "lock-screen-animations-description": "Enable or disable lockscreen animations",
       "lock-on-suspend-description": "Automatically lock the screen when suspending the system.",
       "lock-on-suspend-label": "Lock on suspend",
       "show-hibernate-description": "Show the option 'hibernate' in the power controls.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -80,6 +80,7 @@
     "animationSpeed": 1,
     "animationDisabled": false,
     "compactLockScreen": false,
+    "lockScreenAnimations": false,
     "lockOnSuspend": true,
     "showSessionButtonsOnLockScreen": true,
     "showHibernateOnLockScreen": false,

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -269,6 +269,7 @@ Singleton {
       property real animationSpeed: 1.0
       property bool animationDisabled: false
       property bool compactLockScreen: false
+      property bool lockScreenAnimations: false
       property bool lockOnSuspend: true
       property bool showSessionButtonsOnLockScreen: true
       property bool showHibernateOnLockScreen: false

--- a/Modules/LockScreen/LockScreenHeader.qml
+++ b/Modules/LockScreen/LockScreenHeader.qml
@@ -8,6 +8,30 @@ import qs.Widgets
 // Time, Date, and User Profile Container
 Rectangle {
   id: root
+
+  // Whether to enable lock screen animations (avatar pulse, breathing, smooth cursor blink).
+  // Defaults to false to reduce GPU usage.  Set Settings.data.general.lockScreenAnimations = true to restore.
+  readonly property bool animationsEnabled: Settings.data.general.lockScreenAnimations || false
+
+  // Use timer-driven properties instead of Time.now to avoid per-frame repaints.
+  // Time.now updates every frame (~60+ Hz); these update only when needed.
+  property date currentTime: new Date()
+  property date currentDate: new Date()
+
+  Timer {
+    interval: 1000
+    running: true
+    repeat: true
+    onTriggered: root.currentTime = new Date()
+  }
+
+  Timer {
+    interval: 60000
+    running: true
+    repeat: true
+    onTriggered: root.currentDate = new Date()
+  }
+
   width: Math.max(500, contentRow.implicitWidth + 32)
   height: Math.max(120, contentRow.implicitHeight + 32)
   anchors.horizontalCenter: parent.horizontalCenter
@@ -41,6 +65,7 @@ Rectangle {
 
         SequentialAnimation on border.color {
           loops: Animation.Infinite
+          running: root.animationsEnabled
           ColorAnimation {
             to: Qt.alpha(Color.mPrimary, 1.0)
             duration: 2000
@@ -64,6 +89,7 @@ Rectangle {
 
         SequentialAnimation on scale {
           loops: Animation.Infinite
+          running: root.animationsEnabled
           NumberAnimation {
             to: 1.02
             duration: 4000
@@ -110,7 +136,7 @@ Rectangle {
             "sv": "dddd d MMMM",
             "zh": "yyyy年M月d日 dddd"
           };
-          var dateString = I18n.locale.toString(Time.now, formats[lang] || "dddd, d MMMM");
+          var dateString = I18n.locale.toString(root.currentDate, formats[lang] || "dddd, d MMMM");
           return dateString.charAt(0).toUpperCase() + dateString.slice(1);
         }
         pointSize: Style.fontSizeXL
@@ -136,7 +162,7 @@ Rectangle {
         width: 70
         height: 70
         visible: Settings.data.general.clockStyle === "analog"
-        now: Time.now
+        now: root.currentTime
         clockStyle: "analog"
         backgroundColor: "transparent"
         clockColor: Color.mOnSurface
@@ -149,7 +175,7 @@ Rectangle {
         width: 70
         height: 70
         visible: Settings.data.general.clockStyle === "digital"
-        now: Time.now
+        now: root.currentTime
         clockStyle: "digital"
         showProgress: true
         progressColor: Color.mPrimary
@@ -168,7 +194,7 @@ Rectangle {
         spacing: -3
 
         Repeater {
-          model: I18n.locale.toString(Time.now, (Settings.data.general.clockFormat || "hh\\nmm").replace(/\\n/g, "\n")).split("\n")
+          model: I18n.locale.toString(root.currentTime, (Settings.data.general.clockFormat || "hh\\nmm").replace(/\\n/g, "\n")).split("\n")
           NText {
             text: modelData
             pointSize: Style.fontSizeL

--- a/Modules/LockScreen/LockScreenPanel.qml
+++ b/Modules/LockScreen/LockScreenPanel.qml
@@ -20,6 +20,10 @@ Item {
   required property var keyboardLayout
   required property TextInput passwordInput
 
+  // Whether to enable lock screen animations (smooth cursor blink).
+  // Defaults to false to reduce GPU usage.  Set Settings.data.general.lockScreenAnimations = true to restore.
+  readonly property bool animationsEnabled: Settings.data.general.lockScreenAnimations || false
+
   Component.onCompleted: {
     if (Settings.data.general.autoStartAuth) {
       doUnlock();
@@ -544,9 +548,10 @@ Item {
                 visible: passwordInput.activeFocus && passwordInput.text.length === 0
                 anchors.verticalCenter: parent.verticalCenter
 
+                // Smooth fade animation (when animations enabled)
                 SequentialAnimation on opacity {
                   loops: Animation.Infinite
-                  running: passwordInput.activeFocus && passwordInput.text.length === 0
+                  running: root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length === 0
                   NumberAnimation {
                     to: 0
                     duration: 530
@@ -555,6 +560,14 @@ Item {
                     to: 1
                     duration: 530
                   }
+                }
+
+                // Simple toggle (when animations disabled) — no per-frame repaints
+                Timer {
+                  interval: 530
+                  running: !root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length === 0
+                  repeat: true
+                  onTriggered: parent.opacity = parent.opacity > 0.5 ? 0 : 1
                 }
               }
 
@@ -601,9 +614,10 @@ Item {
                 visible: passwordInput.activeFocus && passwordInput.text.length > 0
                 anchors.verticalCenter: parent.verticalCenter
 
+                // Smooth fade animation (when animations enabled)
                 SequentialAnimation on opacity {
                   loops: Animation.Infinite
-                  running: passwordInput.activeFocus && passwordInput.text.length > 0
+                  running: root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length > 0
                   NumberAnimation {
                     to: 0
                     duration: 530
@@ -612,6 +626,14 @@ Item {
                     to: 1
                     duration: 530
                   }
+                }
+
+                // Simple toggle (when animations disabled) — no per-frame repaints
+                Timer {
+                  interval: 530
+                  running: !root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length > 0
+                  repeat: true
+                  onTriggered: parent.opacity = parent.opacity > 0.5 ? 0 : 1
                 }
               }
             }

--- a/Modules/Panels/Settings/Tabs/LockScreenTab.qml
+++ b/Modules/Panels/Settings/Tabs/LockScreenTab.qml
@@ -77,6 +77,14 @@ ColumnLayout {
   }
 
   NToggle {
+    label: I18n.tr("panels.lock-screen.lock-screen-animations-label")
+    description: I18n.tr("panels.lock-screen.lock-screen-animations-description")
+    checked: Settings.data.general.lockScreenAnimations
+    onToggled: checked => Settings.data.general.lockScreenAnimations = checked
+    defaultValue: Settings.getDefaultValue("general.lockScreenAnimations")
+  }
+
+  NToggle {
     label: I18n.tr("panels.lock-screen.auto-start-auth-label")
     description: I18n.tr("panels.lock-screen.auto-start-auth-description")
     checked: Settings.data.general.autoStartAuth


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Animations on lock screen still pose a significant load on some older GPUs which in turn makes laptop fans go loud. I added an option to remove animations and use a timer to update time only every second not every frame. this significantly lowers the gpu load.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
