### PR TITLE
Plugin hot-reload update

### DIFF
--- a/Services/Noctalia/PluginService.qml
+++ b/Services/Noctalia/PluginService.qml
@@ -1749,7 +1749,7 @@ Singleton {
         import qs.Commons
 
         Item {
-            id: qmlWatcher
+            id: root
             signal fileChanged();
 
             Process {
@@ -1758,7 +1758,7 @@ Singleton {
                 stdout: SplitParser {
                     splitMarker: "\n"
                     onRead: line => {
-                        fileWatcher.createObject(qmlWatcher, { path: Qt.resolvedUrl(line) });
+                        fileWatcher.createObject(root, { path: Qt.resolvedUrl(line) });
                     }
                 }
             }
@@ -1769,7 +1769,7 @@ Singleton {
                     watchChanges: true
 
                     onFileChanged: {
-                        qmlWatcher.fileChanged();
+                        root.fileChanged();
                     }
                 }
             }


### PR DESCRIPTION
# Pull Request

## Motivation
Since a lot of plugins use multiple and different qml / js files to organize the code this PR adds the ability to create multiple watchers for all the qml and js files in the plugin folder. This reduces the time that is needed for plugin developers to either go into one of the entrypoint files and save there or restart the shell from the start. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1719 

## Testing
I've tested the plugin by going into the video-wallpaper plugin folder and saving some of the files that aren't included in the entrypoints and the plugin reloaded correctly. 

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
I'm not sure how to show this with screenshots or videos.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Some ideas for the future that Lemmy suggested, would be to maybe add individual debug buttons for each plugin, so that "NOCTALIA_DEBUG=1" isn't needed. 