### PR TITLE
fix(renderer): remove ambiguous \s* from _BLOCK_RE to prevent ReDoS

### DIFF
--- a/Scripts/python/src/theming/lib/renderer.py
+++ b/Scripts/python/src/theming/lib/renderer.py
@@ -138,7 +138,7 @@ class TemplateRenderer:
     COLOR_ARG_FILTERS = {"blend", "harmonize"}
 
     # Regex for block delimiters: <* ... *>
-    _BLOCK_RE = re.compile(r'<\*\s*(.*?)\s*\*>', re.DOTALL)
+    _BLOCK_RE = re.compile(r'<\*(.*?)\*>', re.DOTALL)
 
     # Regex for expression tags: {{ ... }}
     _EXPR_RE = re.compile(r"\{\{\s*([^}\n]+?)\s*\}\}")


### PR DESCRIPTION
## Summary

Fixes the ReDoS vulnerability reported in #2323.

`_BLOCK_RE` used `\s*(.*?)\s*` which creates ambiguous backtracking — both `(.*?)` and the surrounding `\s*` can match whitespace. When no closing `*>` is found, the engine tries all possible splits polynomially.

## Changes

- Removed `\s*` wrappers from `_BLOCK_RE`
- No functional change: `group(1)` is already `.strip()`ped at the call site (line 278)

## Test

```
n=100   vuln: 0.0003s  fixed: 0.0000s
n=500   vuln: 0.0286s  fixed: 0.0000s
n=1000  vuln: 0.2190s  fixed: 0.0000s
n=5000  vuln: >=5s (HUNG)  fixed: 0.0000s
n=10000 vuln: >=5s (HUNG)  fixed: 0.0001s
```

Closes #2323

Contributors: @cbxcvl @pa1va