### PR TITLE
fix(TemplatesSubTab): Fixed a bug which prevented the qmlformat to run correctly

### DIFF
--- a/Modules/Panels/Settings/Tabs/ColorScheme/TemplatesSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/TemplatesSubTab.qml
@@ -13,17 +13,16 @@ ColumnLayout {
   spacing: Style.marginL
   Layout.fillWidth: true
 
-    // Helper to format path description
+  // Helper to format path description
   function getDesc(fallbackPath) {
     return I18n.tr("panels.color-scheme.templates-write-path", {
-                      "filepath": fallbackPath
-                    });
-                  }
+                     "filepath": fallbackPath
+                   });
+  }
 
   // Build a combined list of all available templates from TemplateRegistry, sorted alphabetically
   readonly property var allTemplates: {
     var templates = [];
-
 
     // Add terminals with category "terminal"
     for (var i = 0; i < TemplateRegistry.terminals.length; i++) {


### PR DESCRIPTION


# Pull Request
As the title this should fix the bug where `qmlformat` doesn't run correctly and crashes. 

## Motivation
Multiple people have encountered this bug and it has stopped them from being able to contribute since `qmlformat` didn't work correctly in the hook. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2333 

## Testing
By running the script and seeing that it got run correctly.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
No screenshots for this are needed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
No additional notes.
