### PR TITLE
nix: add wlr-randr as a runtime dependency

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,6 +8,7 @@
     ddcutil
     wlsunset
     wl-clipboard
+    wlr-randr
     imagemagick
     wget
     (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
@@ -25,6 +26,7 @@
   ddcutil,
   wlsunset,
   wl-clipboard,
+  wlr-randr,
   imagemagick,
   wget,
   python3,


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
`wlr-randr` is used at runtime to turn monitors off for mangowc and labwc, introduced in https://github.com/noctalia-dev/noctalia-shell/commit/9ee707d300af84b085a21e48b33f94889afe1d83 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
