### PR TITLE
fix(brightness): revert minimum brightness regression

### DIFF
--- a/Services/Hardware/BrightnessService.qml
+++ b/Services/Hardware/BrightnessService.qml
@@ -478,7 +478,7 @@ Singleton {
     }
 
     function setBrightness(value: real): void {
-      value = Math.min(1, value);
+      value = Math.max(0, Math.min(1, value));
       var rounded = Math.round(value * 100);
 
       // Always update internal value and trigger UI feedback immediately


### PR DESCRIPTION
This fixes the small regression https://github.com/noctalia-dev/noctalia-shell/pull/2417 caused.

I tested my changes with only the GUI panels and forgot to test with ipc calls. When using ipc calls you could go below 0% since there were no checks anymore.