### PR TITLE
feat(nix): add pluginPackages for declarative plugin management

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -179,6 +179,27 @@ in
         or filepath, to be written to ~/.config/noctalia/plugins/plugin-name/settings.json.
       '';
     };
+
+    pluginPackages = lib.mkOption {
+      type = with lib.types; attrsOf (either package path);
+      default = { };
+      example = lib.literalExpression ''
+        {
+          catwalk = pkgs.callPackage ./plugins/catwalk { };
+        }
+      '';
+      description = ''
+        Declarative plugin packages. Maps plugin names to derivations or paths
+        containing plugin files (QML, assets, manifest.json).
+
+        Each entry is symlinked into ~/.config/noctalia/plugins/{name}/ with
+        settings.json excluded so that runtime settings remain mutable.
+
+        Plugins are discovered automatically by the shell's PluginRegistry
+        if they contain a valid manifest.json. Use plugins.states to
+        pre-enable them if desired.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -197,7 +218,10 @@ in
           ) "${config.xdg.configFile."noctalia/user-templates.toml".source}"
           ++ lib.mapAttrsToList (
             name: _: "${config.xdg.configFile."noctalia/plugins/${name}/settings.json".source}"
-          ) cfg.pluginSettings;
+          ) cfg.pluginSettings
+          ++ lib.mapAttrsToList (
+            name: _: "${config.xdg.configFile."noctalia/plugins/${name}".source}"
+          ) cfg.pluginPackages;
       };
 
       Service = {
@@ -235,7 +259,24 @@ in
       lib.nameValuePair "noctalia/plugins/${name}/settings.json" {
         source = generateJson "${name}-settings" value;
       }
-    ) cfg.pluginSettings;
+    ) cfg.pluginSettings
+    // lib.mapAttrs' (
+      name: pkg:
+      let
+        filtered = pkgs.runCommand "noctalia-plugin-${name}" { } ''
+          mkdir -p $out
+          for f in ${pkg}/*; do
+            if [ "$(basename "$f")" != "settings.json" ]; then
+              ln -s "$f" "$out/$(basename "$f")"
+            fi
+          done
+        '';
+      in
+      lib.nameValuePair "noctalia/plugins/${name}" {
+        source = filtered;
+        recursive = true;
+      }
+    ) cfg.pluginPackages;
 
     assertions = [
       {


### PR DESCRIPTION
# Pull Request

## Motivation
The home-manager module manages `plugins.json` and `pluginSettings`, but actual plugin files (QML, assets) still require runtime git download. Users want declarative management of plugin files via nix derivations, so that plugins can be pinned and reproduced across systems.

This adds a `pluginPackages` option (`attrsOf (either package path)`) that symlinks plugin derivations into `~/.config/noctalia/plugins/{name}/`, with `settings.json` excluded to keep runtime settings mutable. Plugins with a valid `manifest.json` are auto-discovered by `PluginRegistry.scanPluginFolder()` — no registration logic needed.

Example usage:
```nix
programs.noctalia-shell = {
  pluginPackages = {
    catwalk = pkgs.callPackage ./plugins/catwalk { };
  };
};
```

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Create a test derivation with plugin files (including `manifest.json`), add to `pluginPackages`, run `home-manager switch`. Verify symlinks appear in `~/.config/noctalia/plugins/{name}/`, `settings.json` is not symlinked, and the plugin is discoverable by the shell.

## Screenshots / Videos
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
- Only `nix/home-module.nix` is changed
- `pluginSettings` for the same plugin still works (mutable `settings.json`)
- Systemd restart triggers are added so the shell restarts when plugin packages change