### PR TITLE
Auto hide panels

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -696,6 +696,11 @@
       "centered": "Centered panel",
       "window": "Separate window"
     },
+    "settings-panel-auto-hide": {
+      "never": "Never",
+      "once-entered": "Once entered",
+      "always": "Always"
+    },
     "visualizer-types": {
       "linear": "Linear",
       "mirrored": "Mirrored",
@@ -1684,6 +1689,12 @@
       "panel-background-opacity-label": "Panel background opacity",
       "panels-attached-to-bar-description": "Panels lock to the bar and screen edges, creating a seamless look with stylish inverted corners.",
       "panels-attached-to-bar-label": "Snap panels to edges",
+      "panels-auto-hide-description": "Auto-hide a panel after mouse leaves",
+      "panels-auto-hide-label": "Auto-hide",
+      "panels-auto-hide-delay-description": "Time before panel hides automatically after mouse leaves.",
+      "panels-auto-hide-delay-label": "Auto hide delay",
+      "panels-auto-hide-delay-before-enter-description": "Time before panel hides automatically before mouse enters.",
+      "panels-auto-hide-delay-before-enter-label": "Auto hide delay before entering",
       "panels-overlay-description": "Ensures panels and the bar remain visible, even over fullscreen applications.",
       "panels-overlay-label": "Keep panels & bar on top",
       "scaling-description": "Changes the size of the general user interface, excluding the bar.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -155,6 +155,9 @@
     "panelBackgroundOpacity": 0.93,
     "translucentWidgets": false,
     "panelsAttachedToBar": true,
+    "panelsAutoHide": "never",
+    "panelsHideDelay": 300,
+    "panelsHideBeforeEnterDelay": 1000,
     "settingsPanelMode": "attached",
     "settingsPanelSideBarCardStyle": false
   },

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -2443,6 +2443,33 @@
     "subTabLabel": "common.panels"
   },
   {
+    "labelKey": "panels.user-interface.panels-auto-hide-label",
+    "descriptionKey": "panels.user-interface.panels-auto-hide-description",
+    "widget": "NComboBox",
+    "tab": 1,
+    "tabLabel": "panels.user-interface.title",
+    "subTab": 1,
+    "subTabLabel": "common.panels"
+  },
+  {
+    "labelKey": "panels.user-interface.panels-auto-hide-delay-label",
+    "descriptionKey": "panels.user-interface.panels-auto-hide-delay-description",
+    "widget": "NValueSlider",
+    "tab": 1,
+    "tabLabel": "panels.user-interface.title",
+    "subTab": 1,
+    "subTabLabel": "common.panels"
+  },
+  {
+    "labelKey": "panels.user-interface.panels-auto-hide-delay-before-enter-label",
+    "descriptionKey": "panels.user-interface.panels-auto-hide-delay-before-enter-description",
+    "widget": "NValueSlider",
+    "tab": 1,
+    "tabLabel": "panels.user-interface.title",
+    "subTab": 1,
+    "subTabLabel": "common.panels"
+  },
+  {
     "labelKey": "panels.user-interface.settings-panel-mode-label",
     "descriptionKey": "panels.user-interface.settings-panel-mode-description",
     "widget": "NComboBox",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -333,6 +333,9 @@ Singleton {
       property real panelBackgroundOpacity: 0.93
       property bool translucentWidgets: false
       property bool panelsAttachedToBar: true
+      property string panelsAutoHide: "never"
+      property int panelsHideDelay: 300
+      property int panelsHideBeforeEnterDelay: 1000
       property string settingsPanelMode: "attached" // "centered", "attached", "window"
       property bool settingsPanelSideBarCardStyle: false
     }

--- a/Modules/Bar/Extras/TrayMenu.qml
+++ b/Modules/Bar/Extras/TrayMenu.qml
@@ -58,6 +58,8 @@ PopupWindow {
   }
 
   visible: false
+  onVisibleChanged: PanelService.childrenVisible(visible)
+
   color: "transparent"
   anchor.item: anchorItem
   anchor.rect.x: {

--- a/Modules/MainScreen/SmartPanel.qml
+++ b/Modules/MainScreen/SmartPanel.qml
@@ -52,10 +52,19 @@ Item {
   property bool isPanelVisible: false
 
   // Track if the panel is hovered or any popup
-  property bool isHovered: false
   property bool isDirectlyHovered: false
   property bool isChildrenVisible: false
   property bool isChildrenHovered: false
+  property bool isHovered: isDirectlyHovered || isChildrenVisible || isChildrenHovered
+
+  onIsHoveredChanged: {
+    if(isHovered) {
+      hoverEval.stop();
+    } else {
+        hoverEval.interval = Settings.data.ui.panelsHideDelay;
+        hoverEval.restart();
+    }
+  }
 
   // Track size animation completion for sequential opacity animation
   property bool sizeAnimationComplete: false
@@ -283,7 +292,6 @@ Item {
     closeWatchdogTimer.stop();
 
     // Reset hovering status
-    isHovered = false;
     isDirectlyHovered = false;
     isChildrenVisible = false;
     isChildrenHovered = false;
@@ -319,7 +327,6 @@ Item {
     closeWatchdogTimer.stop();
 
     // Reset hovering
-    isHovered = false;
     isDirectlyHovered = false;
     isChildrenVisible = false;
     isChildrenHovered = false;
@@ -792,19 +799,6 @@ Item {
         Logger.w("SmartPanel", "Close watchdog timeout - forcing panel close", root.objectName);
         // Force finalization
         Qt.callLater(root.finalizeClose);
-      }
-    }
-  }
-
-  function hoveringCheck(hovered){
-    if(hovered) {
-      hoverEval.stop();
-      isHovered = true;
-    } else {
-      isHovered = isDirectlyHovered || isChildrenVisible || isChildrenHovered;
-      if (!isHovered) {
-        hoverEval.interval = Settings.data.ui.panelsHideDelay;
-        hoverEval.restart();
       }
     }
   }
@@ -1353,10 +1347,7 @@ Item {
 
       HoverHandler {
         id: hoverHandler
-        onHoveredChanged: {
-          isDirectlyHovered = hovered;
-          root.hoveringCheck(hovered);
-        }
+        onHoveredChanged: isDirectlyHovered = hovered
       }
 
       onLoaded: {

--- a/Modules/MainScreen/SmartPanel.qml
+++ b/Modules/MainScreen/SmartPanel.qml
@@ -51,6 +51,12 @@ Item {
   // Track actual visibility (delayed until content is loaded and sized)
   property bool isPanelVisible: false
 
+  // Track if the panel is hovered or any popup
+  property bool isHovered: false
+  property bool isDirectlyHovered: false
+  property bool isChildrenVisible: false
+  property bool isChildrenHovered: false
+
   // Track size animation completion for sequential opacity animation
   property bool sizeAnimationComplete: false
 
@@ -276,6 +282,13 @@ Item {
     closeWatchdogActive = false;
     closeWatchdogTimer.stop();
 
+    // Reset hovering status
+    isHovered = false;
+    isDirectlyHovered = false;
+    isChildrenVisible = false;
+    isChildrenHovered = false;
+    hoverEval.stop();
+
     // Don't set opacity directly as it breaks the binding
     root.isPanelVisible = false;
     root.sizeAnimationComplete = false;
@@ -304,6 +317,13 @@ Item {
     root.closeFinalized = true;
     root.closeWatchdogActive = false;
     closeWatchdogTimer.stop();
+
+    // Reset hovering
+    isHovered = false;
+    isDirectlyHovered = false;
+    isChildrenVisible = false;
+    isChildrenHovered = false;
+    hoverEval.stop();
 
     root.isPanelVisible = false;
     root.isPanelOpen = false;
@@ -772,6 +792,38 @@ Item {
         Logger.w("SmartPanel", "Close watchdog timeout - forcing panel close", root.objectName);
         // Force finalization
         Qt.callLater(root.finalizeClose);
+      }
+    }
+  }
+
+  function hoveringCheck(hovered){
+    if(hovered) {
+      hoverEval.stop();
+      isHovered = true;
+    } else {
+      isHovered = isDirectlyHovered || isChildrenVisible || isChildrenHovered;
+      if (!isHovered) {
+        hoverEval.interval = Settings.data.ui.panelsHideDelay;
+        hoverEval.restart();
+      }
+    }
+  }
+
+  onOpened: {
+    if (Settings.data.ui.panelsAutoHide === "always") {
+      hoverEval.interval = Settings.data.ui.panelsHideBeforeEnterDelay;
+      hoverEval.restart();
+    }
+  }
+
+  // Hover timer to close panel when exited
+  Timer {
+    id: hoverEval
+    interval: Settings.data.ui.panelsHideDelay
+    repeat: false
+    onTriggered: {
+      if (!isHovered && root.isPanelOpen && Settings.data.ui.panelsAutoHide !== "never"){
+        root.close();
       }
     }
   }
@@ -1298,6 +1350,14 @@ Item {
       width: panelBackground.width
       height: panelBackground.height
       sourceComponent: root.panelContent
+
+      HoverHandler {
+        id: hoverHandler
+        onHoveredChanged: {
+          isDirectlyHovered = hovered;
+          root.hoveringCheck(hovered);
+        }
+      }
 
       onLoaded: {
         // Wait for contentPreferredWidth/Height to be available before making visible

--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -8,6 +8,7 @@ import Quickshell.Widgets
 import qs.Commons
 import qs.Services.System
 import qs.Widgets
+import qs.Services.UI
 
 // Simple notification popup - displays multiple notifications
 Variants {
@@ -435,6 +436,7 @@ Variants {
                   } else {
                     resumeTimer.start();
                   }
+                  PanelService.childrenHovered(hovered);
                 }
               }
 

--- a/Modules/Panels/Dock/StaticDockPanel.qml
+++ b/Modules/Panels/Dock/StaticDockPanel.qml
@@ -16,6 +16,7 @@ SmartPanel {
   readonly property bool isFramed: Settings.data.bar.barType === "framed" && hasBar
   property bool isDockHovered: false
   property bool panelHovered: false
+  isHovered: true // Turn off SmartPanel auto-hide feature by removing the hovering binding
   readonly property int iconSize: Math.round(12 + 24 * (Settings.data.dock.size ?? 1))
   readonly property int maxWidth: screen ? screen.width * 0.8 : 1000
   readonly property int maxHeight: screen ? screen.height * 0.8 : 1000

--- a/Modules/Panels/Media/MediaPlayerPanel.qml
+++ b/Modules/Panels/Media/MediaPlayerPanel.qml
@@ -154,7 +154,7 @@ SmartPanel {
               onClicked: playerContextMenu.open()
             }
 
-            Popup {
+            NPopup {
               id: playerContextMenu
               x: 0
               y: parent.height

--- a/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml
@@ -7,7 +7,7 @@ import qs.Services.UI
 import qs.Widgets
 
 // Widget Settings Dialog Component
-Popup {
+NPopup {
   id: root
 
   property int widgetIndex: -1

--- a/Modules/Panels/Settings/ControlCenter/ControlCenterWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/ControlCenter/ControlCenterWidgetSettingsDialog.qml
@@ -6,7 +6,7 @@ import qs.Services.UI
 import qs.Widgets
 
 // Widget Settings Dialog Component
-Popup {
+NPopup {
   id: root
 
   property int widgetIndex: -1

--- a/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
@@ -8,7 +8,7 @@ import qs.Services.Noctalia
 import qs.Services.UI
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
 
   property int widgetIndex: -1

--- a/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
@@ -8,7 +8,7 @@ import qs.Services.Theming
 import qs.Services.UI
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
 
   property var availableSchemes: []

--- a/Modules/Panels/Settings/Tabs/Hooks/HookEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Hooks/HookEditPopup.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import qs.Commons
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
   modal: true
   closePolicy: Popup.NoAutoClose

--- a/Modules/Panels/Settings/Tabs/Plugins/InstalledSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Plugins/InstalledSubTab.qml
@@ -429,7 +429,7 @@ ColumnLayout {
   }
 
   // Uninstall confirmation dialog
-  Popup {
+  NPopup {
     id: uninstallDialog
     parent: Overlay.overlay
     modal: true

--- a/Modules/Panels/Settings/Tabs/Plugins/SourcesSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Plugins/SourcesSubTab.qml
@@ -91,7 +91,7 @@ ColumnLayout {
   }
 
   // Add source dialog
-  Popup {
+  NPopup {
     id: addSourceDialog
     parent: Overlay.overlay
     modal: true

--- a/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
+++ b/Modules/Panels/Settings/Tabs/SessionMenu/SessionMenuEntrySettingsDialog.qml
@@ -5,7 +5,7 @@ import qs.Commons
 import qs.Widgets
 
 // Session Menu Entry Settings Dialog Component
-Popup {
+NPopup {
   id: root
 
   property int entryIndex: -1

--- a/Modules/Panels/Settings/Tabs/UserInterface/PanelsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/UserInterface/PanelsSubTab.qml
@@ -55,6 +55,59 @@ ColumnLayout {
     text: Math.floor(Settings.data.general.dimmerOpacity * 100) + "%"
   }
 
+  NComboBox {
+    Layout.fillWidth: true
+    label: I18n.tr("panels.user-interface.panels-auto-hide-label")
+    description: I18n.tr("panels.user-interface.panels-auto-hide-description")
+    model: [
+      {
+        "key": "never",
+        "name": I18n.tr("options.settings-panel-auto-hide.never")
+      },
+      {
+        "key": "once-entered",
+        "name": I18n.tr("options.settings-panel-auto-hide.once-entered")
+      },
+      {
+        "key": "always",
+        "name": I18n.tr("options.settings-panel-auto-hide.always")
+      }
+    ]
+    currentKey: Settings.data.ui.panelsAutoHide
+    onSelected: key => Settings.data.ui.panelsAutoHide = key
+    defaultValue: Settings.getDefaultValue("ui.panelsAutoHide")
+  }
+
+  NValueSlider {
+    Layout.fillWidth: true
+    visible: Settings.data.ui.panelsAutoHide !== "never"
+    label: I18n.tr("panels.user-interface.panels-auto-hide-delay-label")
+    description: I18n.tr("panels.user-interface.panels-auto-hide-delay-description")
+    from: 100
+    to: 2000
+    stepSize: 100
+    showReset: true
+    value: Settings.data.ui.panelsHideDelay
+    defaultValue: Settings.getDefaultValue("ui.panelsHideDelay")
+    onMoved: value => Settings.data.ui.panelsHideDelay = value
+    text: Settings.data.ui.panelsHideDelay + "ms"
+  }
+
+  NValueSlider {
+    Layout.fillWidth: true
+    visible: Settings.data.ui.panelsAutoHide === "always"
+    label: I18n.tr("panels.user-interface.panels-auto-hide-delay-before-enter-label")
+    description: I18n.tr("panels.user-interface.panels-auto-hide-delay-before-enter-description")
+    from: 200
+    to: 4000
+    stepSize: 100
+    showReset: true
+    value: Settings.data.ui.panelsHideBeforeEnterDelay
+    defaultValue: Settings.getDefaultValue("ui.panelsHideBeforeEnterDelay")
+    onMoved: value => Settings.data.ui.panelsHideBeforeEnterDelay = value
+    text: Settings.data.ui.panelsHideBeforeEnterDelay + "ms"
+  }
+
   NDivider {
     Layout.fillWidth: true
   }

--- a/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
+++ b/Modules/Panels/Wallpaper/WallhavenSettingsPopup.qml
@@ -6,7 +6,7 @@ import qs.Commons
 import qs.Services.UI
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
 
   property ShellScreen screen

--- a/Modules/Toast/Toast.qml
+++ b/Modules/Toast/Toast.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import qs.Commons
 import qs.Services.System
 import qs.Widgets
+import qs.Services.UI
 
 Item {
   id: root
@@ -76,6 +77,7 @@ Item {
       } else {
         resumeTimer.start();
       }
+      PanelService.childrenHovered(hovered);
     }
   }
 

--- a/Services/UI/PanelService.qml
+++ b/Services/UI/PanelService.qml
@@ -45,6 +45,24 @@ Singleton {
     }
   }
 
+  // Used when a component appears above a panel
+  // See NPopup and TrayMenu
+  function childrenVisible(visible) {
+    if(openedPanel){
+      openedPanel.isChildrenVisible = visible;
+      openedPanel.hoveringCheck(visible);
+    }
+  }
+
+  // Used when hovering a component like notifications
+  // See Toast/Notification
+  function childrenHovered(hovered) {
+    if(openedPanel){
+      openedPanel.isChildrenHovered = hovered;
+      openedPanel.hoveringCheck(hovered);
+    }
+  }
+
   // Popup menu windows (one per screen) - used for both tray menus and context menus
   property var popupMenuWindows: ({})
   signal popupMenuWindowRegistered(var screen)

--- a/Services/UI/PanelService.qml
+++ b/Services/UI/PanelService.qml
@@ -50,7 +50,6 @@ Singleton {
   function childrenVisible(visible) {
     if(openedPanel){
       openedPanel.isChildrenVisible = visible;
-      openedPanel.hoveringCheck(visible);
     }
   }
 
@@ -59,7 +58,6 @@ Singleton {
   function childrenHovered(hovered) {
     if(openedPanel){
       openedPanel.isChildrenHovered = hovered;
-      openedPanel.hoveringCheck(hovered);
     }
   }
 

--- a/Widgets/NColorPickerDialog.qml
+++ b/Widgets/NColorPickerDialog.qml
@@ -7,7 +7,7 @@ import qs.Commons
 import qs.Services.UI
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
 
   property var screen

--- a/Widgets/NComboBox.qml
+++ b/Widgets/NComboBox.qml
@@ -246,7 +246,7 @@ RowLayout {
       pointSize: Style.fontSizeL
     }
 
-    popup: Popup {
+    popup: NPopup {
       y: combo.height + Style.marginS
       implicitWidth: combo.width
       implicitHeight: Math.min(Math.round(root.popupHeight * Style.uiScaleRatio), listView.contentHeight + Style.margin2M)

--- a/Widgets/NContextMenu.qml
+++ b/Widgets/NContextMenu.qml
@@ -30,7 +30,7 @@ import qs.Commons
 *     onClicked: contextMenu.openAtItem(parent, mouse.x, mouse.y)
 *   }
 */
-Popup {
+NPopup {
   id: root
 
   property var model: []

--- a/Widgets/NFilePicker.qml
+++ b/Widgets/NFilePicker.qml
@@ -7,7 +7,7 @@ import Quickshell.Io
 import qs.Commons
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
 
   // Properties

--- a/Widgets/NIconPicker.qml
+++ b/Widgets/NIconPicker.qml
@@ -5,7 +5,7 @@ import QtQuick.Window
 import qs.Commons
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
   modal: true
 

--- a/Widgets/NPluginSettingsPopup.qml
+++ b/Widgets/NPluginSettingsPopup.qml
@@ -6,7 +6,7 @@ import qs.Services.Noctalia
 import qs.Services.UI
 import qs.Widgets
 
-Popup {
+NPopup {
   id: root
   modal: true
   dim: false

--- a/Widgets/NPopup.qml
+++ b/Widgets/NPopup.qml
@@ -1,0 +1,8 @@
+import QtQuick
+import QtQuick.Controls
+import qs.Services.UI
+
+Popup {
+  id: root
+  onVisibleChanged: PanelService.childrenVisible(visible)
+}

--- a/Widgets/NSearchableComboBox.qml
+++ b/Widgets/NSearchableComboBox.qml
@@ -218,7 +218,7 @@ RowLayout {
       pointSize: Style.fontSizeL
     }
 
-    popup: Popup {
+    popup: NPopup {
       y: combo.height + Style.marginS
       width: combo.width
       height: Math.round((root.popupHeight + 60) * Style.uiScaleRatio)


### PR DESCRIPTION
Proof of concept : Auto hide SmartPanels when leaving them.
 
### New settings in `User Interface > Panels`
- "Never" (by default) current behavior
- "Once entered" auto-hide a panel when mouse leaves it
- "Always" also auto-hide the panel if we never enter it
  
Delays when entering and before entering can be changed in settings.

### Implementation

#### Components
This was really tricky, I settled on the version I came up with the less invasive changes : each component that could trigger the auto-hide feature needs to be handled separately, I identified few components : 
- Toast & Notification
- Popup
- Tray Menu
- SmartPanel

For `Toast` and `Notification`, I just used the existing `HoverHandler`. 
For `SmartPanel` I added a `HoverHandler` in the `contentLoader`. 
For `TrayMenu` I used the visibility
For `Popup` I also used visibility, but to avoid duplicating the code everywhere I created a `NPopup` widget which just overloads `Popup` with a simple binding.

#### Logic

The logic is quite simple, I have three properties:
- `isDirectlyHovered`: set by the handler of `SmartPanel`
- `isChildrenHovered`: used by Notification/Toast handlers
- `isChildrenVisible`: It was quite tedious to have handlers everywhere, notably I was not able to factorize the code easily as I did with `NPopup`, so I thought it was a bad idea to use hovering, so I choose visibility instead. If a popup is opened, we do not close panels (for example combo boxes, and many other widgets).
- `isHovered`: disjunction of all the above

And so I have a timer:
- Setting any of the above to `true` stops the timer
- Setting any of the above to `false` will recompute `isHovered` and start the timer if it is false.
- Once the timer triggers, if `isHovered` is still false, the setting is enabled and the panel is still open, we close it. These checks are mainly here to avoid race condition, in theory setting `isHovered` to true stops the timer, and closing the panel too.

TODO: Take into account the hovering of the bar widget corresponding to the opened panel

Known limitation: Well, as mentioned it requires to identify everything that should stop auto-hide. For instance It won't work on plugins that have contextual menus/popups in their panels, since we need to replace `Popup` for example, etc.

@ItsLemmy I'm curious to get your opinion on this one at this point, even if it's still in progress. This part must be done before the "open panel when hovering widget" feature.

Edit: Also I came up with (imo) bad names, so I'll probably find better ones. This also includes setting labels/descriptions

