### PR TITLE
rename bar ipc functions to avoid conflict

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -27,10 +27,10 @@ Item {
     function toggle() {
       BarService.isVisible = !BarService.isVisible;
     }
-    function hide() {
+    function hideBar() {
       BarService.isVisible = false;
     }
-    function show() {
+    function showBar() {
       BarService.isVisible = true;
     }
   }


### PR DESCRIPTION
# Pull Request

## Motivation
`show()` is reserved by quickshell, thus the current implementation of the show function for bar doesnt work.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)