### PR TITLE
fix(1926): cache notification icons

### DIFF
--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -547,7 +547,15 @@ Singleton {
 
   // Image handling
   function queueImage(path, appName, summary, notificationId) {
-    if (!path || !path.startsWith("image://") || !notificationId)
+    if (!path || !notificationId)
+      return;
+
+    // Cache image:// URIs and temporary file paths (e.g. /tmp/ from Chromium)
+    const filePath = path.startsWith("file://") ? path.substring(7) : path;
+    const isImageUri = path.startsWith("image://");
+    const isTempFile = (path.startsWith("/") || path.startsWith("file://")) && filePath.startsWith("/tmp/");
+
+    if (!isImageUri && !isTempFile)
       return;
 
     ImageCacheService.getNotificationIcon(path, appName, summary, function (cachedPath, success) {

--- a/Services/UI/ImageCacheService.qml
+++ b/Services/UI/ImageCacheService.qml
@@ -162,8 +162,11 @@ Singleton {
       return;
     }
 
-    // File paths are used directly, not cached
-    if (imageUri.startsWith("/") || imageUri.startsWith("file://")) {
+    // Resolve bare file path for temp check
+    const filePath = imageUri.startsWith("file://") ? imageUri.substring(7) : imageUri;
+
+    // File paths in persistent locations are used directly, not cached
+    if ((imageUri.startsWith("/") || imageUri.startsWith("file://")) && !isTemporaryPath(filePath)) {
       callback(imageUri, false);
       return;
     }
@@ -171,9 +174,56 @@ Singleton {
     const cacheKey = generateNotificationKey(imageUri, appName, summary);
     const cachedPath = notificationsDir + cacheKey + ".png";
 
+    // Temporary file paths are copied to cache before the source is cleaned up
+    if (imageUri.startsWith("/") || imageUri.startsWith("file://")) {
+      processRequest(cacheKey, cachedPath, imageUri, callback, function () {
+        copyTempFileToCache(filePath, cachedPath, cacheKey);
+      });
+      return;
+    }
+
     processRequest(cacheKey, cachedPath, imageUri, callback, function () {
       // Notifications always use Qt fallback (image:// URIs can't be read by ImageMagick)
       queueFallbackProcessing(imageUri, cachedPath, cacheKey, 64);
+    });
+  }
+
+  // Check if a path is in a temporary directory that may be cleaned up
+  function isTemporaryPath(path) {
+    return path.startsWith("/tmp/");
+  }
+
+  // Copy a temporary file to the cache directory
+  function copyTempFileToCache(sourcePath, destPath, cacheKey) {
+    const srcEsc = sourcePath.replace(/'/g, "'\\''");
+    const dstEsc = destPath.replace(/'/g, "'\\''");
+
+    const processString = `
+      import QtQuick
+      import Quickshell.Io
+      Process {
+        command: ["cp", "--", "${srcEsc}", "${dstEsc}"]
+        stdout: StdioCollector {}
+        stderr: StdioCollector {}
+      }
+    `;
+
+    queueUtilityProcess({
+      name: "CopyTempFile_" + cacheKey,
+      processString: processString,
+      onComplete: function (exitCode) {
+        if (exitCode === 0) {
+          Logger.d("ImageCache", "Temp file cached:", destPath);
+          notifyCallbacks(cacheKey, destPath, true);
+        } else {
+          Logger.w("ImageCache", "Failed to cache temp file:", sourcePath);
+          notifyCallbacks(cacheKey, "", false);
+        }
+      },
+      onError: function () {
+        Logger.e("ImageCache", "Error caching temp file:", sourcePath);
+        notifyCallbacks(cacheKey, "", false);
+      }
     });
   }
 

--- a/Widgets/NImageRounded.qml
+++ b/Widgets/NImageRounded.qml
@@ -15,7 +15,7 @@ Item {
   property color borderColor: "transparent"
   property int imageFillMode: Image.PreserveAspectCrop
 
-  readonly property bool showFallback: (fallbackIcon !== undefined && fallbackIcon !== "") && (imagePath === undefined || imagePath === "")
+  readonly property bool showFallback: (fallbackIcon !== undefined && fallbackIcon !== "") && (imagePath === undefined || imagePath === "" || imageSource.status === Image.Error)
   readonly property int status: imageSource.status
 
   Rectangle {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

Chromium-based browsers send notification icons via temporary directories (`/tmp/org.chromium.Chromium.scoped_dir.*/logo.png`) that are cleaned up shortly after the notification is dispatched. When the notification history panel later tries to render these icons, the files no longer exist, producing `Cannot open` warnings and blank icons (see linked issue).

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1926

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
