### PR TITLE
use the correct axis when calculating content height

### DIFF
--- a/Modules/Bar/Extras/BarPillVertical.qml
+++ b/Modules/Bar/Extras/BarPillVertical.qml
@@ -64,18 +64,14 @@ Item {
 
   readonly property real iconSize: Style.toOdd(pillHeight * 0.48)
 
-  // Content height calculation (for implicit sizing and visual layout)
+  // Content height calculation (for implicit sizing)
   readonly property real contentHeight: {
     if (collapseToIcon) {
       return hasIcon ? buttonSize : 0;
     }
-    if (revealed) {
-      var overlap = hasIcon ? pillOverlap : 0;
-      var baseHeight = hasIcon ? buttonSize : 0;
-      return baseHeight + Math.max(0, maxPillHeight - overlap);
-    }
-    // Fallback to buttonSize in idle state to remain clickable
-    return buttonSize;
+    var overlap = hasIcon ? pillOverlap : 0;
+    var baseHeight = hasIcon ? buttonSize : 0;
+    return baseHeight + Math.max(0, pill.height - overlap);
   }
 
   // Fill parent width to extend horizontal click area


### PR DESCRIPTION
# Pull Request
Use the correct axis when calculating content height in vertical bar layout. Have removed what i can only assume is legacy code. Also a minor change to the surrounding comment so its in line with its horizontal equivalent.

## Motivation
I noticed the animation was jerky and incorrect when hovering expanding widgets such as brightness or volume.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)