### PR TITLE
Hide tooltip when clicking on Pill widget

### DIFF
--- a/Modules/Bar/Extras/BarPillHorizontal.qml
+++ b/Modules/Bar/Extras/BarPillHorizontal.qml
@@ -287,14 +287,15 @@ Item {
       TooltipService.hide();
     }
     onClicked: mouse => {
-                 if (mouse.button === Qt.LeftButton) {
-                   root.clicked();
-                 } else if (mouse.button === Qt.RightButton) {
-                   root.rightClicked();
-                 } else if (mouse.button === Qt.MiddleButton) {
-                   root.middleClicked();
-                 }
-               }
+      TooltipService.hide();
+      if (mouse.button === Qt.LeftButton) {
+        root.clicked();
+      } else if (mouse.button === Qt.RightButton) {
+        root.rightClicked();
+      } else if (mouse.button === Qt.MiddleButton) {
+        root.middleClicked();
+      }
+    }
     onWheel: wheel => root.wheel(wheel.angleDelta.y)
   }
 

--- a/Modules/Bar/Extras/BarPillVertical.qml
+++ b/Modules/Bar/Extras/BarPillVertical.qml
@@ -324,14 +324,15 @@ Item {
       TooltipService.hide();
     }
     onClicked: mouse => {
-                 if (mouse.button === Qt.LeftButton) {
-                   root.clicked();
-                 } else if (mouse.button === Qt.RightButton) {
-                   root.rightClicked();
-                 } else if (mouse.button === Qt.MiddleButton) {
-                   root.middleClicked();
-                 }
-               }
+      TooltipService.hide();
+      if (mouse.button === Qt.LeftButton) {
+        root.clicked();
+      } else if (mouse.button === Qt.RightButton) {
+        root.rightClicked();
+      } else if (mouse.button === Qt.MiddleButton) {
+        root.middleClicked();
+      }
+    }
     onWheel: wheel => root.wheel(wheel.angleDelta.y)
   }
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Previously, when clicking on a pill, the tooltip would not get dismissed leading to a rather cluttered looking UI. This change brings it in line with non pill bar based widgets like calendar and system monitor. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri

## Screenshots / Videos

https://github.com/user-attachments/assets/43d3ea53-3527-4e14-9af1-1a3b61944f70


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Also fixed the formatting for the onClicked method.