### PR TITLE
fix: Update dock on window list change

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -33,6 +33,14 @@ Loader {
         }
       }
 
+      // Update dock apps when window list change
+      Connections {
+        target: CompositorService
+        function onWindowListChanged() {
+          updateDockApps();
+        }
+      }
+
       // Update dock apps when toplevels change
       Connections {
         target: ToplevelManager ? ToplevelManager.toplevels : null


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->
## Motivation
The dock does not track changes in the output window list. When windows are moved between outputs, the dock doesn't update.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/026adf50-3107-46d3-933f-165cf6d24374


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
If the dock only shows windows from the same display, when the display is reconnected (dpms off/on), open windows disappear from the dock until an event occurs that refreshes the dock.
With sway it even worse, windows don't appear in dock until next window open.
Tested with sway virtual output. Moving windows between outputs don't affect dock

