### PR TITLE
fix: Use explicit hardware backends to avoid dGPU wakeup

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -5,6 +5,9 @@
 * but proper credit must be given to the original author.
 */
 
+//@ pragma Env QT_FFMPEG_DECODING_HW_DEVICE_TYPES=vaapi,vdpau
+//@ pragma Env QT_FFMPEG_ENCODING_HW_DEVICE_TYPES=vaapi,vdpau
+
 // Qt & Quickshell Core
 import QtQuick
 import Quickshell


### PR DESCRIPTION
For an explanation of these two variables, see: https://doc.qt.io/qt-6/advanced-ffmpeg-configuration.html#configure-hardware-acceleration-in-backends

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1765

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
