### PR TITLE
feat(ipc): add commands for airplane mode

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -672,6 +672,19 @@ Singleton {
   }
 
   IpcHandler {
+    target: "airplaneMode"
+    function toggle() {
+      BluetoothService.setAirplaneMode(!Settings.data.network.airplaneModeEnabled);
+    }
+    function enable() {
+      BluetoothService.setAirplaneMode(true);
+    }
+    function disable() {
+      BluetoothService.setAirplaneMode(false);
+    }
+  }
+
+  IpcHandler {
     target: "battery"
     function togglePanel() {
       root.screenDetector.withCurrentScreen(screen => {


### PR DESCRIPTION
## Motivation
Add IPC commands to control airplane mode, disabling both Wi-Fi and Bluetooth via rfkill.

## Changes
- `airplaneMode.toggle()` - Toggle airplane mode
- `airplaneMode.enable()` - Enable airplane mode  
- `airplaneMode.disable()` - Disable airplane mode

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)