### PR TITLE
Templates: terminal: foot: Replace [colors] with [colors-dark]

### DIFF
--- a/Assets/Templates/terminal/foot
+++ b/Assets/Templates/terminal/foot
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 background = {{colors.surface.default.hex_stripped}}
 foreground = {{colors.on_surface.default.hex_stripped}}
 

--- a/Scripts/python/src/theming/lib/terminal.py
+++ b/Scripts/python/src/theming/lib/terminal.py
@@ -46,7 +46,7 @@ class TerminalColors:
     visual_bell: str
     indexed: dict[int, str]
     tab_bar: dict
-    
+
     # Kitty border colors
     active_border: str
     inactive_border: str
@@ -127,7 +127,7 @@ class TerminalGenerator:
     def generate_foot(self) -> str:
         """Generate foot terminal theme (INI format, no # prefix)."""
         c = self.colors
-        lines = ["[colors]"]
+        lines = ["[colors-dark]"]
 
         # Primary colors
         lines.append(f"foreground={self._strip_hash(c.foreground)}")


### PR DESCRIPTION
This was replaced in foot 1.26.0

Link: https://codeberg.org/dnkl/foot/commit/cf2b390f6e096e7a2ca93d4dece153eb13261a2e

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This will break foot versions < 1.26.0, also the file in Assets doesn't seem to do anything.
