### PR TITLE
fix(i18n): add missing error toast translation for custom commands

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1847,6 +1847,10 @@
       "unavailable": "Clipboard history unavailable",
       "unavailable-desc": "The 'cliphist' application is not installed. Please install it to use clipboard history features"
     },
+    "custom-command-failed": {
+      "description": "Command failed: {command}\nExit code: {code}",
+      "title": "Custom command failed"
+    },
     "do-not-disturb": {
       "disabled": "Do Not Disturb disabled",
       "disabled-desc": "Showing all notifications",


### PR DESCRIPTION
# Pull Request

## Motivation
This PR fixes an issue where custom command execution errors were not displaying their localized strings, causing the UI to show raw translation keys (e.g., !!!custom-command-failed...!!!) instead of a user-friendly message.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="2560" height="1440" alt="Image" src="https://github.com/user-attachments/assets/512ca35f-008c-4474-9893-be7acc81bf94" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
