### PR TITLE
feat(lockscreen): add highlight selection in the password input field

### DIFF
--- a/Modules/LockScreen/LockScreenPanel.qml
+++ b/Modules/LockScreen/LockScreenPanel.qml
@@ -709,7 +709,7 @@ Item {
 
           // Esc to clear selection
           Shortcut {
-            sequences: [StandardKey.Cancel]
+            sequence: StandardKey.Cancel
             enabled: passwordInput.activeFocus && passwordInput.selectionStart !== passwordInput.selectionEnd
             onActivated: passwordInput.deselect()
           }
@@ -737,7 +737,6 @@ Item {
                 visible: passwordInput.activeFocus && passwordInput.text.length === 0
                 anchors.verticalCenter: parent.verticalCenter
 
-                // Smooth fade animation (when animations enabled)
                 SequentialAnimation on opacity {
                   loops: Animation.Infinite
                   running: root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length === 0
@@ -751,7 +750,6 @@ Item {
                   }
                 }
 
-                // Simple toggle (when animations disabled) — no per-frame repaints
                 Timer {
                   interval: 530
                   running: !root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length === 0
@@ -773,7 +771,7 @@ Item {
                   id: selectionHighlight
                   visible: passwordInput.selectionStart !== passwordInput.selectionEnd && passwordInput.text.length > 0
                   color: Qt.alpha(Color.mPrimary, 0.8)
-                  height: parent.height + 6
+                  height: parent.height + Style.marginS
                   anchors.verticalCenter: parent.verticalCenter
                   x: (passwordInput.selectionStart / passwordInput.text.length) * passwordDisplayContent.width
                   width: ((passwordInput.selectionEnd - passwordInput.selectionStart) / passwordInput.text.length) * passwordDisplayContent.width
@@ -796,8 +794,6 @@ Item {
                       id: icon
 
                       required property int index
-                      // This will be called with index = -1 when the TextInput is deleted
-                      // So we make sur index is positive to avoid warning on array accesses
                       property bool drawCustomChar: index >= 0 && Settings.data.general.passwordChars
                       // Flip color when this dot falls inside the active selection range
                       property bool isSelected: index >= 0 && passwordInput.selectionStart !== passwordInput.selectionEnd && index >= passwordInput.selectionStart && index < passwordInput.selectionEnd
@@ -900,7 +896,6 @@ Item {
                 visible: passwordInput.activeFocus && passwordInput.text.length > 0 && passwordInput.selectionStart === passwordInput.selectionEnd
                 anchors.verticalCenter: parent.verticalCenter
 
-                // Smooth fade animation (when animations enabled)
                 SequentialAnimation on opacity {
                   loops: Animation.Infinite
                   running: root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length > 0 && passwordInput.selectionStart === passwordInput.selectionEnd
@@ -914,7 +909,6 @@ Item {
                   }
                 }
 
-                // Simple toggle (when animations disabled) — no per-frame repaints
                 Timer {
                   interval: 530
                   running: !root.animationsEnabled && passwordInput.activeFocus && passwordInput.text.length > 0 && passwordInput.selectionStart === passwordInput.selectionEnd


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Add highlight selection for the input password field so when a user press Ctrl + A 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes https://github.com/noctalia-dev/noctalia-shell/issues/2263

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1022" height="210" alt="image" src="https://github.com/user-attachments/assets/36d34fdc-1355-44e9-a22e-8f744ff2be01" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
