### PR TITLE
template: update the tab color for yazi template

### DIFF
--- a/Assets/Templates/yazi.toml
+++ b/Assets/Templates/yazi.toml
@@ -76,9 +76,9 @@ selected = { reversed = true }
 # : Tabs [[[
 
 [tabs]
-active = { fg = "{{colors.primary.default.hex}}", bold = true, bg = "{{colors.surface.default.hex}}" }
+active = { fg = "{{colors.surface.default.hex}}", bold = true, bg = "{{colors.primary.default.hex}}" }
 inactive = { fg = "{{colors.secondary.default.hex}}", bg = "{{colors.surface.default.hex}}" }
-sep_inner = { open = "[", close = "]" }
+sep_inner = { open = "", close = "" }
 
 # : ]]]
 


### PR DESCRIPTION
# Pull Request

Currently, the active tab in yazi template has primary color as foreground and surface color as background with square bracket as separator. When I have many tabs open, this makes distinguishing active tab kind of difficult. In this PR I just reversed the colors in the active tab.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before:
<img width="2560" height="1600" alt="Screenshot_2026-03-03-04-29-53" src="https://github.com/user-attachments/assets/c3b98633-d718-45c7-82d9-bbb07ac4eebb" />

After:
<img width="2560" height="1600" alt="Screenshot_2026-03-03-04-31-12" src="https://github.com/user-attachments/assets/ffc473bc-5452-4c1d-ac31-9a41a0817c08" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
