### PR TITLE
Feat/wallpaper only favorites

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1709,6 +1709,8 @@
       "automation-change-mode-alphabetical": "Alphabetical",
       "automation-change-mode-description": "Choose how wallpapers are selected when changing automatically.",
       "automation-change-mode-label": "Change mode",
+      "automation-favorites-only-description": "Only use wallpapers marked as favorites for scheduled changes.",
+      "automation-favorites-only-label": "Favorites only",
       "automation-custom-interval-description": "Enter time as HH:MM (e.g. 01:30).",
       "automation-custom-interval-label": "Custom interval",
       "automation-interval-description": "How often to change wallpapers automatically.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -202,6 +202,7 @@
     "useSolidColor": false,
     "solidColor": "#1a1a2e",
     "automationEnabled": false,
+    "automationFavoritesOnly": false,
     "wallpaperChangeMode": "random",
     "randomIntervalSec": 300,
     "transitionDuration": 1500,

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -2506,6 +2506,15 @@
     "subTabLabel": "common.automation"
   },
   {
+    "labelKey": "panels.wallpaper.automation-favorites-only-label",
+    "descriptionKey": "panels.wallpaper.automation-favorites-only-description",
+    "widget": "NToggle",
+    "tab": 3,
+    "tabLabel": "common.wallpaper",
+    "subTab": 2,
+    "subTabLabel": "common.automation"
+  },
+  {
     "labelKey": "panels.wallpaper.automation-interval-label",
     "descriptionKey": "panels.wallpaper.automation-interval-description",
     "widget": "NSpinBox",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -386,6 +386,7 @@ Singleton {
       property bool useSolidColor: false
       property color solidColor: "#1a1a2e"
       property bool automationEnabled: false
+      property bool automationFavoritesOnly: false
       property string wallpaperChangeMode: "random" // "random" or "alphabetical"
       property int randomIntervalSec: 300 // 5 min
       property int transitionDuration: 1500 // 1500 ms

--- a/Modules/Panels/Settings/Tabs/Wallpaper/AutomationSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Wallpaper/AutomationSubTab.qml
@@ -43,6 +43,14 @@ ColumnLayout {
       defaultValue: Settings.getDefaultValue("wallpaper.wallpaperChangeMode")
     }
 
+    NToggle {
+      label: I18n.tr("panels.wallpaper.automation-favorites-only-label")
+      description: I18n.tr("panels.wallpaper.automation-favorites-only-description")
+      checked: Settings.data.wallpaper.automationFavoritesOnly
+      onToggled: checked => Settings.data.wallpaper.automationFavoritesOnly = checked
+      defaultValue: Settings.getDefaultValue("wallpaper.automationFavoritesOnly")
+    }
+
     NSpinBox {
       label: I18n.tr("panels.wallpaper.automation-interval-label")
       description: I18n.tr("panels.wallpaper.automation-interval-description")

--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -104,6 +104,14 @@ Singleton {
         root.setNextWallpaper();
       }
     }
+    function onAutomationFavoritesOnlyChanged() {
+      // Reset alphabetical indices when source list changes
+      root.alphabeticalIndices = {};
+      if (Settings.data.wallpaper.automationEnabled) {
+        root.restartRandomWallpaperTimer();
+        root.setNextWallpaper();
+      }
+    }
     function onViewModeChanged() {
       // Reset browse paths to root when mode changes
       root.currentBrowsePaths = {};
@@ -439,7 +447,7 @@ Singleton {
         // Pick a random wallpaper per screen
         for (var i = 0; i < Quickshell.screens.length; i++) {
           var screenName = Quickshell.screens[i].name;
-          var wallpaperList = getWallpapersList(screenName);
+          var wallpaperList = _getAutomationWallpapersList(screenName);
 
           if (wallpaperList.length > 0) {
             var randomPath = _pickUnusedRandom(screenName, wallpaperList);
@@ -448,7 +456,7 @@ Singleton {
         }
       } else {
         // Pick a random wallpaper for the specified screen
-        var wallpaperList = getWallpapersList(screen);
+        var wallpaperList = _getAutomationWallpapersList(screen);
         if (wallpaperList.length > 0) {
           var randomPath = _pickUnusedRandom(screen, wallpaperList);
           changeWallpaper(randomPath, screen);
@@ -457,7 +465,7 @@ Singleton {
     } else {
       // Pick a random wallpaper common to all screens
       // We can use any screenName here, so we just pick the primary one.
-      var wallpaperList = getWallpapersList(Screen.name);
+      var wallpaperList = _getAutomationWallpapersList(Screen.name);
       if (wallpaperList.length > 0) {
         var randomPath = _pickUnusedRandom("all", wallpaperList);
         changeWallpaper(randomPath, screen);
@@ -519,7 +527,7 @@ Singleton {
       // Pick next alphabetical wallpaper per screen
       for (var i = 0; i < Quickshell.screens.length; i++) {
         var screenName = Quickshell.screens[i].name;
-        var wallpaperList = getWallpapersList(screenName);
+        var wallpaperList = _getAutomationWallpapersList(screenName);
 
         if (wallpaperList.length > 0) {
           // Get or initialize index for this screen
@@ -541,7 +549,7 @@ Singleton {
       }
     } else {
       // Pick next alphabetical wallpaper common to all screens
-      var wallpaperList = getWallpapersList(Screen.name);
+      var wallpaperList = _getAutomationWallpapersList(Screen.name);
       if (wallpaperList.length > 0) {
         // Use primary screen name as key for single directory mode
         var key = "all";
@@ -595,6 +603,29 @@ Singleton {
       return wallpaperLists[screenName];
     }
     return [];
+  }
+
+  function _getAutomationWallpapersList(screenName) {
+    var wallpapers = getWallpapersList(screenName);
+    if (!Settings.data.wallpaper.automationFavoritesOnly) {
+      return wallpapers;
+    }
+
+    var favorites = Settings.data.wallpaper.favorites || [];
+    if (favorites.length === 0) {
+      return [];
+    }
+
+    var favoriteSet = new Set();
+    for (var i = 0; i < favorites.length; i++) {
+      if (favorites[i] && favorites[i].path) {
+        favoriteSet.add(Settings.preprocessPath(favorites[i].path));
+      }
+    }
+
+    return wallpapers.filter(function (path) {
+      return favoriteSet.has(Settings.preprocessPath(path));
+    });
   }
 
   // -------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Motivation
This PR introduces a new toggle in the Wallpaper / Automation settings tab: "Favorites only". Currently, the wallpaper scheduler iterates through the entire selected directory (randomly or alphabetically). By enabling this new setting, the scheduler will filter the available list and only cycle through wallpapers that the user has marked as favorites.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/2becb11a-fd38-42ac-926a-ba268356e4f7

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
