### PR TITLE
OSD: prioritize volume over input volume

### DIFF
--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -35,6 +35,7 @@ Variants {
     property int currentOSDType: -1 // OSD.Type enum value, -1 means none
     property bool startupComplete: false
     property real currentBrightness: 0
+    property bool suppressInputOSD: false
 
     // Lock Key States
     property string lastLockKeyChanged: ""  // "caps", "num", "scroll", or ""
@@ -258,11 +259,15 @@ Variants {
       }
 
       function onInputVolumeChanged() {
+        if (suppressInputOSD)
+          return;
         if (AudioService.hasInput)
           showOSD(OSD.Type.InputVolume);
       }
 
       function onInputMutedChanged() {
+        if (suppressInputOSD)
+          return;
         if (!AudioService.hasInput)
           return;
         if (AudioService.consumeInputOSDSuppression())
@@ -272,6 +277,8 @@ Variants {
 
       // Refresh OSD when device changes to ensure correct volume is displayed
       function onSinkChanged() {
+        suppressInputOSD = true;
+        inputSuppressionTimer.restart();
         // If volume OSD is currently showing, refresh it to show new device's volume
         if (root.currentOSDType === OSD.Type.Volume) {
           Qt.callLater(() => {
@@ -342,6 +349,14 @@ Variants {
         connectBrightnessMonitors();
         root.startupComplete = true;
       }
+    }
+
+    // Timer to reset the input volume OSD suppression
+    Timer {
+      id: inputSuppressionTimer
+      interval: 300
+      repeat: false
+      onTriggered: root.suppressInputOSD = false
     }
 
     Component.onDestruction: {


### PR DESCRIPTION
This PR prioritizes volume change OSD notifications over input volume OSD notifications if an audio sink gets connected/disconnected.

Currently, for some reason when connecting my Bluetooth headphones i get an OSD notification for the volume change, but when disconnecting it will show a notification for the input volume change. Also, when disconnecting my Bluetooth speakers i get a notification for input volume muted (since I keep it muted on my laptop) although the speakers are purely a sink.