### PR TITLE
Fix kitty predefined selection colors

### DIFF
--- a/Assets/Templates/terminal/kitty-predefined.conf
+++ b/Assets/Templates/terminal/kitty-predefined.conf
@@ -15,11 +15,11 @@ color13 {{colors.terminal_bright_magenta.default.hex}}
 color14 {{colors.terminal_bright_cyan.default.hex}}
 color15 {{colors.terminal_bright_white.default.hex}}
 background {{colors.terminal_background.default.hex}}
-selection_foreground {{colors.terminal_cursor_text.default.hex}}
+selection_foreground {{colors.terminal_selection_fg.default.hex}}
 cursor {{colors.terminal_cursor.default.hex}}
 cursor_text_color {{colors.terminal_cursor_text.default.hex}}
 foreground {{colors.terminal_foreground.default.hex}}
-selection_background {{colors.terminal_foreground.default.hex}}
+selection_background {{colors.terminal_selection_bg.default.hex}}
 active_border_color {{colors.primary.default.hex}}
 inactive_border_color {{colors.secondary.default.hex}}
 


### PR DESCRIPTION
## Summary
Fix the predefined Kitty template to use terminal selection tokens instead of foreground and cursor text tokens.

## Problem
For predefined color schemes, kitty-predefined.conf exported selection_foreground from terminal_cursor_text and selection_background from terminal_foreground.

This produced incorrect selection colors. For example, with the ADW scheme the terminal selection background is defined as blue (#3584e4), but the generated Kitty config used white.

## Fix
Use the correct predefined terminal tokens:
- terminal_selection_fg
- terminal_selection_bg

## Verification
Reproduced with ADW.json where terminal.selectionBackground is #3584e4 and confirmed the old Kitty export incorrectly generated selection_background #ffffff.