### PR TITLE
Use 'tnum' OpenType feature (tabular numbers) in bar clock widget

### DIFF
--- a/Modules/Bar/Widgets/Clock.qml
+++ b/Modules/Bar/Widgets/Clock.qml
@@ -105,6 +105,7 @@ Item {
               color: textColor
               wrapMode: Text.WordWrap
               Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+              features: ({ "tnum": 1 })
             }
           }
         }
@@ -129,6 +130,7 @@ Item {
               color: textColor
               wrapMode: Text.WordWrap
               Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+              features: ({ "tnum": 1 })
             }
           }
         }

--- a/Widgets/NText.qml
+++ b/Widgets/NText.qml
@@ -18,11 +18,13 @@ Text {
     }
     return fontScale;
   }
+  property var features: ({})
 
   opacity: enabled ? 1.0 : 0.6
   font.family: root.family
   font.weight: Style.fontWeightMedium
   font.pointSize: Math.max(1, root.pointSize * fontScale)
+  font.features: root.features
   color: Color.mOnSurface
   elide: Text.ElideRight
   wrapMode: Text.NoWrap


### PR DESCRIPTION
# Pull Request

## Motivation

This adds a `features` property to `NText` which can be used to specify OpenType features, which is in turn used to enable `tnum` (tabular, ie. fixed-width numbers) for the clock bar widget.

This is useful for non-fixed-width fonts, because:

- In the horizontal bar (with seconds enabled), it stops the clock 'wobbling' backwards and forwards in some cases.
- In the vertical bar, it lines the figures up nicely.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
n/a

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Before:

<img width="114" height="109" alt="image" src="https://github.com/user-attachments/assets/f3bd6009-a0a0-4779-8cec-2a1c18d7ba05" />

After:

<img width="114" height="109" alt="2026-03-01-13-03-15" src="https://github.com/user-attachments/assets/cadcc797-9986-4297-ba36-5d142332a40a" />

(I've tested this with a horizontal bar too, but it's more difficult to see the difference with screenshots. Let me know if you want a video!)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant) - *nothing to do here as far as I can tell.*

## Additional Notes
n/a
