### PR TITLE
fix(smart-panel): prevent panel overflow on small screens with floating bar

### DIFF
--- a/Modules/MainScreen/SmartPanel.qml
+++ b/Modules/MainScreen/SmartPanel.qml
@@ -368,6 +368,13 @@ Item {
       h = root.preferredHeight;
     }
     var panelHeight = Math.min(h, root.height - root.barHeight - effMarginT - effMarginB);
+    // For vertical floating bars, clamp panelHeight to available space accounting for corner insets
+    if (root.barFloating && root.barIsVertical) {
+      var floatCornerInsetV = Style.radiusL * 2;
+      var floatBarTopEdge = root.barMarginV + floatCornerInsetV;
+      var floatMaxHeight = root.height - floatBarTopEdge - root.barMarginV - floatCornerInsetV;
+      panelHeight = Math.min(panelHeight, floatMaxHeight);
+    }
 
     // Update panelBackground target size (will be animated)
     panelBackground.targetWidth = panelWidth;


### PR DESCRIPTION
## Problem

When the bar is set to floating mode, SmartPanel adds a `cornerInset`
(= `Style.radiusL * 2`) to panel positioning so the panel does not
overlap the bar's rounded corners. However, `panelWidth` was calculated
*before* accounting for this inset:

```qml
var panelWidth = Math.min(w, root.width - effMarginL - effMarginR);
```

This means on smaller screens (e.g. 1340×800), the panel width can
exceed the available horizontal space after the floating inset is applied.
The panel is then clamped to `barLeftEdge` and overflows the right screen
edge.

## Fix

After the initial width calculation, additionally clamp `panelWidth` to
the space available between the two floating corner insets:

```
maxWidth = screen.width - 2 × barMarginH - 2 × cornerInset
```

This applies only to horizontal floating bars (`barFloating && !barIsVertical`).

## Test

Set bar to floating, open any wide panel (e.g. Clipper) on a screen
≤ ~1400px wide — panel should stay within screen bounds.