### PR TITLE
Allow overriding qs config path for `noctalia-shell` binary

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -94,7 +94,7 @@ stdenvNoCC.mkDerivation {
     qtWrapperArgs+=(
       --prefix PATH : ${lib.makeBinPath (runtimeDeps ++ extraPackages)}
       --prefix XDG_DATA_DIRS : ${wayland-scanner}/share
-      --add-flags "-p $out/share/noctalia-shell"
+      --set-default QS_CONFIG_PATH "$out/share/noctalia-shell"
       ${lib.optionalString calendarSupport "--prefix GI_TYPELIB_PATH : ${giTypelibPath}"}
     )
   '';


### PR DESCRIPTION
# Pull Request

## Motivation

Previously, `noctalia-shell` binary wraps around quickshell binary with `-p` argument pointing into the directory of noctalia-shell. This makes the binary unsuited for development where running commands like `noctalia-shell -p ~/projects/noctalia-shell-dev` would fail due to conflicting argument like:

```
$ noctalia-shell -p .
--path: At most 1 required but received 2
```

This PR the changes the wrapper to use the equivalent enviroment `QS_CONFIG_PATH`. The behavior for running `noctalia-shell` without argument remains unchanged. However, now the user can easily override the environment or specify `-p` argument to load up a custom noctalia-shell instance more easily.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested on nixos
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

Relevant portion of `qs --help`:

```
OPTIONS:
  -p,     --path TEXT (Env:QS_CONFIG_PATH) Excludes: --config
                              Path to a QML file or config folder.
  -c,     --config TEXT (Env:QS_CONFIG_NAME) Excludes: --path
                              Name of a noctalia-qs configuration to run.
```