### PR TITLE
Use general reverse scrolling setting for bar

### DIFF
--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -70,7 +70,6 @@
       ]
     },
     "mouseWheelAction": "none",
-    "reverseScroll": false,
     "mouseWheelWrap": true,
     "middleClickAction": "none",
     "middleClickFollowMouse": false,

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -257,7 +257,6 @@ Singleton {
         ]
       }
       property string mouseWheelAction: "none"
-      property bool reverseScroll: false
       property bool mouseWheelWrap: true
       property string middleClickAction: "none"
       property bool middleClickFollowMouse: false

--- a/Modules/Bar/Bar.qml
+++ b/Modules/Bar/Bar.qml
@@ -460,7 +460,7 @@ Item {
             var step = 120;
 
             if (bar.barWheelAction === "volume") {
-              if (Settings.data.bar.reverseScroll)
+              if (Settings.data.general.reverseScroll)
                 delta *= -1;
 
               bar.barWheelAccumulatedDelta += delta;
@@ -482,7 +482,7 @@ Item {
             bar.barWheelAccumulatedDelta += delta;
             if (Math.abs(bar.barWheelAccumulatedDelta) >= step) {
               var direction = bar.barWheelAccumulatedDelta > 0 ? -1 : 1;
-              if (Settings.data.bar.reverseScroll)
+              if (Settings.data.general.reverseScroll)
                 direction *= -1;
               if (bar.barWheelAction === "workspace") {
                 bar.switchWorkspaceByOffset(direction);

--- a/Modules/Panels/Settings/Tabs/Bar/BehaviorSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/BehaviorSubTab.qml
@@ -48,16 +48,6 @@ ColumnLayout {
 
   NToggle {
     Layout.fillWidth: true
-    label: I18n.tr("panels.general.reverse-scrolling-label")
-    description: I18n.tr("panels.general.reverse-scrolling-description")
-    checked: Settings.data.bar.reverseScroll
-    defaultValue: Settings.getDefaultValue("bar.reverseScroll")
-    onToggled: checked => Settings.data.bar.reverseScroll = checked
-    visible: Settings.data.bar.mouseWheelAction !== "none"
-  }
-
-  NToggle {
-    Layout.fillWidth: true
     label: I18n.tr("panels.bar.behavior-wheel-wrap-label")
     description: I18n.tr("panels.bar.behavior-wheel-wrap-description")
     checked: Settings.data.bar.mouseWheelWrap


### PR DESCRIPTION
I don't see a reason why there should be a separate setting for reverse scrolling for the bar. It makes more sense that the scrolling behavior of the workspace widget and the empty areas of the bar are always the same.