### PR TITLE
fix(active-window): not updating when window title change on Sway/Scroll

### DIFF
--- a/Services/Compositor/SwayService.qml
+++ b/Services/Compositor/SwayService.qml
@@ -496,6 +496,17 @@ Item {
     }
   }
 
+  // browser tab switches change the title without changing focus.
+  // This backend mostly refreshes on focus/raw IPC events, so title-only updates
+  // can be missed on Sway/Scroll unless we listen to titleChanged directly.
+  Connections {
+    target: ToplevelManager ? ToplevelManager.activeToplevel : null
+    enabled: initialized
+    function onTitleChanged() {
+      updateTimer.restart();
+    }
+  }
+
   Connections {
     target: I3
     enabled: initialized


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
ActiveWindow on Scroll WM did not refresh when switching browser tabs while focus stayed on the same window.
Root cause: tab switches update the window title but do not change focused window.
In `SwayService` (also used by Scroll), updates were mainly driven by focus/raw IPC paths, so title-only changes could be missed.
This fix adds a direct listener for `ToplevelManager.activeToplevel.titleChanged`, which is the minimal signal that always fires for this case.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1810 

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested on sway
- [x] Tested on Scroll
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
- Sway and Scroll share this backend path, so one fix covers both.
