### PR TITLE
feat(colorscheme): Add ability to save generated color schemes as predefined presets

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -941,6 +941,8 @@
         "tonal-spot": "Material Design default algorithm. Creates balanced palettes using tonal variations of the source color.",
         "vibrant": "Maximizes color saturation for bold, eye-catching palettes with vivid tones."
       },
+      "save-current-description": "Save the current wallpaper-based palette as a predefined scheme for later use when wallpaper colors are disabled.",
+      "user-saved-theme-name": "User saved theme",
       "predefined-desc": "Choose from a collection of predefined color schemes.",
       "predefined-generate-templates-label": "Generate templates for predefined schemes",
       "predefined-title": "Predefined color schemes",

--- a/Modules/Panels/Settings/Tabs/ColorScheme/ColorsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/ColorsSubTab.qml
@@ -34,6 +34,8 @@ ColumnLayout {
       schemeName = "Tokyo Night";
     } else if (schemeName === "Rosepine") {
       schemeName = "Rose Pine";
+    } else if (schemeName === "User-saved-theme") {
+      return I18n.tr("panels.color-scheme.user-saved-theme-name");
     }
 
     return schemeName;
@@ -291,6 +293,25 @@ ColumnLayout {
             radius: width * 0.5
             color: modelData
           }
+        }
+      }
+
+      RowLayout {
+        width: parent.width
+        spacing: Style.marginM
+
+        NText {
+          Layout.fillWidth: true
+          wrapMode: Text.WordWrap
+          text: I18n.tr("panels.color-scheme.save-current-description")
+          pointSize: Style.fontSizeS
+          color: Color.mOnSurfaceVariant
+        }
+
+        NButton {
+          text: I18n.tr("common.save")
+          icon: "device-floppy"
+          onClicked: ColorSchemeService.saveCurrentAsUserScheme()
         }
       }
     }

--- a/Modules/Panels/Settings/Tabs/ColorScheme/ColorsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/ColorsSubTab.qml
@@ -22,23 +22,7 @@ ColumnLayout {
   signal openDownloadPopup
 
   function extractSchemeName(schemePath) {
-    var pathParts = schemePath.split("/");
-    var filename = pathParts[pathParts.length - 1];
-    var schemeName = filename.replace(".json", "");
-
-    if (schemeName === "Noctalia-default") {
-      schemeName = "Noctalia (default)";
-    } else if (schemeName === "Noctalia-legacy") {
-      schemeName = "Noctalia (legacy)";
-    } else if (schemeName === "Tokyo-Night") {
-      schemeName = "Tokyo Night";
-    } else if (schemeName === "Rosepine") {
-      schemeName = "Rose Pine";
-    } else if (schemeName === "User-saved-theme") {
-      return I18n.tr("panels.color-scheme.user-saved-theme-name");
-    }
-
-    return schemeName;
+    return ColorSchemeService.getBasename(schemePath);
   }
 
   function getSchemeColor(schemeName, colorKey) {

--- a/Services/Theming/ColorSchemeService.qml
+++ b/Services/Theming/ColorSchemeService.qml
@@ -14,8 +14,10 @@ Singleton {
   property bool scanning: false
   property string schemesDirectory: Quickshell.shellDir + "/Assets/ColorScheme"
   property string downloadedSchemesDirectory: Settings.configDir + "colorschemes"
+  readonly property string userSavedSchemeId: "User-saved-theme"
   property string colorsJsonFilePath: Settings.configDir + "colors.json"
   readonly property string gtkRefreshScript: Quickshell.shellDir + "/Scripts/python/src/theming/gtk-refresh.py"
+  readonly property string templateProcessorScript: Quickshell.shellDir + "/Scripts/python/src/theming/template-processor.py"
 
   function pushSystemColorScheme() {
     const mode = Settings.data.colorSchemes.darkMode ? "dark" : "light";
@@ -76,6 +78,8 @@ Singleton {
       return "Tokyo Night";
     } else if (schemeName === "Rosepine") {
       return "Rose Pine";
+    } else if (schemeName === userSavedSchemeId) {
+      return I18n.tr("panels.color-scheme.user-saved-theme-name");
     }
     return schemeName;
   }
@@ -96,6 +100,8 @@ Singleton {
       schemeName = "Tokyo-Night";
     } else if (schemeName === "Rose Pine") {
       schemeName = "Rosepine";
+    } else if (schemeName === I18n.tr("panels.color-scheme.user-saved-theme-name")) {
+      schemeName = userSavedSchemeId;
     }
     // Check preinstalled directory first, then downloaded directory
     var preinstalledPath = schemesDirectory + "/" + schemeName + "/" + schemeName + ".json";
@@ -142,6 +148,97 @@ Singleton {
     }
   }
 
+  function pickGeneratedColor(modeData, key, fallback) {
+    if (modeData && modeData[key]) {
+      return modeData[key];
+    }
+    return fallback;
+  }
+
+  function buildVariantFromGenerated(modeData) {
+    return {
+      "mPrimary": pickGeneratedColor(modeData, "primary", "#000000"),
+      "mOnPrimary": pickGeneratedColor(modeData, "on_primary", "#000000"),
+      "mSecondary": pickGeneratedColor(modeData, "secondary", "#000000"),
+      "mOnSecondary": pickGeneratedColor(modeData, "on_secondary", "#000000"),
+      "mTertiary": pickGeneratedColor(modeData, "tertiary", "#000000"),
+      "mOnTertiary": pickGeneratedColor(modeData, "on_tertiary", "#000000"),
+      "mError": pickGeneratedColor(modeData, "error", "#000000"),
+      "mOnError": pickGeneratedColor(modeData, "on_error", "#000000"),
+      "mSurface": pickGeneratedColor(modeData, "surface", "#000000"),
+      "mOnSurface": pickGeneratedColor(modeData, "on_surface", "#000000"),
+      "mSurfaceVariant": pickGeneratedColor(modeData, "surface_container", pickGeneratedColor(modeData, "surface_variant", "#000000")),
+      "mOnSurfaceVariant": pickGeneratedColor(modeData, "on_surface_variant", "#000000"),
+      "mOutline": pickGeneratedColor(modeData, "outline_variant", pickGeneratedColor(modeData, "outline", "#000000")),
+      "mShadow": pickGeneratedColor(modeData, "shadow", pickGeneratedColor(modeData, "surface", "#000000")),
+      "mHover": pickGeneratedColor(modeData, "tertiary", "#000000"),
+      "mOnHover": pickGeneratedColor(modeData, "on_tertiary", "#000000")
+    };
+  }
+
+  function buildTerminalSectionFromGenerated(modeData) {
+    return {
+      "foreground": pickGeneratedColor(modeData, "on_surface", "#ffffff"),
+      "background": pickGeneratedColor(modeData, "surface", "#000000"),
+      "selectionFg": pickGeneratedColor(modeData, "on_surface_variant", "#ffffff"),
+      "selectionBg": pickGeneratedColor(modeData, "surface_variant", "#222222"),
+      "cursorText": pickGeneratedColor(modeData, "surface", "#000000"),
+      "cursor": pickGeneratedColor(modeData, "on_surface", "#ffffff"),
+      "normal": {
+        "black": pickGeneratedColor(modeData, "surface", "#000000"),
+        "red": pickGeneratedColor(modeData, "error", "#ff5f5f"),
+        "green": pickGeneratedColor(modeData, "primary", "#5fff87"),
+        "yellow": pickGeneratedColor(modeData, "secondary", "#ffd75f"),
+        "blue": pickGeneratedColor(modeData, "tertiary", "#5f87ff"),
+        "magenta": pickGeneratedColor(modeData, "primary_fixed_dim", pickGeneratedColor(modeData, "primary", "#af5fff")),
+        "cyan": pickGeneratedColor(modeData, "secondary_fixed_dim", pickGeneratedColor(modeData, "secondary", "#5fd7d7")),
+        "white": pickGeneratedColor(modeData, "on_surface", "#d0d0d0")
+      },
+      "bright": {
+        "black": pickGeneratedColor(modeData, "outline", "#303030"),
+        "red": pickGeneratedColor(modeData, "error", "#ff5f5f"),
+        "green": pickGeneratedColor(modeData, "primary", "#5fff87"),
+        "yellow": pickGeneratedColor(modeData, "secondary", "#ffd75f"),
+        "blue": pickGeneratedColor(modeData, "tertiary", "#5f87ff"),
+        "magenta": pickGeneratedColor(modeData, "primary_fixed_dim", pickGeneratedColor(modeData, "primary", "#af5fff")),
+        "cyan": pickGeneratedColor(modeData, "secondary_fixed_dim", pickGeneratedColor(modeData, "secondary", "#5fd7d7")),
+        "white": pickGeneratedColor(modeData, "on_surface", "#ffffff")
+      }
+    };
+  }
+
+  function buildSavedSchemeMode(modeData) {
+    var outVariant = buildVariantFromGenerated(modeData);
+    outVariant.terminal = buildTerminalSectionFromGenerated(modeData);
+    return outVariant;
+  }
+
+  function resolveWallpaperForThemeGeneration() {
+    var effectiveMonitor = Settings.data.colorSchemes.monitorForColors;
+    if (effectiveMonitor === "" || effectiveMonitor === undefined) {
+      effectiveMonitor = Quickshell.screens.length > 0 ? Quickshell.screens[0].name : "";
+    }
+    return WallpaperService.getWallpaper(effectiveMonitor);
+  }
+
+  function saveCurrentAsUserScheme() {
+    if (saveSchemeProcess.running || generateSchemeProcess.running)
+      return;
+
+    saveSchemeProcess.schemeDisplayName = I18n.tr("panels.color-scheme.user-saved-theme-name");
+    saveSchemeProcess.schemePath = downloadedSchemesDirectory + "/" + userSavedSchemeId + "/" + userSavedSchemeId + ".json";
+
+    var wallpaperPath = resolveWallpaperForThemeGeneration();
+    if (!wallpaperPath) {
+      Logger.e("ColorScheme", "Cannot save user scheme: wallpaper path missing");
+      ToastService.showError(I18n.tr("panels.color-scheme.title"), I18n.tr("common.error"));
+      return;
+    }
+
+    generateSchemeProcess.command = ["python3", templateProcessorScript, wallpaperPath, "--scheme-type", Settings.data.colorSchemes.generationMethod];
+    generateSchemeProcess.running = true;
+  }
+
   Process {
     id: findProcess
     running: false
@@ -180,6 +277,58 @@ Singleton {
 
     stdout: StdioCollector {}
     stderr: StdioCollector {}
+  }
+
+  Process {
+    id: generateSchemeProcess
+    running: false
+
+    onExited: function (exitCode) {
+      if (exitCode !== 0) {
+        Logger.e("ColorScheme", "Failed to generate dark/light wallpaper palettes for user scheme");
+        ToastService.showError(I18n.tr("panels.color-scheme.title"), I18n.tr("common.error"));
+        return;
+      }
+
+      try {
+        var generatedData = JSON.parse(stdout.text || "{}");
+        var darkModeData = generatedData.dark || generatedData.light || {};
+        var lightModeData = generatedData.light || generatedData.dark || {};
+
+        saveSchemeProcess.schemePayload = {
+          "dark": buildSavedSchemeMode(darkModeData),
+          "light": buildSavedSchemeMode(lightModeData)
+        };
+
+        saveSchemeProcess.command = ["python3", "-c", "import json, pathlib, sys; p=pathlib.Path(sys.argv[1]); p.parent.mkdir(parents=True, exist_ok=True); p.write_text(json.dumps(json.loads(sys.argv[2]), indent=2) + '\\n', encoding='utf-8')", saveSchemeProcess.schemePath, JSON.stringify(saveSchemeProcess.schemePayload)];
+        saveSchemeProcess.running = true;
+      } catch (e) {
+        Logger.e("ColorScheme", "Failed to parse generated wallpaper palettes:", e);
+        ToastService.showError(I18n.tr("panels.color-scheme.title"), I18n.tr("common.error"));
+      }
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  Process {
+    id: saveSchemeProcess
+    running: false
+    property string schemePath: ""
+    property string schemeDisplayName: ""
+    property var schemePayload: ({})
+
+    onExited: function (exitCode) {
+      if (exitCode === 0) {
+        Logger.i("ColorScheme", "Saved user scheme:", schemePath);
+        ToastService.showNotice(I18n.tr("panels.color-scheme.title"), I18n.tr("common.save") + ": " + schemeDisplayName, "settings-color-scheme");
+        loadColorSchemes();
+      } else {
+        Logger.e("ColorScheme", "Failed to save user scheme:", schemePath);
+        ToastService.showError(I18n.tr("panels.color-scheme.title"), I18n.tr("common.error"));
+      }
+    }
   }
 
   // Internal loader to read a scheme file

--- a/Services/Theming/ColorSchemeService.qml
+++ b/Services/Theming/ColorSchemeService.qml
@@ -12,6 +12,7 @@ Singleton {
 
   property var schemes: []
   property bool scanning: false
+  property bool activateUserSavedAfterSave: false
   property string schemesDirectory: Quickshell.shellDir + "/Assets/ColorScheme"
   property string downloadedSchemesDirectory: Settings.configDir + "colorschemes"
   readonly property string userSavedSchemeId: "User-saved-theme"
@@ -250,6 +251,15 @@ Singleton {
           return line.length > 0;
         });
         files.sort(function (a, b) {
+          var fileA = a.split("/");
+          var fileB = b.split("/");
+          var idA = fileA[fileA.length - 1].replace(".json", "");
+          var idB = fileB[fileB.length - 1].replace(".json", "");
+          if (idA === userSavedSchemeId && idB !== userSavedSchemeId)
+            return -1;
+          if (idB === userSavedSchemeId && idA !== userSavedSchemeId)
+            return 1;
+
           var nameA = getBasename(a).toLowerCase();
           var nameB = getBasename(b).toLowerCase();
           return nameA.localeCompare(nameB);
@@ -257,6 +267,14 @@ Singleton {
         schemes = files;
         scanning = false;
         Logger.d("ColorScheme", "Listed", schemes.length, "schemes");
+
+        if (activateUserSavedAfterSave) {
+          activateUserSavedAfterSave = false;
+          Settings.data.colorSchemes.useWallpaperColors = false;
+          setPredefinedScheme(I18n.tr("panels.color-scheme.user-saved-theme-name"));
+          return;
+        }
+
         // Normalize stored scheme to basename and re-apply if necessary
         var stored = Settings.data.colorSchemes.predefinedScheme;
         if (stored) {
@@ -323,6 +341,7 @@ Singleton {
       if (exitCode === 0) {
         Logger.i("ColorScheme", "Saved user scheme:", schemePath);
         ToastService.showNotice(I18n.tr("panels.color-scheme.title"), I18n.tr("common.save") + ": " + schemeDisplayName, "settings-color-scheme");
+        activateUserSavedAfterSave = true;
         loadColorSchemes();
       } else {
         Logger.e("ColorScheme", "Failed to save user scheme:", schemePath);

--- a/Services/Theming/ColorSchemeService.qml
+++ b/Services/Theming/ColorSchemeService.qml
@@ -106,14 +106,13 @@ Singleton {
     }
     // Check preinstalled directory first, then downloaded directory
     var preinstalledPath = schemesDirectory + "/" + schemeName + "/" + schemeName + ".json";
-    var downloadedPath = downloadedSchemesDirectory + "/" + schemeName + "/" + schemeName + ".json";
     // Try to find the scheme in the loaded schemes list to determine which directory it's in
     for (var i = 0; i < schemes.length; i++) {
       if (schemes[i].indexOf("/" + schemeName + "/") !== -1 || schemes[i].indexOf("/" + schemeName + ".json") !== -1) {
         return schemes[i];
       }
     }
-    // Fallback: prefer preinstalled, then downloaded
+    // Fallback: prefer preinstalled path
     return preinstalledPath;
   }
 
@@ -339,7 +338,6 @@ Singleton {
 
     onExited: function (exitCode) {
       if (exitCode === 0) {
-        Logger.i("ColorScheme", "Saved user scheme:", schemePath);
         ToastService.showNotice(I18n.tr("panels.color-scheme.title"), I18n.tr("common.save") + ": " + schemeDisplayName, "settings-color-scheme");
         activateUserSavedAfterSave = true;
         loadColorSchemes();


### PR DESCRIPTION
# Pull Request
This PR introduces the ability to Save the Current Color Scheme.

## Motivation
Currently, Noctalia offers excellent dynamic color generation by extracting colors from wallpapers. However, if a user finds a generated palette they particularly love, there is no easy way to preserve it once the wallpaper changes or a new scheme is generated.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/9af59458-4c48-44c3-8fc4-2876b01dfef6

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
