### PR TITLE
Bump noctalia-qs for flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771796397,
-        "narHash": "sha256-lbZkAMNQl5Ymqhdvp46K8hubZ7n7KQRPnTP5bNJzMSk=",
+        "lastModified": 1772227064,
+        "narHash": "sha256-f821ZSoGpa/aXrWq0gPpea9qBnX8KDyavGKkptz2Mog=",
         "owner": "noctalia-dev",
         "repo": "noctalia-qs",
-        "rev": "1711c5a20b74a31b703394164c5d2d9561f13ee9",
+        "rev": "0741d27d2f7db567270f139c5d1684614ecf9863",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

The flake is currently broken on nixos, starting noctalia-shell produces:

```
No running instances for "/nix/store/i2vl1v44k1lgm2z687x4ia47pxg2hrmm-noctalia-shell-2026-02-27_5e78c21/share/noctalia-shell/shell.qml"
  INFO: Launching config: "/nix/store/i2vl1v44k1lgm2z687x4ia47pxg2hrmm-noctalia-shell-2026-02-27_5e78c21/share/noctalia-shell/shell.qml"
  INFO: Shell ID: "121b248020f9fa3c031d9b301601f88b" Path ID "121b248020f9fa3c031d9b301601f88b"
  INFO: Saving logs to "/run/user/1000/quickshell/by-id/5d01uv85bt/log.qslog"
 ERROR: Failed to load configuration
 ERROR:   caused by @shell.qml[134:7]: Type AllScreens unavailable
 ERROR:   caused by @Modules/MainScreen/AllScreens.qml[51:24]: Type MainScreen unavailable
 ERROR:   caused by @Modules/MainScreen/MainScreen.qml[206:3]: Non-existent attached object
```

`noctalia-qs v0.04` is required for `noctalia-shell` to start, however the noctalia-qs in the flake is currently pinned to https://github.com/noctalia-dev/noctalia-qs/commit/1711c5a20b74a31b703394164c5d2d9561f13ee9, which is v0.02.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Updating the flake, and noctalia-shell launches fine.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
