### PR TITLE
Templates: improve helix highlights

### DIFF
--- a/Assets/Templates/helix.toml
+++ b/Assets/Templates/helix.toml
@@ -1,6 +1,6 @@
 # Syntax highlighting
 # -------------------
-"attribute" = "secondary"
+"attribute" = { fg = "primary", modifiers = ["bold"] }
 
 "type" = "primary"
 "type.enum.variant" = "secondary"
@@ -11,27 +11,30 @@
 "constant.character" = "secondaryContainer"
 "constant.character.escape" = "tertiaryContainer"
 
-"string" = "tertiary"
-"string.regexp" = "tertiaryContainer"
-"string.special" = "tertiary"
-"string.special.symbol" = "tertiary"
+"string" = { fg = "tertiary", bg = "surfaceContainerHigh" }
+"string.regexp" = { fg = "tertiaryContainer", bg = "surfaceContainerHigh" }
+"string.special" = { fg = "tertiary", bg = "surfaceContainerHigh" }
+"string.special.symbol" = { fg = "tertiary", bg = "surfaceContainerHigh" }
+"string.special.path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
 
-"comment" = { fg = "outline", modifiers = ["italic"] }
+"path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
+
+"comment" = { fg = "outline", bg = "surfaceContainerHigh", modifiers = ["italic"] }
 
 "variable" = "onSurface"
 "variable.builtin" = "secondary"
 "variable.parameter" = { fg = "onSurfaceVariant", modifiers = ["italic"] }
-"variable.other.member" = "onSurface"
+"variable.other.member" = "primary"
 
 "label" = "secondary"
 
-"punctuation" = "onBackground"
-"punctuation.special" = "onBackground"
+"punctuation" = "outlineVariant"
+"punctuation.special" = "outline"
 
-"keyword" = "primary"
-"keyword.control.conditional" = { fg = "tertiary", modifiers = ["italic"] }
+"keyword" = { fg = "primary", modifiers = ["bold"] }
+"keyword.control.conditional" = { fg = "tertiary", modifiers = ["italic", "bold"] }
 
-"operator" = "primary"
+"operator" = { fg = "secondary", modifiers = ["bold"] }
 
 "function" = "tertiary"
 "function.macro" = "tertiary"
@@ -44,7 +47,7 @@
 
 "markup.heading" = "primary"
 "markup.list" = "onSurface"
-"markup.bold" = { fg = "second", modifiers = ["bold"] }
+"markup.bold" = { fg = "secondary", modifiers = ["bold"] }
 "markup.italic" = { fg = "secondary", modifiers = ["italic"] }
 "markup.link.url" = { fg = "secondary", modifiers = ["italic", "underlined"] }
 "markup.link.label" = "primary"


### PR DESCRIPTION
# Pull Request

## Motivation
Improve a little the highlight in helix so that it has a better syntax highlighting.

## Screenshots / Videos
|     |     |     |
|----|----|----|
|<img width="949" height="1066" alt="image" src="https://github.com/user-attachments/assets/aec7f5e8-5f82-4f50-800f-a7b8f7f46824" />|<img width="949" height="1066" alt="image" src="https://github.com/user-attachments/assets/306c4698-6ddf-45cb-9540-128983a94343" />|<img width="949" height="1066" alt="image" src="https://github.com/user-attachments/assets/80279497-6a17-47f3-899c-4896a2b2c86f" />|
