### PR TITLE
Reload kitty colors on theme changes when the kitty template is enabled

### DIFF
--- a/Scripts/bash/template-apply.sh
+++ b/Scripts/bash/template-apply.sh
@@ -20,6 +20,8 @@ kitty)
     else
         kitty +runpy "from kitty.utils import *; reload_conf_in_all_kitties()"
     fi
+    # Trigger kitty's live config reload after the template has been regenerated.
+    pkill -USR1 kitty >/dev/null 2>&1 || true
     ;;
 
 ghostty)


### PR DESCRIPTION
## Summary

This updates the kitty template apply hook so kitty hot-reloads its colors whenever Noctalia regenerates themes.

When the kitty template is enabled in Color Scheme Templates and the theme changes, we now send `USR1` to running kitty instances after regenerating the kitty theme file.

## What Changed

- Updated [template-apply.sh](/home/s/noctalia-shell/Scripts/bash/template-apply.sh#L16)
- In the `kitty)` case, added:
  - `pkill -USR1 kitty >/dev/null 2>&1 || true`

## Why

Previously, theme regeneration updated the kitty theme file, but running kitty windows might not immediately pick up the new colors.

Sending `USR1` ensures kitty reloads its config/colors live, which makes theme switching feel consistent with the rest of Noctalia's template-based app theming.

## Behavior

- Only affects users who have the kitty template enabled
- Runs after the existing kitty apply/reload logic
- Safe when kitty is not running because the command is ignored with `|| true`

## Testing

- Enable the kitty template in Color Scheme Templates
- Change dark/light mode or switch color schemes
- Confirm running kitty windows update colors immediately without restarting kitty