### PR TITLE
fix(notifications): prefer default actions for window focus

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -350,12 +350,13 @@ Variants {
 
             function runAction(actionId, isDismissed) {
               if (!isDismissed) {
-                NotificationService.focusSenderWindow(model.appName);
-                NotificationService.invokeActionAndSuppressClose(notificationId, actionId);
-              } else if (Settings.data.notifications.clearDismissed) {
-                NotificationService.removeFromHistory(notificationId);
+                if (NotificationService.invokeActionAndSuppressClose(notificationId, actionId))
+                  card.animateOut();
+              } else {
+                if (Settings.data.notifications.clearDismissed)
+                  NotificationService.removeFromHistory(notificationId);
+                card.animateOut();
               }
-              card.animateOut();
             }
 
             Timer {
@@ -527,9 +528,11 @@ Variants {
                               var hasDefault = actions.some(function (a) {
                                 return a.identifier === "default";
                               });
-                              if (hasDefault) {
-                                card.runAction("default", false);
+                              if (hasDefault && NotificationService.invokeActionAndSuppressClose(notificationId, "default")) {
+                                card.animateOut();
                               } else {
+                                // Without a default action, or if invoking it fails,
+                                // the best fallback is focusing the sender window by app identity.
                                 NotificationService.focusSenderWindow(model.appName);
                                 card.animateOut();
                               }

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -171,7 +171,8 @@ SmartPanel {
       if (actionIndex >= 0) {
         var actions = parseActions(item.actionsJson);
         if (actionIndex < actions.length) {
-          NotificationService.invokeAction(item.id, actions[actionIndex].identifier);
+          if (NotificationService.invokeAction(item.id, actions[actionIndex].identifier))
+            root.close();
         }
       } else {
         var delegate = notificationColumn.children[focusIndex];
@@ -791,18 +792,18 @@ SmartPanel {
                                       return;
                                     }
 
-                                    // Focus sender window (and invoke default action if available)
+                                    // Without a default action, or if invoking it fails,
+                                    // fall back to focusing the sender window by app identity.
                                     var actions = notificationDelegate.actionsList;
                                     var hasDefault = actions.some(function (a) {
                                       return a.identifier === "default";
                                     });
-                                    if (hasDefault) {
-                                      NotificationService.focusSenderWindow(notificationDelegate.appName);
-                                      NotificationService.invokeAction(notificationDelegate.notificationId, "default");
+                                    if (hasDefault && NotificationService.invokeAction(notificationDelegate.notificationId, "default")) {
+                                      root.close();
                                     } else {
                                       NotificationService.focusSenderWindow(notificationDelegate.appName);
+                                      root.close();
                                     }
-                                    root.close();
                                   }
                       onCanceled: {
                         notificationDelegate.isSwiping = false;
@@ -960,9 +961,8 @@ SmartPanel {
                                 // Capture modelData in a property to avoid reference errors
                                 property var actionData: modelData
                                 onClicked: {
-                                  NotificationService.focusSenderWindow(notificationDelegate.appName);
-                                  root.close();
-                                  NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier);
+                                  if (NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier))
+                                    root.close();
                                 }
                               }
                             }

--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -921,13 +921,29 @@ Singleton {
 
   function invokeActionAndSuppressClose(id, actionId) {
     const notifData = popupState[id];
-    if (notifData && notifData.notification && notifData.onClosed) {
+    const notification = notifData?.notification;
+    const onClosed = notifData?.onClosed;
+    let restoreClosedHandler = false;
+
+    if (notification && onClosed) {
       try {
-        notifData.notification.closed.disconnect(notifData.onClosed);
+        // A successful action may synchronously close the notification. Disconnect
+        // our close handler first so the popup is only dismissed by the action path.
+        notification.closed.disconnect(onClosed);
+        restoreClosedHandler = true;
       } catch (e) {}
     }
 
-    return invokeAction(id, actionId);
+    const invoked = invokeAction(id, actionId);
+
+    if (!invoked && restoreClosedHandler && notification && onClosed) {
+      try {
+        // If invoking the action failed, restore normal close handling for this popup.
+        notification.closed.connect(onClosed);
+      } catch (e) {}
+    }
+
+    return invoked;
   }
 
   function invokeAction(id, actionId) {


### PR DESCRIPTION
# Pull Request

## Motivation

This fixes notification activation for multi-window apps like Kitty.

Before this change, Noctalia could focus a window by fuzzy app matching before invoking the notification action. For apps where multiple windows share the same app id, that could focus the wrong window.

This PR invokes the notification action first and only falls back to fuzzy window focus when there is no usable default action or the invoke fails.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

- Closes #2280

## Testing

Manual testing:
- Reproduced with a real notification workflow inside Kitty while multiple Kitty windows were open
- Verified popup click returns to the correct Kitty window
- Verified fresh notification history click returns to the correct Kitty window
- Verified history action buttons no longer pre-focus a fuzzy app match
- Verified a notification without a default action still falls back to fuzzy window focus

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Before

https://github.com/user-attachments/assets/009770a3-b90b-4b0e-9e11-302368dff7e1

After

https://github.com/user-attachments/assets/9e217de1-7876-4f33-8e25-6934941b1dc2



## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes

This stays intentionally small and only changes notification activation paths in popup and history interactions.