### PR TITLE
GTK refresh fix

### DIFF
--- a/Modules/Panels/Clock/ClockPanel.qml
+++ b/Modules/Panels/Clock/ClockPanel.qml
@@ -25,7 +25,7 @@ SmartPanel {
       x: Style.marginL
       y: Style.marginL
       width: parent.width - Style.margin2L
-      spacing: Style.marginL
+      spacing: Style.marginM
 
       // All clock panel cards
       Repeater {

--- a/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/BluetoothSubTab.qml
@@ -138,7 +138,7 @@ Item {
     id: mainLayout
     anchors.left: parent.left
     anchors.right: parent.right
-    spacing: Style.marginL
+    spacing: root.showOnlyLists ? Style.marginM : Style.marginL
 
     // Master Control Section
     NBox {

--- a/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
@@ -125,7 +125,7 @@ Item {
     id: mainLayout
     anchors.left: parent.left
     anchors.right: parent.right
-    spacing: Style.marginL
+    spacing: root.showOnlyLists ? Style.marginM : Style.marginL
 
     // Master Control Section
     NBox {

--- a/Services/Theming/ColorSchemeService.qml
+++ b/Services/Theming/ColorSchemeService.qml
@@ -22,6 +22,8 @@ Singleton {
   function pushSystemColorScheme() {
     if (!Settings.data.colorSchemes.syncGsettings)
       return;
+    if (TemplateProcessor.isTemplateEnabled("gtk"))
+      return;
     const mode = Settings.data.colorSchemes.darkMode ? "dark" : "light";
     Quickshell.execDetached(["python3", gtkRefreshScript, "--appearance-only", mode]);
   }


### PR DESCRIPTION
1. This fixes the inverted color scheme for GTK apps when changing the Noctalia theme. I've looked through the version history and the reason for #2357 was the `force` variable in `pushSystemColorScheme()`, so this should work now.
2. Some margin corrections for panels.