### PR TITLE
Replace hardcoded gradient rectangles in scrollable widgets with NFadeMask abstraction

### DIFF
--- a/Modules/Panels/Audio/AudioPanel.qml
+++ b/Modules/Panels/Audio/AudioPanel.qml
@@ -232,7 +232,6 @@ SmartPanel {
           verticalPolicy: ScrollBar.AsNeeded
           contentWidth: availableWidth
           reserveScrollbarSpace: false
-          gradientColor: Color.mSurface
 
           ColumnLayout {
             spacing: Style.marginM
@@ -741,7 +740,6 @@ SmartPanel {
           verticalPolicy: ScrollBar.AsNeeded
           contentWidth: availableWidth
           reserveScrollbarSpace: false
-          gradientColor: Color.mSurface
 
           // AudioService Devices
           ColumnLayout {

--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -92,7 +92,6 @@ SmartPanel {
         horizontalPolicy: ScrollBar.AlwaysOff
         verticalPolicy: ScrollBar.AsNeeded
         reserveScrollbarSpace: false
-        gradientColor: Color.mSurface
 
         ColumnLayout {
           id: devicesList

--- a/Modules/Panels/Brightness/BrightnessPanel.qml
+++ b/Modules/Panels/Brightness/BrightnessPanel.qml
@@ -146,7 +146,6 @@ SmartPanel {
         verticalPolicy: ScrollBar.AsNeeded
         contentWidth: availableWidth
         reserveScrollbarSpace: false
-        gradientColor: Color.mSurface
 
         // AudioService Devices
         ColumnLayout {

--- a/Modules/Panels/Launcher/LauncherCore.qml
+++ b/Modules/Panels/Launcher/LauncherCore.qml
@@ -730,7 +730,6 @@ Rectangle {
         horizontalPolicy: ScrollBar.AlwaysOff
         verticalPolicy: ScrollBar.AlwaysOff
         reserveScrollbarSpace: false
-        gradientColor: Settings.data.ui.panelBackgroundOpacity < 1 ? "transparent" : Color.mSurface
         wheelScrollMultiplier: 4.0
 
         width: parent.width
@@ -822,7 +821,6 @@ Rectangle {
         horizontalPolicy: ScrollBar.AlwaysOff
         verticalPolicy: ScrollBar.AlwaysOff
         reserveScrollbarSpace: false
-        gradientColor: Settings.data.ui.panelBackgroundOpacity < 1 ? "transparent" : Color.mSurface
         wheelScrollMultiplier: 4.0
         trackedSelectionIndex: root.selectedIndex
 

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -245,7 +245,6 @@ SmartPanel {
           horizontalPolicy: ScrollBar.AlwaysOff
           verticalPolicy: ScrollBar.AsNeeded
           reserveScrollbarSpace: false
-          gradientColor: Color.mSurface
 
           ColumnLayout {
             id: contentColumn

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -498,7 +498,6 @@ SmartPanel {
           horizontalPolicy: ScrollBar.AlwaysOff
           verticalPolicy: ScrollBar.AsNeeded
           reserveScrollbarSpace: false
-          gradientColor: Color.mSurface
 
           // Track which notification is expanded
           property string expandedId: ""

--- a/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/Bar/BarWidgetSettingsDialog.qml
@@ -93,7 +93,6 @@ Popup {
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.minimumHeight: 100
-        gradientColor: Color.mSurface
 
         ColumnLayout {
           width: scrollView.availableWidth

--- a/Modules/Panels/Settings/Bar/WidgetSettings/TraySettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/TraySettings.qml
@@ -133,7 +133,6 @@ ColumnLayout {
     Layout.fillWidth: true
     Layout.preferredHeight: 150
     Layout.topMargin: Style.marginL // Increased top margin
-    gradientColor: Color.mSurface
 
     model: blacklistModel
     delegate: Item {

--- a/Modules/Panels/Settings/ControlCenter/ControlCenterWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/ControlCenter/ControlCenterWidgetSettingsDialog.qml
@@ -91,7 +91,6 @@ Popup {
       Layout.fillWidth: true
       Layout.fillHeight: true
       Layout.minimumHeight: 100
-      gradientColor: Color.mSurface
       reserveScrollbarSpace: false
 
       ColumnLayout {

--- a/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
+++ b/Modules/Panels/Settings/DesktopWidgets/DesktopWidgetSettingsDialog.qml
@@ -92,7 +92,6 @@ Popup {
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.minimumHeight: 100
-        gradientColor: Color.mSurface
 
         ColumnLayout {
           width: scrollView.availableWidth

--- a/Modules/Panels/Settings/SettingsContent.qml
+++ b/Modules/Panels/Settings/SettingsContent.qml
@@ -947,7 +947,6 @@ Item {
               spacing: Style.marginXS
               visible: root.searchText.trim() !== ""
               verticalPolicy: ScrollBar.AsNeeded
-              gradientColor: "transparent"
               reserveScrollbarSpace: false
 
               HoverHandler {
@@ -1048,7 +1047,6 @@ Item {
               currentIndex: root.currentTabIndex
               horizontalPolicy: ScrollBar.AlwaysOff
               verticalPolicy: ScrollBar.AlwaysOff
-              gradientColor: "transparent"
               reserveScrollbarSpace: false
 
               delegate: Rectangle {

--- a/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
@@ -837,7 +837,6 @@ Popup {
       visible: hasInitialData && availableSchemes.length > 0
       verticalPolicy: ScrollBar.AsNeeded
       horizontalPolicy: ScrollBar.AlwaysOff
-      gradientColor: Color.mSurface
 
       ColumnLayout {
         width: schemesScrollView.availableWidth

--- a/Widgets/NComboBox.qml
+++ b/Widgets/NComboBox.qml
@@ -262,7 +262,6 @@ RowLayout {
         property var comboBox: combo
         model: combo.popup.visible ? root.model : null
         highlightMoveDuration: 0
-        //showGradientMasks: false
 
         delegate: Rectangle {
           id: delegateRect

--- a/Widgets/NFadeMask.qml
+++ b/Widgets/NFadeMask.qml
@@ -2,25 +2,51 @@ import QtQuick
 import QtQuick.Effects
 import qs.Commons
 
+/*
+Component {
+id: fadeMaskComponent
+NFadeMask {
+// Adjust fade properties
+}
+
+Component.onCompleted {
+var mask = fadeMaskComponent.createObject(targetParent)
+targetItem.layer.enabled = Qt.binding(() => condition)
+mask.applyTo(targetItem)
+}
+*/
+
 Item {
   id: fadeMaskRoot
 
+  // Gradient.Vertical or Gradient.Horizontal
   property int orientation: Gradient.Vertical
+
+  // Fraction of height/width of component that fades on each side
+  // Value: 0.0 - 0.5
   property real fadeExtent: 0.1
 
+  // Outer stop colors - "transparent" = fade out, "white" = show content through
+  // Bind externally for scroll-position-aware fading
   property color startColor: "transparent"
   property color endColor: "transparent"
+
+  // Enable Behaviour on outer stops for animated "spawning" of the fades
   property bool animateColors: false
   property int animationDuration: Style.animationFast
 
+  // Size adjustments for the inner gradient rectangle relative to the target
+  // e.g. heightAdjustment: -2 * Style.capsuleBorderWidth to avoid sampling over borders
   property real heightAdjustment: 0
   property real widthAdjustment: 0
 
+  // Corner radii for the gradient rectangle
   property real topLeftRadius: 0
   property real topRightRadius: 0
   property real bottomLeftRadius: 0
   property real bottomRightRadius: 0
 
+  // Assign to targetItem.layer.effect declaratively, or use applyTo() dynamically
   readonly property Component effectComponent: Component {
     MultiEffect {
       maskEnabled: true

--- a/Widgets/NFadeMask.qml
+++ b/Widgets/NFadeMask.qml
@@ -1,0 +1,84 @@
+import QtQuick
+import QtQuick.Effects
+import qs.Commons
+
+Item {
+  id: fadeMaskRoot
+
+  property int orientation: Gradient.Vertical
+  property real fadeExtent: 0.1
+
+  property color startColor: "transparent"
+  property color endColor: "transparent"
+  property bool animateColors: false
+  property int animationDuration: Style.animationFast
+
+  property real heightAdjustment: 0
+  property real widthAdjustment: 0
+
+  property real topLeftRadius: 0
+  property real topRightRadius: 0
+  property real bottomLeftRadius: 0
+  property real bottomRightRadius: 0
+
+  readonly property Component effectComponent: Component {
+    MultiEffect {
+      maskEnabled: true
+      maskThresholdMin: 0.5
+      maskSpreadAtMin: 1.0
+      maskSource: fadeMaskRoot
+    }
+  }
+
+  function applyTo(targetItem) {
+    targetItem.layer.effect = effectComponent;
+  }
+
+  visible: false
+  layer.enabled: true
+  layer.smooth: true
+
+  Rectangle {
+    anchors.centerIn: parent
+    width: parent.width + fadeMaskRoot.widthAdjustment
+    height: parent.height + fadeMaskRoot.heightAdjustment
+    topLeftRadius: fadeMaskRoot.topLeftRadius
+    topRightRadius: fadeMaskRoot.topRightRadius
+    bottomLeftRadius: fadeMaskRoot.bottomLeftRadius
+    bottomRightRadius: fadeMaskRoot.bottomRightRadius
+
+    gradient: Gradient {
+      orientation: fadeMaskRoot.orientation
+      GradientStop {
+        position: 0.0
+        color: fadeMaskRoot.startColor
+        Behavior on color {
+          enabled: fadeMaskRoot.animateColors
+          ColorAnimation {
+            duration: fadeMaskRoot.animationDuration
+            easing.type: Easing.InOutQuad
+          }
+        }
+      }
+      GradientStop {
+        position: fadeMaskRoot.fadeExtent
+        color: "white"
+      }
+      GradientStop {
+        position: 1.0 - fadeMaskRoot.fadeExtent
+        color: "white"
+      }
+      GradientStop {
+        position: 1.0
+        color: fadeMaskRoot.endColor
+        Behavior on color {
+          enabled: fadeMaskRoot.animateColors
+          ColorAnimation {
+            duration: fadeMaskRoot.animationDuration
+            easing.type: Easing.InOutQuad
+          }
+        }
+      }
+    }
+  }
+}

--- a/Widgets/NFilePicker.qml
+++ b/Widgets/NFilePicker.qml
@@ -460,7 +460,6 @@ Popup {
           model: filteredModel
           visible: filePickerPanel.viewMode
           reuseItems: true
-          gradientColor: Color.mSurface
 
           property int columns: Math.max(1, Math.floor(availableWidth / 120))
           property int itemSize: Math.floor((availableWidth - leftMargin - rightMargin - (columns * Style.marginS)) / columns)
@@ -666,7 +665,6 @@ Popup {
           anchors.margins: Style.marginS
           model: filteredModel
           visible: !filePickerPanel.viewMode
-          gradientColor: Color.mSurface
 
           delegate: Rectangle {
             id: listItem

--- a/Widgets/NGridView.qml
+++ b/Widgets/NGridView.qml
@@ -26,7 +26,6 @@ Item {
 
   // Gradient properties
   property bool showGradientMasks: true
-  property color gradientColor: Color.mSurfaceVariant
   property int gradientHeight: 16
   property bool reserveScrollbarSpace: true
 

--- a/Widgets/NGridView.qml
+++ b/Widgets/NGridView.qml
@@ -260,52 +260,25 @@ Item {
   }
 
   // Dynamically create gradient overlays
+  Component {
+    id: fadeMaskComponent
+    NFadeMask {
+      anchors.fill: parent
+      orientation: Gradient.Vertical
+      fadeExtent: 0.03
+      animateColors: true
+      animationDuration: Style.animationFast
+      startColor: (gridView.contentY <= 1 || root.selectionOnFirstVisibleRow) ? "white" : "transparent"
+      endColor: (gridView.contentY + gridView.height >= gridView.contentHeight - 1 || root.selectionOnLastVisibleRow) ? "white" : "transparent"
+    }
+  }
+
   function createGradients() {
     if (!showGradientMasks)
       return;
-
-    Qt.createQmlObject(`
-      import QtQuick
-      import qs.Commons
-      Rectangle {
-        x: 0
-        y: 0
-        width: root.availableWidth
-        height: root.gradientHeight
-        z: 1
-        visible: root.showGradientMasks && root.contentOverflows
-        opacity: (gridView.contentY <= 1 || root.selectionOnFirstVisibleRow) ? 0 : 1
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: root.gradientColor }
-          GradientStop { position: 1.0; color: "transparent" }
-        }
-      }
-    `, root, "topGradient");
-
-    Qt.createQmlObject(`
-      import QtQuick
-      import qs.Commons
-      Rectangle {
-        x: 0
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: -1
-        width: root.availableWidth
-        height: root.gradientHeight + 1
-        z: 1
-        visible: root.showGradientMasks && root.contentOverflows
-        opacity: ((gridView.contentY + gridView.height >= gridView.contentHeight - 1) || root.selectionOnLastVisibleRow) ? 0 : 1
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: "transparent" }
-          GradientStop { position: 1.0; color: root.gradientColor }
-        }
-      }
-    `, root, "bottomGradient");
+    var mask = fadeMaskComponent.createObject(gridView);
+    gridView.layer.enabled = Qt.binding(() => root.showGradientMasks && root.contentOverflows);
+    mask.applyTo(gridView);
   }
 
   GridView {

--- a/Widgets/NGridView.qml
+++ b/Widgets/NGridView.qml
@@ -24,7 +24,8 @@ Item {
   }
   readonly property bool contentOverflows: gridView.contentHeight > gridView.height
 
-  // Gradient properties
+  // Fade controls (fadeExtent: 0.0–0.5, fraction of height that fades)
+  property real fadeExtent: 0.03
   property bool showGradientMasks: true
   property bool reserveScrollbarSpace: true
 
@@ -263,7 +264,7 @@ Item {
     NFadeMask {
       anchors.fill: parent
       orientation: Gradient.Vertical
-      fadeExtent: 0.03
+      fadeExtent: root.fadeExtent
       animateColors: true
       animationDuration: Style.animationFast
       startColor: (gridView.contentY <= 1 || root.selectionOnFirstVisibleRow) ? "white" : "transparent"

--- a/Widgets/NGridView.qml
+++ b/Widgets/NGridView.qml
@@ -26,7 +26,6 @@ Item {
 
   // Gradient properties
   property bool showGradientMasks: true
-  property int gradientHeight: 16
   property bool reserveScrollbarSpace: true
 
   // Keep scrollbars visible whenever overflow exists (without forcing visibility when not scrollable)

--- a/Widgets/NIconPicker.qml
+++ b/Widgets/NIconPicker.qml
@@ -92,7 +92,6 @@ Popup {
       cellHeight: root.cellH
       model: root.filteredIcons
       reserveScrollbarSpace: false
-      gradientColor: Color.mSurface
 
       delegate: Rectangle {
         width: grid.cellWidth

--- a/Widgets/NListView.qml
+++ b/Widgets/NListView.qml
@@ -22,7 +22,6 @@ Item {
   readonly property bool contentOverflows: listView.contentHeight > listView.height
 
   property bool showGradientMasks: true
-  property int gradientHeight: 16
   property bool reserveScrollbarSpace: true
 
   // Keep scrollbars visible whenever overflow exists (without forcing visibility when not scrollable)
@@ -197,14 +196,10 @@ Item {
       startColor: {
         if (listView.contentY <= 1)
           return "white";
-        if (listView.currentItem && listView.currentItem.y - listView.contentY < root.gradientHeight)
-          return "white";
         return "transparent";
       }
       endColor: {
         if (listView.contentY + listView.height >= listView.contentHeight - 1)
-          return "white";
-        if (listView.currentItem && listView.currentItem.y + listView.currentItem.height > listView.contentY + listView.height - root.gradientHeight)
           return "white";
         return "transparent";
       }

--- a/Widgets/NListView.qml
+++ b/Widgets/NListView.qml
@@ -22,7 +22,6 @@ Item {
   readonly property bool contentOverflows: listView.contentHeight > listView.height
 
   property bool showGradientMasks: true
-  property color gradientColor: Color.mSurfaceVariant
   property int gradientHeight: 16
   property bool reserveScrollbarSpace: true
 

--- a/Widgets/NListView.qml
+++ b/Widgets/NListView.qml
@@ -187,60 +187,37 @@ Item {
   }
 
   // Dynamically create gradient overlays
+  Component {
+    id: fadeMaskComponent
+    NFadeMask {
+      anchors.fill: parent
+      orientation: Gradient.Vertical
+      fadeExtent: 0.03
+      animateColors: true
+      animationDuration: Style.animationFast
+      startColor: {
+        if (listView.contentY <= 1)
+          return "white";
+        if (listView.currentItem && listView.currentItem.y - listView.contentY < root.gradientHeight)
+          return "white";
+        return "transparent";
+      }
+      endColor: {
+        if (listView.contentY + listView.height >= listView.contentHeight - 1)
+          return "white";
+        if (listView.currentItem && listView.currentItem.y + listView.currentItem.height > listView.contentY + listView.height - root.gradientHeight)
+          return "white";
+        return "transparent";
+      }
+    }
+  }
+
   function createGradients() {
     if (!showGradientMasks)
       return;
-
-    Qt.createQmlObject(`
-      import QtQuick
-      import qs.Commons
-      Rectangle {
-        x: 0
-        y: 0
-        width: root.availableWidth
-        height: root.gradientHeight
-        z: 1
-        visible: root.showGradientMasks && root.contentOverflows
-        opacity: {
-          if (listView.contentY <= 1) return 0;
-          if (listView.currentItem && listView.currentItem.y - listView.contentY < root.gradientHeight) return 0;
-          return 1;
-        }
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: root.gradientColor }
-          GradientStop { position: 1.0; color: "transparent" }
-        }
-      }
-    `, root, "topGradient");
-
-    Qt.createQmlObject(`
-      import QtQuick
-      import qs.Commons
-      Rectangle {
-        x: 0
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: -1
-        width: root.availableWidth
-        height: root.gradientHeight + 1
-        z: 1
-        visible: root.showGradientMasks && root.contentOverflows
-        opacity: {
-          if (listView.contentY + listView.height >= listView.contentHeight - 1) return 0;
-          if (listView.currentItem && listView.currentItem.y + listView.currentItem.height > listView.contentY + listView.height - root.gradientHeight) return 0;
-          return 1;
-        }
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: "transparent" }
-          GradientStop { position: 1.0; color: root.gradientColor }
-        }
-      }
-    `, root, "bottomGradient");
+    var mask = fadeMaskComponent.createObject(listView);
+    listView.layer.enabled = Qt.binding(() => root.showGradientMasks && root.contentOverflows);
+    mask.applyTo(listView);
   }
 
   ListView {

--- a/Widgets/NListView.qml
+++ b/Widgets/NListView.qml
@@ -21,6 +21,8 @@ Item {
   }
   readonly property bool contentOverflows: listView.contentHeight > listView.height
 
+  // Fade controls (fadeExtent: 0.0–0.5, fraction of height that fades)
+  property real fadeExtent: 0.03
   property bool showGradientMasks: true
   property bool reserveScrollbarSpace: true
 
@@ -190,7 +192,7 @@ Item {
     NFadeMask {
       anchors.fill: parent
       orientation: Gradient.Vertical
-      fadeExtent: 0.03
+      fadeExtent: root.fadeExtent
       animateColors: true
       animationDuration: Style.animationFast
       startColor: {

--- a/Widgets/NPluginSettingsPopup.qml
+++ b/Widgets/NPluginSettingsPopup.qml
@@ -73,7 +73,6 @@ Popup {
         Layout.fillHeight: true
         Layout.minimumHeight: 100
         horizontalPolicy: ScrollBar.AlwaysOff
-        gradientColor: Color.mSurface
 
         Loader {
           id: settingsLoader

--- a/Widgets/NScrollText.qml
+++ b/Widgets/NScrollText.qml
@@ -199,5 +199,9 @@ Item {
     bottomLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
     topRightRadius: root.fadeCornerRadius
     bottomRightRadius: root.fadeCornerRadius
+    animateColors: true
+    animationDuration: Style.animationFast
+    startColor: scrollContainer.x < -1 ? "transparent" : "white"
+    endColor: root.contentWidth > root.maxWidth ? "transparent" : "white"
   }
 }

--- a/Widgets/NScrollText.qml
+++ b/Widgets/NScrollText.qml
@@ -60,12 +60,7 @@ Item {
   implicitHeight: titleText.height
 
   layer.enabled: contentWidth > maxWidth
-  layer.effect: MultiEffect {
-    maskEnabled: true
-    maskThresholdMin: 0.5
-    maskSpreadAtMin: 1.0
-    maskSource: fadeMask
-  }
+  layer.effect: fadeMask.effectComponent
 
   enum ScrollState {
     None = 0,
@@ -194,42 +189,15 @@ Item {
     }
   }
 
-  // Transparency Fade Rectangle
-  Item {
+  NFadeMask {
     id: fadeMask
     anchors.fill: root
-
-    Rectangle {
-      anchors.centerIn: parent
-      width: parent.width
-      height: parent.height - 2 * Style.capsuleBorderWidth
-      topLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
-      bottomLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
-      topRightRadius: root.fadeCornerRadius
-      bottomRightRadius: root.fadeCornerRadius
-      gradient: Gradient {
-        GradientStop {
-          position: 0.0
-          color: "transparent"
-        }
-        GradientStop {
-          position: root.fadeExtent
-          color: "white"
-        }
-        GradientStop {
-          position: 1 - root.fadeExtent
-          color: "white"
-        }
-        GradientStop {
-          position: 1.0
-          color: "transparent"
-        }
-        orientation: Gradient.Horizontal
-      }
-    }
-
-    layer.enabled: true
-    layer.smooth: true
-    visible: false
+    orientation: Gradient.Horizontal
+    fadeExtent: root.fadeExtent
+    heightAdjustment: -2 * Style.capsuleBorderWidth
+    topLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
+    bottomLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
+    topRightRadius: root.fadeCornerRadius
+    bottomRightRadius: root.fadeCornerRadius
   }
 }

--- a/Widgets/NScrollText.qml
+++ b/Widgets/NScrollText.qml
@@ -195,35 +195,41 @@ Item {
   }
 
   // Transparency Fade Rectangle
-  Rectangle {
+  Item {
     id: fadeMask
-    width: root.width
-    height: root.height
-    topLeftRadius: fadeRoundLeftCorners ? fadeCornerRadius : 0
-    bottomLeftRadius: fadeRoundLeftCorners ? fadeCornerRadius : 0
-    topRightRadius: fadeCornerRadius
-    bottomRightRadius: fadeCornerRadius
-    gradient: Gradient {
-      GradientStop {
-        position: 0.0
-        color: "transparent"
+    anchors.fill: root
+
+    Rectangle {
+      anchors.centerIn: parent
+      width: parent.width
+      height: parent.height - 2 * Style.capsuleBorderWidth
+      topLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
+      bottomLeftRadius: root.fadeRoundLeftCorners ? root.fadeCornerRadius : 0
+      topRightRadius: root.fadeCornerRadius
+      bottomRightRadius: root.fadeCornerRadius
+      gradient: Gradient {
+        GradientStop {
+          position: 0.0
+          color: "transparent"
+        }
+        GradientStop {
+          position: root.fadeExtent
+          color: "white"
+        }
+        GradientStop {
+          position: 1 - root.fadeExtent
+          color: "white"
+        }
+        GradientStop {
+          position: 1.0
+          color: "transparent"
+        }
+        orientation: Gradient.Horizontal
       }
-      GradientStop {
-        position: fadeExtent
-        color: "white"
-      }
-      GradientStop {
-        position: 1 - fadeExtent
-        color: "white"
-      }
-      GradientStop {
-        position: 1.0
-        color: "transparent"
-      }
-      orientation: Gradient.Horizontal
     }
+
     layer.enabled: true
     layer.smooth: true
-    opacity: 0
+    visible: false
   }
 }

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Effects
 import QtQuick.Templates as T
 import qs.Commons
 
@@ -21,6 +22,8 @@ ScrollView {
   property bool showGradientMasks: true
   property color gradientColor: Color.mSurfaceVariant
   property int gradientHeight: 16
+  // Fade controls (fadeExtent: 0.0–0.5, fraction of height that fades)
+  property real fadeExtent: 0.01
   property bool reserveScrollbarSpace: true
   property real userRightPadding: 0
   // Keep scrollbars visible whenever overflow exists (without forcing visibility when not scrollable)
@@ -30,6 +33,8 @@ ScrollView {
   property real wheelScrollMultiplier: 2.0
   property int smoothWheelAnimationDuration: Style.animationNormal
   property real _wheelTargetY: 0
+
+  property Item _maskSourceItem: null
 
   function clampScrollY(value) {
     if (!root._internalFlickable)
@@ -70,52 +75,68 @@ ScrollView {
     createGradients();
   }
 
-  // Dynamically create gradient overlays to avoid interfering with ScrollView content management
+  Component {
+    id: maskEffectComponent
+    MultiEffect {
+      maskEnabled: true
+      maskThresholdMin: 0.5
+      maskSpreadAtMin: 1.0
+      maskSource: root._maskSourceItem
+    }
+  }
+
+  // Dynamically create fade to avoid interfering with ScrollView content management
   function createGradients() {
     if (!showGradientMasks)
       return;
 
-    Qt.createQmlObject(`
+    var item = Qt.createQmlObject(`
       import QtQuick
+      import QtQuick.Effects
       import qs.Commons
-      Rectangle {
-        x: root.leftPadding
-        y: root.topPadding
-        width: root.availableWidth
-        height: root.gradientHeight
-        z: 1
-        visible: root.showGradientMasks && root.verticalScrollable
-        opacity: root.contentItem.contentY <= 1 ? 0 : 1
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: root.gradientColor }
-          GradientStop { position: 1.0; color: "transparent" }
-        }
-      }
-    `, root, "topGradient");
+      Item {
+        anchors.fill: root
+        opacity: 0
 
-    Qt.createQmlObject(`
-      import QtQuick
-      import qs.Commons
-      Rectangle {
-        x: root.leftPadding
-        y: root.height - root.bottomPadding - height + 1
-        width: root.availableWidth
-        height: root.gradientHeight + 1
-        z: 1
-        visible: root.showGradientMasks && root.verticalScrollable
-        opacity: (root.contentItem.contentY + root.contentItem.height >= root.contentItem.contentHeight - 1) ? 0 : 1
-        Behavior on opacity {
-          NumberAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-        }
-        gradient: Gradient {
-          GradientStop { position: 0.0; color: "transparent" }
-          GradientStop { position: 1.0; color: root.gradientColor }
+        layer.enabled: true
+        layer.smooth: true
+
+        Rectangle {
+          anchors.centerIn: root
+          height: root.height
+          width: root.width
+          gradient: Gradient {
+            orientation: Gradient.Vertical
+            GradientStop {
+              position: 0.0
+              color: root.contentItem.contentY >= 1 ? "transparent" : "white"
+              Behavior on color {
+                ColorAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
+              }
+            }
+            GradientStop {
+              position: fadeExtent
+              color: "white"
+            }
+            GradientStop {
+              position: 1.0 - fadeExtent
+              color: "white"
+            }
+            GradientStop {
+              position: 1.0
+              color: (root.contentItem.contentY + root.contentItem.height <= root.contentItem.contentHeight - 1) ? "transparent" : "white"
+              Behavior on color {
+                ColorAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
+              }
+            }
+          }
         }
       }
-    `, root, "bottomGradient");
+    `, root, "scrollFadeMask");
+
+    root._maskSourceItem = item;
+    root.contentItem.layer.enabled = Qt.binding(() => root.showGradientMasks && root.verticalScrollable);
+    root.contentItem.layer.effect = maskEffectComponent;
   }
 
   // Reference to the internal Flickable for wheel handling
@@ -212,7 +233,6 @@ ScrollView {
           duration: Style.animationFast
         }
       }
-
       Behavior on color {
         ColorAnimation {
           duration: Style.animationFast
@@ -255,7 +275,6 @@ ScrollView {
           duration: Style.animationFast
         }
       }
-
       Behavior on color {
         ColorAnimation {
           duration: Style.animationFast

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -20,7 +20,6 @@ ScrollView {
   readonly property bool verticalScrollable: (contentItem.contentHeight > contentItem.height) || (verticalPolicy == ScrollBar.AlwaysOn)
   readonly property bool horizontalScrollable: (contentItem.contentWidth > contentItem.width) || (horizontalPolicy == ScrollBar.AlwaysOn)
   property bool showGradientMasks: true
-  property int gradientHeight: 16
   // Fade controls (fadeExtent: 0.0–0.5, fraction of height that fades)
   property real fadeExtent: 0.01
   property bool reserveScrollbarSpace: true

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -32,8 +32,6 @@ ScrollView {
   property int smoothWheelAnimationDuration: Style.animationNormal
   property real _wheelTargetY: 0
 
-  property Item _maskSourceItem: null
-
   function clampScrollY(value) {
     if (!root._internalFlickable)
       return 0;
@@ -92,7 +90,6 @@ ScrollView {
       return;
 
     var mask = fadeMaskComponent.createObject(root);
-    root._maskSourceItem = mask;
     root.contentItem.layer.enabled = Qt.binding(() => root.showGradientMasks && root.verticalScrollable);
     mask.applyTo(root.contentItem);
   }

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -20,7 +20,6 @@ ScrollView {
   readonly property bool verticalScrollable: (contentItem.contentHeight > contentItem.height) || (verticalPolicy == ScrollBar.AlwaysOn)
   readonly property bool horizontalScrollable: (contentItem.contentWidth > contentItem.width) || (horizontalPolicy == ScrollBar.AlwaysOn)
   property bool showGradientMasks: true
-  property color gradientColor: Color.mSurfaceVariant
   property int gradientHeight: 16
   // Fade controls (fadeExtent: 0.0–0.5, fraction of height that fades)
   property real fadeExtent: 0.01

--- a/Widgets/NScrollView.qml
+++ b/Widgets/NScrollView.qml
@@ -76,12 +76,15 @@ ScrollView {
   }
 
   Component {
-    id: maskEffectComponent
-    MultiEffect {
-      maskEnabled: true
-      maskThresholdMin: 0.5
-      maskSpreadAtMin: 1.0
-      maskSource: root._maskSourceItem
+    id: fadeMaskComponent
+    NFadeMask {
+      anchors.fill: parent
+      orientation: Gradient.Vertical
+      fadeExtent: root.fadeExtent
+      animateColors: true
+      animationDuration: Style.animationFast
+      startColor: root.contentItem.contentY >= 1 ? "transparent" : "white"
+      endColor: (root.contentItem.contentY + root.contentItem.height <= root.contentItem.contentHeight - 1) ? "transparent" : "white"
     }
   }
 
@@ -90,53 +93,10 @@ ScrollView {
     if (!showGradientMasks)
       return;
 
-    var item = Qt.createQmlObject(`
-      import QtQuick
-      import QtQuick.Effects
-      import qs.Commons
-      Item {
-        anchors.fill: root
-        opacity: 0
-
-        layer.enabled: true
-        layer.smooth: true
-
-        Rectangle {
-          anchors.centerIn: root
-          height: root.height
-          width: root.width
-          gradient: Gradient {
-            orientation: Gradient.Vertical
-            GradientStop {
-              position: 0.0
-              color: root.contentItem.contentY >= 1 ? "transparent" : "white"
-              Behavior on color {
-                ColorAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-              }
-            }
-            GradientStop {
-              position: fadeExtent
-              color: "white"
-            }
-            GradientStop {
-              position: 1.0 - fadeExtent
-              color: "white"
-            }
-            GradientStop {
-              position: 1.0
-              color: (root.contentItem.contentY + root.contentItem.height <= root.contentItem.contentHeight - 1) ? "transparent" : "white"
-              Behavior on color {
-                ColorAnimation { duration: Style.animationFast; easing.type: Easing.InOutQuad }
-              }
-            }
-          }
-        }
-      }
-    `, root, "scrollFadeMask");
-
-    root._maskSourceItem = item;
+    var mask = fadeMaskComponent.createObject(root);
+    root._maskSourceItem = mask;
     root.contentItem.layer.enabled = Qt.binding(() => root.showGradientMasks && root.verticalScrollable);
-    root.contentItem.layer.effect = maskEffectComponent;
+    mask.applyTo(root.contentItem);
   }
 
   // Reference to the internal Flickable for wheel handling


### PR DESCRIPTION
# Pull Request

## Motivation
Introduction of NFadeMask - reusable mask source component that centralises the fade rectangle + MultiEffect pattern and ports all affected widgets to use it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested on sway
- [ ] Tested with multiple monitors (if applicable)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
