### PR TITLE
Notification: left-click invoke default action

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -299,17 +299,24 @@ Variants {
             // Right-click to dismiss
             MouseArea {
               anchors.fill: cardBackground
-              acceptedButtons: Qt.RightButton
+              acceptedButtons: Qt.LeftButton | Qt.RightButton
               hoverEnabled: true
               onEntered: card.hoverCount++
               onExited: card.hoverCount--
               onClicked: {
                 if (mouse.button === Qt.RightButton) {
                   animateOut();
+			    }
+                else if (mouse.button === Qt.LeftButton) {
+                  var actions = model.actionsJson ? JSON.parse(model.actionsJson) : [];
+                  var hasDefault = actions.some(function(a) { return a.identifier === "default" });
+				  if (hasDefault) {
+                    NotificationService.invokeAction(notificationId, "default");
+					animateOut();
+				  }
                 }
               }
-            }
-
+		    }
             // Animation setup
             function triggerEntryAnimation() {
               animInDelayTimer.stop();


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Add left-click support on notification cards. If a notification provides a "default" action, clicking the card triggers it (e.g. opens Telegram). Right-click still dismisses.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
