### PR TITLE
fix(renderer): remove ambiguous \s* from _EXPR_RE to prevent ReDoS

### DIFF
--- a/Scripts/python/src/theming/lib/renderer.py
+++ b/Scripts/python/src/theming/lib/renderer.py
@@ -141,7 +141,7 @@ class TemplateRenderer:
     _BLOCK_RE = re.compile(r'<\*\s*(.*?)\s*\*>', re.DOTALL)
 
     # Regex for expression tags: {{ ... }}
-    _EXPR_RE = re.compile(r"\{\{\s*([^}\n]+?)\s*\}\}")
+    _EXPR_RE = re.compile(r"\{\{([^}\n]+?)\}\}")
 
     def __init__(self, theme_data: dict[str, dict[str, str]], verbose: bool = True, default_mode: str = "dark", image_path: Optional[str] = None, scheme_type: str = "content"):
         self.theme_data = theme_data


### PR DESCRIPTION
## Summary

Fixes the ReDoS bug reported in #2325.

`_EXPR_RE` used `\s*([^}\n]+?)\s*` which creates ambiguous backtracking — both the capture group and surrounding `\s*` can match whitespace. When no closing `}}` is found, the engine tries all possible splits polynomially.

## Changes

- Removed `\s*` wrappers from `_EXPR_RE`
- No functional change: `group(1)` is already `.strip()`ped at the call site

## Test

```
n=100   vuln: 0.0003s  fixed: 0.0000s
n=500   vuln: 0.0297s  fixed: 0.0000s
n=1000  vuln: 0.2244s  fixed: 0.0000s
n=5000  vuln: >=5s (HUNG)  fixed: 0.0001s
n=10000 vuln: >=5s (HUNG)  fixed: 0.0001s
```

Closes #2325

Contributors: @cbxcvl @pa1va