### PR TITLE
fix(nix): inherit noctalia-qs overlay in our overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 result
 build
 /debian/
+.direnv/
+.envrc

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,16 @@
           self.overlays.default
         ]
       );
+
+      mkDate =
+        longDate:
+        nixpkgs.lib.concatStringsSep "-" [
+          (builtins.substring 0 4 longDate)
+          (builtins.substring 4 2 longDate)
+          (builtins.substring 6 2 longDate)
+        ];
+
+      version = mkDate (self.lastModifiedDate or "19700101") + "_" + (self.shortRev or "dirty");
     in
     {
       formatter = eachSystem (system: pkgsFor.${system}.nixfmt);
@@ -33,22 +43,14 @@
       });
 
       overlays = {
-        default = final: prev: {
-          noctalia-shell = final.callPackage ./nix/package.nix {
-            version =
-              let
-                mkDate =
-                  longDate:
-                  final.lib.concatStringsSep "-" [
-                    (builtins.substring 0 4 longDate)
-                    (builtins.substring 4 2 longDate)
-                    (builtins.substring 6 2 longDate)
-                  ];
-              in
-              mkDate (self.lastModifiedDate or "19700101") + "_" + (self.shortRev or "dirty");
-            quickshell = noctalia-qs.packages.${prev.stdenv.hostPlatform.system}.default;
-          };
-        };
+        default = nixpkgs.lib.composeManyExtensions [
+          noctalia-qs.overlays.default
+          (final: prev: {
+            noctalia-shell = final.callPackage ./nix/package.nix {
+              inherit version;
+            };
+          })
+        ];
       };
 
       devShells = eachSystem (system: {


### PR DESCRIPTION

# Pull Request

## Motivation

This avoids a second instantiation of Nixpkgs, when consuming the overlay, instead of using the package output directly.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Smoke test:

```console
nix repl
nix-repl> :lf .

nix-repl> pkgs = imports inputs.nixpkgs { overlays = [outputs.overlays.default]; }

nix-repl> pkgs.noctalia-shell
«derivation /nix/store/30ilvacnyyqyrnqh26vz6x1s095iwysb-noctalia-shell-2026-03-22_df0a16d.drv»

nix-repl> pkgs.quickshell
«derivation /nix/store/zyrm8fb4r4bq6mqrv4ssjc08haf5j2b4-quickshell-2026-03-21_c9beee5.drv»
```

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
