### PR TITLE
feat(brightness): change enforce minimum brightness method

### DIFF
--- a/Modules/Cards/BrightnessCard.qml
+++ b/Modules/Cards/BrightnessCard.qml
@@ -57,7 +57,7 @@ NBox {
     running: false
     repeat: false
     onTriggered: {
-      if (brightnessMonitor && Math.abs(localBrightness - brightnessMonitor.brightness) >= 0.01) {
+      if (brightnessMonitor && Math.abs(localBrightness - brightnessMonitor.brightness) > 0.009) {
         brightnessMonitor.setBrightness(localBrightness);
       }
     }

--- a/Modules/Panels/Media/MediaPlayerPanel.qml
+++ b/Modules/Panels/Media/MediaPlayerPanel.qml
@@ -74,7 +74,7 @@ SmartPanel {
     id: playerContent
     anchors.fill: parent
 
-    property real contentPreferredHeight: mainLayout.implicitHeight + Style.margin2L;
+    property real contentPreferredHeight: mainLayout.implicitHeight + Style.margin2L
 
     property Component visualizerSource: {
       switch (root.visualizerType) {

--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -450,7 +450,6 @@ Singleton {
     }
 
     readonly property real stepSize: Settings.data.brightness.brightnessStep / 100.0
-    readonly property real minBrightnessValue: (Settings.data.brightness.enforceMinimum ? 0.01 : 0.0)
 
     // Timer for debouncing rapid changes
     readonly property Timer timer: Timer {
@@ -470,13 +469,7 @@ Singleton {
 
     function increaseBrightness(): void {
       const value = !isNaN(monitor.queuedBrightness) ? monitor.queuedBrightness : monitor.brightness;
-      // Enforce minimum brightness if enabled
-      if (Settings.data.brightness.enforceMinimum && value < minBrightnessValue) {
-        setBrightnessDebounced(Math.max(stepSize, minBrightnessValue));
-      } else {
-        // Normal brightness increase
-        setBrightnessDebounced(value + stepSize);
-      }
+      setBrightnessDebounced(value + stepSize);
     }
 
     function decreaseBrightness(): void {
@@ -485,7 +478,7 @@ Singleton {
     }
 
     function setBrightness(value: real): void {
-      value = Math.max(minBrightnessValue, Math.min(1, value));
+      value = Math.min(1, value);
       var rounded = Math.round(value * 100);
 
       // Always update internal value and trigger UI feedback immediately
@@ -522,11 +515,12 @@ Singleton {
       } else if (!isDdc) {
         monitor.commandRunning = true;
         monitor.ignoreNextChange = true;
+        var setMin = Settings.data.brightness.enforceMinimum ? "-n" : "";
         var backlightDeviceName = root.getBacklightDeviceName(monitor.backlightDevice);
         if (backlightDeviceName !== "") {
-          setBrightnessProc.command = ["brightnessctl", "-d", backlightDeviceName, "s", rounded + "%"];
+          setBrightnessProc.command = ["brightnessctl", "-d", backlightDeviceName, "s", rounded + "%", setMin];
         } else {
-          setBrightnessProc.command = ["brightnessctl", "s", rounded + "%"];
+          setBrightnessProc.command = ["brightnessctl", "s", rounded + "%", setMin];
         }
         setBrightnessProc.running = true;
       }


### PR DESCRIPTION
# Pull Request

## Motivation
Currently noctalia sets the minimum brightness to 1% of the monitors maximum brightness when toggling enforce minimum brightness on. However monitors can go lower than 1% without turning off completely.

With these changes the brightness controls are more similar to how they are on other DE's (KDE as an example).

Instead of using a seperate minimum brightness value that gets used for if statements, I used the built-in option of `brightnessctl`: `-n, --min-value		set minimum brightness, defaults to 1.`

After these changes, you can lower the brightness to 0% with enforce minimum on, this 0% is the literal 1 value.
1% and onwards isn't changed at all. This to me feels more intuitive but can be changed if needed. 

The change to `BrightnessCard.qml` was needed because now it has to account for a change of 0.9... since we can go from 1 to 1%.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
