### PR TITLE
fix: prevent TypeError when Bluetooth device name or icon are not strings

### DIFF
--- a/Helpers/BluetoothUtils.js
+++ b/Helpers/BluetoothUtils.js
@@ -85,8 +85,8 @@ var signalIcon = (p) => {
 
 // Icon mapping
 var deviceIcon = (name, icon) => {
-  var s1 = (name || "").toLowerCase();
-  var s2 = (icon || "").toLowerCase();
+  var s1 = String(name || "").toLowerCase();
+  var s2 = String(icon || "").toLowerCase();
 
   // Prefer icon-based hints for display devices first to avoid "audio" catching TVs
   var displayHints = ["display", "tv", "monitor", "projector", "screen", "chromecast", "cast"];


### PR DESCRIPTION
# Pull Request

## Motivation
This PR fixes the issue related to evaluation in String(...) to force a safe type conversion, this ensures that string methods can be called safely.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This is a simple defensive programming measure to handle typing inconsistencies.