### PR TITLE
fix: show lock screen on remaining monitor when configured monitor is disconnected

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -78,6 +78,14 @@ Loader {
         }
       }
 
+      // Whether any monitor from the user's lockScreenMonitors list is currently connected.
+      readonly property bool anyConfiguredMonitorConnected: {
+        const configured = Settings.data.general.lockScreenMonitors;
+        if (!configured || configured.length === 0)
+          return false;
+        return (Quickshell.screens || []).some(s => configured.includes(s.name));
+      }
+
       WlSessionLock {
         id: lockSession
         locked: root.active
@@ -88,7 +96,7 @@ Loader {
           Loader {
             anchors.fill: parent
             active: true
-            sourceComponent: (Settings.data.general.lockScreenMonitors.length === 0 || (lockSurface.screen && Settings.data.general.lockScreenMonitors.includes(lockSurface.screen.name))) ? fullLockScreenComponent : blackScreenComponent
+            sourceComponent: (!lockContainer.anyConfiguredMonitorConnected || Settings.data.general.lockScreenMonitors.includes(lockSurface.screen?.name)) ? fullLockScreenComponent : blackScreenComponent
           }
 
           Component {


### PR DESCRIPTION
# Pull Request

## Motivation

When a user configures the lock screen to display only on a specific monitor (e.g., HDMI-1) and that monitor gets disconnected, the remaining monitor was left with the black screen. The lock screen should fall back to showing the full lock screen on all remaining monitors when none of the configured monitors are connected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

- Closes #

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
