### PR TITLE
fix(hyprland): emit workspaceChanged signal when toplevels update #1436

### DIFF
--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -160,6 +160,7 @@ Item {
   function safeUpdate() {
     safeUpdateWindows();
     safeUpdateWorkspaces();
+    workspaceChanged();
     windowListChanged();
   }
 
@@ -410,6 +411,7 @@ Item {
     enabled: initialized
     function onRawEvent(event) {
       Hyprland.refreshWorkspaces();
+      Hyprland.refreshToplevels();
       safeUpdateWorkspaces();
       workspaceChanged();
       updateTimer.restart();


### PR DESCRIPTION
## Motivation

When Hyprland toplevels change (a window opens silently on another workspace), safeUpdate() updated workspace occupancy on the backend but never emitted workspaceChanged(), so CompositorService never synced the updated data to the UI. This caused workspace indicators to disappear for windows like Steam that open silently with a splash screen followed by a main window.

## Type of Change

Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

- Closes [#1436](https://github.com/noctalia-dev/noctalia-shell/issues/1436)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
