### PR TITLE
Grid snapping for scale component in desktop widgets

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1020,6 +1020,7 @@
       "edit-mode-description": "Enable edit mode to move and reposition desktop widgets. When enabled, widgets show a drag outline and can be repositioned.",
       "edit-mode-exit-button": "Exit edit mode",
       "edit-mode-grid-snap-label": "Grid snap",
+      "edit-mode-grid-snap-scale-label": "Snap scale",
       "edit-mode-label": "Edit mode",
       "enabled-description": "Enable or disable desktop widgets entirely.",
       "enabled-label": "Enable desktop widgets",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -539,6 +539,7 @@
     "enabled": false,
     "overviewEnabled": true,
     "gridSnap": false,
+    "gridSnapScale": false,
     "monitorWidgets": []
   }
 }

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -763,6 +763,7 @@ Singleton {
       property bool enabled: false
       property bool overviewEnabled: true
       property bool gridSnap: false
+      property bool gridSnapScale: false
       property list<var> monitorWidgets: []
       // Format: [{ "name": "DP-1", "widgets": [...] }, { "name": "HDMI-1", "widgets": [...] }]
     }

--- a/Modules/DesktopWidgets/DesktopWidgets.qml
+++ b/Modules/DesktopWidgets/DesktopWidgets.qml
@@ -442,6 +442,15 @@ Variants {
               }
 
               NIconButton {
+                icon: "grid-3x3"
+                visible: Settings.data.desktopWidgets.gridSnap
+                tooltipText: I18n.tr("panels.desktop-widgets.edit-mode-grid-snap-scale-label")
+                colorBg: Settings.data.desktopWidgets.gridSnapScale ? Color.mPrimary : Color.mSurfaceVariant
+                colorFg: Settings.data.desktopWidgets.gridSnapScale ? Color.mOnPrimary : Color.mPrimary
+                onClicked: Settings.data.desktopWidgets.gridSnapScale = !Settings.data.desktopWidgets.gridSnapScale
+              }
+
+              NIconButton {
                 icon: "grid-4x4"
                 tooltipText: I18n.tr("panels.desktop-widgets.edit-mode-grid-snap-label")
                 colorBg: Settings.data.desktopWidgets.gridSnap ? Color.mPrimary : Color.mSurfaceVariant

--- a/Modules/DesktopWidgets/DraggableDesktopWidget.qml
+++ b/Modules/DesktopWidgets/DraggableDesktopWidget.qml
@@ -116,7 +116,7 @@ Item {
   }
 
   function snapScaleToGrid(scale) {
-    if (!Settings.data.desktopWidgets.gridSnap) {
+    if (!Settings.data.desktopWidgets.gridSnap || !Settings.data.desktopWidgets.gridSnapScale) {
       return scale;
     }
 


### PR DESCRIPTION
# Pull Request
Added a grid snapping support for the scale in the DraggableDesktopWidget.qml component

## Motivation
When using the grid to position and scale desktop widgets, I would have expected both position and scale to snap to the grid. This PR makes it so that the scale can also snap to the grid. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
No related issue found.

## Testing
By using the desktop widgets, scaling them and seeing that they scale correctly with their background on, on the desktop. 

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Here's a video of the grid scale snapping working, it also showcases (not the best example), of how this can be used to scale the desktop widgets, so that they have a more "correct" size compared to each other. 

https://github.com/user-attachments/assets/fa40e5c7-6dad-4e25-b783-36327d3fd7ca

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
One final note that I was thinking about is that I used the internal.initialWidth. It hasn't been used in any other part of the file as far as I could see, if it does have a function that I can't see / notice, please do let me know so that I can update the code. 