### PR TITLE
enhancement: apply style rounding to burst effects and user icon

### DIFF
--- a/Modules/Bar/Extras/WorkspacePill.qml
+++ b/Modules/Bar/Extras/WorkspacePill.qml
@@ -217,7 +217,7 @@ Item {
     anchors.centerIn: pill
     width: pillContainer.pillWidth + 18 * masterProgress * scale
     height: pillContainer.pillHeight + 18 * masterProgress * scale
-    radius: width / 2
+    radius: Style.radiusM
     color: "transparent"
     border.color: effectColor
     border.width: Math.max(1, Math.round((2 + 6 * (1.0 - masterProgress))))

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -909,7 +909,7 @@ Item {
           anchors.centerIn: groupedWorkspaceNumberContainer
           width: groupedWorkspaceNumberContainer.width + 12 * root.masterProgress
           height: groupedWorkspaceNumberContainer.height + 12 * root.masterProgress
-          radius: width / 2
+          radius: Math.min(Style.radiusL, width / 2)
           color: "transparent"
           border.color: root.effectColor
           border.width: Math.max(1, Math.round((2 + 4 * (1.0 - root.masterProgress))))

--- a/Modules/Cards/ProfileCard.qml
+++ b/Modules/Cards/ProfileCard.qml
@@ -27,7 +27,7 @@ NBox {
     NImageRounded {
       Layout.preferredWidth: Math.round(Style.baseWidgetSize * 1.25 * Style.uiScaleRatio)
       Layout.preferredHeight: Math.round(Style.baseWidgetSize * 1.25 * Style.uiScaleRatio)
-      radius: Layout.preferredWidth / 2
+      radius: Math.min(Style.iRadiusL, width / 2)
       imagePath: Settings.preprocessPath(Settings.data.general.avatarImage)
       fallbackIcon: "person"
       borderColor: Color.mPrimary

--- a/Modules/LockScreen/LockScreenHeader.qml
+++ b/Modules/LockScreen/LockScreenHeader.qml
@@ -51,7 +51,7 @@ Rectangle {
       Layout.preferredWidth: 70
       Layout.preferredHeight: 70
       Layout.alignment: Qt.AlignVCenter
-      radius: width / 2
+      radius: Math.min(Style.iRadiusL, width / 2)
       color: "transparent"
 
       Rectangle {

--- a/Modules/Panels/Settings/Tabs/General/BasicsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/General/BasicsSubTab.qml
@@ -20,9 +20,10 @@ ColumnLayout {
     NImageRounded {
       Layout.preferredWidth: 128 * Style.uiScaleRatio
       Layout.preferredHeight: width
-      radius: width / 2
+      radius: Math.min(Style.iRadiusM * 8, width / 2)
       imagePath: Settings.preprocessPath(Settings.data.general.avatarImage)
       fallbackIcon: "person"
+      fallbackIconSize: width / 4
       borderColor: Color.mPrimary
       borderWidth: Style.borderM
       Layout.alignment: Qt.AlignTop


### PR DESCRIPTION
# Pull Request

## Motivation
Style rounding previously did not apply for workspace pill burst effects and the user icons, which made those particular elements look odd when using little to no rounding (such as myself). This patch doesn't affect users who have set container / interface radius to >=100%, but makes the rounding for users who prefer less or no radius more consistent.

## Type of Change
- [x] Bug fix (enhancement)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- None

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Input radius set to 0:

<img width="419" height="133" alt="image" src="https://github.com/user-attachments/assets/9645d09d-bd92-4385-a3e8-e03048262658" />
<img width="592" height="264" alt="image" src="https://github.com/user-attachments/assets/7fd2ba1e-25c1-4ff4-aaf1-e8dc19836c1a" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
- Also slightly made the `fallbackIconSize` for the avatar preview in the settings tab bigger than previous.
