### PR TITLE
Update labwc.conf osd bg color

### DIFF
--- a/Assets/Templates/labwc.conf
+++ b/Assets/Templates/labwc.conf
@@ -31,7 +31,7 @@ menu.title.bg.color: {{colors.primary.default.hex}}
 menu.title.text.color: {{colors.on_primary.default.hex}}
 
 # on screen display (window-cycle dialog)
-osd.bg.color: {{colors.on_surface.default.hex}}
+osd.bg.color: {{colors.primary.default.hex}}
 osd.border.color: {{colors.on_primary.default.hex}}
 osd.label.text.color: {{colors.on_primary.default.hex}}
 osd.window-switcher.preview.border.color: {{colors.outline.default.hex}}


### PR DESCRIPTION
# Pull Request

This just makes the labwc osd a bit more visually appealing.

## Motivation
it changes the osd bg color from `on_surface`, which originally was a bad choice, to `primary`

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Refactoring

## Related Issue
n/a

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on labwc
- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<details><summary>video of osd and changing themes with the proposed change</summary>

https://github.com/user-attachments/assets/f77207b5-e60e-4d8f-b37c-4a890b6eb7ab

</details>

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This fixes an oversight in the original PR #1874 
