### PR TITLE
Added tracking to wallpaper randomizer

### DIFF
--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -80,6 +80,7 @@ Singleton {
       }
     }
     function onEnableMultiMonitorDirectoriesChanged() {
+      root.usedRandomWallpapers = {};
       root.refreshWallpapersList();
       // Notify all monitors about potential directory changes
       for (var i = 0; i < Quickshell.screens.length; i++) {


### PR DESCRIPTION
# Pull Request

## Motivation
The wallpaper randomizer used pure random selection, which meant the same wallpapers could appear multiple times before others were shown (I actually saw this happen). This change tracks wallpapers that have been displayed in the current cycle and only resets the pool once all images have been shown at least once, even across reboots. This provides a better user experience by ensuring variety without losing the randomness.

**Implementation details:**
- Tracks used wallpapers globally or per screen
- Persists state to cache file across reboots
- Maintains last-shown wallpaper when resetting to prevent immediate back-to-back repeats

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
None

## Testing
I tested this on single- and multi-monitor setups.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
None.