### PR TITLE
[nix/home-manager] Use actual path references to config files in HM module; cleanup nix code

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -6,17 +6,24 @@
 }:
 let
   cfg = config.programs.noctalia-shell;
-  jsonFormat = pkgs.formats.json { };
-  tomlFormat = pkgs.formats.toml { };
 
   generateJson =
     name: value:
     if lib.isString value then
       pkgs.writeText "noctalia-${name}.json" value
-    else if builtins.isPath value || lib.isStorePath value then
+    else if builtins.isPath value then
       value
     else
-      jsonFormat.generate "noctalia-${name}.json" value;
+      pkgs.writers.writeJSON "noctalia-${name}.json" value;
+
+  generateToml =
+    name: value:
+    if lib.isString value then
+      pkgs.writeText "noctalia-${name}.toml" value
+    else if builtins.isPath value then
+      value
+    else
+      pkgs.writers.writeTOML "noctalia-${name}.toml" value;
 in
 {
   options.programs.noctalia-shell = {
@@ -33,7 +40,7 @@ in
       type =
         with lib.types;
         oneOf [
-          jsonFormat.type
+          attrs
           str
           path
         ];
@@ -65,7 +72,7 @@ in
       type =
         with lib.types;
         oneOf [
-          jsonFormat.type
+          (attrsOf str)
           str
           path
         ];
@@ -99,7 +106,7 @@ in
       type =
         with lib.types;
         oneOf [
-          tomlFormat.type
+          attrs
           str
           path
         ];
@@ -128,7 +135,7 @@ in
       type =
         with lib.types;
         oneOf [
-          jsonFormat.type
+          attrs
           str
           path
         ];
@@ -161,7 +168,7 @@ in
       type =
         with lib.types;
         attrsOf (oneOf [
-          jsonFormat.type
+          attrs
           str
           path
         ]);
@@ -189,14 +196,14 @@ in
         PartOf = [ config.wayland.systemd.target ];
         After = [ config.wayland.systemd.target ];
         X-Restart-Triggers =
-          lib.optional (cfg.settings != { }) "${config.xdg.configFile."noctalia/settings.json".source}"
-          ++ lib.optional (cfg.colors != { }) "${config.xdg.configFile."noctalia/colors.json".source}"
-          ++ lib.optional (cfg.plugins != { }) "${config.xdg.configFile."noctalia/plugins.json".source}"
+          lib.optional (cfg.settings != { }) config.xdg.configFile."noctalia/settings.json".source
+          ++ lib.optional (cfg.colors != { }) config.xdg.configFile."noctalia/colors.json".source
+          ++ lib.optional (cfg.plugins != { }) config.xdg.configFile."noctalia/plugins.json".source
           ++ lib.optional (
             cfg.user-templates != { }
-          ) "${config.xdg.configFile."noctalia/user-templates.toml".source}"
+          ) config.xdg.configFile."noctalia/user-templates.toml".source
           ++ lib.mapAttrsToList (
-            name: _: "${config.xdg.configFile."noctalia/plugins/${name}/settings.json".source}"
+            name: _: config.xdg.configFile."noctalia/plugins/${name}/settings.json".source
           ) cfg.pluginSettings;
       };
 
@@ -221,13 +228,7 @@ in
         source = generateJson "plugins" cfg.plugins;
       };
       "noctalia/user-templates.toml" = lib.mkIf (cfg.user-templates != { }) {
-        source =
-          if lib.isString cfg.user-templates then
-            pkgs.writeText "noctalia-user-templates.toml" cfg.user-templates
-          else if builtins.isPath cfg.user-templates || lib.isStorePath cfg.user-templates then
-            cfg.user-templates
-          else
-            tomlFormat.generate "noctalia-user-templates.toml" cfg.user-templates;
+        source = generateToml "user-templates" cfg.user-templates;
       };
     }
     // lib.mapAttrs' (


### PR DESCRIPTION
Store paths converted to strings seem to have caused some inconsistencies in referencing the configs, leading to reload triggers during store path mutations (even before activation)

# Pull Request

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.

I used to get warnings of the form 

```
[jfw12] warning: Using 'builtins.derivation' to create a derivation named 'options.json' that references the store path '/nix/store/ap9dpkyzikzzh04259wlsvha2mw455x4-source' wit
hout a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.
[jfw12] warning: Using 'builtins.derivation' to create a derivation named 'noctalia-settings.json' that references the store path '/nix/store/jv4p3div4pryfvras9h82w2rgzyrfkm0-s
ource' without a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.
[jfw12] warning: Using 'builtins.derivation' to create a derivation named 'options.json' that references the store path '/nix/store/ap9dpkyzikzzh04259wlsvha2mw455x4-source' wit
hout a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.
[jfw12] warning: Using 'builtins.derivation' to create a derivation named 'noctalia-settings.json' that references the store path '/nix/store/jv4p3div4pryfvras9h82w2rgzyrfkm0-s
ource' without a proper context. The resulting derivation will not have a correct store reference, so this is unreliable and may stop working in the future.
```

While this seems to have not been caused exclusively by noctalia (but by a similar (wrong) pattern as in the HM module that referenced stringified store paths instead of the actual path), this PR makes the generation of the settings files more idiomatic. 

I suspect that the other strange behaviour I observed, i.e. getting noctalia reload events even unrelated to HM activation (e.g. during `nix flake update` and similar) may also have been related to this.