### PR TITLE
Small fix for Nord colorscheme

### DIFF
--- a/Assets/ColorScheme/Nord/Nord.json
+++ b/Assets/ColorScheme/Nord/Nord.json
@@ -84,7 +84,7 @@
         "white": "#eceff4"
       },
       "foreground": "#414858",
-      "background": "#e5e9f0",
+      "background": "#eceff4",
       "selectionFg": "#4c556a",
       "selectionBg": "#d8dee9",
       "cursorText": "#3b4252",


### PR DESCRIPTION
# Pull Request

## Motivation
There is a slight visual inconsistency in the way colors are defined/used in the Nord color scheme.

The documentation of the Nord theme explicitly states that nord6, aka `#eceff4` should be used for background color in light mode, yet the Noctalia implementation uses nord5.

This causes visual inconsistencies, for example with `vim` themes.

This PR fixes thie little glitch,

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Before (notice that the `vim` background is a different color than the terminal borders. The `vim` theme is right, Noctalia is wrong)

<img width="1389" height="876" alt="before" src="https://github.com/user-attachments/assets/64ae383d-9b08-458d-afa0-e3ae54a851e0" />

After the patch:

<img width="1389" height="876" alt="after" src="https://github.com/user-attachments/assets/9593be18-bd21-4161-8675-00597ddc2699" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
