### PR TITLE
GTK4 Theming fixed

### DIFF
--- a/Assets/Templates/gtk.css
+++ b/Assets/Templates/gtk.css
@@ -50,3 +50,53 @@
 @define-color theme_unfocused_base_color @window_bg_color;
 @define-color theme_unfocused_selected_bg_color @accent_bg_color;
 @define-color theme_unfocused_selected_fg_color @accent_fg_color;
+
+:root {
+    --accent-color: {{colors.on_primary.default.hex}};
+    --accent-bg-color: {{colors.primary.default.hex}}; 
+    --accent-fg-color: {{colors.on_primary.default.hex}};
+
+    --destructive-bg-color: {{colors.error.default.hex}};
+    --destructive-fg-color: {{colors.on_error.default.hex}};
+
+    --error-bg-color: {{colors.error.default.hex}};
+    --error-fg-color: {{colors.on_error.default.hex}};
+    --error-color: {{colors.error.default.hex}};
+
+    --window-bg-color: {{colors.surface.default.hex}};
+    --window-fg-color: {{colors.on_surface.default.hex}};
+
+    --view-bg-color: {{colors.surface_container.default.hex}};
+    --view-fg-color: {{colors.on_surface.default.hex}};
+
+    --headerbar-bg-color: {{colors.surface.default.hex}};
+    --headerbar-fg-color: {{colors.on_surface.default.hex}};
+    --headerbar-backdrop-color: @window_bg_color;
+
+    --popover-bg-color: {{colors.surface_container.default.hex}};
+    --popover-fg-color: {{colors.on_surface.default.hex}};
+
+    --card-bg-color: {{colors.surface_container.default.hex}};
+    --card-fg-color: {{colors.on_surface.default.hex}};
+
+    --dialog-bg-color: {{colors.surface.default.hex}};
+    --dialog-fg-color: {{colors.on_surface.default.hex}};
+
+    --overview-bg-color: {{colors.surface_container.default.hex}};
+    --overview-fg-color: {{colors.on_surface.default.hex}};
+
+    --sidebar-bg-color: {{colors.surface_container.default.hex}};
+    --sidebar-fg-color: {{colors.on_surface.default.hex}};
+    --sidebar-backdrop-color: @sidebar_bg_color;
+    --sidebar-border-color: @window_bg_color;
+
+    --warning-bg-color: {{colors.tertiary_container.default.hex}};
+    --warning-fg-color: {{colors.on_tertiary_container.default.hex}};
+    --warning-color: {{colors.tertiary.default.hex}};
+
+    --success-color: {{colors.secondary.default.hex}};
+    --success-bg-color: {{colors.secondary_container.default.hex}};
+    --success-fg-color: {{colors.on_secondary_container.default.hex}};
+    
+    --shade-color: rgba(0, 0, 0, 0.36);
+}


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Most GTK4 apps are improperly themed, despite following carefully the instructions in the documentation, and clearing the cache of GTK4 in `~/.config/gtk-4.0` (see images below).
This PR fixes these issues (tested on pavucontrol and nautilus, 2 GTK4 apps that both failed being themed by the current older method)

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

This fix works by adding the following block to the `gtk.css` template:
```
:root {
    --color: {{xxx}};
}
```
This block is ignored by GTK3 apps, so this does not cause any issue with them.\
However, it does fix GTK4 apps.\
As a result, both `~/.config/gtk-3.0/gtk.css` and `~/.config/gtk-4.0/gtk.css` end up with both contents, but this not an issue at all.\
GTK3 apps ignore the `:root {}` block, while GTK4 apps use everything (but mostly the `:root {}` block).

## Related Issue
No currently opened issue, but there were older issues on the subject.

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)
- [x]  Tested with both GTK3 and GTK4 apps

## Screenshots / Videos

Example of `pavucontrol`, a GTK4 app **before** the PR (current situation):
<img width="1246" height="704" alt="not-working" src="https://github.com/user-attachments/assets/537234ca-a783-48ed-9aeb-0723899edb5a" />

And `pavucontrol` **after** this PR (my wallpaper is red-pink):
<img width="1246" height="704" alt="working" src="https://github.com/user-attachments/assets/f4f085c6-50ca-49fd-b7ae-6be1dbc34139" />

Another example: `nautilus`, GTK4

<img width="1246" height="704" alt="nautilus" src="https://github.com/user-attachments/assets/3dab74fa-02bb-405c-86d7-bdfb39db7154" />


## Checklist
- [x] Code follows project style guidelines: I used exactly the same colors in the GTK4 block, as thoses used in the GTK3 block
- [x] Self-reviewed my code
- [x] No new warnings or errors: I checked that all colors are interpreted correctly (no parsing error notification on noctalia stat)
- [ ] Documentation or comments updated (if relevant): no need to update the documentation, this is transparent to the user.

## Additional Notes
None
