### PR TITLE
Dismiss toast ipc call

### DIFF
--- a/Modules/Toast/ToastScreen.qml
+++ b/Modules/Toast/ToastScreen.qml
@@ -32,6 +32,10 @@ Item {
                           "timestamp": Date.now()
                         });
     }
+
+    function onDismiss() {
+      root.dismissToast();
+    }
   }
 
   // Clear queue on component destruction to prevent orphaned toasts
@@ -40,6 +44,13 @@ Item {
     isShowingToast = false;
     hideTimer.stop();
     quickSwitchTimer.stop();
+  }
+
+  function dismissToast(){
+    if (windowLoader.item) {
+      hideTimer.stop();
+      windowLoader.item.hideToast();
+    }
   }
 
   function enqueueToast(toastData) {
@@ -59,10 +70,7 @@ Item {
       messageQueue.push(toastData);
 
       // Hide current toast immediately
-      if (windowLoader.item) {
-        hideTimer.stop();
-        windowLoader.item.hideToast();
-      }
+      root.dismissToast();
 
       // Process new toast after a brief delay
       isShowingToast = false;

--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -282,6 +282,10 @@ Singleton {
         Logger.e("IPC", "Failed to parse toast JSON: " + error);
       }
     }
+
+    function dismiss() {
+      ToastService.dismissToast();
+    }
   }
 
   // Idle Inhibitor / Keep Awake

--- a/Services/UI/ToastService.qml
+++ b/Services/UI/ToastService.qml
@@ -10,6 +10,7 @@ Singleton {
   // actionLabel: optional label for clickable action link
   // actionCallback: optional function to call when action is clicked
   signal notify(string title, string description, string icon, string type, int duration, string actionLabel, var actionCallback)
+  signal dismiss()
 
   // Convenience methods
   function showNotice(title, description = "", icon = "", duration = 3000, actionLabel = "", actionCallback = null) {
@@ -22,5 +23,9 @@ Singleton {
 
   function showError(title, description = "", duration = 6000, actionLabel = "", actionCallback = null) {
     notify(title, description, "", "error", duration, actionLabel, actionCallback);
+  }
+
+  function dismissToast(){
+    dismiss();
   }
 }


### PR DESCRIPTION
This is a simple MR which adds an IPC call to dismiss toasts. In my case I used the same keybind than notifications dismiss and it seems to work: `spawn-sh "noctalia notifications dismissAll && noctalia toast dismiss";`

I noticed that using IPC call to dismiss notifications does not trigger the `animateOut` animation from `Notification.qml`, I'm not sure it is intended (?) For now I did not used `hideImmediately` for toast because it looks better to have the animation, but maybe I should for better consistency with notifications ?

This PR updates the doc for toast IPC calls: https://github.com/noctalia-dev/noctalia-docs/pull/106