### PR TITLE
Add loginctl to default Reboot to UEFI

### DIFF
--- a/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
+++ b/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
@@ -22,7 +22,7 @@ Popup {
     "suspend": "systemctl suspend || loginctl suspend",
     "hibernate": "systemctl hibernate || loginctl hibernate",
     "reboot": "systemctl reboot || loginctl reboot",
-    "rebootToUefi": "systemctl reboot --firmware-setup",
+    "rebootToUefi": "systemctl reboot --firmware-setup || loginctl reboot --firmware-setup",
     "logout": I18n.tr("panels.session-menu.entry-settings-default-command-logout"),
     "shutdown": "systemctl poweroff || loginctl poweroff"
   }

--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -494,7 +494,7 @@ Singleton {
       return;
 
     HooksService.executeSessionHook("rebootToUefi", () => {
-                                      Quickshell.execDetached(["sh", "-c", "systemctl reboot --firmware-setup"]);
+                                      Quickshell.execDetached(["sh", "-c", "systemctl reboot --firmware-setup || loginctl reboot --firmware-setup"]);
                                     });
   }
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
All the other Session menu items have a default command that supports both systemctl and loginctl (for non-systemd distros), this was missed for the Reboot to UEFI.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

I can confirm `loginctl reboot --firmware-setup` works on void with loginctl installed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors 
  - I assume not given the change, but didn't check
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
