### PR TITLE
SystemMonitor: Add option to pad the text

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -224,7 +224,11 @@
       "swap-usage-description": "Swap-Speichernutzung anzeigen.",
       "swap-usage-label": "Swap-Auslastung",
       "use-monospace-font-description": "Verwende eine Monospace-Schriftart für eine konsistente Zeichenbreite.",
-      "use-monospace-font-label": "Schriftart mit fester Breite"
+      "use-monospace-font-label": "Schriftart mit fester Breite",
+      "use-padding-description": "Füllt die Textwerte mit Leerzeichen auf. Verhindert Layoutverschiebungen.",
+      "use-padding-description-disabled-monospace-font": "Eine Monospace-Schriftart ist notwendig, um dieses Option wählen zu können.",
+      "use-padding-description-disabled-vertical": "Vertikale Taskleiste unterstützt keine Titelanzeige.",
+      "use-padding-label": "Text mit führenden Leerzeichen auffüllen"
     },
     "taskbar": {
       "colorize-icons-description": "Themenfarben auf Taskbar-Symbole anwenden.",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -224,7 +224,11 @@
       "swap-usage-description": "Show swap memory usage.",
       "swap-usage-label": "Swap usage",
       "use-monospace-font-description": "Use monospace font for consistent character width.",
-      "use-monospace-font-label": "Monospace font"
+      "use-monospace-font-label": "Monospace font",
+      "use-padding-description": "Pads the text values with leading spaces to prevent layout shifting.",
+      "use-padding-description-disabled-monospace-font": "A monospace font is needed for this feature.",
+      "use-padding-description-disabled-vertical": "Vertical taskbar does not support padding text.",
+      "use-padding-label": "Pad text"
     },
     "taskbar": {
       "colorize-icons-description": "Apply theme colors to taskbar icons.",

--- a/Assets/settings-widgets-default.json
+++ b/Assets/settings-widgets-default.json
@@ -146,6 +146,7 @@
       "iconColor": "none",
       "textColor": "none",
       "useMonospaceFont": true,
+      "usePadding": false,
       "showCpuUsage": true,
       "showCpuFreq": false,
       "showCpuTemp": true,

--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -44,6 +44,7 @@ Item {
   readonly property string textColorKey: widgetSettings.textColor !== undefined ? widgetSettings.textColor : widgetMetadata.textColor
 
   readonly property bool useMonospaceFont: widgetSettings.useMonospaceFont !== undefined ? widgetSettings.useMonospaceFont : widgetMetadata.useMonospaceFont
+  readonly property bool usePadding: !compactMode && !isVertical && useMonospaceFont && (widgetSettings.usePadding !== undefined) ? widgetSettings.usePadding : widgetMetadata.usePadding
   readonly property bool showCpuUsage: (widgetSettings.showCpuUsage !== undefined) ? widgetSettings.showCpuUsage : widgetMetadata.showCpuUsage
   readonly property bool showCpuFreq: (widgetSettings.showCpuFreq !== undefined) ? widgetSettings.showCpuFreq : widgetMetadata.showCpuFreq
   readonly property bool showCpuTemp: (widgetSettings.showCpuTemp !== undefined) ? widgetSettings.showCpuTemp : widgetMetadata.showCpuTemp
@@ -58,6 +59,11 @@ Item {
   readonly property bool showLoadAverage: (widgetSettings.showLoadAverage !== undefined) ? widgetSettings.showLoadAverage : widgetMetadata.showLoadAverage
   readonly property string diskPath: (widgetSettings.diskPath !== undefined) ? widgetSettings.diskPath : widgetMetadata.diskPath
   readonly property string fontFamily: useMonospaceFont ? Settings.data.ui.fontFixed : Settings.data.ui.fontDefault
+
+  readonly property int paddingPercent: usePadding ? String("100%").length : 0
+  readonly property int paddingTemp: usePadding ? String("999°").length : 0
+  readonly property int paddingCpuFreq: usePadding ? String("9.9GHz").length : 0
+  readonly property int paddingSpeed: usePadding ? String("9999G").length : 0
 
   readonly property real iconSize: Style.toOdd(capsuleHeight * 0.48)
   readonly property real miniGaugeWidth: Math.max(3, Style.toOdd(root.iconSize * 0.25))
@@ -259,7 +265,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: `${Math.round(SystemStatService.cpuUsage)}%`
+            text: `${Math.round(SystemStatService.cpuUsage)}%`.padStart(paddingPercent, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -327,7 +333,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: SystemStatService.cpuFreq.replace(" ", "")
+            text: SystemStatService.cpuFreq.replace(" ", "").padStart(paddingCpuFreq, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -395,7 +401,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: `${Math.round(SystemStatService.cpuTemp)}°`
+            text: `${Math.round(SystemStatService.cpuTemp)}°`.padStart(paddingTemp, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -463,7 +469,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: `${Math.round(SystemStatService.gpuTemp)}°`
+            text: `${Math.round(SystemStatService.gpuTemp)}°`.padStart(paddingTemp, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -531,7 +537,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: SystemStatService.loadAvg1.toFixed(1)
+            text: `${SystemStatService.loadAvg1.toFixed(1)}`.padStart(usePadding ? `${SystemStatService.nproc.toFixed(1)}`.length : 0, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -599,7 +605,10 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: showMemoryAsPercent ? `${Math.round(SystemStatService.memPercent)}%` : SystemStatService.formatGigabytes(SystemStatService.memGb)
+            text: SystemStatService.formatRamDisplay({
+                                                       percent: showMemoryAsPercent,
+                                                       padding: usePadding
+                                                     })
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -667,7 +676,11 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: `${Math.round(SystemStatService.swapPercent)}%`
+            text: SystemStatService.formatRamDisplay({
+                                                       swap: true,
+                                                       percent: true,
+                                                       padding: usePadding
+                                                     })
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -734,7 +747,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: isVertical ? SystemStatService.formatCompactSpeed(SystemStatService.rxSpeed) : SystemStatService.formatSpeed(SystemStatService.rxSpeed)
+            text: isVertical ? SystemStatService.formatCompactSpeed(SystemStatService.rxSpeed) : SystemStatService.formatSpeed(SystemStatService.rxSpeed).padStart(paddingSpeed, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -800,7 +813,7 @@ Item {
           // Text mode
           NText {
             visible: !compactMode
-            text: isVertical ? SystemStatService.formatCompactSpeed(SystemStatService.txSpeed) : SystemStatService.formatSpeed(SystemStatService.txSpeed)
+            text: isVertical ? SystemStatService.formatCompactSpeed(SystemStatService.txSpeed) : SystemStatService.formatSpeed(SystemStatService.txSpeed).padStart(paddingSpeed, " ")
             family: fontFamily
             pointSize: barFontSize
             applyUiScale: false
@@ -869,7 +882,8 @@ Item {
             visible: !compactMode
             text: SystemStatService.formatDiskDisplay(diskPath, {
                                                         percent: showDiskUsageAsPercent,
-                                                        available: showDiskAvailable
+                                                        available: showDiskAvailable,
+                                                        padding: usePadding
                                                       })
             family: fontFamily
             pointSize: barFontSize

--- a/Modules/Panels/Settings/Bar/WidgetSettings/SystemMonitorSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/SystemMonitorSettings.qml
@@ -15,11 +15,14 @@ ColumnLayout {
 
   signal settingsChanged(var settings)
 
+  readonly property bool isVerticalBar: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
+
   // Local, editable state for checkboxes
   property bool valueCompactMode: widgetData.compactMode !== undefined ? widgetData.compactMode : widgetMetadata.compactMode
   property string valueIconColor: widgetData.iconColor !== undefined ? widgetData.iconColor : widgetMetadata.iconColor
   property string valueTextColor: widgetData.textColor !== undefined ? widgetData.textColor : widgetMetadata.textColor
   property bool valueUseMonospaceFont: widgetData.useMonospaceFont !== undefined ? widgetData.useMonospaceFont : widgetMetadata.useMonospaceFont
+  property bool valueUsePadding: isVerticalBar ? false : widgetData.usePadding !== undefined ? widgetData.usePadding : widgetMetadata.usePadding
   property bool valueShowCpuUsage: widgetData.showCpuUsage !== undefined ? widgetData.showCpuUsage : widgetMetadata.showCpuUsage
   property bool valueShowCpuFreq: widgetData.showCpuFreq !== undefined ? widgetData.showCpuFreq : widgetMetadata.showCpuFreq
   property bool valueShowCpuTemp: widgetData.showCpuTemp !== undefined ? widgetData.showCpuTemp : widgetMetadata.showCpuTemp
@@ -40,6 +43,7 @@ ColumnLayout {
     settings.iconColor = valueIconColor;
     settings.textColor = valueTextColor;
     settings.useMonospaceFont = valueUseMonospaceFont;
+    settings.usePadding = valueUsePadding;
     settings.showCpuUsage = valueShowCpuUsage;
     settings.showCpuFreq = valueShowCpuFreq;
     settings.showCpuTemp = valueShowCpuTemp;
@@ -103,6 +107,19 @@ ColumnLayout {
                  settingsChanged(saveSettings());
                }
     visible: !valueCompactMode
+  }
+
+  NToggle {
+    Layout.fillWidth: true
+    label: I18n.tr("bar.system-monitor.use-padding-label")
+    description: isVerticalBar ? I18n.tr("bar.system-monitor.use-padding-description-disabled-vertical") : !valueUseMonospaceFont ? I18n.tr("bar.system-monitor.use-padding-description-disabled-monospace-font") : I18n.tr("bar.system-monitor.use-padding-description")
+    checked: valueUsePadding
+    onToggled: checked => {
+                 valueUsePadding = checked;
+                 settingsChanged(saveSettings());
+               }
+    visible: !valueCompactMode
+    enabled: !isVerticalBar && valueUseMonospaceFont
   }
 
   NToggle {

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -222,6 +222,7 @@ Singleton {
                                     "iconColor": "none",
                                     "textColor": "none",
                                     "useMonospaceFont": true,
+                                    "usePadding": false,
                                     "showCpuUsage": true,
                                     "showCpuFreq": false,
                                     "showCpuTemp": true,


### PR DESCRIPTION
# Pull Request

This option is only shown if compact mode is off and a monospace font is enabled. If the bar is vertical the setting will be ignored. Everything should not shift and the width is calculated from the maximum value (which can be system dependent).

## Motivation

This PR adds the option to have the text values of the SystemMonitor padded with leading spaces.
This is done to prevent the layout to shift.
Some people have it easier to parse the number instead of the bars from the compact mode.
Having the numbers without the padding can lead to visual changes that can be distracting.
The setting is not possible if:

- compact mode is enabled (the setting is hidden) -> no text is shown
- the bar is a vertical bar (the setting is disabled) -> using leading padding to the left does not make sense when the icons and values are from top to bottom 
- the font is not monospace (the setting is disabled) -> the bar would start shifting if the letters do not have a fixed size

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1652

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions ~~and density settings~~
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="702" height="242" alt="Screenshot_2026-02-13T01-08-28" src="https://github.com/user-attachments/assets/2d402806-24c6-40a6-bff5-58445ab81b00" />

## Checklist
- [x] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

I have not tested the behavior if nproc and/or loadAvg1 is 0.
I have only provided English and German translations, as those are the two languages I can speak.

This implementation uses the (probable) maximum value for how much a value needs to be padded.
Here are some explanations:

- `100%` is the maximum value of a scale that goes between `0%` and `100%`. Note that a previous version of noctalia-shell used `99%` as the maximum value which dropped the `%` for `100%` values which I think is distracting as well.
- `999°`C is hopefully the maximum value for the temperature of the CPU and GPU. I think it is realistic that it could go above 100°C still, but maybe `99°`C would be a reasonable maximum. If it gets higher than that maybe the bar shifting is a good thing. Otherwise the space will always be there. Also note that my CPU got really hot lately; I don't remember if it got to >= 100°C, but the noctalia-shell made me realise and so I removed all the dust.
- `9.9GHz` for the CPU frequency. I looked at this random website I found: https://valid.x86.fr/records.php
- The number of total CPUs is used for the maximum value of the avarage load. E.g. if someone has 20 CPUs, then the average load could reach up to 20.
- For the network speed I picked `9999G` as the maximum. Usually the text is between 4 (e.g. `20KB`) and 5 (e.g. ) in length.
- For the RAM and disk sizes the code is calculating the maximum value. In the case of RAM it is the total amount of RAM and in the case of a disk it is the total size of the disk.

Maybe it would be better to move the icons to the right side of the numbers when using that setting.
I noticed that when the widget is displayed vertically that the icons are also after the text (when reading from top to bottom).