### PR TITLE
style: add Material Design 3 easing curve constants

### DIFF
--- a/Commons/Style.qml
+++ b/Commons/Style.qml
@@ -76,6 +76,12 @@ Singleton {
   readonly property int animationSlow: (Settings.data.general.animationDisabled || PowerProfileService.noctaliaPerformanceMode) ? 0 : Math.round(450 / Settings.data.general.animationSpeed)
   readonly property int animationSlowest: (Settings.data.general.animationDisabled || PowerProfileService.noctaliaPerformanceMode) ? 0 : Math.round(750 / Settings.data.general.animationSpeed)
 
+  // Animation easing curves (Material Design 3)
+  readonly property int easingType: Easing.BezierSpline
+  readonly property var easingCurve: [0.2, 0, 0, 1] // M3 emphasized
+  readonly property var easingCurveEnter: [0.05, 0.7, 0.1, 1] // M3 emphasizedDecelerate
+  readonly property var easingCurveExit: [0.3, 0, 0.8, 0.15] // M3 emphasizedAccelerate
+
   // Delays
   readonly property int tooltipDelay: 300
   readonly property int tooltipDelayLong: 1200


### PR DESCRIPTION
This adds the standard Material Design 3 easing curves as constants in Style.qml.

M3 defines specific bezier curves for different animation scenarios,  emphasized for general use, emphasizedDecelerate for elements entering the screen, and emphasizedAccelerate for elements exiting. Having these as shared constants means components can use them without hardcoding the bezier values everywhere.

The change is just 6 lines of readonly properties. Nothing existing is modified and there's no performance impact since these are just constants sitting there until something decides to use them.

Reference: https://m3.material.io/styles/motion/easing-and-duration