### PR TITLE
Update pywalfox.json

### DIFF
--- a/Assets/Templates/pywalfox.json
+++ b/Assets/Templates/pywalfox.json
@@ -2,7 +2,7 @@
   "wallpaper": "{{image}}",
   "alpha": "100",
   "colors": {
-    "color0": "{{colors.surface.default.hex}}",
+    "color0": "{{colors.surface.dark.hex}}",
     "color1": "",
     "color2": "",
     "color3": "{{colors.primary.default.hex}}",
@@ -18,9 +18,5 @@
     "color13": "{{colors.secondary.default.hex}}",
     "color14": "",
     "color15": "{{colors.on_background.default.hex}}",
-    "color16": "{{colors.on_surface.default.hex}}",
-    "color17": "{{colors.surface_container.default.hex}}",
-    "color18": "",
-    "color19": "{{colors.background.default.hex}}"
   }
 }


### PR DESCRIPTION

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->



## Motivation
Previous changes to this template broke either light or dark mode. The template also used more than the 15 colors that pywalfox reads when it creates a palette. The extra colors were not read in and did nothing. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Tested with Firefox and various color schemes including cyberpunk, everforest, rose pine. 

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
The dark mode browser background color matches Noctalia's surface color.  When in light mode, pywalfox tries to generate a light surface color and various text colors from color 1 in the template. This results in an unusable  palette when light mode Noctalia supplies a light color for color 1. The fix is to always use a dark color for color 1. This creates a usable light mode template but the browser background color does not perfectly match Noctalia's surface color.