### PR TITLE
Fix transparency issues with connected box for Bluetooth/WiFi

### DIFF
--- a/Modules/Panels/Network/WiFiNetworksList.qml
+++ b/Modules/Panels/Network/WiFiNetworksList.qml
@@ -82,7 +82,7 @@ NBox {
 
         opacity: (NetworkService.disconnectingFrom === modelData.ssid || NetworkService.forgettingNetwork === modelData.ssid) ? 0.6 : 1.0
 
-        color: modelData.connected ? Qt.alpha(Color.mPrimary, 0.15) : Color.mSurface
+        color: modelData.connected ? Qt.alpha(Color.mPrimary, Math.min(1.15 - Settings.data.ui.panelBackgroundOpacity, 0.75)) : Color.mSurface
 
         Behavior on opacity {
           NumberAnimation {

--- a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
@@ -198,6 +198,7 @@ Item {
       Layout.fillWidth: true
       Layout.preferredHeight: connectedDevicesCol.implicitHeight + Style.margin2M
       border.color: showOnlyLists ? Style.boxBorderColor : "transparent"
+      color: showOnlyLists ? Color.mSurfaceVariant : "transparent"
 
       ColumnLayout {
         id: connectedDevicesCol
@@ -228,6 +229,7 @@ Item {
       Layout.fillWidth: true
       Layout.preferredHeight: pairedDevicesCol.implicitHeight + Style.margin2M
       border.color: showOnlyLists ? Style.boxBorderColor : "transparent"
+      color: showOnlyLists ? Color.mSurfaceVariant : "transparent"
 
       ColumnLayout {
         id: pairedDevicesCol
@@ -258,6 +260,7 @@ Item {
       Layout.fillWidth: true
       Layout.preferredHeight: availableDevicesCol.implicitHeight + Style.margin2M
       border.color: "transparent"
+      color: showOnlyLists ? Color.mSurfaceVariant : "transparent"
 
       ColumnLayout {
         id: availableDevicesCol
@@ -386,7 +389,7 @@ Item {
       radius: Style.radiusM
       clip: true
 
-      color: (modelData.connected && modelData.state !== BluetoothDeviceState.Disconnecting) ? Qt.alpha(Color.mPrimary, 0.15) : Color.mSurface
+      color: (modelData.connected && modelData.state !== BluetoothDeviceState.Disconnecting) ? Qt.alpha(Color.mPrimary, Math.min(1.15 - Settings.data.ui.panelBackgroundOpacity, 0.75)) : Color.mSurface
 
       ColumnLayout {
         id: deviceColumn

--- a/Widgets/NBox.qml
+++ b/Widgets/NBox.qml
@@ -24,7 +24,7 @@ Item {
         return root.color;
       }
 
-      // Reuse panel opacity, but limit it to 0.5
+      // Reuse panel opacity, but limit it to 0.4
       let alpha = Math.max(Settings.data.ui.panelBackgroundOpacity, 0.4);
       alpha = Math.max(0, root.color.a - (1.0 - alpha));
       return Qt.alpha(root.color, alpha);


### PR DESCRIPTION
There are some layout issues for the Bluetooth & WiFi when panel transparency is used due to recent changes in NBox. This PR should fix those.