### PR TITLE
Fix ignore notification sound for app without a name but with a desktopEntry defined

### DIFF
--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -180,7 +180,7 @@ Singleton {
 
     // Add new notification
     addPopup(quickshellId, notification, data);
-    playNotificationSound(data.urgency, notification.appName);
+    playNotificationSound(data.urgency, data.appName);
   }
 
   function playNotificationSound(urgency, appName) {


### PR DESCRIPTION
# Pull Request

Fix ignore sound for app without a name but with a desktopEntry defined. The bug is due to the wrong object passed to the play sound function.

## Motivation
Fome flatpak app, in my system is Teams for linux, are defined without an appName but with a desktopEntry and even if you define the right name in the exclude list of notification sound, the sound is played anyway.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
None

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
