### PR TITLE
Fix Toast: same model than Notifications

### DIFF
--- a/Modules/Toast/ToastOverlay.qml
+++ b/Modules/Toast/ToastOverlay.qml
@@ -6,7 +6,14 @@ import qs.Commons
 import qs.Widgets
 
 Variants {
-  model: Quickshell.screens.filter(screen => (Settings.data.notifications.monitors.includes(screen.name) || (Settings.data.notifications.monitors.length === 0)))
+  model: {
+    const screens = Quickshell.screens.filter(screen => Settings.data.notifications.monitors.includes(screen.name));
+    // Empty list can mean two things :
+    // - No (visible) notification display activated in settings
+    // - One or more (not visible) displays are activated but unplugged
+    // In both cases we fallback to show notification on all screens
+    return screens.length === 0 ? Quickshell.screens : screens;
+  }
 
   delegate: ToastScreen {
     required property ShellScreen modelData


### PR DESCRIPTION
# Pull Request

## Motivation

We recently changed how screens were selected for notifications, but did not apply the same thing for toasts.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)