### PR TITLE
Feat/launcher category animations

### DIFF
--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -27,7 +27,7 @@ Rectangle {
   }
 
   // Expose for preview panel positioning
-  readonly property var resultsView: resultsViewLoader.item
+  readonly property var resultsView: resultsSwapView.item
 
   // State
   property string searchText: ""
@@ -44,13 +44,6 @@ Rectangle {
   property real globalLastMouseY: 0
   property bool globalMouseInitialized: false
   property bool mouseTrackingReady: false // Delay tracking until panel is settled
-  property bool categoryTransitionRunning: false
-  property real resultsSlideInOffset: 0
-  property real resultsSlideInOpacity: 1
-  property real resultsSnapshotOffset: 0
-  property real resultsSnapshotOpacity: 0
-  property real resultsSnapshotTargetOffset: 0
-  property int pendingCategoryTabIndex: -1
 
   readonly property bool animationsDisabled: Settings.data.general.animationDisabled
 
@@ -196,7 +189,8 @@ Rectangle {
   function onClosed() {
     searchText = "";
     ignoreMouseHover = true;
-    resetCategoryTransitionVisuals();
+    if (resultsSwapView)
+      resultsSwapView.resetVisuals();
     for (let provider of providers) {
       if (provider.onClosed)
         provider.onClosed();
@@ -205,17 +199,6 @@ Rectangle {
 
   function close() {
     requestClose();
-  }
-
-  function resetCategoryTransitionVisuals() {
-    categoryTransitionRunning = false;
-    pendingCategoryTabIndex = -1;
-    resultsSlideInOffset = 0;
-    resultsSlideInOpacity = 1;
-    resultsSnapshotOffset = 0;
-    resultsSnapshotOpacity = 0;
-    resultsSnapshot.visible = false;
-    categorySlideTransition.stop();
   }
 
   function applyCategorySelection(tabIndex, categories) {
@@ -240,44 +223,14 @@ Rectangle {
     if (tabIndex === currentIdx)
       return;
 
-    const canAnimate = !animationsDisabled && resultsViewport.width > 0 && resultsViewport.height > 0;
+    const canAnimate = !animationsDisabled && resultsSwapView.width > 0 && resultsSwapView.height > 0;
     if (!canAnimate) {
       applyCategorySelection(tabIndex, cats);
       return;
     }
 
-    if (categoryTransitionRunning)
-      resetCategoryTransitionVisuals();
-
-    const movingForward = tabIndex > currentIdx;
-    const slideDistance = Math.max(1, resultsViewport.width + Style.marginXL);
-
-    resultsSnapshot.visible = true;
-    resultsSnapshotOffset = 0;
-    resultsSnapshotOpacity = 1;
-    resultsSnapshotTargetOffset = movingForward ? -slideDistance : slideDistance;
-
-    resultsSlideInOffset = movingForward ? slideDistance : -slideDistance;
-    resultsSlideInOpacity = 0.0;
-
-    pendingCategoryTabIndex = tabIndex;
-    categoryTransitionRunning = true;
-    resultsSnapshot.scheduleUpdate();
-
-    Qt.callLater(() => {
-                   if (!categoryTransitionRunning || pendingCategoryTabIndex < 0)
-                     return;
-
-                   const pendingIndex = pendingCategoryTabIndex;
-                   pendingCategoryTabIndex = -1;
-
-                   const pendingCategories = providerCategories;
-                   if (!applyCategorySelection(pendingIndex, pendingCategories)) {
-                     resetCategoryTransitionVisuals();
-                     return;
-                   }
-                   categorySlideTransition.restart();
-                 });
+    const direction = tabIndex > currentIdx ? 1 : -1;
+    resultsSwapView.swap(direction, () => applyCategorySelection(tabIndex, providerCategories));
   }
 
   // Public API
@@ -757,70 +710,14 @@ Rectangle {
     }
 
     // Results view
-    Item {
-      id: resultsViewport
+    NSlideSwapView {
+      id: resultsSwapView
       Layout.fillWidth: true
       Layout.leftMargin: Style.marginL
       Layout.rightMargin: Style.marginL
       Layout.fillHeight: true
-      clip: true
-
-      ShaderEffectSource {
-        id: resultsSnapshot
-        visible: false
-        width: parent.width
-        height: parent.height
-        y: 0
-        sourceItem: resultsViewLoader
-        hideSource: false
-        live: false
-        smooth: true
-        z: 2
-        x: root.resultsSnapshotOffset
-        opacity: root.resultsSnapshotOpacity
-      }
-
-      Loader {
-        id: resultsViewLoader
-        width: parent.width
-        height: parent.height
-        x: root.resultsSlideInOffset
-        opacity: root.resultsSlideInOpacity
-        sourceComponent: root.isSingleView ? singleViewComponent : (root.isGridView ? gridViewComponent : listViewComponent)
-      }
-    }
-
-    ParallelAnimation {
-      id: categorySlideTransition
-      NumberAnimation {
-        target: root
-        property: "resultsSlideInOffset"
-        to: 0
-        duration: Style.animationNormal
-        easing.type: Easing.OutCubic
-      }
-      NumberAnimation {
-        target: root
-        property: "resultsSlideInOpacity"
-        to: 1
-        duration: Style.animationNormal
-        easing.type: Easing.OutCubic
-      }
-      NumberAnimation {
-        target: root
-        property: "resultsSnapshotOffset"
-        to: root.resultsSnapshotTargetOffset
-        duration: Style.animationNormal
-        easing.type: Easing.OutCubic
-      }
-      NumberAnimation {
-        target: root
-        property: "resultsSnapshotOpacity"
-        to: 0.25
-        duration: Style.animationNormal
-        easing.type: Easing.OutCubic
-      }
-      onFinished: root.resetCategoryTransitionVisuals()
+      animationsEnabled: !root.animationsDisabled
+      sourceComponent: root.isSingleView ? singleViewComponent : (root.isGridView ? gridViewComponent : listViewComponent)
     }
 
     // --------------------------

--- a/Widgets/NSlideSwapView.qml
+++ b/Widgets/NSlideSwapView.qml
@@ -1,0 +1,134 @@
+import QtQuick
+import qs.Commons
+
+Item {
+  id: root
+
+  property Component sourceComponent
+  property bool animationsEnabled: true
+  property int duration: Style.animationNormal
+  property real transitionGap: Style.marginXL
+  property real incomingStartOpacity: 0.0
+  property real outgoingTargetOpacity: 0.25
+
+  readonly property var item: contentLoader.item
+  readonly property bool running: _running
+
+  property bool _running: false
+  property var _pendingApplyChange: null
+  property real _contentOffset: 0
+  property real _contentOpacity: 1
+  property real _snapshotOffset: 0
+  property real _snapshotOpacity: 0
+  property real _snapshotTargetOffset: 0
+
+  clip: true
+
+  function resetVisuals() {
+    _running = false;
+    _pendingApplyChange = null;
+    _contentOffset = 0;
+    _contentOpacity = 1;
+    _snapshotOffset = 0;
+    _snapshotOpacity = 0;
+    snapshot.visible = false;
+    transition.stop();
+  }
+
+  function swap(direction, applyChange) {
+    if (!animationsEnabled || width <= 0 || height <= 0 || direction === 0) {
+      if (applyChange)
+        applyChange();
+      return;
+    }
+
+    if (_running)
+      resetVisuals();
+
+    const slideDistance = Math.max(1, width + transitionGap);
+    const movingForward = direction > 0;
+
+    snapshot.visible = true;
+    _snapshotOffset = 0;
+    _snapshotOpacity = 1;
+    _snapshotTargetOffset = movingForward ? -slideDistance : slideDistance;
+
+    _contentOffset = movingForward ? slideDistance : -slideDistance;
+    _contentOpacity = incomingStartOpacity;
+
+    _pendingApplyChange = applyChange || null;
+    _running = true;
+    snapshot.scheduleUpdate();
+
+    Qt.callLater(() => {
+                   if (!_running)
+                     return;
+
+                   const applyFn = _pendingApplyChange;
+                   _pendingApplyChange = null;
+                   const shouldAnimate = applyFn ? applyFn() !== false : true;
+                   if (!shouldAnimate) {
+                     resetVisuals();
+                     return;
+                   }
+                   transition.restart();
+                 });
+  }
+
+  ShaderEffectSource {
+    id: snapshot
+    visible: false
+    width: parent.width
+    height: parent.height
+    y: 0
+    sourceItem: contentLoader
+    hideSource: false
+    live: false
+    smooth: true
+    z: 2
+    x: root._snapshotOffset
+    opacity: root._snapshotOpacity
+  }
+
+  Loader {
+    id: contentLoader
+    width: parent.width
+    height: parent.height
+    x: root._contentOffset
+    opacity: root._contentOpacity
+    sourceComponent: root.sourceComponent
+  }
+
+  ParallelAnimation {
+    id: transition
+    NumberAnimation {
+      target: root
+      property: "_contentOffset"
+      to: 0
+      duration: root.duration
+      easing.type: Easing.OutCubic
+    }
+    NumberAnimation {
+      target: root
+      property: "_contentOpacity"
+      to: 1
+      duration: root.duration
+      easing.type: Easing.OutCubic
+    }
+    NumberAnimation {
+      target: root
+      property: "_snapshotOffset"
+      to: root._snapshotTargetOffset
+      duration: root.duration
+      easing.type: Easing.OutCubic
+    }
+    NumberAnimation {
+      target: root
+      property: "_snapshotOpacity"
+      to: root.outgoingTargetOpacity
+      duration: root.duration
+      easing.type: Easing.OutCubic
+    }
+    onFinished: root.resetVisuals()
+  }
+}


### PR DESCRIPTION
# Pull Request

## Motivation
This PR makes category switching in the launcher feel smoother and easier to follow. Tabs now slide left or right like Settings subtabs, so movement feels more natural and consistent. It improves the overall polish while keeping behavior the same for both mouse and keyboard navigation.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/297b27f0-1cb3-47e6-a430-c45111fca554

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
