### PR TITLE
fix(zen-browser): removed unused groupboxes background

### DIFF
--- a/Assets/Templates/zen-browser/zen-userContent.css
+++ b/Assets/Templates/zen-browser/zen-userContent.css
@@ -44,10 +44,6 @@
       --zen-primary-color: {{colors.primary.default.hex}} !important;
     }
 
-    groupbox , moz-card{
-      background: {{colors.surface_container.default.hex}} !important;
-    }
-
     button,
     groupbox menulist {
       background: {{colors.surface_container_high.default.hex}} !important;


### PR DESCRIPTION
# Pull Request

## Motivation
It fixes unused groupboxes background styling, cause it's dosen't have a padding and looks broken. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- Closes #2083 

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
