### PR TITLE
Increase notification close button margin

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -718,9 +718,9 @@ Variants {
               tooltipText: I18n.tr("tooltips.dismiss-notification")
               baseSize: Style.baseWidgetSize * 0.6
               anchors.top: cardBackground.top
-              anchors.topMargin: Style.marginM
+              anchors.topMargin: Style.marginXL
               anchors.right: cardBackground.right
-              anchors.rightMargin: Style.marginM
+              anchors.rightMargin: Style.marginXL
 
               onClicked: {
                 card.runAction("", true);


### PR DESCRIPTION
# Pull Request

## Motivation

With max `Container radius` setting value, the notification's close button appeared out of the notification background. I increased margins to fix this, it still feels good with normal settings I think?

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

### Before

Default: 
<img width="406" height="556" alt="image" src="https://github.com/user-attachments/assets/71d8db7e-6745-45a9-93cc-8097f8d043e3" />

Max radius
<img width="406" height="556" alt="image" src="https://github.com/user-attachments/assets/a9f82134-9c1e-4e46-8d8f-35346b25e70d" />

### After

Default: 
<img width="406" height="556" alt="image" src="https://github.com/user-attachments/assets/c28d8d93-818e-4363-bdee-3320f4a2d44b" />

Max radius
<img width="418" height="495" alt="image" src="https://github.com/user-attachments/assets/f8ae1c7f-38cf-4883-a933-5e179a75db9d" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)