### PR TITLE
SystemMonitor.qml: fix launching external Monitor app

### DIFF
--- a/Modules/Bar/Widgets/SystemMonitor.qml
+++ b/Modules/Bar/Widgets/SystemMonitor.qml
@@ -175,7 +175,12 @@ Item {
                    PanelService.closeContextMenu(screen);
 
                    if (action === "sysmon-settings") {
+                     let monitorCmd = Settings.data.systemMonitor.externalMonitor;
+                     if (monitorCmd && monitorCmd.trim() !== "") {
+                       openExternalMonitor();
+                     } else {
                      SettingsPanelService.openToTab(SettingsPanel.Tab.System, 0, screen);
+                     }
                    } else if (action === "widget-settings") {
                      BarService.openWidgetSettings(screen, section, sectionWidgetIndex, widgetId, widgetSettings);
                    }


### PR DESCRIPTION
# Pull Request

## Motivation
Fixes whether to open External System Monitor app or open the settings to change it if the field is empty.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
This is the button it fixes
<img width="306" height="112" alt="image" src="https://github.com/user-attachments/assets/3f90a4c0-2578-42fc-b320-28dc58b2dddd" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
