### PR TITLE
Remove app2unit in launcher settings

### DIFF
--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -235,7 +235,6 @@
     "clipboardWatchImageCommand": "wl-paste --type image --watch cliphist store",
     "position": "center",
     "pinnedApps": [],
-    "useApp2Unit": false,
     "sortByMostUsed": true,
     "terminalCommand": "alacritty -e",
     "customLaunchPrefixEnabled": false,

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -1309,15 +1309,6 @@
     ]
   },
   {
-    "labelKey": "panels.launcher.settings-use-app2unit-label",
-    "descriptionKey": "panels.launcher.settings-use-app2unit-description",
-    "widget": "NToggle",
-    "tab": 8,
-    "tabLabel": "panels.launcher.title",
-    "subTab": 2,
-    "subTabLabel": "common.execute"
-  },
-  {
     "labelKey": "panels.launcher.settings-terminal-command-label",
     "descriptionKey": "panels.launcher.settings-terminal-command-description",
     "widget": "NTextInput",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -424,7 +424,6 @@ Singleton {
       property string clipboardWatchImageCommand: "wl-paste --type image --watch cliphist store"
       property string position: "center"  // Position: center, top_left, top_right, bottom_left, bottom_right, bottom_center, top_center
       property list<string> pinnedApps: []
-      property bool useApp2Unit: false
       property bool sortByMostUsed: true
       property string terminalCommand: "alacritty -e"
       property bool customLaunchPrefixEnabled: false

--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -425,14 +425,7 @@ Item {
           const command = prefix.concat(app.command);
           Quickshell.execDetached(command);
         }
-      } else if (Settings.data.appLauncher.useApp2Unit && ProgramCheckerService.app2unitAvailable && app.id) {
-        Logger.d("Taskbar", `Using app2unit for: ${app.id}`);
-        if (app.runInTerminal)
-          Quickshell.execDetached(["app2unit", "--", app.id + ".desktop"]);
-        else
-          Quickshell.execDetached(["app2unit", "--"].concat(app.command));
       } else {
-        // Fallback logic when app2unit is not used
         if (app.runInTerminal) {
           Logger.d("Taskbar", "Executing terminal app manually: " + app.name);
           const terminal = Settings.data.appLauncher.terminalCommand.split(" ");

--- a/Modules/Dock/DockContent.qml
+++ b/Modules/Dock/DockContent.qml
@@ -156,12 +156,6 @@ Item {
             const command = prefix.concat(app.command);
             Quickshell.execDetached(command);
           }
-        } else if (Settings.data.appLauncher.useApp2Unit && ProgramCheckerService.app2unitAvailable && app.id) {
-          Logger.d("Dock", `Using app2unit for: ${app.id}`);
-          if (app.runInTerminal)
-            Quickshell.execDetached(["app2unit", "--", app.id + ".desktop"]);
-          else
-            Quickshell.execDetached(["app2unit", "--"].concat(app.command));
         } else {
           if (app.runInTerminal) {
             Logger.d("Dock", "Executing terminal app manually: " + app.name);

--- a/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
+++ b/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
@@ -568,14 +568,7 @@ Item {
                            Logger.d("ApplicationsProvider", `Executing command (with prefix): ${command.join(" ")}`);
                            Quickshell.execDetached(command);
                          }
-                       } else if (Settings.data.appLauncher.useApp2Unit && ProgramCheckerService.app2unitAvailable && app.id) {
-                         Logger.d("ApplicationsProvider", `Using app2unit for: ${app.id}`);
-                         if (app.runInTerminal)
-                         Quickshell.execDetached(["app2unit", "--", app.id + ".desktop"]);
-                         else
-                         Quickshell.execDetached(["app2unit", "--"].concat(app.command));
                        } else {
-                         // Fallback logic when app2unit is not used
                          if (app.runInTerminal) {
                            Logger.d("ApplicationsProvider", "Executing terminal app manually: " + app.name);
                            const terminal = Settings.data.appLauncher.terminalCommand.split(" ");

--- a/Modules/Panels/Settings/Tabs/Launcher/ExecuteSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Launcher/ExecuteSubTab.qml
@@ -10,23 +10,6 @@ ColumnLayout {
   spacing: Style.marginL
   Layout.fillWidth: true
 
-  NToggle {
-    label: I18n.tr("panels.launcher.settings-use-app2unit-label")
-    description: I18n.tr("panels.launcher.settings-use-app2unit-description")
-    checked: Settings.data.appLauncher.useApp2Unit && ProgramCheckerService.app2unitAvailable
-    enabled: ProgramCheckerService.app2unitAvailable && !Settings.data.appLauncher.customLaunchPrefixEnabled
-    opacity: ProgramCheckerService.app2unitAvailable ? 1.0 : 0.6
-    onToggled: checked => {
-                 if (ProgramCheckerService.app2unitAvailable) {
-                   Settings.data.appLauncher.useApp2Unit = checked;
-                   if (checked) {
-                     Settings.data.appLauncher.customLaunchPrefixEnabled = false;
-                   }
-                 }
-               }
-    defaultValue: Settings.getDefaultValue("appLauncher.useApp2Unit")
-  }
-
   NTextInput {
     label: I18n.tr("panels.launcher.settings-terminal-command-label")
     description: I18n.tr("panels.launcher.settings-terminal-command-description")
@@ -41,13 +24,7 @@ ColumnLayout {
     label: I18n.tr("panels.launcher.settings-custom-launch-prefix-enabled-label")
     description: I18n.tr("panels.launcher.settings-custom-launch-prefix-enabled-description")
     checked: Settings.data.appLauncher.customLaunchPrefixEnabled
-    enabled: !Settings.data.appLauncher.useApp2Unit
-    onToggled: checked => {
-                 Settings.data.appLauncher.customLaunchPrefixEnabled = checked;
-                 if (checked) {
-                   Settings.data.appLauncher.useApp2Unit = false;
-                 }
-               }
+    onToggled: checked => Settings.data.appLauncher.customLaunchPrefixEnabled = checked
     defaultValue: Settings.getDefaultValue("appLauncher.customLaunchPrefixEnabled")
   }
 

--- a/Services/System/ProgramCheckerService.qml
+++ b/Services/System/ProgramCheckerService.qml
@@ -14,7 +14,6 @@ Singleton {
   property bool nmcliAvailable: false
   property bool bluetoothctlAvailable: false
   property bool wlsunsetAvailable: false
-  property bool app2unitAvailable: false
   property bool gnomeCalendarAvailable: false
   property bool pythonAvailable: false
   property bool wtypeAvailable: false
@@ -24,7 +23,6 @@ Singleton {
                                             "bluetoothctlAvailable": ["sh", "-c", "command -v bluetoothctl"],
                                             "nmcliAvailable": ["sh", "-c", "command -v nmcli"],
                                             "wlsunsetAvailable": ["sh", "-c", "command -v wlsunset"],
-                                            "app2unitAvailable": ["sh", "-c", "command -v app2unit"],
                                             "gnomeCalendarAvailable": ["sh", "-c", "command -v gnome-calendar"],
                                             "wtypeAvailable": ["sh", "-c", "command -v wtype"],
                                             "pythonAvailable": ["sh", "-c", "command -v python3"]
@@ -42,19 +40,10 @@ Singleton {
   // Signal emitted when all checks are complete
   signal checksCompleted
 
-  // disable app2unit in settings if it is not available
+  // disable Night Light in settings if wlsunset is not available
   onChecksCompleted: {
-    if (!app2unitAvailable && Settings.data.appLauncher.useApp2Unit) {
-      Settings.data.appLauncher.useApp2Unit = false;
-    }
     if (!wlsunsetAvailable && Settings.data.nightLight.enabled) {
       Settings.data.nightLight.enabled = false;
-    }
-  }
-
-  onApp2unitAvailableChanged: {
-    if (!app2unitAvailable && Settings.data.appLauncher.useApp2Unit) {
-      Settings.data.appLauncher.useApp2Unit = false;
     }
   }
 


### PR DESCRIPTION
This removes the app2unit toggle from the launcher settings since there are problems with it (#1893) and it has been made redundant by the custom launch prefix option.

2 i18n entries also can be removed.