### PR TITLE
style(settings): group bar opacity toggle and slider for better UX

### DIFF
--- a/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
@@ -127,20 +127,6 @@ ColumnLayout {
 
   NValueSlider {
     Layout.fillWidth: true
-    label: I18n.tr("panels.bar.appearance-font-scale-label")
-    description: I18n.tr("panels.bar.appearance-font-scale-description")
-    from: 0.5
-    to: 2.0
-    stepSize: 0.01
-    showReset: true
-    value: Settings.data.bar.fontScale
-    defaultValue: Settings.getDefaultValue("bar.fontScale")
-    onMoved: value => Settings.data.bar.fontScale = value
-    text: Math.floor(Settings.data.bar.fontScale * 100) + "%"
-  }
-
-  NValueSlider {
-    Layout.fillWidth: true
     visible: Settings.data.bar.useSeparateOpacity
     label: I18n.tr("panels.bar.appearance-background-opacity-label")
     description: I18n.tr("panels.bar.appearance-background-opacity-description")
@@ -152,6 +138,20 @@ ColumnLayout {
     defaultValue: Settings.getDefaultValue("bar.backgroundOpacity")
     onMoved: value => Settings.data.bar.backgroundOpacity = value
     text: Math.floor(Settings.data.bar.backgroundOpacity * 100) + "%"
+  }
+
+  NValueSlider {
+    Layout.fillWidth: true
+    label: I18n.tr("panels.bar.appearance-font-scale-label")
+    description: I18n.tr("panels.bar.appearance-font-scale-description")
+    from: 0.5
+    to: 2.0
+    stepSize: 0.01
+    showReset: true
+    value: Settings.data.bar.fontScale
+    defaultValue: Settings.getDefaultValue("bar.fontScale")
+    onMoved: value => Settings.data.bar.fontScale = value
+    text: Math.floor(Settings.data.bar.fontScale * 100) + "%"
   }
 
   NValueSlider {


### PR DESCRIPTION
# Pull Request


## Motivation
Groups the bar opacity toggle and its slider together. Currently, they are separated by the "Font Scale" setting, which is counter-intuitive.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1265" height="1369" alt="Image" src="https://github.com/user-attachments/assets/d98dbafd-058d-4cc1-9efd-6f9bcf8812f9" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
