### PR TITLE
Proper fix for Airplane Mode

### DIFF
--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -423,6 +423,15 @@
     "subTabLabel": "common.bluetooth"
   },
   {
+    "labelKey": "toast.airplane-mode.title",
+    "descriptionKey": null,
+    "widget": "NToggle",
+    "tab": 15,
+    "tabLabel": "panels.connections.title",
+    "subTab": 0,
+    "subTabLabel": "common.wifi"
+  },
+  {
     "labelKey": "common.wifi",
     "descriptionKey": null,
     "widget": "NToggle",

--- a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
@@ -169,11 +169,11 @@ Item {
 
         NDivider {
           Layout.fillWidth: true
-          visible: BluetoothService.enabled
+          visible: BluetoothService.enabled && isDiscoverable
         }
 
         NText {
-          visible: (BluetoothService.enabled && isDiscoverable)
+          visible: BluetoothService.enabled && isDiscoverable
           Layout.fillWidth: true
           text: I18n.tr("panels.connections.bluetooth-discoverable", {
                           hostName: HostService.hostName

--- a/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
@@ -31,13 +31,13 @@ ColumnLayout {
       anchors.margins: Style.marginL
 
       // Airplane Mode Toggle
-      // NToggle {
-      //   Layout.fillWidth: true
-      //   label: I18n.tr("toast.airplane-mode.title")
-      //   icon: Settings.data.network.airplaneModeEnabled ? "plane" : "plane-off"
-      //   checked: Settings.data.network.airplaneModeEnabled
-      //   onToggled: checked => NetworkService.setAirplaneMode(checked)
-      // }
+      NToggle {
+        Layout.fillWidth: true
+        label: I18n.tr("toast.airplane-mode.title")
+        icon: Settings.data.network.airplaneModeEnabled ? "plane" : "plane-off"
+        checked: Settings.data.network.airplaneModeEnabled
+        onToggled: checked => BluetoothService.setAirplaneMode(checked)
+      }
 
       // Wi-Fi Master Control
       NToggle {

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -258,16 +258,6 @@ Singleton {
     wifiStateEnableProcess.running = true;
   }
 
-  function setAirplaneMode(enabled) {
-    if (enabled) {
-      Quickshell.execDetached(["rfkill", "block", "wifi"]);
-      Quickshell.execDetached(["rfkill", "block", "bluetooth"]);
-    } else {
-      Quickshell.execDetached(["rfkill", "unblock", "wifi"]);
-      Quickshell.execDetached(["rfkill", "unblock", "bluetooth"]);
-    }
-  }
-
   function scan() {
     if (!ProgramCheckerService.nmcliAvailable || !Settings.data.network.wifiEnabled) {
       return;


### PR DESCRIPTION
This should make Airplane Mode now work properly, at least if the Bluetooth adapter is managed by Quickshell, since there is currently a bug in bluez 5.86 that prevents the bluetoothctl fallback from working at all (use bluez 5.85 to test).
(I also reordered some code in BluetoothService)