### PR TITLE
Fix remove keybind matching in notification history

### DIFF
--- a/Commons/Keybinds.qml
+++ b/Commons/Keybinds.qml
@@ -102,8 +102,13 @@ QtObject {
   }
 
   function checkKey(event, settingName, settings) {
-    // Map simplified names to the actual setting property names
-    var propName = "key" + settingName.charAt(0).toUpperCase() + settingName.slice(1);
+    // Accept both simplified names ("remove") and full property names ("keyRemove")
+    // so callers are less error-prone.
+    var normalized = String(settingName || "");
+    if (!normalized)
+      return false;
+
+    var propName = normalized.startsWith("key") ? normalized : ("key" + normalized.charAt(0).toUpperCase() + normalized.slice(1));
     var boundKeys = settings.data.general.keybinds[propName];
     if (!boundKeys || boundKeys.length === 0)
       return false;

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -79,7 +79,7 @@ SmartPanel {
                       }
 
                       // Removal (Delete/Remove)
-                      if (checkKey(event, 'keyRemove') || event.key === Qt.Key_Delete) {
+                      if (checkKey(event, 'remove') || event.key === Qt.Key_Delete) {
                         removeSelection();
                         event.accepted = true;
                         return;


### PR DESCRIPTION
# Pull Request
## Motivation
`Keybinds.checkKey()` assumed callers always pass simplified action names and auto-prefixed them to setting keys (e.g. `keyRemove`).
Notification history passed `keyRemove` directly, which got transformed into `keyKeyRemove`, so configured bindings were never matched.
This caused the delete keybind in Notification History to not work.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

