### PR TITLE
fix: Allow Shift+Home, Delete text selection/deletion in Launcher search box

### DIFF
--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -474,10 +474,16 @@ Rectangle {
       event.accepted = true;
       break;
     case Qt.Key_Home:
+      if (searchInput.inputItem && searchInput.inputItem.activeFocus && (event.modifiers & Qt.ShiftModifier)) {
+        break;
+      }
       selectFirst();
       event.accepted = true;
       break;
     case Qt.Key_End:
+      if (searchInput.inputItem && searchInput.inputItem.activeFocus && (event.modifiers & Qt.ShiftModifier)) {
+        break;
+      }
       selectLast();
       event.accepted = true;
       break;
@@ -490,6 +496,9 @@ Rectangle {
       event.accepted = true;
       break;
     case Qt.Key_Delete:
+      if (searchInput.inputItem && searchInput.inputItem.activeFocus && searchInput.inputItem.selectedText.length > 0) {
+        break;
+      }
       if (selectedIndex >= 0 && results && results[selectedIndex]) {
         var item = results[selectedIndex];
         var provider = item.provider || currentProvider;

--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -481,9 +481,6 @@ Rectangle {
       event.accepted = true;
       break;
     case Qt.Key_End:
-      if (searchInput.inputItem && searchInput.inputItem.activeFocus && (event.modifiers & Qt.ShiftModifier)) {
-        break;
-      }
       selectLast();
       event.accepted = true;
       break;


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Small UX change to pass Shift+Home key combination to search input (Home without Shift is handled as usual), to allow selecting entered text. Delete key is passed to search input if search input contains any selected text. This allows to delete previously typed text without the need to hold Backspace. This change makes the text box behaviour more canonical. No other changes, previous key binds work as usual.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.

