### PR TITLE
Allow password input from monitors without active lockscreen

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -25,6 +25,12 @@ Loader {
     } else {
       CavaService.unregisterComponent("lockscreen");
     }
+
+    if (root.active) {
+      LockKeysService.registerComponent("lockscreen");
+    } else {
+      LockKeysService.unregisterComponent("lockscreen");
+    }
   }
 
   onNeedsCavaChanged: {
@@ -38,6 +44,11 @@ Loader {
   Component.onCompleted: {
     // Register with panel service
     PanelService.lockScreen = this;
+  }
+
+  Component.onDestruction: {
+    CavaService.unregisterComponent("lockscreen");
+    LockKeysService.unregisterComponent("lockscreen");
   }
 
   Timer {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
With many monitors it's more convenient to allow password input without the need of focus on a monitor with an active lockscreen

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1895

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

