### PR TITLE
fix(1771): start clipboard watchers at shell boot instead of first la…

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -30,6 +30,7 @@ import qs.Modules.Panels.Settings
 import qs.Modules.Toast
 import qs.Services.Control
 import qs.Services.Hardware
+import qs.Services.Keyboard
 import qs.Services.Location
 import qs.Services.Networking
 import qs.Services.Noctalia
@@ -115,6 +116,12 @@ ShellRoot {
           SupporterService.init();
           CustomButtonIPCService.init();
           IPCService.init(screenDetector);
+
+          // Force ClipboardService initialization so clipboard watchers
+          // start immediately instead of waiting for first launcher open
+          if (Settings.data.appLauncher.enableClipboardHistory) {
+            ClipboardService.checkCliphistAvailability();
+          }
         });
 
         delayedInitTimer.running = true;


### PR DESCRIPTION
## Motivation

After a fresh shell start, the clipboard history doesn't capture any entries until the user opens the clipboard UI for the first time. This happens because `ClipboardService` is a lazily-instantiated `pragma Singleton` whose only references live inside `ClipboardProvider`, which is only loaded when the launcher panel opens. As a result, the `wl-paste --watch cliphist store` watchers never start until that first open, and all clipboard copies before that point are silently lost.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes https://github.com/noctalia-dev/noctalia-shell/issues/1771

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.