### PR TITLE
ActiveWindow: per-screen focus tracking (sway) & instant updates

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -35,7 +35,9 @@
       "hide-mode-description": "Controls how the widget behaves when no window is active.",
       "scrolling-mode-description": "Control when text scrolling is enabled for long window titles.",
       "show-app-icon-description": "Display the application icon next to the window title.",
-      "show-app-icon-label": "Show app icon"
+      "show-app-icon-label": "Show app icon",
+      "per-screen-label": "Per-screen focus",
+      "per-screen-description": "Show the focused window for this screen only, instead of the globally focused window."
     },
     "audio-visualizer": {
       "color-name-description": "Select the color for the visualizer.",

--- a/Modules/Bar/Widgets/ActiveWindow.qml
+++ b/Modules/Bar/Widgets/ActiveWindow.qml
@@ -48,14 +48,26 @@ Item {
   readonly property bool useFixedWidth: (widgetSettings.useFixedWidth !== undefined) ? widgetSettings.useFixedWidth : (widgetMetadata.useFixedWidth || false)
   readonly property string textColorKey: (widgetSettings.textColor !== undefined) ? widgetSettings.textColor : widgetMetadata.textColor
   readonly property color textColor: Color.resolveColorKey(textColorKey)
+  readonly property bool perScreen: (widgetSettings.perScreen !== undefined) ? widgetSettings.perScreen : (widgetMetadata.perScreen !== undefined ? widgetMetadata.perScreen : true)
 
   readonly property string barPosition: Settings.getBarPositionForScreen(screenName)
   readonly property bool isVerticalBar: barPosition === "left" || barPosition === "right"
   readonly property real barHeight: Style.getBarHeightForScreen(screenName)
   readonly property real capsuleHeight: Style.getCapsuleHeightForScreen(screenName)
   readonly property real barFontSize: Style.getBarFontSizeForScreen(screenName)
-  readonly property bool hasFocusedWindow: CompositorService.getFocusedWindow() !== null
-  readonly property string windowTitle: CompositorService.getFocusedWindowTitle() || "No active window"
+
+  // Revision counter incremented on focus/window-list signals to trigger binding re-evaluation
+  property int _focusRevision: 0
+
+  readonly property bool hasFocusedWindow: {
+    void (_focusRevision);
+    return perScreen ? CompositorService.getFocusedWindowForScreen(screenName) !== null : CompositorService.getFocusedWindow() !== null;
+  }
+  readonly property string windowTitle: {
+    void (_focusRevision);
+    return (perScreen ? CompositorService.getFocusedWindowTitleForScreen(screenName) : CompositorService.getFocusedWindowTitle()) || "No active window";
+  }
+
   readonly property int iconSize: Style.toOdd(capsuleHeight * 0.75)
   readonly property int verticalSize: Style.toOdd(capsuleHeight * 0.85)
 
@@ -126,9 +138,11 @@ Item {
   }
 
   function getAppIcon() {
+    // Force re-evaluation when focus revision changes
+    void (_focusRevision);
+
     try {
-      // Try CompositorService first
-      const focusedWindow = CompositorService.getFocusedWindow();
+      const focusedWindow = perScreen ? CompositorService.getFocusedWindowForScreen(screenName) : CompositorService.getFocusedWindow();
       if (focusedWindow && focusedWindow.appId) {
         try {
           const idValue = focusedWindow.appId;
@@ -355,20 +369,10 @@ Item {
   Connections {
     target: CompositorService
     function onActiveWindowChanged() {
-      try {
-        windowIcon.source = Qt.binding(getAppIcon);
-        windowIconVertical.source = Qt.binding(getAppIcon);
-      } catch (e) {
-        Logger.w("ActiveWindow", "Error in onActiveWindowChanged:", e);
-      }
+      _focusRevision++;
     }
     function onWindowListChanged() {
-      try {
-        windowIcon.source = Qt.binding(getAppIcon);
-        windowIconVertical.source = Qt.binding(getAppIcon);
-      } catch (e) {
-        Logger.w("ActiveWindow", "Error in onWindowListChanged:", e);
-      }
+      _focusRevision++;
     }
   }
 }

--- a/Modules/Bar/Widgets/ActiveWindow.qml
+++ b/Modules/Bar/Widgets/ActiveWindow.qml
@@ -56,8 +56,6 @@ Item {
   readonly property real barFontSize: Style.getBarFontSizeForScreen(screenName)
   readonly property bool hasFocusedWindow: CompositorService.getFocusedWindow() !== null
   readonly property string windowTitle: CompositorService.getFocusedWindowTitle() || "No active window"
-  readonly property string fallbackIcon: "user-desktop"
-
   readonly property int iconSize: Style.toOdd(capsuleHeight * 0.75)
   readonly property int verticalSize: Style.toOdd(capsuleHeight * 0.85)
 
@@ -163,10 +161,11 @@ Item {
         }
       }
 
-      return ThemeIcons.iconFromName(fallbackIcon);
+      // No focused window -- return empty string to avoid fallback icon lookup warnings
+      return "";
     } catch (e) {
       Logger.w("ActiveWindow", "Error in getAppIcon:", e);
-      return ThemeIcons.iconFromName(fallbackIcon);
+      return "";
     }
   }
 

--- a/Modules/Panels/Settings/Bar/WidgetSettings/ActiveWindowSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/ActiveWindowSettings.qml
@@ -22,6 +22,7 @@ ColumnLayout {
   property bool valueUseFixedWidth: widgetData.useFixedWidth !== undefined ? widgetData.useFixedWidth : widgetMetadata.useFixedWidth
   property bool valueColorizeIcons: widgetData.colorizeIcons !== undefined ? widgetData.colorizeIcons : widgetMetadata.colorizeIcons
   property string valueTextColor: widgetData.textColor !== undefined ? widgetData.textColor : widgetMetadata.textColor
+  property bool valuePerScreen: widgetData.perScreen !== undefined ? widgetData.perScreen : widgetMetadata.perScreen
 
   Component.onCompleted: {
     if (widgetData && widgetData.hideMode !== undefined) {
@@ -38,6 +39,7 @@ ColumnLayout {
     settings.useFixedWidth = valueUseFixedWidth;
     settings.colorizeIcons = valueColorizeIcons;
     settings.textColor = valueTextColor;
+    settings.perScreen = valuePerScreen;
     return settings;
   }
 
@@ -64,6 +66,17 @@ ColumnLayout {
                   root.valueHideMode = key;
                   settingsChanged(saveSettings());
                 }
+  }
+
+  NToggle {
+    Layout.fillWidth: true
+    label: I18n.tr("bar.active-window.per-screen-label")
+    description: I18n.tr("bar.active-window.per-screen-description")
+    checked: root.valuePerScreen
+    onToggled: checked => {
+                 root.valuePerScreen = checked;
+                 settingsChanged(saveSettings());
+               }
   }
 
   NComboBox {

--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -347,6 +347,30 @@ Singleton {
     return "";
   }
 
+  // Get focused window for a specific screen/output (per-output tracking)
+  function getFocusedWindowForScreen(screenName) {
+    if (backend && backend.getFocusedWindowForScreen) {
+      return backend.getFocusedWindowForScreen(screenName);
+    }
+    return getFocusedWindow();
+  }
+
+  // Get focused window title for a specific screen/output
+  function getFocusedWindowTitleForScreen(screenName) {
+    if (backend && backend.getFocusedWindowForScreen) {
+      const win = backend.getFocusedWindowForScreen(screenName);
+      if (win) {
+        var title = win.title;
+        if (title !== undefined) {
+          title = title.replace(/(\r\n|\n|\r)/g, "");
+        }
+        return title || "";
+      }
+      return "";
+    }
+    return getFocusedWindowTitle();
+  }
+
   // Get clean app name from appId
   // Extracts the last segment from reverse domain notation (e.g., "org.kde.dolphin" -> "Dolphin")
   // Falls back to title if appId is empty

--- a/Services/Compositor/SwayService.qml
+++ b/Services/Compositor/SwayService.qml
@@ -32,6 +32,9 @@ Item {
   // Track window usage counts per workspace to handle duplicates
   property var windowUsageCountsPerWorkspace: ({})
 
+  // Per-output focused window tracking: maps output name -> { appId, title, handle }
+  property var focusedWindowPerOutput: ({})
+
   // Initialization
   function initialize() {
     if (initialized)
@@ -44,6 +47,7 @@ Item {
                      queryWindowWorkspaces();
                      queryDisplayScales();
                      queryKeyboardLayout();
+                     updateFocusedWindowPerOutput();
                    });
       initialized = true;
       Logger.i("SwayService", "Service started");
@@ -82,6 +86,8 @@ Item {
         const treeData = JSON.parse(accumulatedOutput);
         const newMap = {};
         const workspaceWindows = {}; // Track windows per workspace
+        let treeHasFocusedWindow = false;
+        let focusedWorkspaceNum = -1;
 
         // Recursively find all windows and their workspaces
         function traverseTree(node, workspaceNum) {
@@ -94,10 +100,15 @@ Item {
             if (!workspaceWindows[workspaceNum]) {
               workspaceWindows[workspaceNum] = [];
             }
+            if (node.focused)
+              focusedWorkspaceNum = workspaceNum;
           }
 
           // If this is a container with app_id or class (i.e., a window)
           if (node.type === "con" && (node.app_id || node.window_properties)) {
+            if (node.focused)
+              treeHasFocusedWindow = true;
+
             const appId = node.app_id || (node.window_properties ? node.window_properties.class : null);
             const title = node.name || "";
             const id = node.id;
@@ -156,6 +167,25 @@ Item {
         }
 
         windowWorkspaceMap = newMap;
+
+        // Sync per-output focus with the tree's actual focus state
+        const monName = I3.focusedMonitor ? I3.focusedMonitor.name : "";
+        const focusedWsEmpty = focusedWorkspaceNum >= 0 && (!workspaceWindows[focusedWorkspaceNum] || workspaceWindows[focusedWorkspaceNum].length === 0);
+        if (monName) {
+          if (!treeHasFocusedWindow && focusedWsEmpty) {
+            // Truly empty workspace: clear the per-output focus
+            if (focusedWindowPerOutput[monName]) {
+              const newFocusMap = Object.assign({}, focusedWindowPerOutput);
+              delete newFocusMap[monName];
+              focusedWindowPerOutput = newFocusMap;
+              activeWindowChanged();
+            }
+          } else if (!focusedWindowPerOutput[monName]) {
+            // Window is focused but entry was cleared: restore it
+            updateFocusedWindowPerOutput();
+            activeWindowChanged();
+          }
+        }
 
         // Update windows with new workspace information
         Qt.callLater(safeUpdateWindows);
@@ -349,6 +379,20 @@ Item {
 
       windows = windowsList;
 
+      // Validate per-output map: remove entries whose handles are no longer alive
+      const currentHandles = new Set(hlToplevels);
+      const newMap = Object.assign({}, focusedWindowPerOutput);
+      let mapChanged = false;
+      for (const output in newMap) {
+        if (newMap[output] && newMap[output].handle && !currentHandles.has(newMap[output].handle)) {
+          delete newMap[output];
+          mapChanged = true;
+        }
+      }
+      if (mapChanged) {
+        focusedWindowPerOutput = newMap;
+      }
+
       if (newFocusedIndex !== focusedWindowIndex) {
         focusedWindowIndex = newFocusedIndex;
         activeWindowChanged();
@@ -358,6 +402,55 @@ Item {
     } catch (e) {
       Logger.e("SwayService", "Error updating windows:", e);
     }
+  }
+
+  // Update per-output focused window map from the current activeToplevel
+  function updateFocusedWindowPerOutput() {
+    try {
+      const active = ToplevelManager.activeToplevel;
+      const newMap = Object.assign({}, focusedWindowPerOutput);
+
+      if (active) {
+        // Determine which output this toplevel is on
+        let outputName = "";
+        if (active.screens && active.screens.length > 0) {
+          outputName = active.screens[0].name;
+        }
+        if (!outputName && I3.focusedMonitor) {
+          outputName = I3.focusedMonitor.name;
+        }
+        if (outputName) {
+          newMap[outputName] = {
+            appId: getAppId(active),
+            title: safeGetProperty(active, "title", ""),
+            handle: active
+          };
+        }
+      }
+      // Note: we intentionally do NOT clear on null activeToplevel here.
+      // Transient null states occur when focus moves between windows/workspaces.
+      // The tree query (queryWindowWorkspaces) handles clearing for truly empty workspaces.
+
+      focusedWindowPerOutput = newMap;
+    } catch (e) {
+      Logger.e("SwayService", "Error updating per-output focus:", e);
+    }
+  }
+
+  // Get focused window data for a specific screen/output
+  function getFocusedWindowForScreen(screenName) {
+    if (!screenName)
+      return null;
+    const entry = focusedWindowPerOutput[screenName];
+    if (entry && entry.handle) {
+      // Return live title from the handle so unfocused screens stay current
+      return {
+        appId: entry.appId,
+        title: safeGetProperty(entry.handle, "title", entry.title),
+        handle: entry.handle
+      };
+    }
+    return null;
   }
 
   // Extract window data safely from a toplevel
@@ -479,6 +572,7 @@ Item {
     enabled: initialized
     function onActiveToplevelChanged() {
       safeUpdateWindows();
+      updateFocusedWindowPerOutput();
       activeWindowChanged();
     }
   }
@@ -489,6 +583,10 @@ Item {
     enabled: initialized && ToplevelManager.activeToplevel !== null
     function onTitleChanged() {
       safeUpdateWindows();
+      // Do NOT call updateFocusedWindowPerOutput() here: the I3.focusedMonitor
+      // fallback can assign this window to the wrong output when focus is on
+      // an empty workspace.  getFocusedWindowForScreen() reads the live title
+      // from the handle, so the cached snapshot doesn't need refreshing.
       activeWindowChanged();
     }
   }
@@ -501,6 +599,11 @@ Item {
         safeUpdateWorkspaces();
         workspaceChanged();
         Qt.callLater(queryWindowWorkspaces);
+
+        // Window events include title changes; notify so per-output
+        // widgets re-read the live title from the handle.
+        if (event.type === "window")
+          activeWindowChanged();
       }
 
       if (event.type === "output") {

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -83,7 +83,8 @@ Singleton {
                                     "maxWidth": 145,
                                     "useFixedWidth": false,
                                     "colorizeIcons": false,
-                                    "textColor": "none"
+                                    "textColor": "none",
+                                    "perScreen": true
                                   },
                                   "AudioVisualizer": {
                                     "width": 200,


### PR DESCRIPTION
# Pull Request

- I used AI to create these changes, and as such, probably missed some of the implementation nuance. However, I've thoroughly tested the feature on my multi-monitor sway setup and it seems to work well. Feel free to close on that basis.


<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This PR changes the ActiveWindow widget, mainly on sway, to:
- increase the update speed by removing the debounce timer
- add an option to do focus tracking per-screen (just like on waybar)
- properly hide when an empty workspace is selected
- also update the widget when the relevant window changes its title
- remove the user-desktop fallback icon, since it doesn't load for me and the widget auto-hides when it would be shown.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
- The per-screen focus setting does nothing on other WMs, which might be an issue.