### PR TITLE
fix(notifications): sanitize notification text by removing unknown ta…

### DIFF
--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -823,8 +823,8 @@ Singleton {
           // Preserve valid HTML tag
           result += part;
         } else {
-          // Unknown tag: strip brackets and escape inner content
-          result += escapeHtml(content);
+          // Unknown tag: drop tag without leaking attributes
+          result += "";
         }
       } else {
         // Normal text: escape everything


### PR DESCRIPTION
…gs so attribute noise doesn’t appear in rendered messages

# Pull Request

## Motivation
This change ensures notification text stays readable by stripping unsupported HTML tags rather than leaking their attributes into the UI. It preserves the intended content while keeping the sanitizer simple and safe for untrusted notification payloads.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="476" height="141" alt="Image" src="https://github.com/user-attachments/assets/dbaa7f4d-54c3-4edf-9695-66c8300a469d" />

<img width="482" height="130" alt="Image" src="https://github.com/user-attachments/assets/eea68323-5342-47d3-80b5-7d7991b383e3" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
