### PR TITLE
fix(audio): filter out intermediate stream nodes

### DIFF
--- a/Services/Media/AudioService.qml
+++ b/Services/Media/AudioService.qml
@@ -189,6 +189,9 @@ Singleton {
     node: root.sink
   }
 
+  // Track all streams globally to prevent binding loops for filtered out streams
+  readonly property var streamNodes: Pipewire.ready ? Pipewire.nodes.values.filter(n => n && n.isStream) : []
+
   // Find application streams that are connected to the default sink
   readonly property var appStreams: {
     if (!Pipewire.ready || !root.sink) {
@@ -240,8 +243,10 @@ Singleton {
         continue;
       }
 
-      // If it's a stream node, add it directly
-      if (sourceNode.isStream && sourceNode.audio) {
+      // Filter out filter (intermediate) streams
+      const isVirtual = (sourceNode.properties && sourceNode.properties["node.virtual"]) || "";
+      // If it's an application stream node, add it directly
+      if (sourceNode.isStream && sourceNode.audio && !isVirtual) {
         if (!connectedStreamIds[sourceNode.id]) {
           connectedStreamIds[sourceNode.id] = true;
           connectedStreams.push(sourceNode);
@@ -269,6 +274,12 @@ Singleton {
           const nodeName = node.name || "";
           const nodeMediaName = (node.properties && node.properties["media.name"]) || "";
           if (nodeName === "quickshell" || nodeMediaName === "quickshell") {
+            continue;
+          }
+
+          // Filter out filter streams
+          const nodeIsVirtual = (node.properties && node.properties["node.virtual"]) || "";
+          if (nodeIsVirtual) {
             continue;
           }
 
@@ -302,7 +313,7 @@ Singleton {
   property bool _isApplyingAppOverride: false
 
   PwObjectTracker {
-    objects: root.appStreams
+    objects: root.streamNodes
   }
 
   // Keep appVolumeOverrides aligned with PipeWire when apps change volume/mute.


### PR DESCRIPTION
# Pull Request
## Motivation
Previously, custom pipewire filter streams were being treated as application streams. This meant that only the filter stream would be shown in the volume widget since there weren't any checks for streams connected to streams.

This pr adds a check for whether the output stream is virtual or not, and if it is, treats is as an intermediate node.

The main use case for the pipewire filters are sound effects, mixing audio and in my use case, equalizers. This pr should fix this for every filter as they are all always virtual.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
My filter setup:
<img width="1527" height="385" alt="image" src="https://github.com/user-attachments/assets/5822d515-c43f-4f81-9e82-9b2edda35b35" />

Before changes:
<img width="436" height="381" alt="image" src="https://github.com/user-attachments/assets/d660a3c3-4771-4242-bc9f-063ff2b57120" />

After changes:
<img width="436" height="422" alt="image" src="https://github.com/user-attachments/assets/ce84db02-9d99-44e8-8a7e-1f658628f395" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
