### PR TITLE
fix(notifications): prevent expansion of non-expandable items in history

### DIFF
--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -172,10 +172,12 @@ SmartPanel {
           NotificationService.invokeAction(item.id, actions[actionIndex].identifier);
         }
       } else {
-        // Toggle expansion or open?
-        // User request didn't specify. Let's toggle expansion logic if we can access it.
-        // We can communicate with the delegate via a property or signal?
-        // Delegates read 'scrollView.expandedId'.
+        var delegate = notificationColumn.children[focusIndex];
+        if (!delegate)
+          return;
+        if (!(delegate.canExpand || delegate.isExpanded))
+          return;
+          
         if (scrollView.expandedId === item.id) {
           scrollView.expandedId = "";
         } else {


### PR DESCRIPTION
# Pull Request

fix(notifications): check expandability before toggling history items via keyboard

## Motivation
This PR fixes a bug reported by a user on Discord.
Previously, pressing Enter while navigating the notification history with a keyboard would attempt to expand the selected notification even if it had no additional content or actions. This resulted in the expansion icon appearing on items that were already fully displayed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
