### PR TITLE
fix: mark skipped changelogs as seen

### DIFF
--- a/Services/Noctalia/UpdateService.qml
+++ b/Services/Noctalia/UpdateService.qml
@@ -304,11 +304,7 @@ Singleton {
 
   function showLatestChangelog() {
     if (!currentVersion)
-      return;
-
-    if (!Settings.data.general.showChangelogOnStartup) {
-      return;
-    }
+      return; 
 
     if (!changelogStateLoaded) {
       pendingShowRequest = true;
@@ -321,6 +317,12 @@ Singleton {
 
     if (lastSeen === target)
       return;
+
+    if (!Settings.data.general.showChangelogOnStartup) {
+      // user has opted out of seeing changelogs, mark as seen
+      markChangelogSeen(target);
+      return;
+    }
 
     changelogFromVersion = lastSeen;
     changelogToVersion = target;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

marks skipped changelogs as seen - otherwise telemetry wizard appears every time if general.showChangelogOnStartup = false since shell-state changelogState.lastSeenVersion is never updated from ""

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1663 #1576

## Testing
Describe how you tested your changes and mark the relevant items.

tested that telemetry popup still shows on first launch but not subsequent ones with general.showChangelogOnStartup set to false

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
