### PR TITLE
fix(NFilePicker): Added multiSelection choice

### DIFF
--- a/Widgets/NFilePicker.qml
+++ b/Widgets/NFilePicker.qml
@@ -168,6 +168,55 @@ Popup {
                       }
                     }
 
+    // Function when an item is clicked, either a folder or a file since both have the same functionality, reduces repetitive code
+    function itemClicked(modifiers, path) {
+      var list = currentSelection.slice();
+      const index = list.indexOf(path);
+      if (root.allowMultiSelection && (modifiers & Qt.ShiftModifier) && list.length > 0) {
+        if (index > -1) {
+          list.splice(index, 1);
+          currentSelection = list;
+        } else {
+          var i = 0;
+          var toggle = false;
+          const firstItemPath = list[0];
+          while (i < filteredModel.count) {
+            const itemPath = filteredModel.get(i).filePath;
+
+            // This should be called twice, when we get to the item selected and when we get to the starting item.
+            if (itemPath === firstItemPath || itemPath === path) {
+              toggle = !toggle;
+            }
+
+            // Add all files between the starting item and the item selected.
+            if (toggle) {
+              if (!list.includes(itemPath)) {
+                list.push(itemPath);
+              }
+            }
+
+            i++;
+          }
+
+          // Add the path selected as well since it's skipped in the while loop
+          if (!list.includes(path)) {
+            list.push(path);
+          }
+          currentSelection = list;
+        }
+      } else if (root.allowMultiSelection && (modifiers & Qt.ControlModifier)) {
+        if (index > -1) {
+          list.splice(index, 1);
+          currentSelection = list;
+        } else {
+          list.push(path);
+          currentSelection = list;
+        }
+      } else {
+        currentSelection = [path];
+      }
+    }
+
     ColumnLayout {
       anchors.fill: parent
       spacing: Style.marginM
@@ -579,39 +628,13 @@ Popup {
                              if (model.fileIsDir) {
                                // In folder mode, single click selects the folder
                                if (root.selectionMode === "folders") {
-                                 if (root.allowMultiSelection && (mouse.modifiers & Qt.ShiftModifier)) {
-                                   // Deep copy otherwise the isSelected might not get updated.
-                                   var list = JSON.parse(JSON.stringify(filePickerPanel.currentSelection));
-                                   const index = list.indexOf(model.filePath);
-                                   if (index > -1) {
-                                     list.splice(index, 1);
-                                     filePickerPanel.currentSelection = list;
-                                   } else {
-                                     list.push(model.filePath);
-                                     filePickerPanel.currentSelection = list;
-                                   }
-                                 } else {
-                                   filePickerPanel.currentSelection = [model.filePath];
-                                 }
+                                 filePickerPanel.itemClicked(mouse.modifiers, model.filePath);
                                }
                                // In file mode, single click on folder does nothing (must double-click to enter)
                              } else {
                                // Single click on file selects it (only in file mode)
                                if (root.selectionMode === "files") {
-                                 if (root.allowMultiSelection && (mouse.modifiers & Qt.ShiftModifier)) {
-                                   // Deep copy otherwise the isSelected might not get updated.
-                                   var list = JSON.parse(JSON.stringify(filePickerPanel.currentSelection));
-                                   const index = list.indexOf(model.filePath);
-                                   if (index > -1) {
-                                     list.splice(index, 1);
-                                     filePickerPanel.currentSelection = list;
-                                   } else {
-                                     list.push(model.filePath);
-                                     filePickerPanel.currentSelection = list;
-                                   }
-                                 } else {
-                                   filePickerPanel.currentSelection = [model.filePath];
-                                 }
+                                 filePickerPanel.itemClicked(mouse.modifiers, model.filePath);
                                }
                              }
                            }
@@ -704,39 +727,13 @@ Popup {
                              if (model.fileIsDir) {
                                // In folder mode, single click selects the folder
                                if (root.selectionMode === "folders") {
-                                 // Deep copy otherwise the isSelected might not get updated.
-                                 if (root.allowMultiSelection && (mouse.modifiers & Qt.ShiftModifier)) {
-                                   var list = JSON.parse(JSON.stringify(filePickerPanel.currentSelection));
-                                   const index = list.indexOf(model.filePath);
-                                   if (index > -1) {
-                                     list.splice(index, 1);
-                                     filePickerPanel.currentSelection = list;
-                                   } else {
-                                     list.push(model.filePath);
-                                     filePickerPanel.currentSelection = list;
-                                   }
-                                 } else {
-                                   filePickerPanel.currentSelection = [model.filePath];
-                                 }
+                                 filePickerPanel.itemClicked(mouse.modifiers, model.filePath);
                                }
                                // In file mode, single click on folder does nothing (must double-click to enter)
                              } else {
                                // Single click on file selects it (only in file mode)
                                if (root.selectionMode === "files") {
-                                 if (root.allowMultiSelection && (mouse.modifiers & Qt.ShiftModifier)) {
-                                   // Deep copy otherwise the isSelected might not get updated.
-                                   var list = JSON.parse(JSON.stringify(filePickerPanel.currentSelection));
-                                   const index = list.indexOf(model.filePath);
-                                   if (index > -1) {
-                                     list.splice(index, 1);
-                                     filePickerPanel.currentSelection = list;
-                                   } else {
-                                     list.push(model.filePath);
-                                     filePickerPanel.currentSelection = list;
-                                   }
-                                 } else {
-                                   filePickerPanel.currentSelection = [model.filePath];
-                                 }
+                                 filePickerPanel.itemClicked(mouse.modifiers, model.filePath);
                                }
                              }
                            }


### PR DESCRIPTION
# Pull Request
Added the choice to have a `NFilePicker` where you can choose multiple items at the same time

## Motivation
The `NFilePicker` component currently only supports choosing one item but I believe it would be good for the developers to have the choice for multiple items to be chosen at the same time. The boolean to enable multiple choices at the same time is false by default since that's how it has been working so far. Right now you can select multiple items with the Shift button.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
No related issue found.

## Testing
The testing was done by using it, opening multiple file pickers and seeing that it works. 

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
A screenshot showing multiple folders being selected at the same time. 
<img width="844" height="505" alt="image" src="https://github.com/user-attachments/assets/ad794dbf-57bb-4fb3-80ea-184cdd1b03be" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
This PR only adds support for selecting multiple files / folders with holding the shift button. Some people are used to having the shift button select from the first item in a list to the last item in the list, so in that case maybe ctrl might have been better but I'm not really sure tbh.

Also the code is very repetitive, in that case I can refactor it to put everything under one function instead to make it less repetitive if that's wished for.