### PR TITLE
Fix: Khal event lasting multiple days

### DIFF
--- a/Scripts/python/src/calendar/khal-events.py
+++ b/Scripts/python/src/calendar/khal-events.py
@@ -55,6 +55,7 @@ def main():
         '--json', 'calendar',
         '--json', 'description',
         '--json', 'location',
+        '--json', 'repeat-pattern',
         khal_start,
         duration
     ]

--- a/Services/Location/Calendar/Khal.qml
+++ b/Services/Location/Calendar/Khal.qml
@@ -131,13 +131,16 @@ Singleton {
 
   function parseEvents(text) {
     const result = [];
+    const duplicates = new Set();
 
     for (const line of text.split("\n")) {
       if (!line.trim())
         continue;
       const dayEvents = JSON.parse(line);
       for (const event of dayEvents) {
-        result.push({
+        if (event["repeat-pattern"] !== "") {
+          // if there is a repeat pattern, the event must be included each time
+          result.push({
                       uid: event.uid,
                       calendar: event.calendar,
                       summary: event.title,
@@ -145,7 +148,21 @@ Singleton {
                       end: parseTimestamp(event["end-long-full"]),
                       location: event.location,
                       description: event.description
-                    });
+                      });
+          }
+        else if (!duplicates.has(event.uid) ) {
+          // in any other cases, we must remove duplicates using the uid of the event
+          result.push({
+                      uid: event.uid,
+                      calendar: event.calendar,
+                      summary: event.title,
+                      start: parseTimestamp(event["start-long-full"]),
+                      end: parseTimestamp(event["end-long-full"]),
+                      location: event.location,
+                      description: event.description
+                      });
+          duplicates.add(event.uid)
+        } 
       }
     }
 


### PR DESCRIPTION
Multiple days events are now displayed only once. This fix is also compatible with a previous fix, which was meant to deal with recurring events.

fix #1908

# Pull Request

## Motivation

fix #1908

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1908 

## Testing
Created simple events, recurring events, and events lasting multiple days. Each one was displayed correctly in the calendar widget. However in the Weekly calendar plugin, some events are missing. I suppose this is an issue with the weekly calendar plugin.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before
<img width="536" height="312" alt="image" src="https://github.com/user-attachments/assets/199c21d2-2a15-417b-ad7c-eff79223a152" />

After the fix
<img width="527" height="313" alt="image" src="https://github.com/user-attachments/assets/e238993e-2838-4451-9cad-92e257f64199" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
N/A
