### PR TITLE
fix(i18n): better swedish translation for suspend

### DIFF
--- a/Assets/Translations/sv.json
+++ b/Assets/Translations/sv.json
@@ -505,7 +505,7 @@
     "start": "Starta",
     "stop": "Stoppa",
     "supporters": "Stödjare",
-    "suspend": "Avbryt",
+    "suspend": "Strömsparläge",
     "templates": "Mallar",
     "tertiary": "Tertiär",
     "test": "Testa",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
The current swedish translation for "suspend" ("avbryt") is completely inappropriate and reads as machine translated. "Avbryt" means, essentially, to cancel something, although it could also be used about suspending some ongoing work being done. However, the conventional swedish term for "suspending" a computer is "försätta i strömsparläge" (literally: "put into power saving mode") or "försätta i vänteläge" ("put into waiting mode"). In UI contexts, this is usually shortened to simply the noun describing the mode the computer being put into. For instance, the current translation in noctalia for "hibernate" is "viloläge" ("resting mode"). Microsoft Windows uses "strömsparläge" as it's translation of "suspend". I therefore suggest accepting this PR to change the swedish translation to that (although if you want something more terse for UI layout reasons I would happily accept "vänteläge" as well :-) )

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Translation help

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
