### PR TITLE
fix(#2184): automatically refresh Wi-Fi UI 3s and 5s after system resume

### DIFF
--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -133,6 +133,13 @@ Singleton {
       Logger.i("Network", "System resumed - forcing state poll");
       ethernetStateProcess.running = true;
       root.scan();
+
+      // NetworkManager usually takes a few seconds to reconnect to a new/known AP
+      // after waking up. Delayed scans handle the UI refresh automatically.
+      delayedScanTimer.interval = 3000;
+      delayedScanTimer.restart();
+      resumeScanTimer.restart();
+
       root.refreshActiveWifiDetails();
       root.refreshActiveEthernetDetails();
       connectivityCheckProcess.running = true;
@@ -209,6 +216,13 @@ Singleton {
   Timer {
     id: delayedScanTimer
     interval: 7000
+    onTriggered: scan()
+  }
+
+  // Secondary scan timer for resume double-checking (5 seconds)
+  Timer {
+    id: resumeScanTimer
+    interval: 5000
     onTriggered: scan()
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation
This PR fixes an issue where the Wi-Fi icon and signal bars in the status bar do not update to reflect the newly connected network after closing and reopening the laptop lid (system resume). 

Previously, [NetworkService.qml] was polling the network state instantly on resume, but `NetworkManager` still requires a few seconds to discover and authenticate with access points. By the time it connected, the UI was displaying stale data. I added a delayed secondary timer (at 3 seconds) and a double-check timer (at 5 seconds) to `Time.onResumed()` so the UI elegantly refreshes once the delayed background handshake finishes, requiring no manual menu click from the user.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2184

## Testing
Tested by simulating a system suspend, intentionally breaking the previous Wi-Fi connection, and verifying the Noctalia bar successfully captures and updates to the fallback connection 3 seconds after resuming.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
N/A - Background logic / UI refresh timing only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
N/A
