### PR TITLE
Apply reduced light mode opacity also to dock, notifications & OSD

### DIFF
--- a/Commons/Color.qml
+++ b/Commons/Color.qml
@@ -324,21 +324,20 @@ Singleton {
     }
   }
 
-  // Smart alpha calculation: automatically makes light mode more transparent
+  // Adaptive opacity calculation: automatically makes light mode more transparent
+  function adaptiveOpacity(baseOpacity) {
+    return Settings.data.colorSchemes.darkMode ? baseOpacity : Math.pow(baseOpacity, 1.5);
+  }
+
   function smartAlpha(baseColor, minAlpha = 0.4) {
     if (!Settings.data.ui.translucentWidgets)
       return baseColor;
 
-    let alpha = Math.max(root.panelBackgroundOpacity, minAlpha);
+    let alpha = Math.max(adaptiveOpacity(Settings.data.ui.panelBackgroundOpacity), minAlpha);
 
     // Combine with the base color's existing alpha
     let resultAlpha = Math.max(0, baseColor.a - (1.0 - alpha));
     return Qt.alpha(baseColor, resultAlpha);
-  }
-
-  readonly property real panelBackgroundOpacity: {
-    let baseOpacity = Settings.data.ui.panelBackgroundOpacity;
-    return Settings.data.colorSchemes.darkMode ? baseOpacity : Math.pow(baseOpacity, 2);
   }
 
   readonly property var colorKeyModel: [

--- a/Modules/Dock/DockContent.qml
+++ b/Modules/Dock/DockContent.qml
@@ -26,7 +26,7 @@ Item {
     // For vertical dock, swap width and height logic
     width: dockRoot.isVertical ? Math.round(dockRoot.iconSize * 1.5) : Math.min(dockLayout.implicitWidth + Style.marginXL, dockRoot.maxWidth)
     height: dockRoot.isVertical ? Math.min(dockLayout.implicitHeight + Style.marginXL, dockRoot.maxHeight) : Math.round(dockRoot.iconSize * 1.5)
-    color: Qt.alpha(Color.mSurface, (isAttachedMode ? 0 : Settings.data.dock.backgroundOpacity))
+    color: Qt.alpha(Color.mSurface, (isAttachedMode ? 0 : Color.adaptiveOpacity(Settings.data.dock.backgroundOpacity)))
 
     // Anchor based on padding to achieve centering shift
     anchors.horizontalCenter: extraLeft > 0 || extraRight > 0 ? undefined : parent.horizontalCenter
@@ -39,7 +39,7 @@ Item {
 
     radius: Style.radiusL
     border.width: Style.borderS
-    border.color: Qt.alpha(Color.mOutline, (isAttachedMode ? 0 : Settings.data.dock.backgroundOpacity))
+    border.color: Qt.alpha(Color.mOutline, (isAttachedMode ? 0 : Color.adaptiveOpacity(Settings.data.dock.backgroundOpacity)))
 
     MouseArea {
       id: dockMouseArea

--- a/Modules/MainScreen/Backgrounds/AllBackgrounds.qml
+++ b/Modules/MainScreen/Backgrounds/AllBackgrounds.qml
@@ -38,7 +38,7 @@ Item {
 
       // Enable layer caching to prevent continuous re-rendering
       layer.enabled: true
-      opacity: Color.panelBackgroundOpacity
+      opacity: Color.adaptiveOpacity(Settings.data.ui.panelBackgroundOpacity)
 
       Shape {
         id: unifiedBackgroundsShape
@@ -106,7 +106,7 @@ Item {
         anchors.fill: parent
 
         layer.enabled: true
-        opacity: Color.panelBackgroundOpacity
+        opacity: Color.adaptiveOpacity(Settings.data.ui.panelBackgroundOpacity)
 
         Shape {
           id: panelBackgroundsShape

--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -549,9 +549,9 @@ Variants {
                 id: cardBackground
                 anchors.fill: parent
                 radius: Style.radiusL
-                border.color: Qt.alpha(Color.mOutline, Settings.data.notifications.backgroundOpacity || 1.0)
+                border.color: Qt.alpha(Color.mOutline, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0)
                 border.width: Style.borderS
-                color: Qt.alpha(Color.mSurface, Settings.data.notifications.backgroundOpacity || 1.0)
+                color: Qt.alpha(Color.mSurface, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0)
 
                 // Progress bar
                 Rectangle {
@@ -570,7 +570,7 @@ Variants {
 
                     color: {
                       var baseColor = model.urgency === 2 ? Color.mError : model.urgency === 0 ? Color.mOnSurface : Color.mPrimary;
-                      return Qt.alpha(baseColor, Settings.data.notifications.backgroundOpacity || 1.0);
+                      return Qt.alpha(baseColor, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0);
                     }
 
                     antialiasing: true

--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -575,8 +575,8 @@ Variants {
           anchors.fill: parent
           anchors.margins: Style.marginM * 1.5
           radius: Style.radiusL
-          color: Qt.alpha(Color.mSurface, Settings.data.osd.backgroundOpacity || 1.0)
-          border.color: Qt.alpha(Color.mOutline, Settings.data.osd.backgroundOpacity || 1.0)
+          color: Qt.alpha(Color.mSurface, Color.adaptiveOpacity(Settings.data.osd.backgroundOpacity) || 1.0)
+          border.color: Qt.alpha(Color.mOutline, Color.adaptiveOpacity(Settings.data.osd.backgroundOpacity) || 1.0)
           border.width: {
             const bw = Math.max(2, Style.borderM);
             return bw % 2 === 0 ? bw : bw + 1;

--- a/Modules/Panels/Launcher/LauncherOverlayWindow.qml
+++ b/Modules/Panels/Launcher/LauncherOverlayWindow.qml
@@ -255,7 +255,7 @@ Variants {
 
           ShapePath {
             strokeWidth: -1
-            fillColor: Qt.alpha(Color.mSurface, Color.panelBackgroundOpacity)
+            fillColor: Qt.alpha(Color.mSurface, Color.adaptiveOpacity(Settings.data.ui.panelBackgroundOpacity))
 
             // Offset by radius to account for Shape's extended bounds
             startX: panelShape.radius + panelShape.radius * panelShape.tlMultX

--- a/Modules/Panels/Settings/Tabs/Dock/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Dock/AppearanceSubTab.qml
@@ -392,7 +392,6 @@ ColumnLayout {
         color: Color.smartAlpha(Color.mSurfaceVariant)
         border.color: Color.mOutline
         border.width: Style.borderS
-        opacity: Style.opacityMedium
 
         Image {
           anchors.centerIn: parent

--- a/Modules/Panels/Settings/Tabs/Wallpaper/GeneralSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Wallpaper/GeneralSubTab.qml
@@ -182,6 +182,7 @@ ColumnLayout {
     label: I18n.tr("panels.wallpaper.settings-use-original-images-label")
     description: I18n.tr("panels.wallpaper.settings-use-original-images-description")
     checked: Settings.data.wallpaper.useOriginalImages
+    enabled: Settings.data.wallpaper.enabled
     onToggled: checked => Settings.data.wallpaper.useOriginalImages = checked
     defaultValue: Settings.getDefaultValue("wallpaper.useOriginalImages")
   }
@@ -189,6 +190,7 @@ ColumnLayout {
   RowLayout {
     spacing: Style.marginM
     Layout.fillWidth: true
+    enabled: Settings.data.wallpaper.enabled
 
     NLabel {
       label: I18n.tr("panels.wallpaper.settings-clear-cache-label")
@@ -228,10 +230,9 @@ ColumnLayout {
 
     NValueSlider {
       Layout.fillWidth: true
-      enabled: Settings.data.wallpaper.overviewEnabled
+      visible: Settings.data.wallpaper.overviewEnabled
       label: I18n.tr("panels.wallpaper.settings-overview-blur-strength-label")
       description: I18n.tr("panels.wallpaper.settings-overview-blur-strength-description")
-      visible: CompositorService.isNiri
       from: 0.0
       to: 1.0
       stepSize: 0.01
@@ -244,10 +245,9 @@ ColumnLayout {
 
     NValueSlider {
       Layout.fillWidth: true
-      enabled: Settings.data.wallpaper.overviewEnabled
+      visible: Settings.data.wallpaper.overviewEnabled
       label: I18n.tr("panels.wallpaper.settings-overview-tint-label")
       description: I18n.tr("panels.wallpaper.settings-overview-tint-description")
-      visible: CompositorService.isNiri
       from: 0.0
       to: 1.0
       stepSize: 0.01

--- a/Modules/Toast/Toast.qml
+++ b/Modules/Toast/Toast.qml
@@ -96,7 +96,7 @@ Item {
     anchors.fill: parent
     anchors.margins: shadowPadding
     radius: Style.radiusL
-    color: Qt.alpha(Color.mSurface, Settings.data.notifications.backgroundOpacity || 1.0)
+    color: Qt.alpha(Color.mSurface, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0)
 
     // Colored border based on type
     border.width: Style.borderS
@@ -110,7 +110,7 @@ Item {
         baseColor = Color.mOutline;
         break;
       }
-      return Qt.alpha(baseColor, Settings.data.notifications.backgroundOpacity || 1.0);
+      return Qt.alpha(baseColor, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0);
     }
 
     // Progress bar
@@ -142,7 +142,7 @@ Item {
             baseColor = Color.mPrimary; // Match standard notification color
             break;
           }
-          return Qt.alpha(baseColor, Settings.data.notifications.backgroundOpacity || 1.0);
+          return Qt.alpha(baseColor, Color.adaptiveOpacity(Settings.data.notifications.backgroundOpacity) || 1.0);
         }
       }
     }


### PR DESCRIPTION
This PR extends the reduced opacity in light mode that applies to panels also to the dock, notifications, toasts and OSD so that this behavior is more consistent. Also changing the light mode opacity from `Math.pow(baseOpacity, 2)` to `Math.pow(baseOpacity, 1.5)`.