### PR TITLE
fix(hyprland): sort toplevels by x/y coordinates to fix workspace widget ordering in dynamic layouts

### DIFF
--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -281,7 +281,7 @@ Item {
         }
       }
 
-      windows = windowsList;
+      windows = toSortedWindowList(windowsList);
 
       if (newFocusedIndex !== focusedWindowIndex) {
         focusedWindowIndex = newFocusedIndex;
@@ -309,17 +309,52 @@ Item {
       const focused = toplevel.activated === true;
       const output = toplevel.monitor?.name || "";
 
+      // Extract position
+      let x = 0;
+      let y = 0;
+      try {
+        const ipcData = toplevel.lastIpcObject;
+        if (ipcData && ipcData.at) {
+          x = ipcData.at[0];
+          y = ipcData.at[1];
+        } else if (typeof toplevel.x !== 'undefined') {
+          x = toplevel.x;
+          y = toplevel.y;
+        }
+      } catch (e) {}
+
       return {
         "id": windowId,
         "title": title,
         "appId": appId,
         "workspaceId": wsId || -1,
         "isFocused": focused,
-        "output": output
+        "output": output,
+        "x": x,
+        "y": y
       };
     } catch (e) {
       return null;
     }
+  }
+
+  function toSortedWindowList(windowList) {
+    return windowList.sort((a, b) => {
+                             // Sort by workspace first (just in case they are mixed)
+                             if (a.workspaceId !== b.workspaceId) {
+                               return a.workspaceId - b.workspaceId;
+                             }
+                             // Then sort by X position (left to right)
+                             if (a.x !== b.x) {
+                               return a.x - b.x;
+                             }
+                             // Then sort by Y position (top to bottom)
+                             if (a.y !== b.y) {
+                               return a.y - b.y;
+                             }
+                             // Fallback to Window ID mapping
+                             return a.id.localeCompare(b.id);
+                           });
   }
 
   function getAppTitle(toplevel) {


### PR DESCRIPTION
Bug In Hyprland, when using dynamic tiling layouts that aren't purely chronological (like Master Layout or the new Scrolling Layout), the Workspaces widget displays the application icons out of order compared to their physical placement on the screen. This happens because Hyprland.toplevels.values returns the windows in an unstructured order, usually chronologically based on focus history.

Fix This PR modifies 

HyprlandService.qml
 to:

Safely extract the geometric x and y coordinates directly from the raw IPC data (lastIpcObject.at), falling back to standard variables.
Introduce a toSortedWindowList manual fallback mapping function right before the return iteration.
Sort the matrix based on Spatial representation: workspace first, then X coordinates (left to right), then Y coordinates (top to bottom).
The new automatic parsing in v4.6.0 handles the raw events gorgeously, but chaining it with this geometric sorting creates a bullet-proof, 1:1 screen representation on the Workspaces widget.