### PR TITLE
Launcher: reduce label font for grid view

### DIFF
--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -1367,9 +1367,9 @@ Rectangle {
                     return Style.fontSizeS * Style.uiScaleRatio;
                   }
                   // Scale font size relative to cell width for low res, but cap at maximum
-                  const cellBasedSize = gridEntry.width * 0.12;
-                  const baseSize = Style.fontSizeS * Style.uiScaleRatio;
-                  const maxSize = Style.fontSizeM * Style.uiScaleRatio;
+                  const cellBasedSize = gridEntry.width * 0.1;
+                  const baseSize = Style.fontSizeXS * Style.uiScaleRatio;
+                  const maxSize = Style.fontSizeS * Style.uiScaleRatio;
                   return Math.min(Math.max(cellBasedSize, baseSize), maxSize);
                 }
                 font.weight: Style.fontWeightSemiBold

--- a/Modules/Panels/Settings/Tabs/Idle/BehaviorSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Idle/BehaviorSubTab.qml
@@ -95,7 +95,7 @@ ColumnLayout {
       actionName: I18n.tr("panels.idle.screen-off-label")
       actionDescription: I18n.tr("panels.idle.screen-off-description")
       timeoutValue: Settings.data.idle.screenOffTimeout
-      defaultValue: 0
+      defaultValue: Settings.getDefaultValue("idle.screenOffTimeout")
       command: Settings.data.idle.screenOffCommand
       resumeCommand: Settings.data.idle.resumeScreenOffCommand
       onActionTimeoutChanged: val => Settings.data.idle.screenOffTimeout = val
@@ -113,7 +113,7 @@ ColumnLayout {
       actionName: I18n.tr("panels.idle.lock-label")
       actionDescription: I18n.tr("panels.idle.lock-description")
       timeoutValue: Settings.data.idle.lockTimeout
-      defaultValue: 0
+      defaultValue: Settings.getDefaultValue("idle.lockTimeout")
       command: Settings.data.idle.lockCommand
       resumeCommand: Settings.data.idle.resumeLockCommand
       onActionTimeoutChanged: val => Settings.data.idle.lockTimeout = val
@@ -131,7 +131,7 @@ ColumnLayout {
       actionName: I18n.tr("common.suspend")
       actionDescription: I18n.tr("panels.idle.suspend-description")
       timeoutValue: Settings.data.idle.suspendTimeout
-      defaultValue: 0
+      defaultValue: Settings.getDefaultValue("idle.suspendTimeout")
       command: Settings.data.idle.suspendCommand
       resumeCommand: Settings.data.idle.resumeSuspendCommand
       onActionTimeoutChanged: val => Settings.data.idle.suspendTimeout = val


### PR DESCRIPTION
The label font for launcher entries in grid view is quite large, I have reduced it a bit.
Also fixing missing default values for some idle settings.