### PR TITLE
Small adjustments to GTK theme

### DIFF
--- a/Assets/Templates/gtk3.css
+++ b/Assets/Templates/gtk3.css
@@ -38,7 +38,7 @@
 
 @define-color sidebar_bg_color {{colors.surface_container.default.hex}};
 @define-color sidebar_fg_color {{colors.on_surface.default.hex}};
-@define-color sidebar_backdrop_color @sidebar_bg_color;
+@define-color sidebar_backdrop_color @window_bg_color;
 @define-color sidebar_border_color @window_bg_color;
 
 @define-color secondary_sidebar_bg_color {{colors.surface.default.hex}};

--- a/Assets/Templates/gtk4.css
+++ b/Assets/Templates/gtk4.css
@@ -38,7 +38,7 @@
 
 @define-color sidebar_bg_color {{colors.surface_container.default.hex}};
 @define-color sidebar_fg_color {{colors.on_surface.default.hex}};
-@define-color sidebar_backdrop_color @sidebar_bg_color;
+@define-color sidebar_backdrop_color @window_bg_color;
 @define-color sidebar_border_color @window_bg_color;
 
 @define-color secondary_sidebar_bg_color {{colors.surface.default.hex}};
@@ -53,7 +53,7 @@
 @define-color theme_unfocused_selected_fg_color @accent_fg_color;
 
 :root {
-    --accent-color: {{colors.on_primary.default.hex}};
+    --accent-color: {{colors.primary.default.hex}};
     --accent-bg-color: {{colors.primary.default.hex}}; 
     --accent-fg-color: {{colors.on_primary.default.hex}};
 
@@ -67,7 +67,7 @@
     --window-bg-color: {{colors.surface.default.hex}};
     --window-fg-color: {{colors.on_surface.default.hex}};
 
-    --view-bg-color: {{colors.surface_container.default.hex}};
+    --view-bg-color: {{colors.surface.default.hex}};
     --view-fg-color: {{colors.on_surface.default.hex}};
 
     --headerbar-bg-color: {{colors.surface.default.hex}};
@@ -88,7 +88,7 @@
 
     --sidebar-bg-color: {{colors.surface_container.default.hex}};
     --sidebar-fg-color: {{colors.on_surface.default.hex}};
-    --sidebar-backdrop-color: @sidebar_bg_color;
+    --sidebar-backdrop-color: @window_bg_color;
     --sidebar-border-color: @window_bg_color;
 
     --warning-bg-color: {{colors.tertiary_container.default.hex}};


### PR DESCRIPTION
Just some small adjustments to the GTK theme files since the colors for --accent-color and --view-bg-color differed from the other definitions. I also restored the behavior that the sidebar takes the main window color if the window is not focused.