### PR TITLE
Feat/floating bar edge radius

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -849,6 +849,8 @@
       "appearance-margins-description": "Adjust the margins around the floating bar.",
       "appearance-margins-horizontal": "Horizontal Margin ",
       "appearance-margins-vertical": "Vertical Margin",
+      "appearance-floating-outer-edge-rounding-description": "When the floating bar touches a screen edge, draw outward rounding on that edge. Requires the opposite margin to be at least {minMargin}px (container radius + screen corners radius).",
+      "appearance-floating-outer-edge-rounding-label": "Outer rounding on touching edge",
       "appearance-outer-corners-description": "Display outwardly curved corners on the bar.",
       "appearance-outer-corners-label": "Outer corners",
       "appearance-position-description": "Choose where to place the bar on the screen.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -17,6 +17,7 @@
     "useSeparateOpacity": false,
     "marginVertical": 4,
     "marginHorizontal": 4,
+    "floatingOuterEdgeRounding": false,
     "frameThickness": 8,
     "frameRadius": 12,
     "outerCorners": true,

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -372,6 +372,18 @@
     ]
   },
   {
+    "labelKey": "panels.bar.appearance-floating-outer-edge-rounding-label",
+    "descriptionKey": "panels.bar.appearance-floating-outer-edge-rounding-description",
+    "widget": "NToggle",
+    "tab": 4,
+    "tabLabel": "panels.bar.title",
+    "subTab": 0,
+    "subTabLabel": "common.appearance",
+    "visibleWhen": [
+      "Settings.data.bar.barType === \"floating\""
+    ]
+  },
+  {
     "labelKey": "panels.bar.appearance-auto-hide-delay-label",
     "descriptionKey": "panels.bar.appearance-auto-hide-delay-description",
     "widget": "NValueSlider",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -194,6 +194,7 @@ Singleton {
       // Floating bar settings
       property int marginVertical: 4
       property int marginHorizontal: 4
+      property bool floatingOuterEdgeRounding: false
 
       // Framed bar settings
       property int frameThickness: 8

--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -68,8 +68,11 @@ Item {
   readonly property string barPosition: Settings.getBarPositionForScreen(screen?.name)
   readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
   readonly property bool barFloating: Settings.data.bar.barType === "floating"
+  readonly property bool floatingOuterEdgeRounding: barFloating && (Settings.data.bar.floatingOuterEdgeRounding ?? false)
   readonly property real barFloatMarginH: barFloating ? (Settings.data.bar.marginHorizontal ?? 0) : 0
   readonly property real barFloatMarginV: barFloating ? (Settings.data.bar.marginVertical ?? 0) : 0
+  readonly property real floatingOuterRoundingThreshold: Style.radiusL + Style.screenRadius
+  readonly property bool floatingOuterRoundingAllowed: barIsVertical ? (barFloatMarginV >= floatingOuterRoundingThreshold) : (barFloatMarginH >= floatingOuterRoundingThreshold)
 
   // Bar density (per-screen)
   readonly property string barDensity: Settings.getBarDensityForScreen(screen?.name)
@@ -229,9 +232,9 @@ Item {
           // Floating bar: flatten corners only on side touching screen edge
           if (barFloating) {
             if (barPosition === "top" && root.barFloatMarginV <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 1 : -1;
             if (barPosition === "left" && root.barFloatMarginH <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 2 : -1;
             return 0;
           }
           // Top bar: top corners against screen edge = no radius
@@ -252,9 +255,9 @@ Item {
           // Floating bar: flatten corners only on side touching screen edge
           if (barFloating) {
             if (barPosition === "top" && root.barFloatMarginV <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 1 : -1;
             if (barPosition === "right" && root.barFloatMarginH <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 2 : -1;
             return 0;
           }
           // Top bar: top corners against screen edge = no radius
@@ -275,9 +278,9 @@ Item {
           // Floating bar: flatten corners only on side touching screen edge
           if (barFloating) {
             if (barPosition === "bottom" && root.barFloatMarginV <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 1 : -1;
             if (barPosition === "left" && root.barFloatMarginH <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 2 : -1;
             return 0;
           }
           // Bottom bar: bottom corners against screen edge = no radius
@@ -298,9 +301,9 @@ Item {
           // Floating bar: flatten corners only on side touching screen edge
           if (barFloating) {
             if (barPosition === "bottom" && root.barFloatMarginV <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 1 : -1;
             if (barPosition === "right" && root.barFloatMarginH <= 0)
-              return -1;
+              return (root.floatingOuterEdgeRounding && root.floatingOuterRoundingAllowed) ? 2 : -1;
             return 0;
           }
           // Bottom bar: bottom corners against screen edge = no radius

--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -68,6 +68,8 @@ Item {
   readonly property string barPosition: Settings.getBarPositionForScreen(screen?.name)
   readonly property bool barIsVertical: barPosition === "left" || barPosition === "right"
   readonly property bool barFloating: Settings.data.bar.barType === "floating"
+  readonly property real barFloatMarginH: barFloating ? (Settings.data.bar.marginHorizontal ?? 0) : 0
+  readonly property real barFloatMarginV: barFloating ? (Settings.data.bar.marginVertical ?? 0) : 0
 
   // Bar density (per-screen)
   readonly property string barDensity: Settings.getBarDensityForScreen(screen?.name)
@@ -224,9 +226,14 @@ Item {
         // State 1: Horizontal inversion (outer curve on X-axis)
         // State 2: Vertical inversion (outer curve on Y-axis)
         readonly property int topLeftCornerState: {
-          // Floating bar: always simple rounded corners
-          if (barFloating)
+          // Floating bar: flatten corners only on side touching screen edge
+          if (barFloating) {
+            if (barPosition === "top" && root.barFloatMarginV <= 0)
+              return -1;
+            if (barPosition === "left" && root.barFloatMarginH <= 0)
+              return -1;
             return 0;
+          }
           // Top bar: top corners against screen edge = no radius
           if (barPosition === "top")
             return -1;
@@ -242,9 +249,14 @@ Item {
         }
 
         readonly property int topRightCornerState: {
-          // Floating bar: always simple rounded corners
-          if (barFloating)
+          // Floating bar: flatten corners only on side touching screen edge
+          if (barFloating) {
+            if (barPosition === "top" && root.barFloatMarginV <= 0)
+              return -1;
+            if (barPosition === "right" && root.barFloatMarginH <= 0)
+              return -1;
             return 0;
+          }
           // Top bar: top corners against screen edge = no radius
           if (barPosition === "top")
             return -1;
@@ -260,9 +272,14 @@ Item {
         }
 
         readonly property int bottomLeftCornerState: {
-          // Floating bar: always simple rounded corners
-          if (barFloating)
+          // Floating bar: flatten corners only on side touching screen edge
+          if (barFloating) {
+            if (barPosition === "bottom" && root.barFloatMarginV <= 0)
+              return -1;
+            if (barPosition === "left" && root.barFloatMarginH <= 0)
+              return -1;
             return 0;
+          }
           // Bottom bar: bottom corners against screen edge = no radius
           if (barPosition === "bottom")
             return -1;
@@ -278,9 +295,14 @@ Item {
         }
 
         readonly property int bottomRightCornerState: {
-          // Floating bar: always simple rounded corners
-          if (barFloating)
+          // Floating bar: flatten corners only on side touching screen edge
+          if (barFloating) {
+            if (barPosition === "bottom" && root.barFloatMarginV <= 0)
+              return -1;
+            if (barPosition === "right" && root.barFloatMarginH <= 0)
+              return -1;
             return 0;
+          }
           // Bottom bar: bottom corners against screen edge = no radius
           if (barPosition === "bottom")
             return -1;

--- a/Modules/MainScreen/MainScreen.qml
+++ b/Modules/MainScreen/MainScreen.qml
@@ -442,6 +442,8 @@ PanelWindow {
       readonly property bool barFloating: Settings.data.bar.barType === "floating"
       readonly property real barMarginH: barFloating ? Math.floor(Settings.data.bar.marginHorizontal) : 0
       readonly property real barMarginV: barFloating ? Math.floor(Settings.data.bar.marginVertical) : 0
+      readonly property real barFloatMarginH: barFloating ? (Settings.data.bar.marginHorizontal ?? 0) : 0
+      readonly property real barFloatMarginV: barFloating ? (Settings.data.bar.marginVertical ?? 0) : 0
       readonly property real barHeight: Style.getBarHeightForScreen(screen?.name)
 
       // Auto-hide properties (read by AllBackgrounds for background fade)
@@ -492,8 +494,13 @@ PanelWindow {
 
       // Corner states (same as Bar.qml)
       readonly property int topLeftCornerState: {
-        if (barFloating)
+        if (barFloating) {
+          if (barPosition === "top" && barFloatMarginV <= 0)
+            return -1;
+          if (barPosition === "left" && barFloatMarginH <= 0)
+            return -1;
           return 0;
+        }
         if (barPosition === "top")
           return -1;
         if (barPosition === "left")
@@ -505,8 +512,13 @@ PanelWindow {
       }
 
       readonly property int topRightCornerState: {
-        if (barFloating)
+        if (barFloating) {
+          if (barPosition === "top" && barFloatMarginV <= 0)
+            return -1;
+          if (barPosition === "right" && barFloatMarginH <= 0)
+            return -1;
           return 0;
+        }
         if (barPosition === "top")
           return -1;
         if (barPosition === "right")
@@ -518,8 +530,13 @@ PanelWindow {
       }
 
       readonly property int bottomLeftCornerState: {
-        if (barFloating)
+        if (barFloating) {
+          if (barPosition === "bottom" && barFloatMarginV <= 0)
+            return -1;
+          if (barPosition === "left" && barFloatMarginH <= 0)
+            return -1;
           return 0;
+        }
         if (barPosition === "bottom")
           return -1;
         if (barPosition === "left")
@@ -531,8 +548,13 @@ PanelWindow {
       }
 
       readonly property int bottomRightCornerState: {
-        if (barFloating)
+        if (barFloating) {
+          if (barPosition === "bottom" && barFloatMarginV <= 0)
+            return -1;
+          if (barPosition === "right" && barFloatMarginH <= 0)
+            return -1;
           return 0;
+        }
         if (barPosition === "bottom")
           return -1;
         if (barPosition === "right")

--- a/Modules/MainScreen/MainScreen.qml
+++ b/Modules/MainScreen/MainScreen.qml
@@ -440,10 +440,13 @@ PanelWindow {
       readonly property bool isFramed: Settings.data.bar.barType === "framed"
       readonly property real frameThickness: Settings.data.bar.frameThickness ?? 12
       readonly property bool barFloating: Settings.data.bar.barType === "floating"
+      readonly property bool floatingOuterEdgeRounding: barFloating && (Settings.data.bar.floatingOuterEdgeRounding ?? false)
       readonly property real barMarginH: barFloating ? Math.floor(Settings.data.bar.marginHorizontal) : 0
       readonly property real barMarginV: barFloating ? Math.floor(Settings.data.bar.marginVertical) : 0
       readonly property real barFloatMarginH: barFloating ? (Settings.data.bar.marginHorizontal ?? 0) : 0
       readonly property real barFloatMarginV: barFloating ? (Settings.data.bar.marginVertical ?? 0) : 0
+      readonly property real floatingOuterRoundingThreshold: Style.radiusL + Style.screenRadius
+      readonly property bool floatingOuterRoundingAllowed: barIsVertical ? (barFloatMarginV >= floatingOuterRoundingThreshold) : (barFloatMarginH >= floatingOuterRoundingThreshold)
       readonly property real barHeight: Style.getBarHeightForScreen(screen?.name)
 
       // Auto-hide properties (read by AllBackgrounds for background fade)
@@ -496,9 +499,9 @@ PanelWindow {
       readonly property int topLeftCornerState: {
         if (barFloating) {
           if (barPosition === "top" && barFloatMarginV <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 1 : -1;
           if (barPosition === "left" && barFloatMarginH <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 2 : -1;
           return 0;
         }
         if (barPosition === "top")
@@ -514,9 +517,9 @@ PanelWindow {
       readonly property int topRightCornerState: {
         if (barFloating) {
           if (barPosition === "top" && barFloatMarginV <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 1 : -1;
           if (barPosition === "right" && barFloatMarginH <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 2 : -1;
           return 0;
         }
         if (barPosition === "top")
@@ -532,9 +535,9 @@ PanelWindow {
       readonly property int bottomLeftCornerState: {
         if (barFloating) {
           if (barPosition === "bottom" && barFloatMarginV <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 1 : -1;
           if (barPosition === "left" && barFloatMarginH <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 2 : -1;
           return 0;
         }
         if (barPosition === "bottom")
@@ -550,9 +553,9 @@ PanelWindow {
       readonly property int bottomRightCornerState: {
         if (barFloating) {
           if (barPosition === "bottom" && barFloatMarginV <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 1 : -1;
           if (barPosition === "right" && barFloatMarginH <= 0)
-            return -1;
+            return (floatingOuterEdgeRounding && floatingOuterRoundingAllowed) ? 2 : -1;
           return 0;
         }
         if (barPosition === "bottom")

--- a/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
@@ -297,9 +297,15 @@ ColumnLayout {
   }
 
   ColumnLayout {
+    id: floatingSettings
     visible: Settings.data.bar.barType === "floating"
     spacing: Style.marginL
     Layout.fillWidth: true
+
+    readonly property real floatingOuterRoundingThreshold: Style.radiusL + Style.screenRadius
+    readonly property bool floatingOuterRoundingAllowed: (Settings.data.bar.position === "top" || Settings.data.bar.position === "bottom")
+      ? Settings.data.bar.marginHorizontal >= floatingOuterRoundingThreshold
+      : Settings.data.bar.marginVertical >= floatingOuterRoundingThreshold
 
     NDivider {
       Layout.fillWidth: true
@@ -325,6 +331,18 @@ ColumnLayout {
       value: Settings.data.bar.marginHorizontal
       defaultValue: Settings.getDefaultValue("bar.marginHorizontal")
       onValueChanged: Settings.data.bar.marginHorizontal = value
+    }
+
+    NToggle {
+      Layout.fillWidth: true
+      label: I18n.tr("panels.bar.appearance-floating-outer-edge-rounding-label")
+      description: I18n.tr("panels.bar.appearance-floating-outer-edge-rounding-description", {
+                             minMargin: Math.ceil(floatingSettings.floatingOuterRoundingThreshold)
+                           })
+      checked: Settings.data.bar.floatingOuterEdgeRounding
+      enabled: floatingSettings.floatingOuterRoundingAllowed
+      defaultValue: Settings.getDefaultValue("bar.floatingOuterEdgeRounding")
+      onToggled: checked => Settings.data.bar.floatingOuterEdgeRounding = checked
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation
This PR refines floating bar corner rendering when the bar touches a screen edge, so attached sides no longer keep inappropriate rounding and now behave consistently across all bar positions and orientations. It also introduces a new setting that allows optional outer rounding on the touching edge for users who prefer that style. To prevent visual artifacts, the outer rounding is only applied when there is enough opposite-side margin based on the container radius and screen corner radius thresholds.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/ca10dab5-cd65-44c5-9637-5f5b49477fd7

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
