### PR TITLE
Add default setting action on CustomButton

### DIFF
--- a/Modules/Bar/Widgets/CustomButton.qml
+++ b/Modules/Bar/Widgets/CustomButton.qml
@@ -221,13 +221,22 @@ Item {
       if (showExecTooltip && hasExec) {
         if (leftClickExec !== "") {
           lines.push(I18n.tr("bar.custom-button.left-click-label") + `: ${leftClickExec}`);
+        } else {
+          lines.push(I18n.tr("bar.custom-button.left-click-label") + ": " + I18n.tr("actions.widget-settings"));
         }
+
         if (rightClickExec !== "") {
           lines.push(I18n.tr("bar.custom-button.right-click-label") + `: ${rightClickExec}`);
+        } else {
+          lines.push(I18n.tr("bar.custom-button.right-click-label") + ": " + I18n.tr("actions.widget-settings"));
         }
+
         if (middleClickExec !== "") {
           lines.push(I18n.tr("bar.custom-button.middle-click-label") + `: ${middleClickExec}`);
+        } else {
+          lines.push(I18n.tr("bar.custom-button.middle-click-label") + ": " + I18n.tr("actions.widget-settings"));
         }
+
         if (wheelMode === "unified" && wheelExec !== "") {
           lines.push(I18n.tr("bar.custom-button.wheel-label") + `: ${wheelExec}`);
         } else if (wheelMode === "separate") {
@@ -513,6 +522,8 @@ Item {
     if (rightClickExec) {
       Quickshell.execDetached(["sh", "-lc", rightClickExec]);
       Logger.i("CustomButton", `Executing command: ${rightClickExec}`);
+    } if (!rightClickUpdateText) {
+      BarService.openWidgetSettings(screen, section, sectionWidgetIndex, widgetId, widgetSettings);
     }
     if (!textStream && rightClickUpdateText) {
       runTextCommand();
@@ -523,6 +534,8 @@ Item {
     if (middleClickExec) {
       Quickshell.execDetached(["sh", "-lc", middleClickExec]);
       Logger.i("CustomButton", `Executing command: ${middleClickExec}`);
+    } if (!middleClickUpdateText) {
+      BarService.openWidgetSettings(screen, section, sectionWidgetIndex, widgetId, widgetSettings);
     }
     if (!textStream && middleClickUpdateText) {
       runTextCommand();


### PR DESCRIPTION
# Pull Request

## Motivation

Once you define the left click action, there is no way left to open CustomButton settings except from "Bar > Widget" panel. This MR just add "open settings" has defualt behavior for right/middle click, and also display setting action in the tooltip.

Another way to do this would be to add an option "Open settings as default action" (true by default), so that people can decide if they want the ability to open settings like this. What do you think ?

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
