### PR TITLE
fix(settings): escape colorscheme downloadUrl

### DIFF
--- a/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
@@ -521,8 +521,9 @@ Popup {
       var localDir = localPath.substring(0, localPath.lastIndexOf('/'));
 
       downloadScript += "mkdir -p '" + localDir + "'\n";
-      var downloadUrl = file.url || file.download_url;
-      if (downloadUrl) {
+      var rawUrl = file.url || file.download_url;
+      if (rawUrl) {
+        var downloadUrl = encodeURI(rawUrl);
         downloadScript += "curl -L -s -o '" + localPath + "' '" + downloadUrl + "' || wget -q -O '" + localPath + "' '" + downloadUrl + "'\n";
       }
     }


### PR DESCRIPTION
# Pull Request

## Motivation
This simply escapes the urls for curl.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes https://github.com/noctalia-dev/noctalia-shell/issues/2402

## Testing
Tested locally and works fine with curl now.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
