### PR TITLE
Fix Grid SessionMenu right/down press when nothing is selected

### DIFF
--- a/Modules/Panels/SessionMenu/SessionMenu.qml
+++ b/Modules/Panels/SessionMenu/SessionMenu.qml
@@ -327,13 +327,15 @@ SmartPanel {
       newCol = newCol - 1 < 0 ? grid.itemsInRow(newRow) - 1 : newCol - 1;
       break;
     case "right":
-      newCol = newCol + 1 >= grid.itemsInRow(newRow) ? 0 : newCol + 1;
+      // We already moved to newCol to 0 if grid.currentCol was negative
+      newCol = grid.currentCol < 0 ? newRow : newCol + 1 >= grid.itemsInRow(newRow) ? 0 : newCol + 1;
       break;
     case "up":
       newRow = newRow - 1 < 0 ? grid.rows - 1 : newRow - 1;
       break;
     case "down":
-      newRow = newRow + 1 >= grid.rows ? 0 : newRow + 1;
+      // We already moved to newRow to 0 if grid.currentRow was negative
+      newRow = grid.currentRow < 0 ? newRow : newRow + 1 >= grid.rows ? 0 : newRow + 1;
       break;
     }
 


### PR DESCRIPTION
# Pull Request

## Motivation

In case of no selection, we consider we're on the 0,0 index of the grid. but this causes the first Right/Down press to actually skip the first cell. This MR fixes this by staying on `0` when a Right/Down key is pressed on a negative index value.

I also fixed the behavior when trying to display an empty menu: We close the panel if the menu is empty. I'm not sure this is the best solution tho, makes the screen flicker for me.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
