### PR TITLE
Fix reinstalling 3rd party plugins

### DIFF
--- a/Services/Noctalia/PluginService.qml
+++ b/Services/Noctalia/PluginService.qml
@@ -396,6 +396,12 @@ Singleton {
   // skipCollisionCheck: set to true when updating an existing plugin
   function installPlugin(pluginMetadata, skipCollisionCheck, callback) {
     var pluginId = pluginMetadata.id;
+    // Do not include hash for 3rd party plugins
+    var pluginIdRegex = /^[a-f0-9]{6}:/;
+    if (pluginIdRegex.test(pluginId)) {
+      pluginId = pluginId.substring(7);
+    }
+
     var source = pluginMetadata.source;
 
     // Check for collision first (skip when updating)


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
When trying to transfer noctalia to a fresh install by copying a `plugins.json` with no (or empty) plugins directory, installing 3rd party plugins fails.

E.g. with the following `plugins.json`:

```json
{
    "sources": [
        {
            "enabled": true,
            "name": "Noctalia Plugins",
            "url": "https://github.com/noctalia-dev/noctalia-plugins"
        },
        {
            "enabled": true,
            "name": "Iynaix's Noctalia Plugins",
            "url": "https://github.com/iynaix/noctalia-plugins-iynaix"
        }
    ],
    "states": {
        "749a5a:projects-provider": {
            "enabled": true,
            "sourceUrl": "https://github.com/iynaix/noctalia-plugins-iynaix"
        }
    },
    "version": 2
}
```

More specifically, Noctalia attempts to `mkdir -p "749a5a:749a5a:projects-provider"` and `git sparse-checkout set "749a5a:projects-provider"`.

I've traced the behaviour when installing the plugin for the first time (which doesn't error), and it does `mkdir -p "749a5a:projects-provider"` and `git sparse-checkout set "projects-provider"` instead.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Used the `plugins.json` from above with an empty plugins directory and it downloads the plugin with no errors.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
