### PR TITLE
feat(theming): add qimgv template

### DIFF
--- a/Assets/Templates/qimgv.conf
+++ b/Assets/Templates/qimgv.conf
@@ -1,0 +1,14 @@
+[Colors]
+accent={{colors.on_surface_variant.default.hex}}
+background={{colors.surface.default.hex}}
+background_fullscreen={{colors.surface.default.hex}}
+folderview={{colors.surface.default.hex}}
+folderview_topbar={{colors.surface_variant.default.hex}}
+icons={{colors.primary_container.default.hex | auto_lightness 15}}
+overlay={{colors.surface_variant.default.hex}}
+overlay_text={{colors.on_surface.default.hex}}
+scrollbar={{colors.surface_bright.default.hex}}
+text={{colors.on_surface.default.hex}}
+tid=3
+widget={{colors.surface_variant.default.hex}}
+widget_border={{colors.primary.default.hex}}

--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -421,6 +421,17 @@ Singleton {
           "path": "~/.steam/steam/steamui/skins/Material-Theme/css/main/colors/matugen.css"
         }
       ]
+    },
+    {
+      "id": "qimgv",
+      "name": "qimgv",
+      "category": "misc",
+      "input": "qimgv.conf",
+      "outputs": [
+        {
+          "path": "~/.config/qimgv/theme.conf"
+        }
+      ]
     }
   ]
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation

Adds theme template for [qimgv](https://github.com/easymodo/qimgv).

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing

Tested with multiple predefined color schemes.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

<img width="1256" height="1378" alt="Screenshot from 2026-02-28 21-14-57" src="https://github.com/user-attachments/assets/f298d7c9-5834-4f0d-845c-7e8eac8ecdc6" />
<img width="1256" height="1378" alt="Screenshot from 2026-02-28 21-21-38" src="https://github.com/user-attachments/assets/ef9c9ae6-596a-47fa-aa49-5f0c5e4bb61a" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

If you can, please check that the theme looks somewhat decent and is similar to other apps.
Also, I couldn't find anything about hot-reloading the theme, so it only updates when relaunching the app.