### PR TITLE
fix(plugins): preserve settings.json during plugin update

### DIFF
--- a/Services/Noctalia/PluginService.qml
+++ b/Services/Noctalia/PluginService.qml
@@ -441,8 +441,11 @@ Singleton {
     // Use git sparse-checkout to clone only the plugin subfolder
     // GIT_TERMINAL_PROMPT=0 prevents hanging on private repos that need auth
     // Note: We download from the original pluginId folder in the repo, but save to compositeKey folder
-    var downloadCmd = "temp_dir=$(mktemp -d) && GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none --sparse --depth=1 --quiet '" + repoUrl + "' \"$temp_dir\" 2>/dev/null && cd \"$temp_dir\" && git sparse-checkout set '" + pluginId + "' 2>/dev/null && mkdir -p '" + pluginDir + "' && cp -r \"$temp_dir/" + pluginId + "/.\" '" + pluginDir
-        + "/'; exit_code=$?; rm -rf \"$temp_dir\"; exit $exit_code";
+    var downloadCmd = "temp_dir=$(mktemp -d) && GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none --sparse --depth=1 --quiet '" + repoUrl + "' \"$temp_dir\" 2>/dev/null && cd \"$temp_dir\" && git sparse-checkout set '" + pluginId + "' 2>/dev/null && mkdir -p '" + pluginDir + "'"
+        + " && { [ -f '" + pluginDir + "/settings.json' ] && cp '" + pluginDir + "/settings.json' '" + pluginDir + "/settings.json.bak' || true; }"
+        + " && cp -r \"$temp_dir/" + pluginId + "/.\" '" + pluginDir + "/'"
+        + " && { [ -f '" + pluginDir + "/settings.json.bak' ] && mv '" + pluginDir + "/settings.json.bak' '" + pluginDir + "/settings.json' || true; }"
+        + "; exit_code=$?; rm -rf \"$temp_dir\"; exit $exit_code";
 
     // Mark as installing
     var newInstalling = Object.assign({}, root.installingPlugins);


### PR DESCRIPTION
# Pull Request

## Motivation
When updating a plugin, `installPlugin()` uses `cp -r` to copy downloaded plugin files into the plugin directory, which overwrites the user's `settings.json`. This means any user customizations to plugin settings are lost on every update.

This adds a backup/restore of `settings.json` around the `cp -r` call, preserving user customizations across plugin updates. For fresh installs, the backup step is a no-op (`[ -f ... ]` fails, `|| true` continues).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Install a plugin via UI, modify its `settings.json`, trigger an update, confirm settings are preserved. Fresh install a new plugin, confirm it works normally (no stale backup interferes).

## Screenshots / Videos
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Only `PluginService.qml` is changed. The existing `updatePlugin()` backup logic for bar/desktop widgets is unaffected.