### PR TITLE
lock screen: add option for media controls

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1271,6 +1271,8 @@
       "clock-style-label": "Clock style",
       "compact-lockscreen-description": "Show only the login input and system controls, hiding weather and media widgets.",
       "compact-lockscreen-label": "Compact lock screen",
+      "enable-lockscreen-media-controls-description": "Show interactive media playback controls on the lock screen.",
+      "enable-lockscreen-media-controls-label": "Lock screen media controls",
       "lock-on-suspend-description": "Automatically lock the screen when suspending the system.",
       "lock-on-suspend-label": "Lock on suspend",
       "lock-screen-animations-description": "Enable or disable lockscreen animations.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -84,6 +84,7 @@
     "lockOnSuspend": true,
     "showSessionButtonsOnLockScreen": true,
     "showHibernateOnLockScreen": false,
+    "enableLockScreenMediaControls": false,
     "enableShadows": true,
     "shadowDirection": "bottom_right",
     "shadowOffsetX": 2,

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -1072,6 +1072,15 @@
     "subTabLabel": "common.appearance"
   },
   {
+    "labelKey": "panels.lock-screen.enable-lockscreen-media-controls-label",
+    "descriptionKey": "panels.lock-screen.enable-lockscreen-media-controls-description",
+    "widget": "NToggle",
+    "tab": 11,
+    "tabLabel": "panels.lock-screen.title",
+    "subTab": 0,
+    "subTabLabel": "common.appearance"
+  },
+  {
     "labelKey": "panels.lock-screen.lock-screen-animations-label",
     "descriptionKey": "panels.lock-screen.lock-screen-animations-description",
     "widget": "NToggle",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -273,6 +273,7 @@ Singleton {
       property bool lockOnSuspend: true
       property bool showSessionButtonsOnLockScreen: true
       property bool showHibernateOnLockScreen: false
+      property bool enableLockScreenMediaControls: false
       property bool enableShadows: true
       property string shadowDirection: "bottom_right"
       property int shadowOffsetX: 2

--- a/Modules/LockScreen/LockScreenPanel.qml
+++ b/Modules/LockScreen/LockScreenPanel.qml
@@ -310,6 +310,124 @@ Item {
                 elide: Text.ElideRight
               }
             }
+
+            // Media controls (when enabled)
+            RowLayout {
+              spacing: Style.marginXS
+              visible: Settings.data.general.enableLockScreenMediaControls
+              Layout.alignment: Qt.AlignHCenter
+
+              Rectangle {
+                width: 28
+                height: 28
+                radius: Math.min(Style.radiusL, width / 2)
+                color: prevButtonArea.containsMouse ? Color.mPrimary : Qt.alpha(Color.mOnSurface, 0.1)
+                visible: MediaService.canGoPrevious
+
+                NIcon {
+                  anchors.centerIn: parent
+                  icon: "media-prev"
+                  pointSize: Style.fontSizeM
+                  color: prevButtonArea.containsMouse ? Color.mOnPrimary : Color.mOnSurface
+
+                  Behavior on color {
+                    ColorAnimation {
+                      duration: Style.animationFast
+                      easing.type: Easing.OutCubic
+                    }
+                  }
+                }
+
+                MouseArea {
+                  id: prevButtonArea
+                  anchors.fill: parent
+                  hoverEnabled: true
+                  cursorShape: Qt.PointingHandCursor
+                  onClicked: MediaService.canGoPrevious ? MediaService.previous() : {}
+                }
+
+                Behavior on color {
+                  ColorAnimation {
+                    duration: Style.animationFast
+                    easing.type: Easing.OutCubic
+                  }
+                }
+              }
+
+              Rectangle {
+                width: 32
+                height: 32
+                radius: Math.min(Style.radiusL, width / 2)
+                color: playPauseButtonArea.containsMouse ? Color.mPrimary : Qt.alpha(Color.mOnSurface, 0.15)
+                visible: MediaService.canPlay || MediaService.canPause
+
+                NIcon {
+                  anchors.centerIn: parent
+                  icon: MediaService.isPlaying ? "media-pause" : "media-play"
+                  pointSize: Style.fontSizeL
+                  color: playPauseButtonArea.containsMouse ? Color.mOnPrimary : Color.mOnSurface
+
+                  Behavior on color {
+                    ColorAnimation {
+                      duration: Style.animationFast
+                      easing.type: Easing.OutCubic
+                    }
+                  }
+                }
+
+                MouseArea {
+                  id: playPauseButtonArea
+                  anchors.fill: parent
+                  hoverEnabled: true
+                  cursorShape: Qt.PointingHandCursor
+                  onClicked: (MediaService.canPlay || MediaService.canPause) ? MediaService.playPause() : {}
+                }
+
+                Behavior on color {
+                  ColorAnimation {
+                    duration: Style.animationFast
+                    easing.type: Easing.OutCubic
+                  }
+                }
+              }
+
+              Rectangle {
+                width: 28
+                height: 28
+                radius: Math.min(Style.radiusL, width / 2)
+                color: nextButtonArea.containsMouse ? Color.mPrimary : Qt.alpha(Color.mOnSurface, 0.1)
+                visible: MediaService.canGoNext
+
+                NIcon {
+                  anchors.centerIn: parent
+                  icon: "media-next"
+                  pointSize: Style.fontSizeM
+                  color: nextButtonArea.containsMouse ? Color.mOnPrimary : Color.mOnSurface
+
+                  Behavior on color {
+                    ColorAnimation {
+                      duration: Style.animationFast
+                      easing.type: Easing.OutCubic
+                    }
+                  }
+                }
+
+                MouseArea {
+                  id: nextButtonArea
+                  anchors.fill: parent
+                  hoverEnabled: true
+                  cursorShape: Qt.PointingHandCursor
+                  onClicked: MediaService.canGoNext ? MediaService.next() : {}
+                }
+
+                Behavior on color {
+                  ColorAnimation {
+                    duration: Style.animationFast
+                    easing.type: Easing.OutCubic
+                  }
+                }
+              }
+            }
           }
         }
 

--- a/Modules/Panels/Settings/Tabs/LockScreen/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/LockScreen/AppearanceSubTab.qml
@@ -77,6 +77,15 @@ ColumnLayout {
   }
 
   NToggle {
+    label: I18n.tr("panels.lock-screen.enable-lockscreen-media-controls-label")
+    description: I18n.tr("panels.lock-screen.enable-lockscreen-media-controls-description")
+    checked: Settings.data.general.enableLockScreenMediaControls
+    onToggled: checked => Settings.data.general.enableLockScreenMediaControls = checked
+    visible: !Settings.data.general.compactLockScreen
+    defaultValue: Settings.getDefaultValue("general.enableLockScreenMediaControls")
+  }
+
+  NToggle {
     label: I18n.tr("panels.lock-screen.lock-screen-animations-label")
     description: I18n.tr("panels.lock-screen.lock-screen-animations-description")
     checked: Settings.data.general.lockScreenAnimations


### PR DESCRIPTION
# Pull Request

Adding a media controls option for the lock screen

## Motivation
Lacking media controls in lock screen ( I like pausing music in the lockscreen for example)

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos


## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I dont really like how it looks with the previous and next buttons, but if you have any ideas I'd be glad to hear them