### PR TITLE
fix: hardcoded space when city name is disabled in CalendarHeaderCard.qml

### DIFF
--- a/Modules/Cards/CalendarHeaderCard.qml
+++ b/Modules/Cards/CalendarHeaderCard.qml
@@ -104,7 +104,7 @@ Rectangle {
           }
 
           NText {
-            text: root.weatherReady && !Settings.data.location.hideWeatherTimezone ? ` (${LocationService.data.weather.timezone_abbreviation})` : ""
+            text: root.weatherReady && !Settings.data.location.hideWeatherTimezone ? `${Settings.data.location.hideWeatherCityName ? "" : " "}(${LocationService.data.weather.timezone_abbreviation})` : ""
             pointSize: Style.fontSizeXS
             color: Qt.alpha(Color.mOnPrimary, 0.7)
           }


### PR DESCRIPTION
…Card.qml

# Pull Request

## Motivation
I do screen share a lot, so for privacy I disabled the city name in the Region / Weather. But when I do that there is an hardcoded space that I bothering me enough to do this PR to fix it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
None

## Testing
I have the git version so I did the update and recompiled and reloaded my whole config. Without the space now.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested on Mangowc
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots of the bug
When city name is enabled:
<img width="469" height="158" alt="2026-03-01_19-12-54 (Edit)" src="https://github.com/user-attachments/assets/6750a62c-17f7-4341-9f8a-14a7b01d4196" />

When City name is disabled:
<img width="468" height="147" alt="2026-03-01_19-13-17 (Edit)" src="https://github.com/user-attachments/assets/3c8dfe11-6057-41b3-8687-f67aa9b37559" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
None
