### PR TITLE
feat(plugin-panel-slot): forward panelBackgroundColor from plugin to SmartPanel

### DIFF
--- a/Modules/Panels/Plugins/PluginPanelSlot.qml
+++ b/Modules/Panels/Plugins/PluginPanelSlot.qml
@@ -31,7 +31,7 @@ SmartPanel {
   panelAnchorLeft: pluginInstance?.panelAnchorLeft ?? false
   panelAnchorRight: pluginInstance?.panelAnchorRight ?? false
 
-  // Allow plugin to override the panel background color (e.g. for transparent mode)
+  // Panel background color
   panelBackgroundColor: pluginInstance?.panelBackgroundColor ?? Color.mSurface
 
   // Panel content is dynamically loaded


### PR DESCRIPTION
## Problem

Plugins had no way to control the SmartPanel background color.
`PanelBackground` reads `assignedPanel.panelBackgroundColor`, but
`PluginPanelSlot` never forwarded this property from the loaded plugin
instance — so a plugin defining `panelBackgroundColor: "transparent"`
had no visual effect; the panel always rendered with `Color.mSurface`.

## Fix

One line added to `PluginPanelSlot.qml`:

```qml
panelBackgroundColor: pluginInstance?.panelBackgroundColor ?? Color.mSurface
```

Falls back to `Color.mSurface` (existing behavior) when the plugin does
not define the property — fully backwards compatible.

## Use case

Enables plugins to expose a "transparent background" mode where cards
float over the desktop blur/wallpaper. Used by Clipper v2.3.0
(noctalia-dev/noctalia-plugins#400).