### PR TITLE
sway: include floating_con windows in workspace mapping

### DIFF
--- a/Services/Compositor/SwayService.qml
+++ b/Services/Compositor/SwayService.qml
@@ -103,8 +103,8 @@ Item {
             }
           }
 
-          // If this is a container with app_id or class (i.e., a window)
-          if (node.type === "con" && (node.app_id || node.window_properties)) {
+          // If this is a regular or floating container with app_id/class (i.e., a window)
+          if ((node.type === "con" || node.type === "floating_con") && (node.app_id || node.window_properties)) {
             const appId = node.app_id || (node.window_properties ? node.window_properties.class : null);
             const title = node.name || "";
             const id = node.id;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

Adds float_con to open Application for Sway so they show up on the bar

## Motivation
Allows people to see all open applications including floating ones.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2088

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [X] Tested on sway
- [ ] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)


## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [X] Documentation or comments updated (if relevant)
