### PR TITLE
fix(network): reset connectivity state on resume

### DIFF
--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -131,6 +131,8 @@ Singleton {
     target: Time
     function onResumed() {
       Logger.i("Network", "System resumed - forcing state poll");
+      // Reset so periodic connectivity check triggers a rescan after NM reconnects
+      root.networkConnectivity = "unknown";
       ethernetStateProcess.running = true;
       root.scan();
       root.refreshActiveWifiDetails();


### PR DESCRIPTION
# Pull Request

## Motivation
After resuming from suspend, the wifi bar icon stays stuck showing disconnected even though NetworkManager has reconnected. The onResumed handler fires a scan immediately before NM has had time to reconnect, so the networks map gets rebuilt with connected: false for everything.

The periodic connectivity check (every 15s) should self-correct this, but it only triggers a rescan when the state actually changes. If connectivity was "full" before suspend and comes back "full" after, the condition `result !== root.networkConnectivity` is false, no rescan fires, and the icon stays wrong until you click on it.

Fix is just resetting networkConnectivity to "unknown" on resume. We genuinely don't know the state after waking up so this is accurate, and it means the next connectivity check will see a transition and trigger the rescan.

Alternative to #2240 which adds hardcoded rescans at 3s and 5s. That doesn't fix the actual problem (the polling loop can't self-correct) and falls apart if NM takes longer than 5s to reconnect.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2007
- Closes #2184
- Alternative to #2240

## Testing
Resumed from suspension and observed that the natural polling corrected after the fix patch was applied on various connections.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated