### PR TITLE
fix(renderer): remove ambiguous \s* from _parse_if regex to prevent ReDoS

### DIFF
--- a/Scripts/python/src/theming/lib/renderer.py
+++ b/Scripts/python/src/theming/lib/renderer.py
@@ -359,7 +359,7 @@ class TemplateRenderer:
             condition_part = condition_part[4:].strip()
 
         # Extract expression from {{ ... }} if present
-        expr_match = re.match(r'\{\{\s*(.+?)\s*\}\}', condition_part)
+        expr_match = re.match(r'\{\{(.+?)\}\}', condition_part)
         if expr_match:
             condition_expr = expr_match.group(1).strip()
         else:


### PR DESCRIPTION
## Summary

Fixes the ReDoS bug reported in #2326.

`_parse_if` used `\s*(.+?)\s*` which creates ambiguous backtracking — both `(.+?)` and the surrounding `\s*` can match whitespace. When no closing `}}` is found, the engine tries all possible splits polynomially.

## Changes

- Removed `\s*` wrappers from the inline regex in `_parse_if`
- No functional change: `group(1)` is already `.strip()`ped at the call site

## Test

```
n=100   vuln: 0.0003s  fixed: 0.0000s
n=500   vuln: 0.0283s  fixed: 0.0000s
n=1000  vuln: 0.2179s  fixed: 0.0000s
n=5000  vuln: >=5s (HUNG)  fixed: 0.0000s
n=10000 vuln: >=5s (HUNG)  fixed: 0.0001s
```

Closes #2326

Contributors: @cbxcvl @pa1va