### PR TITLE
fix(desktop-widget-settings): Title should now print much nicer for plugins.

### DIFF
--- a/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
@@ -63,7 +63,7 @@ Popup {
 
         NText {
           text: I18n.tr("system.widget-settings-title", {
-                          "widget": root.widgetId
+                          "widget": DesktopWidgetRegistry.getWidgetDisplayName(root.widgetId)
                         })
           pointSize: Style.fontSizeL
           font.weight: Style.fontWeightBold


### PR DESCRIPTION
# Pull Request
A small PR to make the title of the desktop widget settings dialog print much nicer for plugins. 

## Motivation
Before the title for plugins would be something along the lines of "plugin:plugin-id", now it prints out the name in the manifest instead. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
As far as I know there isn't any issues.

## Testing
Testing was done by opening a desktop widget settings dialog popup and seeing that the name for plugins look much nicer now. 

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Picture of how the fancy audio visualizer plugin settings look for me now. Much better in my opinion rather than it being "plugin:fancy-audiovisualizer"
<img width="489" height="569" alt="image" src="https://github.com/user-attachments/assets/7aaba383-7817-4c74-88fa-12270517be4d" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
No additional notes that I can think of. 