### PR TITLE
Re-sync Bluetooth state after system resume (wake from sleep).

### DIFF
--- a/Services/Networking/BluetoothService.qml
+++ b/Services/Networking/BluetoothService.qml
@@ -241,6 +241,28 @@ Singleton {
     }
   }
 
+  // Re-sync Bluetooth state after system resume (wake from sleep).
+  Connections {
+    target: Time
+    function onResumed() {
+      Logger.i("Bluetooth", "System resumed - power-cycling Bluetooth adapter");
+      btExec(["bluetoothctl", "power", "off"]);
+      resumePowerOnTimer.restart();
+    }
+  }
+
+  Timer {
+    id: resumePowerOnTimer
+    interval: 1500
+    repeat: false
+    onTriggered: {
+      Logger.i("Bluetooth", "Resume power-cycle: powering adapter back on");
+      btExec(["bluetoothctl", "power", "on"]);
+      root.ctlPowered = true;
+      requestCtlPoll(ctlPollSoonMs);
+    }
+  }
+
   Process {
     id: checkWifiBlocked
     running: false


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Fixed an issue where Bluetooth remains disabled or unresponsive after the system wakes from sleep. 

The root cause was a deadlock in [BluetoothService.qml] the periodic polling timer (`ctlPollTimer`) only runs when `root.enabled` is true. After sleep, the adapter often briefly reports as disabled, which stops the timer and creates a state where nothing triggers a re-check. Additionally, the adapter can sometimes report as "Powered: yes" while remaining unresponsive.

This PR implements an unconditional power cycle (off → 1.5s delay → on) on every system resume, simulating the manual toggle that reliably resolves the issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1750

## Testing
- [x] Verified by user: Confirmed that an unconditional power cycle fixes the unresponsive state after wake.
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway

## Screenshots / Videos
N/A (Logic change)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
The power cycle uses `Time.resumed` (time-jump detection) which is already used by `DarkModeService` and `NightLightService` for reliable post-sleep recovery.