### PR TITLE
Added scroll with keyboard in searchable dropdown

### DIFF
--- a/Widgets/NSearchableComboBox.qml
+++ b/Widgets/NSearchableComboBox.qml
@@ -241,67 +241,40 @@ RowLayout {
           onTextChanged: root.searchText = text
           fontSize: Style.fontSizeS
 
-          Keys.onUpPressed: {
-            if (listView.currentIndex > 0) {
-              listView.currentIndex--;
-              listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
-
-              if (root.selectOnNavigation) {
-                selectHighlighted()
-              }
-            }
-          }
-
-          Keys.onDownPressed: {
-            if (listView.currentIndex < listView.count - 1) {
-              listView.currentIndex++;
-              listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
-
-              if (root.selectOnNavigation) {
-                selectHighlighted()
-              }
-            }
-          }
-
-          Keys.onReturnPressed: {
-            selectHighlighted()
-            combo.popup.close();
-          }
-          Keys.onEnterPressed:  {
-            selectHighlighted()
-            combo.popup.close();
-          }
-
-          Keys.onEscapePressed: combo.popup.close()
-
           Keys.onPressed: (event) => {
-            switch (event.key) {
-              case Qt.Key_Home:
-                listView.currentIndex = 0;
-                listView.positionViewAtIndex(0, ListView.Beginning);
-                event.accepted = true;
-                break;
-              case Qt.Key_End:
-                listView.currentIndex = listView.count - 1;
-                listView.positionViewAtIndex(listView.count - 1, ListView.End);
-                event.accepted = true;
-                break;
-              case Qt.Key_PageUp:
-                listView.currentIndex = Math.max(0, listView.currentIndex - pageStep());
-                listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
-                event.accepted = true;
-                break;
-              case Qt.Key_PageDown:
-                listView.currentIndex = Math.min(listView.count - 1, listView.currentIndex + pageStep());
-                listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
-                event.accepted = true;
-                break;
-              default:
-                return;
+            if (Keybinds.checkKey(event, 'enter', Settings)) {
+              selectHighlighted()
+              combo.popup.close();
+              event.accepted = true;
+              return;
             }
 
-            if (root.selectOnNavigation) {
-              selectHighlighted()
+            if (Keybinds.checkKey(event, 'escape', Settings)) {
+              combo.popup.close()
+              event.accepted = true;
+              return;
+            }
+
+            if (Keybinds.checkKey(event, 'up', Settings)) {
+              if (listView.currentIndex > 0) {
+                listView.currentIndex--;
+                listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
+                if (root.selectOnNavigation)
+                  selectHighlighted();
+              }
+              event.accepted = true;
+              return;
+            }
+
+            if (Keybinds.checkKey(event, 'down', Settings)) {
+              if (listView.currentIndex < listView.count - 1) {
+                listView.currentIndex++;
+                listView.positionViewAtIndex(listView.currentIndex, ListView.Contain);
+                if (root.selectOnNavigation)
+                  selectHighlighted();
+              }
+              event.accepted = true;
+              return;
             }
           }
 


### PR DESCRIPTION
# Pull Request

Added scroll with keyboard on dropdown

## Motivation
Searchable dropdown are usually used when there are a lot of items. If the user want to try differente values currently he has to:
- open the dropdown
- search the value
- select
- repeat again

With this PR the user is able to change values using the keyboard selecting the highlighted value

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

