### PR TITLE
IPC dismiss also clear from history

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -229,13 +229,13 @@ Singleton {
 
       var actions = JSON.parse(notif.actionsJson || "[]");
       if (actions.length === 0) {
-        NotificationService.dismissActiveNotification(notif.id);
+        NotificationService.userDismissNotification(notif.id);
         return false;
       }
 
       var actionId = actions.find(a => a.identifier === "default")?.identifier ?? actions[0].identifier;
       var result = NotificationService.invokeAction(notif.id, actionId);
-      NotificationService.dismissActiveNotification(notif.id);
+      NotificationService.userDismissNotification(notif.id);
       return result;
     }
 

--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -888,6 +888,9 @@ Singleton {
     if (index >= 0) {
       activeList.remove(index);
     }
+    if (Settings.data.notifications.clearDismissed) {
+      removeFromHistory(id);
+    }
   }
 
   function dismissOldestActive() {
@@ -901,6 +904,9 @@ Singleton {
     for (const id in activeNotifications) {
       activeNotifications[id].notification?.dismiss();
       activeNotifications[id].watcher?.destroy();
+      if (activeNotifications[id].notification && Settings.data.notifications.clearDismissed) {
+        removeFromHistory(activeNotifications[id].notification.id);
+      }
     }
     activeList.clear();
     activeNotifications = {};

--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -878,16 +878,16 @@ Singleton {
 
   // Public API
   function dismissActiveNotification(id) {
-    userDismissNotification(id);
+    const index = findNotificationIndex(id);
+    if (index >= 0) {
+      activeList.remove(index);
+    }
   }
 
   // User dismissed from active view (e.g. clicked close, or swipe)
   // This behaves like "overflow" - removes from active list but KEEPS data for history
   function userDismissNotification(id) {
-    const index = findNotificationIndex(id);
-    if (index >= 0) {
-      activeList.remove(index);
-    }
+    dismissActiveNotification(id);
     if (Settings.data.notifications.clearDismissed) {
       removeFromHistory(id);
     }
@@ -896,7 +896,7 @@ Singleton {
   function dismissOldestActive() {
     if (activeList.count > 0) {
       const lastNotif = activeList.get(activeList.count - 1);
-      dismissActiveNotification(lastNotif.id);
+      userDismissNotification(lastNotif.id);
     }
   }
 
@@ -904,8 +904,8 @@ Singleton {
     for (const id in activeNotifications) {
       activeNotifications[id].notification?.dismiss();
       activeNotifications[id].watcher?.destroy();
-      if (activeNotifications[id].notification && Settings.data.notifications.clearDismissed) {
-        removeFromHistory(activeNotifications[id].notification.id);
+      if (Settings.data.notifications.clearDismissed) {
+        userDismissNotification(id);
       }
     }
     activeList.clear();


### PR DESCRIPTION
# Pull Request

## Motivation

I added recently a setting to clear notification from history when manually dismissed (close/right click/swipe the notification), but I didn't do the IPC calls, this MR do that.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1213

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
