### PR TITLE
Add labwc theme template

### DIFF
--- a/Assets/Templates/labwc.conf
+++ b/Assets/Templates/labwc.conf
@@ -1,0 +1,37 @@
+# window border
+window.active.border.color: {{colors.primary.default.hex}}
+window.inactive.border.color: {{colors.secondary.default.hex}}
+
+# ToggleKeybinds status indicator
+window.active.indicator.toggled-keybind.color: {{colors.error.default.hex}}
+
+# window titlebar background
+window.active.title.bg.color: {{colors.primary.default.hex}}
+window.inactive.title.bg.color: {{colors.secondary.default.hex}}
+
+window.active.label.text.color: {{colors.on_primary.default.hex}}
+window.inactive.label.text.color: {{colors.on_secondary.default.hex}}
+window.label.text.justify: center
+
+# window button hover overlay
+window.button.hover.bg.color: {{colors.hover.default.hex}}
+
+# window buttons
+window.active.button.unpressed.image.color: {{colors.on_primary.default.hex}}
+window.inactive.button.unpressed.image.color: {{colors.on_primary.default.hex}}
+
+# menu
+menu.border.color: {{colors.on_primary.default.hex}}
+menu.items.bg.color: {{colors.primary.default.hex}}
+menu.items.text.color: {{colors.on_primary.default.hex}}
+menu.items.active.bg.color: {{colors.secondary.default.hex}}
+menu.items.active.text.color: {{colors.on_secondary.default.hex}}
+menu.separator.color: {{colors.on_primary.default.hex}}
+menu.title.bg.color: {{colors.primary.default.hex}}
+menu.title.text.color: {{colors.on_primary.default.hex}}
+
+# on screen display (window-cycle dialog)
+osd.bg.color: {{colors.on_surface.default.hex}}
+osd.border.color: {{colors.on_primary.default.hex}}
+osd.label.text.color: {{colors.on_primary.default.hex}}
+osd.window-switcher.preview.border.color: {{colors.outline.default.hex}}

--- a/Scripts/bash/template-apply.sh
+++ b/Scripts/bash/template-apply.sh
@@ -4,7 +4,7 @@
 if [ "$#" -lt 1 ]; then
     # Print usage information to standard error.
     echo "Error: No application specified." >&2
-    echo "Usage: $0 {kitty|ghostty|foot|alacritty|wezterm|fuzzel|walker|pywalfox|cava|yazi|niri|hyprland|sway|scroll|mango|btop|zathura} [dark|light]" >&2
+    echo "Usage: $0 {kitty|ghostty|foot|alacritty|wezterm|fuzzel|walker|pywalfox|cava|yazi|labwc|niri|hyprland|sway|scroll|mango|btop|zathura} [dark|light]" >&2
     exit 1
 fi
 
@@ -286,6 +286,11 @@ EOF
             echo 'light = "noctalia"' >>"$CONFIG_FILE"
         fi
     fi
+    ;;
+
+labwc)
+    # Update the theme
+    labwc -r
     ;;
 
 niri)

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -303,6 +303,18 @@ Singleton {
       "input": "emacs.el"
     },
     {
+      "id": "labwc",
+      "name": "Labwc",
+      "category": "compositor",
+      "input": "labwc.conf",
+      "outputs": [
+        {
+          "path": "~/.config/labwc/themerc-override"
+        }
+      ],
+      "postProcess": () => `${templateApplyScript} labwc`
+    },
+    {
       "id": "niri",
       "name": "Niri",
       "category": "compositor",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Adds a template for `labwc` theming.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Related to #1825 

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on labwc
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
Please refer to this YT video link: https://youtu.be/oxOPz38acH0

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.

This is a simple and necessary change to keep `labwc` titlebars, borders, menus, text and osd in line with the current theme.
