### PR TITLE
Fix notification history tab highlight desync after mouse click

### DIFF
--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -455,7 +455,7 @@ SmartPanel {
             NTabButton {
               tabIndex: 0
               text: I18n.tr("launcher.categories.all") + " (" + panelContent.countForRange(0) + ")"
-              checked: tabsBox.currentIndex === 0
+              checked: panelContent.currentRange === 0
               onClicked: panelContent.currentRange = 0
               pointSize: Style.fontSizeXS
             }
@@ -463,7 +463,7 @@ SmartPanel {
             NTabButton {
               tabIndex: 1
               text: I18n.tr("notifications.range.today") + " (" + panelContent.countForRange(1) + ")"
-              checked: tabsBox.currentIndex === 1
+              checked: panelContent.currentRange === 1
               onClicked: panelContent.currentRange = 1
               pointSize: Style.fontSizeXS
             }
@@ -471,7 +471,7 @@ SmartPanel {
             NTabButton {
               tabIndex: 2
               text: I18n.tr("notifications.range.yesterday") + " (" + panelContent.countForRange(2) + ")"
-              checked: tabsBox.currentIndex === 2
+              checked: panelContent.currentRange === 2
               onClicked: panelContent.currentRange = 2
               pointSize: Style.fontSizeXS
             }
@@ -479,7 +479,7 @@ SmartPanel {
             NTabButton {
               tabIndex: 3
               text: I18n.tr("notifications.range.earlier") + " (" + panelContent.countForRange(3) + ")"
-              checked: tabsBox.currentIndex === 3
+              checked: panelContent.currentRange === 3
               onClicked: panelContent.currentRange = 3
               pointSize: Style.fontSizeXS
             }


### PR DESCRIPTION
# Pull Request

## Motivation
This change fixes a state synchronization issue in the notification history filter tabs where clicking a tab with the mouse could break the visual active-tab indicator during keyboard Tab navigation. The content filter was still updating correctly, but the highlighted tab didn't reflect the current range.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
to reproduce the issue:

1. open Notification History
2. click any range tab (for example “Yesterday”) with the mouse
3. then press Tab to cycle ranges

***The list content changes, but the highlighted tab indicator does not update accordingly.***
