### PR TITLE
fix (calculator): support comma as decimal seperator

### DIFF
--- a/Helpers/AdvancedMath.js
+++ b/Helpers/AdvancedMath.js
@@ -27,7 +27,7 @@ var constants = {
 function evaluate(expression) {
     try {
         // Fixes decimal arithmetic
-        var cleanExpr = expression.replace(/\s+/g, '').toLowerCase();
+        var cleanExpr = expression.replace(/\s+/g, '').replace(/,/g, '.').toLowerCase();
         
         // Allows numbers (including decimals), basic operators, and explicitly permitted math terms only
         var safeRegex = /^(\d*\.?\d+|[+\-*/()^%,]|sin|cos|tan|asin|acos|atan|atan2|sinh|cosh|tanh|asinh|acosh|atanh|log|ln|exp|pow|sqrt|cbrt|abs|floor|ceil|round|trunc|min|max|random|pi|e|sind|cosd|tand)+$/;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
If you wanted to do some calculations in the launcher, you could only use a dot to separate decimal places.
But since the numpad on my laptop uses a comma instead of a dot, I added a little fix (or feature, I don't know) so that commas can also be used to separate decimal places.

Below are before-and-after screenshots.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
before
<img width="667" height="149" alt="Noctalia Launcher calc" src="https://github.com/user-attachments/assets/ffd62afe-626f-4cc1-892a-676fbfd52855" />

after
<img width="650" height="172" alt="Noctalia Launcher calc fix" src="https://github.com/user-attachments/assets/0b77bc3e-7fd8-48a3-a342-b0a674470956" />
<img width="646" height="161" alt="Noctalia Launcher calc 2" src="https://github.com/user-attachments/assets/c46009ad-7348-48be-8676-925aef224474" />
