### PR TITLE
control-center: open at right-click position on bar

### DIFF
--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -292,12 +292,13 @@ Item {
                          }
                          // Click is on empty bar background - open control center
                          var controlCenterPanel = PanelService.getPanel("controlCenterPanel", screen);
-                         if (Settings.data.controlCenter.position === "close_to_bar_button") {
-                           // Will attempt to open the panel next to the bar button if any.
-                           controlCenterPanel?.toggle(null, "ControlCenter");
-                         } else {
-                           controlCenterPanel?.toggle();
-                         }
+
+                         // Map click position to screen-relative coordinates
+                         // We need to map from bar coordinates to screen coordinates
+                         var screenRelativePos = mapToItem(null, mouse.x, mouse.y);
+
+                         // Pass click position directly
+                         controlCenterPanel?.toggle(null, screenRelativePos);
                          mouse.accepted = true;
                        }
                      }

--- a/Modules/MainScreen/SmartPanel.qml
+++ b/Modules/MainScreen/SmartPanel.qml
@@ -157,7 +157,17 @@ Item {
     PanelService.closedImmediately = false;
 
     if (!buttonItem && buttonName) {
-      buttonItem = BarService.lookupWidget(buttonName, screen.name);
+      // Check if buttonName is actually a point object (click coordinates)
+      if (typeof buttonName === "object" && buttonName.x !== undefined && buttonName.y !== undefined) {
+        root.buttonItem = null;
+        root.buttonPosition = buttonName;
+        root.buttonWidth = 0;
+        root.buttonHeight = 0;
+        root.useButtonPosition = true;
+      } else {
+        // buttonName is a widget name, look it up
+        buttonItem = BarService.lookupWidget(buttonName, screen.name);
+      }
     }
 
     // Validate buttonItem is a valid QML Item with mapToItem function
@@ -201,10 +211,9 @@ Item {
         root.buttonItem = null;
         root.useButtonPosition = false;
       }
-    } else {
-      // No valid button provided: reset button position mode
+    } else if (!root.useButtonPosition) {
+      // No valid button provided and no click position: reset button position mode
       root.buttonItem = null;
-      root.useButtonPosition = false;
     }
 
     // Set isPanelOpen to trigger content loading, but don't show yet


### PR DESCRIPTION
# Pull Request

## Motivation
when right clicking on the bar, it was very annoying (for me at least) that the control center does not open right over it.
I am also adding a .editorconfig file so IDEs can follow the project indentations 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue


## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [X] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Tell me what you think about this, I am unsure about some stuff  ! 
