### PR TITLE
fix(calendar): Missing python-dateutil in package.nix

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,7 +10,9 @@
     wlr-randr
     imagemagick
     wget
-    (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
+    (python3.withPackages (
+      pp: lib.optionals calendarSupport [ pp.pygobject3 pp.python-dateutil ]
+    ))
   ],
 
   lib,


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This fixes an issue with calendar-events.py imports dateutil.relativedelta for monthly/yearly recurrence, but python-dateutil isn't in the Python environment, so recurring events silently fail and skip remaining events in that calendar. Tested on NixOS and niri.

#
## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
None.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
None.
