### PR TITLE
fix(IdleService): respect lockOnSuspend when idle triggers suspend

### DIFF
--- a/Services/Power/IdleService.qml
+++ b/Services/Power/IdleService.qml
@@ -203,7 +203,11 @@ Singleton {
     } else if (stage === "suspend") {
       if (Settings.data.idle.suspendCommand)
         Quickshell.execDetached(["sh", "-c", Settings.data.idle.suspendCommand]);
-      CompositorService.suspend();
+      if (Settings.data.general.lockOnSuspend) {
+        CompositorService.lockAndSuspend();
+      } else {
+        CompositorService.suspend();
+      }
       root.suspendRequested();
     } else {
       Logger.w("IdleService", "Unknown idle stage action:", stage);


### PR DESCRIPTION
## Summary

- When the IdleService triggers a suspend after the idle timeout, it calls `CompositorService.suspend()` directly, bypassing the `lockOnSuspend` setting. This means the lock screen is not guaranteed to activate before an idle-triggered suspend.
- This change checks `Settings.data.general.lockOnSuspend` in the idle suspend stage and calls `CompositorService.lockAndSuspend()` instead, consistent with how the SessionMenu and SessionProvider already handle it.

## Details

The `lockOnSuspend` setting is currently only respected in two UI-initiated code paths:
- `Modules/Panels/SessionMenu/SessionMenu.qml`
- `Modules/Panels/Launcher/Providers/SessionProvider.qml`

The IdleService's `_executeAction("suspend")` was missing this check, so idle-triggered suspends would not lock the screen first (unless the separate lock idle stage happened to fire earlier due to timeout ordering).

This is a one-line logic change with no new dependencies.