### PR TITLE
Show notification on all screens when 0 screens are found

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -11,8 +11,15 @@ import qs.Widgets
 
 // Simple notification popup - displays multiple notifications
 Variants {
-  // If no notification display activated in settings, then show them all
-  model: Quickshell.screens.filter(screen => (Settings.data.notifications.monitors.includes(screen.name) || (Settings.data.notifications.monitors.length === 0)))
+
+  model: {
+    const screens = Quickshell.screens.filter(screen => Settings.data.notifications.monitors.includes(screen.name));
+    // Empty list can mean two things :
+    // - No (visible) notification display activated in settings
+    // - One or more (not visible) displays are activated but unplugged
+    // In both cases we fallback to show notification on all screens
+    return screens.length === 0 ? Quickshell.screens : screens;
+  }
 
   delegate: Loader {
     id: root


### PR DESCRIPTION
# Pull Request

## Motivation

The behavior to select displays for notification was the following : 
- If some screens are checked in settings, we use them
- Else (if the list of checked monitors is empty) we notify on all screens

But this behavior does not work in cases where a display is checked in settings but unplugged : it still appears as checked in settings data, even if not visible in the panel, and we end up without any screens to display the notification since we have "unplugged yet checked" monitors.

This PR just changes the logic : 
- If some ***plugged*** screens are selected in settings, we use them
- Else we notify on all screens

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)