### PR TITLE
fix(wallpaper selector): fix auto scroll overshot

### DIFF
--- a/Modules/Panels/Wallpaper/WallpaperPanel.qml
+++ b/Modules/Panels/Wallpaper/WallpaperPanel.qml
@@ -892,7 +892,10 @@ SmartPanel {
             if (itemY < viewportTop) {
               contentY = Math.max(0, itemY - cellHeight);
             } else if (itemY + cellHeight > viewportBottom) {
-              contentY = itemY + cellHeight - height + cellHeight;
+              // Calculate desired position and clamp to max scroll position
+              let desiredY = itemY + cellHeight - height + cellHeight;
+              let maxContentY = Math.max(0, contentHeight - height);
+              contentY = Math.min(desiredY, maxContentY);
             }
           }
         }
@@ -1253,7 +1256,10 @@ SmartPanel {
               if (itemY < viewportTop) {
                 contentY = Math.max(0, itemY - cellHeight);
               } else if (itemY + cellHeight > viewportBottom) {
-                contentY = itemY + cellHeight - height + cellHeight;
+                // Calculate desired position and clamp to max scroll position
+                let desiredY = itemY + cellHeight - height + cellHeight;
+                let maxContentY = Math.max(0, contentHeight - height);
+                contentY = Math.min(desiredY, maxContentY);
               }
             }
           }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

fix the issue that auto scrolling will overshot, which is demonstrated in the videos:

https://github.com/user-attachments/assets/355a7dd5-36e7-4b34-89c2-0a08e5708c0d




## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

after fixed:

https://github.com/user-attachments/assets/43bde43c-d709-4a0a-8faf-92b9cea196d6

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
