### PR TITLE
Added min/max events in audio service to notify subscribers

### DIFF
--- a/Modules/Bar/Widgets/Volume.qml
+++ b/Modules/Bar/Widgets/Volume.qml
@@ -73,6 +73,28 @@ Item {
         externalHideTimer.restart();
       }
     }
+
+    function onVolumeAtMaximum() {
+      if (!firstVolumeReceived) {
+       firstVolumeReceived = true;
+      } else {
+        // Hide any tooltip while the pill is visible / being updated
+        TooltipService.hide();
+        pill.show();
+        externalHideTimer.restart();
+      }
+    }
+
+    function onVolumeAtMinimum() {
+      if (!firstVolumeReceived) {
+       firstVolumeReceived = true;
+      } else {
+        // Hide any tooltip while the pill is visible / being updated
+        TooltipService.hide();
+        pill.show();
+        externalHideTimer.restart();
+      }
+    }
   }
 
   Timer {

--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -251,6 +251,14 @@ Variants {
         showOSD(OSD.Type.Volume);
       }
 
+      function onVolumeAtMaximum() {
+        showOSD(OSD.Type.Volume);
+      }
+
+      function onVolumeAtMinimum() {
+        showOSD(OSD.Type.Volume);
+      }
+
       function onMutedChanged() {
         if (AudioService.consumeOutputOSDSuppression())
           return;

--- a/Services/Media/AudioService.qml
+++ b/Services/Media/AudioService.qml
@@ -29,6 +29,9 @@ Singleton {
   property real wpctlOutputVolume: 0
   property bool wpctlOutputMuted: true
 
+  signal volumeAtMaximum()
+  signal volumeAtMinimum()
+
   function clampOutputVolume(vol: real): real {
     if (vol === undefined || isNaN(vol)) {
       return 0;
@@ -556,6 +559,7 @@ Singleton {
       return;
     }
     if (volume >= root.maxVolume) {
+      volumeAtMaximum();
       return;
     }
     setVolume(Math.min(root.maxVolume, volume + stepVolume));
@@ -566,6 +570,7 @@ Singleton {
       return;
     }
     if (volume <= 0) {
+      volumeAtMinimum();
       return;
     }
     setVolume(Math.max(0, volume - stepVolume));


### PR DESCRIPTION
# Pull Request
Added two new events in AudioService `volumeAtMaximum` and `volumeAtMinimum` to notify subscriber when audio limit is reached. In this way, the user has a visual feedback even when there are no changes in the audio volume.

## Motivation
When using hotkeys to change volume audio and the volume is already at its maximum or minimum, the user does not have any clue if the command has executed or not. With this PR, the OSD with the current volume value pops out.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- None

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
