### PR TITLE
nix: fix noctalia-qs not being included in `overlays.default`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,6 @@
         system:
         nixpkgs.legacyPackages.${system}.appendOverlays [
           self.overlays.default
-          noctalia-qs.overlays.default
         ]
       );
     in
@@ -47,12 +46,15 @@
                   ];
               in
               mkDate (self.lastModifiedDate or "19700101") + "_" + (self.shortRev or "dirty");
+            quickshell = noctalia-qs.packages.${prev.stdenv.hostPlatform.system}.default;
           };
         };
       };
 
       devShells = eachSystem (system: {
-        default = pkgsFor.${system}.callPackage ./nix/shell.nix { };
+        default = pkgsFor.${system}.callPackage ./nix/shell.nix {
+          quickshell = noctalia-qs.packages.${system}.default;
+        };
       });
 
       homeModules.default =


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Currently, using the `noctalia-shell` overlay doesn't include the `noctalia-qs` overlay, as mentioned here: https://github.com/noctalia-dev/noctalia-shell/issues/1995#issuecomment-3976413546.  I've also added the same override for the devshell.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #1995

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
@bokicoder @stefanboca