### PR TITLE
Fix: replace Screen with Quickshell.screens[0] in WallpaperService

### DIFF
--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -808,7 +808,7 @@ Singleton {
     } else {
       // Pick a random wallpaper common to all screens
       // We can use any screenName here, so we just pick the primary one.
-      var wallpaperList = getWallpapersList(Screen.name);
+      var wallpaperList = getWallpapersList(Quickshell.screens[0].name);
       if (wallpaperList.length > 0) {
         var randomPath = _pickUnusedRandom("all", wallpaperList);
         changeWallpaper(randomPath, screen);
@@ -892,13 +892,13 @@ Singleton {
       }
     } else {
       // Pick next alphabetical wallpaper common to all screens
-      var wallpaperList = getWallpapersList(Screen.name);
+      var wallpaperList = getWallpapersList(Quickshell.screens[0].name);
       if (wallpaperList.length > 0) {
         // Use primary screen name as key for single directory mode
         var key = "all";
         if (alphabeticalIndices[key] === undefined) {
           // Find current wallpaper in list to set initial index
-          var currentWallpaper = getWallpaper(Screen.name) || "";
+          var currentWallpaper = getWallpaper(Quickshell.screens[0].name) || "";
           var foundIndex = wallpaperList.indexOf(currentWallpaper);
           alphabeticalIndices[key] = (foundIndex >= 0) ? foundIndex : 0;
         }


### PR DESCRIPTION

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
When display turned off and on compositor recreate screen object but Screen still points to old object which no longer exists. WallpaperService tries to get Screen.name, but it's empty.
`Quickshell.screens[0]` is already used in some parts of WallpaperService.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
https://github.com/quickshell-mirror/quickshell/issues/477

## Testing
1. Enable wallpaper automation
2. Turn off monitor for 1 minute
3. Turn on monitor and wait for wallpaper to change

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Objects after display turned off/on
`Quickshell.screens[0]`:  `QScreen(0x7f9e55944370, name="DP-3"))`
`Screen`: `QQuickScreenAttached(0x7f9e1d24eb30)  name:    model:    mnfrr:    orientation:  0`
