### PR TITLE
fix(control-center): prevent panel being stuck in one position

### DIFF
--- a/Modules/MainScreen/SmartPanel.qml
+++ b/Modules/MainScreen/SmartPanel.qml
@@ -155,6 +155,8 @@ Item {
   function open(buttonItem, buttonName) {
     // Reset immediate close flag to ensure animations work properly
     PanelService.closedImmediately = false;
+    // Reset to default - fixes panel being stuck in one position
+    root.useButtonPosition = false;
 
     if (!buttonItem && buttonName) {
       // Check if buttonName is actually a point object (click coordinates)


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

Fixes control panel being stuck in one position, after opening next to mouse.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Caused by #1835.

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://youtu.be/jPtL4X97DLo

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes