### PR TITLE
Added a way to be able to move the desktop widgets settings popup

### DIFF
--- a/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
@@ -149,25 +149,25 @@ Popup {
     property real pressX: 0
     property real pressY: 0
 
-    onPressed: (mouse) => {
-      pressX = mouse.x;
-      pressY = mouse.y;
-      cursorShape = Qt.ClosedHandCursor
-    }
+    onPressed: mouse => {
+                 pressX = mouse.x;
+                 pressY = mouse.y;
+                 cursorShape = Qt.ClosedHandCursor;
+               }
 
     onReleased: {
-      cursorShape = Qt.OpenHandCursor
+      cursorShape = Qt.OpenHandCursor;
     }
 
-    onPositionChanged: (mouse) => {
-      if (pressed) {
-        var deltaX = mouse.x - pressX;
-        var deltaY = mouse.y - pressY;
+    onPositionChanged: mouse => {
+                         if (pressed) {
+                           var deltaX = mouse.x - pressX;
+                           var deltaY = mouse.y - pressY;
 
-        root.x += deltaX;
-        root.y += deltaY;
-      }
-    }
+                           root.x += deltaX;
+                           root.y += deltaY;
+                         }
+                       }
   }
 
   Timer {


### PR DESCRIPTION
# Pull Request
Added a way to be able to move the Desktop Widget Settings popup.

## Motivation
When editing a widget settings, the popup dialog can be on top of the desktop widget itself, that's why being able to move the settings dialog out of the way makes it easier to edit the widget "live" while it is changing. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
I'm not sure there's an issue about this.

## Testing
I tested the feature as shown in the video below, opening the widget settings dialog and dragging it around.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
A video showcasing the motivation and how it looks like.
https://github.com/user-attachments/assets/cb51b5d8-ed3d-4002-8e64-eae1303f0352

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
One thing is that I'm not sure if that's the "correct" cursor that we need to show when moving the window around. Otherwise no additional notes. 