### PR TITLE
fix(khal-events): add subprocess timeout to prevent DoS

### DIFF
--- a/Scripts/python/src/calendar/khal-events.py
+++ b/Scripts/python/src/calendar/khal-events.py
@@ -60,10 +60,16 @@ def main():
         duration
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        print("[]", file=sys.stderr)
+        sys.exit(1)
     output = result.stdout.strip()
 
     for line in output.split('\n'):
+        if not line:
+            continue
         day_events = json.loads(line)
         print(json.dumps([convert_event(e, khal_format) for e in day_events]))
 


### PR DESCRIPTION
## Summary

Fixes the DoS bug reported in #2321.

`subprocess.run` was called without a `timeout`, allowing any caller to pass an unbounded duration (e.g. `999999d`) and hang the process indefinitely. Confirmed: process blocked for 98+ seconds before `KeyboardInterrupt`.

## Changes

- Added `timeout=30` to `subprocess.run`
- Added `subprocess.TimeoutExpired` handler — exits with code 1 and prints `[]` to stderr
- Skips empty lines in khal output to prevent `JSONDecodeError`

## Test

```bash
# triggers timeout after 30s, exits cleanly
time python3 khal-events.py "2023-01-01" "999999d"

# works normally
python3 khal-events.py "2023-01-01" "7d"
```

Closes #2321

Contributors: @cbxcvl @pa1va