### PR TITLE
feat: add panel positioning option, link speed toggle, and airplane mode IPC

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Gewitter"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Linkgeschwindigkeit anzeigen",
+      "show-link-speed-description": "Die Netzwerk-Linkgeschwindigkeit neben dem WLAN-Namen im Widget anzeigen"
+    },
     "color-picker": {
       "palette-description": "Wählen Sie aus einer großen Auswahl vordefinierter Farben.",
       "palette-label": "Palette",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Thunderstorm"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Show link speed",
+      "show-link-speed-description": "Display the network link speed next to the Wi-Fi name in the widget"
+    },
     "color-picker": {
       "palette-description": "Choose from a wide range of predefined colors.",
       "palette-label": "Palette",

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Tormenta"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Mostrar velocidad de enlace",
+      "show-link-speed-description": "Mostrar la velocidad de enlace de red junto al nombre del Wi-Fi en el widget"
+    },
     "color-picker": {
       "palette-description": "Elige entre una amplia gama de colores predefinidos.",
       "palette-label": "Paleta",

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Orage"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Afficher la vitesse de liaison",
+      "show-link-speed-description": "Afficher la vitesse de liaison réseau à côté du nom Wi-Fi dans le widget"
+    },
     "color-picker": {
       "palette-description": "Choisissez parmi une large gamme de couleurs prédéfinies.",
       "palette-label": "Palette",

--- a/Assets/Translations/hu.json
+++ b/Assets/Translations/hu.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Zivatar"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Kapcsolat sebesség megjelenítése",
+      "show-link-speed-description": "A hálózati kapcsolat sebességének megjelenítése a widget Wi-Fi neve mellett"
+    },
     "color-picker": {
       "palette-description": "Válassz az előre meghatározott színek széles skálájából.",
       "palette-label": "Paletta",

--- a/Assets/Translations/it.json
+++ b/Assets/Translations/it.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Temporale"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Mostra velocità del collegamento",
+      "show-link-speed-description": "Visualizza la velocità di collegamento della rete accanto al nome Wi-Fi nel widget"
+    },
     "color-picker": {
       "palette-description": "Scegli da un’ampia gamma di colori predefiniti.",
       "palette-label": "Tavolozza",

--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "雷雨"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "リンク速度を表示",
+      "show-link-speed-description": "ウィジェットのWi-Fi名の横にネットワークリンク速度を表示する"
+    },
     "color-picker": {
       "palette-description": "豊富なプリセットカラーから選択します。",
       "palette-label": "パレット",

--- a/Assets/Translations/ko-KR.json
+++ b/Assets/Translations/ko-KR.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "뇌우"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "연결 속도 표시",
+      "show-link-speed-description": "위젯의 Wi-Fi 이름 옆에 네트워크 연결 속도를 표시합니다"
+    },
     "color-picker": {
       "palette-description": "다양한 미리 정의된 색상 중에서 선택하세요.",
       "palette-label": "팔레트",

--- a/Assets/Translations/ku.json
+++ b/Assets/Translations/ku.json
@@ -1775,6 +1775,10 @@
     "thunderstorm": "Bahoza bruskî"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Leztiya girêdanê nîşan bide",
+      "show-link-speed-description": "Leztiya girêdana torê li aliyê navê Wi-Fi yê di widget de nîşan bide"
+    },
     "color-picker": {
       "palette-description": "Ji rêzek fereh ji rengên pêşdanasînkirî hilbijêre.",
       "palette-label": "Destgeh",

--- a/Assets/Translations/nl.json
+++ b/Assets/Translations/nl.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Onweer"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Link snelheid tonen",
+      "show-link-speed-description": "Toon de netwerk linksnelheid naast de Wi-Fi naam in de widget"
+    },
     "color-picker": {
       "palette-description": "Kies uit een breed scala aan vooraf gedefinieerde kleuren.",
       "palette-label": "Palet",

--- a/Assets/Translations/nn-NO.json
+++ b/Assets/Translations/nn-NO.json
@@ -1955,6 +1955,10 @@
     "thunderstorm": "Storm"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Vis linkhastigheit",
+      "show-link-speed-description": "Vis nettverkslinkhastigheita ved sidan av Wi-Fi-namnet i widgeten"
+    },
     "color-picker": {
       "palette-description": "Vel frå mange ulike fargar.",
       "palette-label": "Palett",

--- a/Assets/Translations/pl.json
+++ b/Assets/Translations/pl.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Burza"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Pokaż prędkość łącza",
+      "show-link-speed-description": "Wyświetl prędkość połączenia sieciowego obok nazwy Wi-Fi w widżecie"
+    },
     "color-picker": {
       "palette-description": "Wybierz z szerokiej gamy predefiniowanych kolorów.",
       "palette-label": "Paleta",

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Tempestade"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Mostrar velocidade de ligação",
+      "show-link-speed-description": "Exibir a velocidade da ligação de rede ao lado do nome Wi-Fi no widget"
+    },
     "color-picker": {
       "palette-description": "Escolha entre uma vasta gama de cores predefinidas.",
       "palette-label": "Paleta",

--- a/Assets/Translations/ru.json
+++ b/Assets/Translations/ru.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Гроза"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Показывать скорость соединения",
+      "show-link-speed-description": "Отображать скорость сетевого соединения рядом с именем Wi-Fi в виджете"
+    },
     "color-picker": {
       "palette-description": "Выберите из широкого диапазона предопределённых цветов.",
       "palette-label": "Палитра",

--- a/Assets/Translations/sv.json
+++ b/Assets/Translations/sv.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Åskväder"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Visa länkhastighet",
+      "show-link-speed-description": "Visa nätverkets länkhastighet bredvid Wi-Fi-namnet i widgeten"
+    },
     "color-picker": {
       "palette-description": "Välj bland ett stort utbud av fördefinierade färger.",
       "palette-label": "Palett",

--- a/Assets/Translations/tr.json
+++ b/Assets/Translations/tr.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Fırtına"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Bağlantı hızını göster",
+      "show-link-speed-description": "Widget'te Wi-Fi adının yanında ağ bağlantı hızını göster"
+    },
     "color-picker": {
       "palette-description": "Önceden tanımlı renkler geniş yelpazesinden seçin.",
       "palette-label": "Palet",

--- a/Assets/Translations/uk-UA.json
+++ b/Assets/Translations/uk-UA.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Гроза"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Показувати швидкість з'єднання",
+      "show-link-speed-description": "Відображати швидкість мережевого з'єднання поруч із назвою Wi-Fi у віджеті"
+    },
     "color-picker": {
       "palette-description": "Виберіть із широкого діапазону попередньо визначених кольорів.",
       "palette-label": "Палітра",

--- a/Assets/Translations/vi.json
+++ b/Assets/Translations/vi.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "Bão"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "Hiển thị tốc độ liên kết",
+      "show-link-speed-description": "Hiển thị tốc độ liên kết mạng bên cạnh tên Wi-Fi trong widget"
+    },
     "color-picker": {
       "palette-description": "Chọn từ nhiều màu sắc có sẵn.",
       "palette-label": "Bảng màu",

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "雷暴"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "显示连接速度",
+      "show-link-speed-description": "在小组件中的Wi-Fi名称旁显示网络连接速度"
+    },
     "color-picker": {
       "palette-description": "从各种预定义颜色中选择。",
       "palette-label": "调色板",

--- a/Assets/Translations/zh-TW.json
+++ b/Assets/Translations/zh-TW.json
@@ -2115,6 +2115,10 @@
     "thunderstorm": "閃電暴雨"
   },
   "widgets": {
+    "network": {
+      "show-link-speed": "顯示連線速度",
+      "show-link-speed-description": "在小工具中的Wi-Fi名稱旁顯示網路連線速度"
+    },
     "color-picker": {
       "palette-description": "從各種預先設定的顏色中挑選",
       "palette-label": "調色盤",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -586,6 +586,7 @@ Singleton {
       property bool bluetoothHideUnnamedDevices: false
       property bool disableDiscoverability: false
       property bool bluetoothAutoConnect: true
+      property bool showLinkSpeedInWidget: false
     }
 
     // session menu

--- a/Modules/Panels/Settings/Bar/WidgetSettings/NetworkSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/NetworkSettings.qml
@@ -71,4 +71,17 @@ ColumnLayout {
                 }
     defaultValue: widgetMetadata.textColor
   }
+
+  NToggle {
+    id: showLinkSpeedSwitch
+    Layout.fillWidth: true
+    label: I18n.tr("widgets.network.show-link-speed")
+    description: I18n.tr("widgets.network.show-link-speed-description")
+    checked: Settings.data.network.showLinkSpeedInWidget
+    onToggled: checked => {
+                 Settings.data.network.showLinkSpeedInWidget = checked;
+               }
+    defaultValue: widgetMetadata.showLinkSpeedInWidget
+  }
 }
+

--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -494,13 +494,13 @@ Singleton {
     function togglePanel() {
       root.screenDetector.withCurrentScreen(screen => {
                                               var panel = PanelService.getPanel("audioPanel", screen);
-                                              panel?.toggle();
+                                              panel?.toggle(null, "Volume");
                                             });
     }
     function openPanel() {
       root.screenDetector.withCurrentScreen(screen => {
                                               var panel = PanelService.getPanel("audioPanel", screen);
-                                              panel?.open();
+                                              panel?.open(null, "Volume");
                                             });
     }
     function closePanel() {
@@ -637,7 +637,7 @@ Singleton {
     function togglePanel() {
       root.screenDetector.withCurrentScreen(screen => {
                                               var networkPanel = PanelService.getPanel("networkPanel", screen);
-                                              networkPanel?.toggle(null, "WiFi");
+                                              networkPanel?.toggle(null, "Network");
                                             });
     }
   }
@@ -667,6 +667,19 @@ Singleton {
     }
     function disableAutoConnect() {
       Settings.data.network.bluetoothAutoConnect = false;
+    }
+  }
+
+  IpcHandler {
+    target: "airplaneMode"
+    function toggle() {
+      BluetoothService.setAirplaneMode(!Settings.data.network.airplaneModeEnabled);
+    }
+    function enable() {
+      BluetoothService.setAirplaneMode(true);
+    }
+    function disable() {
+      BluetoothService.setAirplaneMode(false);
     }
   }
 
@@ -921,3 +934,4 @@ Singleton {
     }
   }
 }
+

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -530,7 +530,7 @@ Singleton {
       const eth = root.activeEthernetDetails;
       const name = eth.connectionName || (root.ethernetInterfaces.length > 0 ? root.ethernetInterfaces[0].connectionName : "") || "";
       const speed = eth.speed || "";
-      p.push(name + (speed ? " - " + speed : ""));
+      p.push(name + (speed && Settings.data.network.showLinkSpeedInWidget ? " - " + speed : ""));
     }
 
     // Wi-Fi
@@ -539,7 +539,7 @@ Singleton {
       const speed = wl.rateShort || wl.rate || "";
       const connectedNet = Object.values(root.networks).find(net => net.connected);
       const name = connectedNet ? connectedNet.ssid : (wl.connectionName || "");
-      p.push(name + (speed ? " - " + speed : ""));
+      p.push(name + (speed && Settings.data.network.showLinkSpeedInWidget ? " - " + speed : ""));
     }
 
     if (p.length > 0) {
@@ -1721,3 +1721,4 @@ Singleton {
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- Add widget position parameter to audio panel toggle/open methods
- Fix network panel widget identifier from WiFi to Network
- Add showLinkSpeedInWidget option to display network speed in widget (hidden by default)
- Add dedicated IPC command for airplane mode (toggle/enable/disable)

## Changes
- `Services/Control/IPCService.qml` - Panel positioning and airplane mode IPC
- `Services/Networking/NetworkService.qml` - Link speed conditional display
- `Commons/Settings.qml` - New setting option
- `Modules/Panels/Settings/Bar/WidgetSettings/NetworkSettings.qml` - UI toggle

## Usage
- `qs -c noctalia-shell ipc call airplaneMode toggle`
- Enable link speed in widget settings