### PR TITLE
IPC Call Wallpaper Get

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -557,6 +557,14 @@ Singleton {
       }
     }
 
+    function get(screen: string): string {
+      if (screen === "all" || screen === "") {
+        return Quickshell.screens.map(screen => WallpaperService.currentWallpapers[screen.name]);
+      } else {
+        return [ WallpaperService.currentWallpapers[screen]];
+      };
+    }
+
     function set(path: string, screen: string) {
       if (screen === "all" || screen === "") {
         screen = undefined;


### PR DESCRIPTION
# Pull Request



## Motivation
Noctalia already implements an IPC call to _set_ the wallpaper on a given monitor, but not one to _get/retrieve_ it.\
This PR adds this missing call. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Example:

```bash
$  ~ noctalia-shell ipc call wallpaper get DP-1           
/nix/store/h0r84a633rz6bm445bs3hjsx9c9ii6w1-Wallpapers/abstract-bird-3840x2160.jpg
$  ~ noctalia-shell ipc call wallpaper get DP-1234

$  ~ 
```

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (will add in the documentation after this PR gets accepted)

## Additional Notes
The user has to provide:
- either a valid monitor name, like `DP-1` or `eDP-1`. In this case, the call returns a list with a single element, which is the path to the corresponding wallpaper
- either `all`, which returns a list of all wallpapers on all monitors.

**Question 1**: What do you think about the behavior in case of several monitors?\
In my opinion, we should NOT support it (although this PR does), because it's inconvenient to show the association between a wallpaper and a specific display (since this call returns a list of paths, not a pair `display:path`).

Let me know your opinion, and I can modify the PR to only support one monitor.


**Note**: if the provided monitor alias is invalid, the current implementation returns a blank line, which seems consistent to me. I couldn't find other examples of already-implemented IPC calls returning errors in case of invalid input.