### PR TITLE
fix(wallpaper): wait for ImageCacheService to be ready before scanning

### DIFF
--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -730,6 +730,12 @@ Singleton {
 
   // -------------------------------------------------------------------
   function refreshWallpapersList() {
+    // Wait for imageMagickAvailable to be correctly set for ImageCacheService.imageFilters
+    if (!ImageCacheService.initialized) {
+      Qt.callLater(refreshWallpapersList);
+      return;
+    }
+
     var mode = Settings.data.wallpaper.viewMode;
     Logger.d("Wallpaper", "refreshWallpapersList", "viewMode:", mode);
     scanningCount = 0;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Currently, the scanning begins before the ImageCacheService is initialized, so hasImageMagick is always false, leading to image formats in extendedImageFilters not being shown (all my images are webp). Relevant (truncated) section of the logs:

``` 
  INFO qml: [20260322-143507]     ImageCache Service started
  INFO qml: [20260322-143507] AppThemeServic Service started
  INFO qml: [20260322-143507]    ColorScheme Service started
  INFO qml: [20260322-143507] DarkModeServic Service started
  INFO qml: [20260322-143507]      Wallpaper Starting scan for HDMI-A-1 in /home/iynaix/Pictures/Wallpapers recursive: false
  INFO qml: [20260322-143507]      Wallpaper Starting scan for DP-2 in /home/iynaix/Pictures/Wallpapers recursive: false
  INFO qml: [20260322-143507]      Wallpaper Starting scan for DP-1 in /home/iynaix/Pictures/Wallpapers recursive: false
  INFO qml: [20260322-143507]       Location Service started
  WARN quickshell.dbus.objectmanager: Failed to create DBusObjectManagerInterface for "org.bluez" "/" : QDBusError("org.freedesktop.DBus.Error.ServiceUnknown", "The name is not activatable")
  INFO qml: [20260322-143507]      Bluetooth Service started
  INFO qml: [20260322-143507]  IdleInhibitor Service started
  INFO qml: [20260322-143507]    IdleService Service started
  INFO qml: [20260322-143507]    IdleService screenOff monitor created, timeout 300 s
  INFO qml: [20260322-143507]    HostService Service started
  INFO qml: [20260322-143507]         GitHub Service started
  INFO qml: [20260322-143507]      Supporter Service started
  INFO qml: [20260322-143507] CustomButtonIP Service started
  INFO qml: [20260322-143507]     IPCService Service started
  WARN quickshell.dbus: Could not launch service org.freedesktop.UPower.PowerProfiles: QDBusError(org.freedesktop.DBus.Error.ServiceUnknown, The name is not activatable)
  WARN quickshell.service.powerprofiles: Could not start PowerProfilesDaemon. The PowerProfiles service will not work.
  WARN: Cannot enable background effect as ext-background-effect-v1 is not supported by the current compositor.
  WARN: Cannot enable background effect as ext-background-effect-v1 is not supported by the current compositor.
  WARN: Cannot enable background effect as ext-background-effect-v1 is not supported by the current compositor.
  INFO qml: [20260322-143507]       Location Coordinates ready
  WARN scene: QML FileView at @Services/Noctalia/PluginRegistry.qml[102:38]: Write of /home/iynaix/.config/noctalia/plugins.json failed: Permission denied.
  INFO qml: [20260322-143507]    HostService Detected NixOS 26.05 (Yarara)
  INFO qml: [20260322-143507]    HostService Looking for logo icon: nix-snowflake
  INFO qml: [20260322-143507]         GitHub Checking cache - timestamp: 1774159649 now: 1774161307 age: 28 minutes
  INFO qml: [20260322-143507]         GitHub Cache is fresh, using cached data (age: 28 minutes)
  INFO qml: [20260322-143507]      Supporter Cache is fresh, using cached data
  INFO qml: [20260322-143507] KeyboardLayout Service started
  INFO qml: [20260322-143507] PluginRegistry Loaded plugin: 749a5a:projects-provider - Projects Provider
  INFO qml: [20260322-143507] PluginRegistry Loaded plugin: kaomoji-provider - Kaomoji Provider
  INFO qml: [20260322-143507] PluginRegistry Loaded plugin: polkit-agent - Polkit Agent
  INFO qml: [20260322-143507] PluginRegistry Loaded plugin: screen-recorder - Screen Recorder
  INFO qml: [20260322-143507] PluginRegistry Loaded plugin: timer - Timer
  INFO qml: [20260322-143507] PluginRegistry All plugin manifests loaded. Total plugins: 5
  INFO qml: [20260322-143507]  PluginService Initializing plugin system
  INFO qml: [20260322-143507]  PluginService Found 5 enabled plugins: ["749a5a:projects-provider","kaomoji-provider","polkit-agent","screen-recorder","timer"]
  INFO qml: [20260322-143507]  PluginService Loading plugin: 749a5a:projects-provider
  INFO qml: [20260322-143507]  PluginService Loading plugin: kaomoji-provider
  INFO qml: [20260322-143507]  PluginService Loading plugin: polkit-agent
  INFO qml: [20260322-143507]  PluginService Loading plugin: screen-recorder
  INFO qml: [20260322-143507]  PluginService Loading plugin: timer
  WARN quickshell.dbus: Could not launch service org.freedesktop.UPower: QDBusError(org.freedesktop.DBus.Error.ServiceUnknown, The name is not activatable)
  WARN quickshell.service.upower: Could not start UPower. The UPower service will not work.
  INFO qml: [20260322-143507]     ImageCache ImageMagick available
```

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
