### PR TITLE
Fix border clipping for tooltips and dock

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -791,8 +791,9 @@ Loader {
             readonly property int extraLeft: (!isVertical && !exclusive && barOnLeft) ? barHeight : 0
             readonly property int extraRight: (!isVertical && !exclusive && barOnRight) ? barHeight : 0
 
-            width: dockContent.dockContainer.width + extraLeft + extraRight
-            height: dockContent.dockContainer.height + extraTop + extraBottom
+            // Add +2 buffer for fractional scaling issues
+            width: dockContent.dockContainer.width + extraLeft + extraRight + (root.isVertical ? 2 : Style.margin2XL * 6)
+            height: dockContent.dockContainer.height + extraTop + extraBottom + 2
 
             anchors.horizontalCenter: isVertical ? undefined : parent.horizontalCenter
             anchors.verticalCenter: isVertical ? parent.verticalCenter : undefined
@@ -801,6 +802,9 @@ Loader {
             anchors.bottom: dockPosition === "bottom" ? parent.bottom : undefined
             anchors.left: dockPosition === "left" ? parent.left : undefined
             anchors.right: dockPosition === "right" ? parent.right : undefined
+
+            // Enable layer caching to reduce GPU usage from continuous animations
+            layer.enabled: true
 
             opacity: hidden ? 0 : 1
             scale: hidden ? 0.85 : 1

--- a/Modules/Dock/DockContent.qml
+++ b/Modules/Dock/DockContent.qml
@@ -41,9 +41,6 @@ Item {
     border.width: Style.borderS
     border.color: Qt.alpha(Color.mOutline, (isStaticMode ? 0 : Settings.data.dock.backgroundOpacity))
 
-    // Enable layer caching to reduce GPU usage from continuous animations
-    layer.enabled: true
-
     MouseArea {
       id: dockMouseArea
       anchors.fill: parent

--- a/Modules/Tooltip/Tooltip.qml
+++ b/Modules/Tooltip/Tooltip.qml
@@ -260,19 +260,17 @@ PopupWindow {
     const tipWidth = Math.ceil(Math.min(contentWidth + (padding * 2), maxWidth));
     root.implicitWidth = tipWidth;
 
-    // Add +2 buffer for fractional scaling issues (especially with "top" direction)
-    const tipHeight = Math.ceil(contentHeight + (padding * 2)) + 2;
+    const tipHeight = Math.ceil(contentHeight + (padding * 2));
     root.implicitHeight = tipHeight;
 
     // Get target's global position and convert to screen-relative
-    // Round all values to avoid sub-pixel positioning issues with fractional scaling
     var targetGlobalAbs = targetItem.mapToGlobal(0, 0);
     var targetGlobal = {
-      "x": Math.round(targetGlobalAbs.x - screenX),
-      "y": Math.round(targetGlobalAbs.y - screenY)
+      "x": targetGlobalAbs.x - screenX,
+      "y": targetGlobalAbs.y - screenY
     };
-    const targetWidth = Math.round(targetItem.width);
-    const targetHeight = Math.round(targetItem.height);
+    const targetWidth = targetItem.width;
+    const targetHeight = targetItem.height;
 
     var newAnchorX = 0;
     var newAnchorY = 0;
@@ -427,7 +425,6 @@ PopupWindow {
     }
 
     // Apply position first (before making visible)
-    // Round to avoid sub-pixel positioning issues with fractional scaling
     // Use floor for negative values to push tooltip away from target
     anchorX = newAnchorX < 0 ? Math.floor(newAnchorX) : Math.round(newAnchorX);
     anchorY = newAnchorY < 0 ? Math.floor(newAnchorY) : Math.round(newAnchorY);
@@ -519,19 +516,18 @@ PopupWindow {
     const tipWidth = Math.ceil(Math.min(contentWidth + (padding * 2), maxWidth));
     root.implicitWidth = tipWidth;
 
-    // Add +2 buffer for fractional scaling issues (especially with "top" direction)
-    const tipHeight = Math.ceil(contentHeight + (padding * 2)) + 2;
+    const tipHeight = Math.ceil(contentHeight + (padding * 2));
     root.implicitHeight = tipHeight;
 
     // Reposition based on current direction (screen-relative)
     // Round all values to avoid sub-pixel positioning issues with fractional scaling
     var targetGlobalAbs = targetItem.mapToGlobal(0, 0);
     var targetGlobal = {
-      "x": Math.round(targetGlobalAbs.x - screenX),
-      "y": Math.round(targetGlobalAbs.y - screenY)
+      "x": targetGlobalAbs.x - screenX,
+      "y": targetGlobalAbs.y - screenY
     };
-    const targetWidth = Math.round(targetItem.width);
-    const targetHeight = Math.round(targetItem.height);
+    const targetWidth = targetItem.width;
+    const targetHeight = targetItem.height;
 
     // Recalculate base anchor position (center on target for top/bottom, etc.)
     var newAnchorX = anchorX;
@@ -608,7 +604,6 @@ PopupWindow {
     }
 
     // Apply the new anchor positions
-    // Round to avoid sub-pixel positioning issues with fractional scaling
     // Use floor for negative values to push tooltip away from target
     anchorX = newAnchorX < 0 ? Math.floor(newAnchorX) : Math.round(newAnchorX);
     anchorY = newAnchorY < 0 ? Math.floor(newAnchorY) : Math.round(newAnchorY);
@@ -663,6 +658,7 @@ PopupWindow {
 
     Rectangle {
       anchors.fill: parent
+      anchors.margins: border.width / 2
       color: Color.mSurface
       border.color: Color.mOutline
       border.width: Style.borderS


### PR DESCRIPTION
I finally found a way to fix the clipping of borders that can appear when fractional scaling is enabled.

For the tooltips, I added `anchors.margins: border.width / 2` to ensure that the border is always positioned fully within the tooltip. I also reverted some changes from a previous attempt to fix this problem.

For the dock, I've just added a safety margin of 2px. Further, I re-implemented the larger (horizontal) dockContainerWrapper for tooltips that caused some glitches the last time it was added. I've found that they are related to `layer.enabled` and that moving this to dockContainerWrapper prevents the glitches.


Tested on Hyprland, not on Niri.