### PR TITLE
Respect lockOnSuspend in all suspend cases

### DIFF
--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -562,6 +562,50 @@ Singleton {
     }
   }
 
+  // Lock screen before external suspend (power button, lid close) by
+  // monitoring systemd-logind's PrepareForSleep D-Bus signal.
+  Process {
+    id: sleepMonitor
+    running: true
+    command: [
+      "gdbus", "monitor", "--system",
+      "--dest", "org.freedesktop.login1",
+      "--object-path", "/org/freedesktop/login1"
+    ]
+
+    stdout: SplitParser {
+      onRead: line => {
+        if (line.indexOf("PrepareForSleep") !== -1 && line.indexOf("true") !== -1)
+          root._lockIfNeeded("PrepareForSleep");
+      }
+    }
+
+    onExited: () => sleepMonitorRestart.start()
+  }
+
+  Timer {
+    id: sleepMonitorRestart
+    interval: 2000
+    onTriggered: sleepMonitor.running = true
+  }
+
+  // Fallback: lock on resume via time-jump detection if D-Bus signal was missed.
+  Connections {
+    target: Time
+    function onResumed() {
+      root._lockIfNeeded("resume fallback");
+    }
+  }
+
+  function _lockIfNeeded(source) {
+    if (!Settings.data.general.lockOnSuspend)
+      return;
+    if (!PanelService || !PanelService.lockScreen || PanelService.lockScreen.active)
+      return;
+    Logger.i("Compositor", "Locking screen (" + source + ")");
+    root.lock();
+  }
+
   property int lockAndSuspendCheckCount: 0
 
   function lockAndSuspend() {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Fix lock-on-suspend not working when suspend is triggered externally (power button, lid close). Previously, only user-initiated suspend from the session menu would properly lock the screen before suspending. External suspend events bypassed the lock on suspend setting.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2036

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
