### PR TITLE
fix(notifications): disable initial layout animations in notification…

### DIFF
--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -33,6 +33,8 @@ SmartPanel {
     }
     property real contentPreferredHeight: Math.min(root.preferredHeight, Math.ceil(calculatedHeight))
 
+    property real layoutWidth: Math.max(1, root.preferredWidth - (Style.marginL * 2))
+
     // State (lazy-loaded with panelContent)
     property var rangeCounts: [0, 0, 0, 0]
     property var lastKnownDate: null  // Track the current date to detect day changes
@@ -264,7 +266,7 @@ SmartPanel {
           property string expandedId: ""
 
           ColumnLayout {
-            width: scrollView.availableWidth
+            width: panelContent.layoutWidth
             spacing: Style.marginM
 
             // Empty state when no notifications
@@ -321,7 +323,7 @@ SmartPanel {
 
               Column {
                 id: notificationColumn
-                width: scrollView.width
+                width: panelContent.layoutWidth
                 spacing: Style.marginM
 
                 Repeater {


### PR DESCRIPTION
… history panel

# Pull Request


## Motivation
Panel open felt sluggish because each notification delegate animated initial geometry changes on creation (height/opacity/y), causing layout thrash before the panel settled. This change limits those animations to removal only, keeping swipe-dismiss behavior intact while making the menu open immediately and align with its content.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/67d3208c-8ad2-4224-811b-6e7be7ee7d0d

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
