### PR TITLE
Add vencord-flatpak template to TemplateRegistry

### DIFF
--- a/Services/Theming/TemplateRegistry.qml
+++ b/Services/Theming/TemplateRegistry.qml
@@ -190,6 +190,10 @@ Singleton {
           "path": "~/.config/Vencord"
         },
         {
+          "name": "vencord-flatpak",
+          "path": "~/.var/app/com.discordapp.Discord/config/Vencord"
+        },
+        {
           "name": "betterdiscord",
           "path": "~/.config/BetterDiscord"
         }


### PR DESCRIPTION
# Pull Request

## Motivation
I use flatpak discord with vencord since I don't want to run pacman -Syu everytime discord complains about updates, I wanted to use noctalia's discord themes with it.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
none

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/9b90af4d-b36f-41c0-9e3f-dad66777aed2" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
