### PR TITLE
Hide NDivider in bar settings panel if not needed

### DIFF
--- a/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
@@ -284,6 +284,7 @@ ColumnLayout {
   NDivider {
     Layout.fillWidth: true
     Layout.topMargin: Style.marginS
+    visible: Settings.data.bar.displayMode === "auto_hide"
   }
 
   ColumnLayout {


### PR DESCRIPTION
This is a small issue but there is a NDivider at the bottom of the Bar/Appearance settings that shouldn't be visible always.