### PR TITLE
feat(notifications): focus sender window on click in notification hist

### DIFF
--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -945,8 +945,8 @@ SmartPanel {
                                 property var actionData: modelData
                                 onClicked: {
                                   NotificationService.focusSenderWindow(notificationDelegate.appName);
-                                  NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier);
                                   root.close();
+                                  NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier);
                                 }
                               }
                             }


### PR DESCRIPTION
# Pull Request

This change brings consistency between [pop-up notifications](https://github.com/noctalia-dev/noctalia-shell/pull/1883) and notification history panel click behavior. 
Clicking a notification body in history now focuses the sender application window (invoking the default action if available) and closes the panel. 
Clicking explicit action buttons also focuses the sender window before invoking the action.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)