### PR TITLE
bug fix for the widgets position context menu

### DIFF
--- a/Modules/Panels/Settings/Bar/MonitorWidgetsConfig.qml
+++ b/Modules/Panels/Settings/Bar/MonitorWidgetsConfig.qml
@@ -14,11 +14,9 @@ NBox {
 
   required property var screen
   readonly property string screenName: screen?.name || ""
-  // Determine if the bar on a per screen basis is vertical
-  readonly property bool barIsVertical: {
-    var pos = Settings.getBarPositionForScreen(screenName);
-    return pos === "left" || pos === "right";
-  }
+  // determine bar orientation
+  readonly property string barPosition: Settings.getBarPositionForScreen(screenName)
+  readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
 
   color: Color.mSurfaceVariant
   Layout.fillWidth: true
@@ -160,6 +158,7 @@ NBox {
     NSectionEditor {
       sectionName: root.barIsVertical ? I18n.tr("positions.top") : I18n.tr("positions.left")
       sectionId: "left"
+      barIsVertical: root.barIsVertical
       screen: root.screen
       settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
       widgetRegistry: BarWidgetRegistry
@@ -177,6 +176,7 @@ NBox {
     NSectionEditor {
       sectionName: I18n.tr("positions.center")
       sectionId: "center"
+      barIsVertical: root.barIsVertical
       screen: root.screen
       settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
       widgetRegistry: BarWidgetRegistry
@@ -194,6 +194,7 @@ NBox {
     NSectionEditor {
       sectionName: root.barIsVertical ? I18n.tr("positions.bottom") : I18n.tr("positions.right")
       sectionId: "right"
+      barIsVertical: root.barIsVertical
       screen: root.screen
       settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
       widgetRegistry: BarWidgetRegistry

--- a/Modules/Panels/Settings/Tabs/Bar/WidgetsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/WidgetsSubTab.qml
@@ -19,8 +19,9 @@ ColumnLayout {
   property var moveWidgetBetweenSections
 
   signal openPluginSettings(var manifest)
-  // determine if the bar is vertical
-  readonly property bool barIsVertical: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
+  // determine bar orientation
+  readonly property string barPosition: Settings.data.bar.position
+  readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
 
   function getSectionIcons() {
     return {
@@ -40,6 +41,7 @@ ColumnLayout {
   NSectionEditor {
     sectionName: root.barIsVertical ? I18n.tr("positions.top") : I18n.tr("positions.left")
     sectionId: "left"
+    barIsVertical: root.barIsVertical
     settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
     widgetRegistry: BarWidgetRegistry
     widgetModel: Settings.data.bar.widgets.left
@@ -57,6 +59,7 @@ ColumnLayout {
   NSectionEditor {
     sectionName: I18n.tr("positions.center")
     sectionId: "center"
+    barIsVertical: root.barIsVertical
     settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
     widgetRegistry: BarWidgetRegistry
     widgetModel: Settings.data.bar.widgets.center
@@ -74,6 +77,7 @@ ColumnLayout {
   NSectionEditor {
     sectionName: root.barIsVertical ? I18n.tr("positions.bottom") : I18n.tr("positions.right")
     sectionId: "right"
+    barIsVertical: root.barIsVertical
     settingsDialogComponent: Qt.resolvedUrl(Quickshell.shellDir + "/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml")
     widgetRegistry: BarWidgetRegistry
     widgetModel: Settings.data.bar.widgets.right

--- a/Widgets/NSectionEditor.qml
+++ b/Widgets/NSectionEditor.qml
@@ -17,6 +17,7 @@ NBox {
   property var availableSections: ["left", "center", "right"]
   property var sectionLabels: ({}) // Map of sectionId -> display label
   property var sectionIcons: ({}) // Map of sectionId -> icon name
+  property bool barIsVertical: false // When true, map left/right to top/bottom in labels
   property int maxWidgets: -1 // -1 means unlimited
   property bool draggable: true // Enable/disable drag reordering
 
@@ -388,8 +389,14 @@ NBox {
                   if (section !== root.sectionId) {
                     var label = root.getSectionLabel(section);
                     var displayLabel = '';
-                    if (I18n.hasTranslation("positions." + section)) {
-                      displayLabel = I18n.tr("positions." + section);
+                    // Map section IDs to correct position keys based on bar orientation
+                    var positionKey = section;
+                    if (root.barIsVertical) {
+                      if (section === "left") positionKey = "top";
+                      else if (section === "right") positionKey = "bottom";
+                    }
+                    if (I18n.hasTranslation("positions." + positionKey)) {
+                      displayLabel = I18n.tr("positions." + positionKey);
                     } else {
                       displayLabel = label.charAt(0).toUpperCase() + label.slice(1);
                     }


### PR DESCRIPTION
# Pull Request
widget position context menus weren't respecting bar orientation.

## Motivation
Bug #1723.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1723  

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)