### PR TITLE
fix (ci): Fix that workflow isn't triggered if it's not the main repo

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   cache:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'noctalia-dev/noctalia-shell' }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Every time I synced my repo, the Cachix workflow was triggered and I received a failure notification via email and on GitHub.
To prevent this from happening again, I took inspiration from the Plugins Registry workflow so that the workflow isn't triggered unless it's the main repo.

I tested it with Act.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
