### PR TITLE
Fix network tooltip

### DIFF
--- a/Modules/Bar/Widgets/Network.qml
+++ b/Modules/Bar/Widgets/Network.qml
@@ -131,7 +131,7 @@ Item {
       PanelService.showContextMenu(contextMenu, pill, screen);
     }
     tooltipText: {
-      if (PanelService.getPanel("networkPanel", screen)) {
+      if (PanelService.getPanel("networkPanel", screen)?.isPanelOpen) {
         return "";
       }
       try {


### PR DESCRIPTION
Sorry for this, just a bug I introduced by using the panel as a condition instead of `isPanelOpen`. I've check all the other I changed in my PR and it's the only case like this.