### PR TITLE
bar(auto-hide): properly hide bar on boot

### DIFF
--- a/Modules/Background/Background.qml
+++ b/Modules/Background/Background.qml
@@ -428,6 +428,12 @@ Variants {
           currentWallpaper.source = tempSource;
           transitionProgress = 0.0;
 
+          // Notify if this was the startup transition
+          if (isStartupTransition) {
+            WallpaperService.completeStartup(screen.name);
+            isStartupTransition = false;
+          }
+
           // Now clear nextWallpaper after currentWallpaper has the new source
           // Force complete cleanup to free texture memory
           Qt.callLater(() => {
@@ -749,11 +755,12 @@ Variants {
       function _executeStartupTransition() {
         if (transitionType === "none") {
           setWallpaperImmediate(futureWallpaper);
+          // For "none" transition, complete immediately
+          WallpaperService.completeStartup(screen.name);
+          isStartupTransition = false;
         } else {
           setWallpaperWithTransition(futureWallpaper);
         }
-        // Mark startup transition complete
-        isStartupTransition = false;
       }
     }
   }

--- a/Services/UI/BarService.qml
+++ b/Services/UI/BarService.qml
@@ -43,15 +43,32 @@ Singleton {
   // Auto-hide state per screen: { screenName: { hovered: bool, hidden: bool } }
   property var screenAutoHideState: ({})
 
+  // Track which screens have completed the boot hide sequence
+  property var bootCompletedScreens: ({})
+
   // Get or create auto-hide state for a screen
   function getOrCreateAutoHideState(screenName) {
     if (!screenAutoHideState[screenName]) {
+      // Start visible (hidden: false), will auto-hide after boot delay
       screenAutoHideState[screenName] = {
         "hovered": false,
-        "hidden": Settings.data.bar.displayMode === "auto_hide"
+        "hidden": false
       };
     }
     return screenAutoHideState[screenName];
+  }
+
+  // Check if boot sequence is complete for a screen
+  function isBootCompleted(screenName) {
+    return bootCompletedScreens[screenName] || false;
+  }
+
+  // Mark boot as completed for a screen
+  function completeBoot(screenName) {
+    if (!bootCompletedScreens[screenName]) {
+      bootCompletedScreens[screenName] = true;
+      Logger.d("BarService", "Boot sequence completed for screen:", screenName);
+    }
   }
 
   // Set hover state for a screen

--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -45,8 +45,26 @@ Singleton {
   signal wallpaperDirectoryChanged(string screenName, string directory)
   // Emitted when a monitor's directory changes
   signal wallpaperListChanged(string screenName, int count)
-
   // Emitted when available wallpapers list changes
+  signal startupTransitionComplete(string screenName)
+  // Emitted when the wallpaper startup transition finishes for a screen
+
+  // Track which screens have completed startup transition
+  property var startupCompleteScreens: ({})
+
+  // Check if startup transition is complete for a screen
+  function isStartupComplete(screenName) {
+    return startupCompleteScreens[screenName] || false;
+  }
+
+  // Mark startup transition as complete for a screen
+  function completeStartup(screenName) {
+    if (!startupCompleteScreens[screenName]) {
+      startupCompleteScreens[screenName] = true;
+      startupTransitionComplete(screenName);
+      Logger.d("WallpaperService", "Startup transition complete for screen:", screenName);
+    }
+  }
 
   // Browse mode: track current browse path per screen (separate from root directory)
   property var currentBrowsePaths: ({})


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Currently on boot the bar doesn't auto hide unless mouse hovered and taken.
So this pr aims to address this by auto hiding the bar after boot with a delay from the startup transition.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested on mangowc
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/38fc742b-ff47-456f-a78f-dbff9dadb14a



## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
