### PR TITLE
feat(AudioPanel): volume change on mouse wheel

### DIFF
--- a/Modules/Cards/AudioCard.qml
+++ b/Modules/Cards/AudioCard.qml
@@ -79,13 +79,13 @@ NBox {
     onTriggered: {
       // Only sync if sink hasn't changed
       if (AudioService.sink && AudioService.sink.id === lastSinkId) {
-        if (Math.abs(localOutputVolume - AudioService.volume) >= 0.01) {
+        if (Math.round(Math.abs(localOutputVolume - AudioService.volume) * 100) / 100 >= 0.01) {
           AudioService.setVolume(localOutputVolume);
         }
       }
       // Only sync if source hasn't changed
       if (AudioService.source && AudioService.source.id === lastSourceId) {
-        if (Math.abs(localInputVolume - AudioService.inputVolume) >= 0.01) {
+        if (Math.round(Math.abs(localInputVolume - AudioService.inputVolume) * 100) / 100 >= 0.01) {
           AudioService.setInputVolume(localInputVolume);
         }
       }

--- a/Modules/Cards/AudioCard.qml
+++ b/Modules/Cards/AudioCard.qml
@@ -183,24 +183,15 @@ NBox {
         onPressedChanged: localOutputVolumeChanging = pressed
         tooltipText: `${Math.round((outputVolumeGuard ? localOutputVolume : AudioService.volume) * 100)}%`
         tooltipDirection: "bottom"
-
-        // MouseArea to handle wheel events when hovering over the slider
-        MouseArea {
-          anchors.fill: parent
-          hoverEnabled: true
-          acceptedButtons: Qt.NoButton
-          propagateComposedEvents: true
-
-          onWheel: wheel => {
-                     if (outputVolumeSlider.enabled && AudioService.sink) {
-                       const delta = wheel.angleDelta.y || wheel.angleDelta.x;
-                       const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
-                       const increment = delta > 0 ? step : -step;
-                       const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                       const newValue = Math.max(0, Math.min(maxVolume, localOutputVolume + increment));
-                       localOutputVolume = newValue;
-                     }
-                   }
+        onWheel: function (wheel) {
+          if (outputVolumeSlider.enabled && AudioService.sink) {
+            const delta = wheel.angleDelta.y || wheel.angleDelta.x;
+            const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+            const increment = delta > 0 ? step : -step;
+            const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+            const newValue = Math.max(0, Math.min(maxVolume, localOutputVolume + increment));
+            localOutputVolume = newValue;
+          }
         }
       }
     }
@@ -251,24 +242,15 @@ NBox {
         onPressedChanged: localInputVolumeChanging = pressed
         tooltipText: `${Math.round((inputVolumeGuard ? localInputVolume : AudioService.inputVolume) * 100)}%`
         tooltipDirection: "bottom"
-
-        // MouseArea to handle wheel events when hovering over the slider
-        MouseArea {
-          anchors.fill: parent
-          hoverEnabled: true
-          acceptedButtons: Qt.NoButton
-          propagateComposedEvents: true
-
-          onWheel: wheel => {
-                     if (inputVolumeSlider.enabled && AudioService.source) {
-                       const delta = wheel.angleDelta.y || wheel.angleDelta.x;
-                       const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
-                       const increment = delta > 0 ? step : -step;
-                       const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                       const newValue = Math.max(0, Math.min(maxVolume, localInputVolume + increment));
-                       localInputVolume = newValue;
-                     }
-                   }
+        onWheel: function (wheel) {
+          if (inputVolumeSlider.enabled && AudioService.source) {
+            const delta = wheel.angleDelta.y || wheel.angleDelta.x;
+            const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+            const increment = delta > 0 ? step : -step;
+            const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+            const newValue = Math.max(0, Math.min(maxVolume, localInputVolume + increment));
+            localInputVolume = newValue;
+          }
         }
       }
     }

--- a/Modules/Cards/AudioCard.qml
+++ b/Modules/Cards/AudioCard.qml
@@ -92,6 +92,20 @@ NBox {
     }
   }
 
+  // Timer to reset local*VolumeChanging variables after onWheel events
+  Timer {
+    id: wheelDebounceTimer
+    interval: 100
+    repeat: false
+    onTriggered: {
+      if (panelContent.localOutputVolumeChanging)
+        panelContent.localOutputVolumeChanging = false;
+      if (panelContent.localInputVolumeChanging)
+        panelContent.localInputVolumeChanging = false;
+    }
+  }
+
+  // Connections to update local volumes when AudioService changes
   Connections {
     target: AudioService
     function onVolumeChanged() {
@@ -185,6 +199,8 @@ NBox {
         tooltipDirection: "bottom"
         onWheel: function (wheel) {
           if (outputVolumeSlider.enabled && AudioService.sink) {
+            localOutputVolumeChanging = true;
+            wheelDebounceTimer.restart();
             const delta = wheel.angleDelta.y || wheel.angleDelta.x;
             const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
             const increment = delta > 0 ? step : -step;
@@ -244,6 +260,8 @@ NBox {
         tooltipDirection: "bottom"
         onWheel: function (wheel) {
           if (inputVolumeSlider.enabled && AudioService.source) {
+            localInputVolumeChanging = true;
+            wheelDebounceTimer.restart();
             const delta = wheel.angleDelta.y || wheel.angleDelta.x;
             const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
             const increment = delta > 0 ? step : -step;

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -288,6 +288,24 @@ SmartPanel {
                     onPressedChanged: function (pressed) {
                       localOutputVolumeChanging = pressed;
                     }
+
+                    MouseArea {
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      acceptedButtons: Qt.NoButton
+                      propagateComposedEvents: true
+
+                      onWheel: wheel => {
+                                 if (AudioService.sink) {
+                                   const delta = wheel.angleDelta.y || wheel.angleDelta.x;
+                                   const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                                   const increment = delta > 0 ? step : -step;
+                                   const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                                   const newValue = Math.max(0, Math.min(maxVolume, localOutputVolume + increment));
+                                   localOutputVolume = newValue;
+                                 }
+                               }
+                    }
                   }
 
                   NText {
@@ -363,6 +381,24 @@ SmartPanel {
                     }
                     onPressedChanged: function (pressed) {
                       localInputVolumeChanging = pressed;
+                    }
+
+                    MouseArea {
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      acceptedButtons: Qt.NoButton
+                      propagateComposedEvents: true
+
+                      onWheel: wheel => {
+                                 if (AudioService.source) {
+                                   const delta = wheel.angleDelta.y || wheel.angleDelta.x;
+                                   const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                                   const increment = delta > 0 ? step : -step;
+                                   const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                                   const newValue = Math.max(0, Math.min(maxVolume, localInputVolume + increment));
+                                   localInputVolume = newValue;
+                                 }
+                               }
                     }
                   }
 
@@ -686,6 +722,24 @@ SmartPanel {
                             appBox.nodeAudio.volume = value;
                             AudioService.setPanelAppStreamVolume(appBox.modelData, value);
                           }
+                        }
+
+                        MouseArea {
+                          anchors.fill: parent
+                          hoverEnabled: true
+                          acceptedButtons: Qt.NoButton
+                          propagateComposedEvents: true
+
+                          onWheel: wheel => {
+                                     if (appBox.nodeAudio && appBox.modelData && appBox.modelData.ready === true) {
+                                       const delta = wheel.angleDelta.y || wheel.angleDelta.x;
+                                       const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                                       const increment = delta > 0 ? step : -step;
+                                       const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                                       const newValue = Math.max(0, Math.min(maxVolume, appBox.nodeAudio.volume + increment));
+                                       appBox.nodeAudio.volume = newValue;
+                                     }
+                                   }
                         }
                       }
 

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -133,13 +133,13 @@ SmartPanel {
       onTriggered: {
         // Only sync if sink hasn't changed
         if (AudioService.sink && AudioService.sink.id === panelContent.lastSinkId) {
-          if (Math.abs(panelContent.localOutputVolume - AudioService.volume) >= 0.01) {
+          if (Math.round(Math.abs(panelContent.localOutputVolume - AudioService.volume) * 100) / 100 >= 0.01) {
             AudioService.setVolume(panelContent.localOutputVolume);
           }
         }
         // Only sync if source hasn't changed
         if (AudioService.source && AudioService.source.id === panelContent.lastSourceId) {
-          if (Math.abs(panelContent.localInputVolume - AudioService.inputVolume) >= 0.01) {
+          if (Math.round(Math.abs(panelContent.localInputVolume - AudioService.inputVolume) * 100) / 100 >= 0.01) {
             AudioService.setInputVolume(panelContent.localInputVolume);
           }
         }

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -146,6 +146,18 @@ SmartPanel {
       }
     }
 
+    Timer {
+      id: wheelDebounceTimer
+      interval: 100
+      repeat: false
+      onTriggered: {
+        if (panelContent.localOutputVolumeChanging)
+          panelContent.localOutputVolumeChanging = false;
+        if (panelContent.localInputVolumeChanging)
+          panelContent.localInputVolumeChanging = false;
+      }
+    }
+
     // Find application streams that are actually playing audio (connected to default sink)
     // Use linkGroups to find nodes connected to the default audio sink
     // Note: We need to use link IDs since source/target properties require binding
@@ -290,6 +302,8 @@ SmartPanel {
                     }
                     onWheel: function (event) {
                       if (AudioService.sink) {
+                        localOutputVolumeChanging = true;
+                        wheelDebounceTimer.restart();
                         const delta = event.angleDelta.y || event.angleDelta.x;
                         const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
                         const increment = delta > 0 ? step : -step;
@@ -376,6 +390,8 @@ SmartPanel {
                     }
                     onWheel: function (event) {
                       if (AudioService.source) {
+                        localInputVolumeChanging = true;
+                        wheelDebounceTimer.restart();
                         const delta = event.angleDelta.y || event.angleDelta.x;
                         const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
                         const increment = delta > 0 ? step : -step;

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -715,6 +715,9 @@ SmartPanel {
                             const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
                             const newValue = Math.max(0, Math.min(maxVolume, appBox.nodeAudio.volume + increment));
                             appBox.nodeAudio.volume = newValue;
+                            var key = AudioService.getAppKey(appBox.modelData);
+                            if (key)
+                              AudioService.setAppStreamVolume(key, newValue);
                           }
                         }
                       }

--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -288,23 +288,15 @@ SmartPanel {
                     onPressedChanged: function (pressed) {
                       localOutputVolumeChanging = pressed;
                     }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      hoverEnabled: true
-                      acceptedButtons: Qt.NoButton
-                      propagateComposedEvents: true
-
-                      onWheel: wheel => {
-                                 if (AudioService.sink) {
-                                   const delta = wheel.angleDelta.y || wheel.angleDelta.x;
-                                   const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
-                                   const increment = delta > 0 ? step : -step;
-                                   const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                                   const newValue = Math.max(0, Math.min(maxVolume, localOutputVolume + increment));
-                                   localOutputVolume = newValue;
-                                 }
-                               }
+                    onWheel: function (event) {
+                      if (AudioService.sink) {
+                        const delta = event.angleDelta.y || event.angleDelta.x;
+                        const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                        const increment = delta > 0 ? step : -step;
+                        const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                        const newValue = Math.max(0, Math.min(maxVolume, localOutputVolume + increment));
+                        localOutputVolume = newValue;
+                      }
                     }
                   }
 
@@ -382,23 +374,15 @@ SmartPanel {
                     onPressedChanged: function (pressed) {
                       localInputVolumeChanging = pressed;
                     }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      hoverEnabled: true
-                      acceptedButtons: Qt.NoButton
-                      propagateComposedEvents: true
-
-                      onWheel: wheel => {
-                                 if (AudioService.source) {
-                                   const delta = wheel.angleDelta.y || wheel.angleDelta.x;
-                                   const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
-                                   const increment = delta > 0 ? step : -step;
-                                   const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                                   const newValue = Math.max(0, Math.min(maxVolume, localInputVolume + increment));
-                                   localInputVolume = newValue;
-                                 }
-                               }
+                    onWheel: function (event) {
+                      if (AudioService.source) {
+                        const delta = event.angleDelta.y || event.angleDelta.x;
+                        const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                        const increment = delta > 0 ? step : -step;
+                        const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                        const newValue = Math.max(0, Math.min(maxVolume, localInputVolume + increment));
+                        localInputVolume = newValue;
+                      }
                     }
                   }
 
@@ -723,23 +707,15 @@ SmartPanel {
                             AudioService.setPanelAppStreamVolume(appBox.modelData, value);
                           }
                         }
-
-                        MouseArea {
-                          anchors.fill: parent
-                          hoverEnabled: true
-                          acceptedButtons: Qt.NoButton
-                          propagateComposedEvents: true
-
-                          onWheel: wheel => {
-                                     if (appBox.nodeAudio && appBox.modelData && appBox.modelData.ready === true) {
-                                       const delta = wheel.angleDelta.y || wheel.angleDelta.x;
-                                       const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
-                                       const increment = delta > 0 ? step : -step;
-                                       const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                                       const newValue = Math.max(0, Math.min(maxVolume, appBox.nodeAudio.volume + increment));
-                                       appBox.nodeAudio.volume = newValue;
-                                     }
-                                   }
+                        onWheel: function (event) {
+                          if (appBox.nodeAudio && appBox.modelData && appBox.modelData.ready === true) {
+                            const delta = event.angleDelta.y || event.angleDelta.x;
+                            const step = Settings.data.audio.volumeStep / 100.0; // Convert percentage to 0-1 range
+                            const increment = delta > 0 ? step : -step;
+                            const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                            const newValue = Math.max(0, Math.min(maxVolume, appBox.nodeAudio.volume + increment));
+                            appBox.nodeAudio.volume = newValue;
+                          }
                         }
                       }
 

--- a/Widgets/NSlider.qml
+++ b/Widgets/NSlider.qml
@@ -41,16 +41,6 @@ Slider {
 
     readonly property real fillWidth: root.visualPosition * width
 
-    MouseArea {
-      anchors.left: parent.left
-      anchors.right: parent.right
-      anchors.verticalCenter: parent.verticalCenter
-      height: root.knobDiameter
-      hoverEnabled: true
-      acceptedButtons: Qt.NoButton
-      propagateComposedEvents: true
-      onWheel: event => root.wheel(event)
-    }
     // Background track
     Shape {
       anchors.fill: parent
@@ -261,5 +251,13 @@ Slider {
         }
       }
     }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    hoverEnabled: true
+    acceptedButtons: Qt.NoButton
+    propagateComposedEvents: true
+    onWheel: event => root.wheel(event)
   }
 }

--- a/Widgets/NSlider.qml
+++ b/Widgets/NSlider.qml
@@ -23,6 +23,8 @@ Slider {
   readonly property real trackRadius: Math.min(Style.iRadiusL, trackHeight / 2)
   readonly property real cutoutExtra: Math.round((Style.baseWidgetSize * 0.1 * Style.uiScaleRatio) / 2) * 2
 
+  signal wheel(WheelEvent event)
+
   padding: cutoutExtra / 2
 
   snapMode: snapAlways ? Slider.SnapAlways : Slider.SnapOnRelease
@@ -39,6 +41,16 @@ Slider {
 
     readonly property real fillWidth: root.visualPosition * width
 
+    MouseArea {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      height: root.knobDiameter
+      hoverEnabled: true
+      acceptedButtons: Qt.NoButton
+      propagateComposedEvents: true
+      onWheel: event => root.wheel(event)
+    }
     // Background track
     Shape {
       anchors.fill: parent

--- a/Widgets/NValueSlider.qml
+++ b/Widgets/NValueSlider.qml
@@ -29,6 +29,7 @@ RowLayout {
   // Signals
   signal moved(real value)
   signal pressedChanged(bool pressed, real value)
+  signal wheel(WheelEvent event)
 
   readonly property bool sliderActive: slider.activeFocus || slider.pressed
   readonly property bool isValueChanged: defaultValue !== undefined && (value !== defaultValue)
@@ -82,6 +83,7 @@ RowLayout {
         heightRatio: root.customHeightRatio > 0 ? root.customHeightRatio : root.heightRatio
         onMoved: root.moved(value)
         onPressedChanged: root.pressedChanged(pressed, value)
+        onWheel: event => root.wheel(event)
       }
 
       NText {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Previously you could not adjust volumes with the mouse wheel on the volume widget, despite being able to in the control center, which annoyed me to no end.
This works on inputs, outputs and, per application audio.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Just regular day-to-day use.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

![sliders](https://github.com/user-attachments/assets/ca1760f6-1836-4746-b1ba-4e536fd482dd)


## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

I just copied and adapted the code from [AudioCard](https://github.com/noctalia-dev/noctalia-shell/blob/f6d398eccc7a5e7588d10a2e99bd51cb8def8a1f/Modules/Cards/AudioCard.qml#L185). Not sure if there's more that needs to be considered.

I'm also testing it on version 4.5.0 which is the one packaged in nixpkgs at the moment, but I made sure to check it does work on main with noctalia-qs.

This introduces this warning, which I'm not sure how to fix without breaking functionality.
```
WARN scene: QML MouseArea at @Modules/Panels/Audio/AudioPanel.qml[674:25]: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.
```