### PR TITLE
Play volume feedback sound when changing volume externally

### DIFF
--- a/Services/Media/AudioService.qml
+++ b/Services/Media/AudioService.qml
@@ -14,6 +14,10 @@ Singleton {
   property var lastVolumeFeedbackTime: 0
   readonly property int minVolumeFeedbackInterval: 100
 
+  // Track the last sink that produced volume feedback so we can suppress the
+  // initial onVolumeChanged that fires on startup and device switches.
+  property PwNode _lastFeedbackSink: null
+
   // Devices
   readonly property PwNode sink: Pipewire.ready ? Pipewire.defaultAudioSink : null
   readonly property PwNode source: validatedSource
@@ -500,6 +504,12 @@ Singleton {
       const vol = root.sink.audio.volume;
       if (vol === undefined || isNaN(vol)) {
         return;
+      }
+
+      if (root.sink !== root._lastFeedbackSink) {
+        root._lastFeedbackSink = root.sink;
+      } else {
+        playVolumeFeedback(clampOutputVolume(vol));
       }
 
       // If volume exceeds max, clamp it (but only if we didn't just set it)


### PR DESCRIPTION
# Pull Request

## Motivation

I have key bindings to change volumes using `wpctl` directly. However, when the volume gets changed this way, the feedback sound does not play despite the volume change OSD shows up. I checked the code and found that the volume change feedback sound is only played when users change the volume through noctalia.

I think this behavior is inconsistent because if noctalia is expected to pick up external volume change, it should playback the feedback sound to indicate the volume change audibly in the same logic that it pops up an OSD as to show the event.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

To test it out, run `wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.05+`.