### PR TITLE
Fix visual focus in launcher with (back)tab key

### DIFF
--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -547,7 +547,9 @@ Rectangle {
       if (showProviderCategories) {
         var cats = providerCategories;
         var idx = cats.indexOf(currentProvider.selectedCategory);
-        currentProvider.selectCategory(cats[(idx + 1) % cats.length]);
+        var nextIdx = (idx + 1) % cats.length;
+        currentProvider.selectCategory(cats[nextIdx]);
+        categoryTabs.currentIndex = nextIdx;
       } else {
         selectNextWrapped();
       }
@@ -557,7 +559,9 @@ Rectangle {
       if (showProviderCategories) {
         var cats2 = providerCategories;
         var idx2 = cats2.indexOf(currentProvider.selectedCategory);
-        currentProvider.selectCategory(cats2[((idx2 - 1) % cats2.length + cats2.length) % cats2.length]);
+        var prevIdx = ((idx2 - 1) % cats2.length + cats2.length) % cats2.length;
+        currentProvider.selectCategory(cats2[prevIdx]);
+        categoryTabs.currentIndex = prevIdx;
       } else {
         selectPreviousWrapped();
       }


### PR DESCRIPTION
# Pull Request

## Motivation

Pressing Tab/Backtab to switch categories in the Launcher stop working if we click on a provider category. Tbh I'm not sure why it works before the click, my fix might not be the best solution.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/48a12531-5c9e-4424-9210-0bdef51c58bb

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
