### PR TITLE
fix: show ethernet connection in network widget

### DIFF
--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -385,7 +385,6 @@
   "network": {
     "bluetoothRssiPollingEnabled": false,
     "bluetoothRssiPollIntervalMs": 60000,
-    "networkPanelView": "wifi",
     "wifiDetailsViewMode": "grid",
     "bluetoothDetailsViewMode": "grid",
     "bluetoothHideUnnamedDevices": false,

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -611,7 +611,6 @@ Singleton {
     property JsonObject network: JsonObject {
       property bool bluetoothRssiPollingEnabled: false  // Opt-in Bluetooth RSSI polling (uses bluetoothctl)
       property int bluetoothRssiPollIntervalMs: 60000 // Polling interval in milliseconds for RSSI queries
-      property string networkPanelView: "wifi"
       property string wifiDetailsViewMode: "grid"   // "grid" or "list"
       property string bluetoothDetailsViewMode: "grid" // "grid" or "list"
       property bool bluetoothHideUnnamedDevices: false

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -1144,6 +1144,7 @@ SmartPanel {
 
                         NButton {
                           text: I18n.tr("common.disconnect")
+                          visible: VPNService.disconnectingUuid !== modelData.uuid
                           fontSize: Style.fontSizeS
                           backgroundColor: Color.mSurfaceVariant
                           textColor: Color.mOnSurface
@@ -1246,6 +1247,7 @@ SmartPanel {
 
                         NButton {
                           text: I18n.tr("common.connect")
+                          visible: VPNService.connectingUuid !== modelData.uuid
                           fontSize: Style.fontSizeS
                           backgroundColor: Color.mPrimary
                           textColor: Color.mOnPrimary

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -27,13 +27,13 @@ SmartPanel {
   property string panelViewMode: "wifi"
   property bool panelViewPersistEnabled: false
 
-  // Whether VPN configurations exist (tab only shown when true)
-  readonly property bool vpnAvailable: Object.keys(VPNService.connections).length > 0
-
   // If VPN configs vanish while on VPN tab, switch away
-  onVpnAvailableChanged: {
-    if (!vpnAvailable && panelViewMode === "vpn") {
-      panelViewMode = NetworkService.wifiAvailable ? "wifi" : "ethernet";
+  Connections {
+    target: VPNService
+    function onHasConnectionsChanged() {
+      if (!VPNService.hasConnections && root.panelViewMode === "vpn") {
+        root.panelViewMode = NetworkService.wifiAvailable ? "wifi" : "ethernet";
+      }
     }
   }
 
@@ -42,12 +42,12 @@ SmartPanel {
     target: NetworkService
     function onEthernetAvailableChanged() {
       if (!NetworkService.ethernetAvailable && root.panelViewMode === "ethernet") {
-        root.panelViewMode = NetworkService.wifiAvailable ? "wifi" : root.vpnAvailable ? "vpn" : "wifi";
+        root.panelViewMode = NetworkService.wifiAvailable ? "wifi" : VPNService.hasConnections ? "vpn" : "wifi";
       }
     }
     function onWifiAvailableChanged() {
       if (!NetworkService.wifiAvailable && root.panelViewMode === "wifi") {
-        root.panelViewMode = NetworkService.ethernetAvailable ? "ethernet" : root.vpnAvailable ? "vpn" : "ethernet";
+        root.panelViewMode = NetworkService.ethernetAvailable ? "ethernet" : VPNService.hasConnections ? "vpn" : "ethernet";
       }
     }
   }
@@ -171,7 +171,7 @@ SmartPanel {
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
-      if (vpnAvailable) {
+      if (VPNService.hasConnections) {
         VPNService.refresh();
       }
     } else {
@@ -184,10 +184,10 @@ SmartPanel {
       panelViewMode = "wifi";
     } else if (NetworkService.ethernetAvailable) {
       panelViewMode = "ethernet";
-    } else if (vpnAvailable) {
+    } else if (VPNService.hasConnections) {
       panelViewMode = "vpn";
     } else {
-      panelViewMode = "wifi"; // fallback (shows empty/disabled state)
+      panelViewMode = "ethernet"; // fallback
     }
     panelViewPersistEnabled = true;
   }
@@ -302,7 +302,7 @@ SmartPanel {
               let count = 0;
               if (NetworkService.wifiAvailable) count++;
               if (NetworkService.ethernetAvailable) count++;
-              if (root.vpnAvailable) count++;
+              if (VPNService.hasConnections) count++;
               return count > 1;
             }
             margins: Style.marginS
@@ -332,7 +332,7 @@ SmartPanel {
               text: "VPN"
               tabIndex: 2
               checked: modeTabBar.currentIndex === 2
-              visible: root.vpnAvailable
+              visible: VPNService.hasConnections
             }
           }
         }
@@ -1308,42 +1308,6 @@ SmartPanel {
                       }
                     }
                   }
-                }
-              }
-            }
-
-            // VPN empty state
-            NBox {
-              visible: panelViewMode === "vpn" && Object.keys(VPNService.connections).length === 0
-              Layout.fillWidth: true
-              Layout.preferredHeight: emptyVpnColumn.implicitHeight + Style.margin2M
-
-              ColumnLayout {
-                id: emptyVpnColumn
-                anchors.fill: parent
-                anchors.margins: Style.marginM
-                spacing: Style.marginL
-
-                Item {
-                  Layout.fillHeight: true
-                }
-
-                NIcon {
-                  icon: "shield-off"
-                  pointSize: 48
-                  color: Color.mOnSurfaceVariant
-                  Layout.alignment: Qt.AlignHCenter
-                }
-
-                NText {
-                  text: I18n.tr("tooltips.manage-vpn")
-                  pointSize: Style.fontSizeL
-                  color: Color.mOnSurfaceVariant
-                  Layout.alignment: Qt.AlignHCenter
-                }
-
-                Item {
-                  Layout.fillHeight: true
                 }
               }
             }

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -37,12 +37,17 @@ SmartPanel {
     }
   }
 
-  // If Ethernet adapter disappears while on Ethernet tab, switch to WiFi
+  // If an adapter disappears while its tab is active, switch to the best available
   Connections {
     target: NetworkService
     function onEthernetAvailableChanged() {
       if (!NetworkService.ethernetAvailable && root.panelViewMode === "ethernet") {
-        root.panelViewMode = "wifi";
+        root.panelViewMode = NetworkService.wifiAvailable ? "wifi" : root.vpnAvailable ? "vpn" : "wifi";
+      }
+    }
+    function onWifiAvailableChanged() {
+      if (!NetworkService.wifiAvailable && root.panelViewMode === "wifi") {
+        root.panelViewMode = NetworkService.ethernetAvailable ? "ethernet" : root.vpnAvailable ? "vpn" : "ethernet";
       }
     }
   }
@@ -171,10 +176,14 @@ SmartPanel {
   }
 
   onOpened: {
-    if (NetworkService.ethernetAvailable && !NetworkService.wifiEnabled) {
-      panelViewMode = "ethernet";
-    } else {
+    if (NetworkService.wifiAvailable && NetworkService.wifiEnabled) {
       panelViewMode = "wifi";
+    } else if (NetworkService.ethernetAvailable) {
+      panelViewMode = "ethernet";
+    } else if (vpnAvailable) {
+      panelViewMode = "vpn";
+    } else {
+      panelViewMode = "wifi"; // fallback (shows empty/disabled state)
     }
     panelViewPersistEnabled = true;
   }
@@ -307,6 +316,7 @@ SmartPanel {
               text: I18n.tr("common.wifi")
               tabIndex: 0
               checked: modeTabBar.currentIndex === 0
+              visible: NetworkService.wifiAvailable
             }
 
             NTabButton {

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -25,7 +25,6 @@ SmartPanel {
 
   // Unified panel view mode: "wifi" | "ethernet" (persisted)
   property string panelViewMode: "wifi"
-  property bool panelViewPersistEnabled: false
 
   // If VPN configs vanish while on VPN tab, switch away
   Connections {
@@ -133,14 +132,10 @@ SmartPanel {
     } else if (panelViewMode === "vpn") {
       _tabIdx = 2;
     }
-    if (modeTabBar.currentIndex !== _tabIdx) {
+    if (modeTabBar && modeTabBar.currentIndex !== _tabIdx) {
       modeTabBar.currentIndex = _tabIdx;
     }
 
-    // Persist last view (only after restored the initial value)
-    if (panelViewPersistEnabled) {
-      Settings.data.network.networkPanelView = panelViewMode;
-    }
     if (panelViewMode === "wifi") {
       ethernetInfoExpanded = false;
       if (NetworkService.wifiEnabled && !NetworkService.scanningActive) {
@@ -186,10 +181,11 @@ SmartPanel {
       panelViewMode = "ethernet";
     } else if (VPNService.hasConnections) {
       panelViewMode = "vpn";
+    } else if (NetworkService.wifiAvailable) {
+      panelViewMode = "wifi";
     } else {
       panelViewMode = "ethernet"; // fallback
     }
-    panelViewPersistEnabled = true;
   }
 
   panelContent: Rectangle {
@@ -269,6 +265,15 @@ SmartPanel {
               enabled: !NetworkService.airplaneModeEnabled && NetworkService.wifiAvailable
               onToggled: checked => NetworkService.setWifiEnabled(checked)
               baseSize: Style.baseWidgetSize * 0.7 // Slightly smaller
+            }
+
+            NIconButton {
+              icon: "refresh"
+              visible: panelViewMode === "wifi"
+              tooltipText: I18n.tr("common.refresh")
+              baseSize: Style.baseWidgetSize * 0.8
+              enabled: NetworkService.wifiEnabled && !NetworkService.scanningActive
+              onClicked: NetworkService.scan()
             }
 
             NIconButton {

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -18,20 +18,120 @@ SmartPanel {
   preferredHeight: Math.round(500 * Style.uiScaleRatio)
 
   // Info panel collapsed by default, view mode persisted in settings
-  // Ethernet details UI state (mirrors Wi-Fi info behavior)
+  // Ethernet details UI state (mirrors Wi‑Fi info behavior)
   property bool ethernetInfoExpanded: false
   property bool ethernetDetailsGrid: (Settings.data.network.wifiDetailsViewMode === "grid")
   property int ipVersion: 4
 
-  // Unified panel view mode: "wifi" | "ethernet" | "vpn" (persisted)
+  // Unified panel view mode: "wifi" | "ethernet" (persisted)
   property string panelViewMode: "wifi"
   property bool panelViewPersistEnabled: false
 
+  // Whether VPN configurations exist (tab only shown when true)
+  readonly property bool vpnAvailable: Object.keys(VPNService.connections).length > 0
+
+  // If VPN configs vanish while on VPN tab, switch away
+  onVpnAvailableChanged: {
+    if (!vpnAvailable && panelViewMode === "vpn") {
+      panelViewMode = NetworkService.wifiAvailable ? "wifi" : "ethernet";
+    }
+  }
+
+  // If Ethernet adapter disappears while on Ethernet tab, switch to WiFi
+  Connections {
+    target: NetworkService
+    function onEthernetAvailableChanged() {
+      if (!NetworkService.ethernetAvailable && root.panelViewMode === "ethernet") {
+        root.panelViewMode = "wifi";
+      }
+    }
+  }
+
+  // VPN connect toast workaround: VPNService's stdout handler doesn't fire
+  // for WireGuard (and possibly other types) because nmcli doesn't print
+  // "successfully activated". We track the pending connect and watch
+  // VPNService.connections (refreshed every 5s / 1s after connect) for
+  // the UUID becoming active.
+  property string _vpnPendingUuid: ""
+  property string _vpnPendingName: ""
+
+  Connections {
+    target: VPNService
+    function onConnectingUuidChanged() {
+      if (VPNService.connectingUuid) {
+        // A new connect started — capture UUID/name
+        root._vpnPendingUuid = VPNService.connectingUuid;
+        const conn = VPNService.connections[root._vpnPendingUuid];
+        root._vpnPendingName = conn ? conn.name : "";
+        _vpnConnectTimeout.restart();
+      }
+    }
+
+    function onConnectingChanged() {
+      if (!VPNService.connecting && root._vpnPendingUuid) {
+        // connecting went false — check why:
+        const conn = VPNService.connections[root._vpnPendingUuid];
+        if (conn && conn.active) {
+          // VPNService's stdout handler worked (OpenVPN etc.) and already
+          // showed a toast + set active. Just clean up.
+          root._vpnPendingUuid = "";
+          root._vpnPendingName = "";
+          _vpnConnectTimeout.stop();
+        } else if (VPNService.lastError) {
+          // stderr handler fired with an error and already showed a
+          // warning toast. Clean up.
+          root._vpnPendingUuid = "";
+          root._vpnPendingName = "";
+          _vpnConnectTimeout.stop();
+        }
+        // Otherwise (WireGuard success): connecting=false via empty stderr
+        // handler, but active not yet set — keep pending, let
+        // onConnectionsChanged pick it up after the next refresh.
+      }
+    }
+  }
+
+  Connections {
+    target: VPNService
+    function onConnectionsChanged() {
+      if (!root._vpnPendingUuid) return;
+      const conn = VPNService.connections[root._vpnPendingUuid];
+      if (conn && conn.active) {
+        ToastService.showNotice(root._vpnPendingName, I18n.tr("toast.vpn.connected", {
+                                                                  "name": root._vpnPendingName
+                                                                }), "shield-lock");
+        root._vpnPendingUuid = "";
+        root._vpnPendingName = "";
+        _vpnConnectTimeout.stop();
+      }
+    }
+  }
+
+  Timer {
+    id: _vpnConnectTimeout
+    interval: 15000
+    repeat: false
+    onTriggered: {
+      if (root._vpnPendingName) {
+        ToastService.showWarning(root._vpnPendingName, I18n.tr("toast.wifi.connection-timeout"), "shield-off");
+      }
+      root._vpnPendingUuid = "";
+      root._vpnPendingName = "";
+    }
+  }
+
   onPanelViewModeChanged: {
+    // Sync tab bar (imperative – avoids declarative binding being broken by NTabButton clicks)
+    let _tabIdx = 0;
+    if (panelViewMode === "ethernet") _tabIdx = 1;
+    else if (panelViewMode === "vpn") _tabIdx = 2;
+    if (modeTabBar.currentIndex !== _tabIdx)
+      modeTabBar.currentIndex = _tabIdx;
+
+    // Persist last view (only after restored the initial value)
     if (panelViewPersistEnabled) {
       Settings.data.network.networkPanelView = panelViewMode;
     }
-
     if (panelViewMode === "wifi") {
       ethernetInfoExpanded = false;
       if (NetworkService.wifiEnabled && !NetworkService.scanningActive) {
@@ -39,14 +139,17 @@ SmartPanel {
         NetworkService.refreshActiveWifiDetails();
       }
     } else if (panelViewMode === "ethernet") {
+      ethernetInfoExpanded = false;
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
     } else if (panelViewMode === "vpn") {
+      ethernetInfoExpanded = false;
       VPNService.refresh();
     }
   }
 
+  // Effectively visible tracking
   readonly property bool effectivelyVisible: root.visible && Window.window && Window.window.visible
 
   onEffectivelyVisibleChanged: {
@@ -59,23 +162,20 @@ SmartPanel {
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
-      VPNService.refresh();
+      if (vpnAvailable) {
+        VPNService.refresh();
+      }
     } else {
       SystemStatService.unregisterComponent("network-panel");
     }
   }
 
   onOpened: {
-    // Default opening logic:
-    // - If Wi-Fi is actively connected, open Wi-Fi first
-    // - Otherwise always open Ethernet first
-    // VPN is manual-only and should not be auto-selected
-    if (NetworkService.wifiConnected) {
-      panelViewMode = "wifi";
-    } else {
+    if (NetworkService.ethernetAvailable && !NetworkService.wifiEnabled) {
       panelViewMode = "ethernet";
+    } else {
+      panelViewMode = "wifi";
     }
-
     panelViewPersistEnabled = true;
   }
 
@@ -90,6 +190,7 @@ SmartPanel {
       anchors.margins: Style.marginL
       spacing: Style.marginM
 
+      // Header
       NBox {
         Layout.fillWidth: true
         Layout.preferredHeight: header.implicitHeight + Style.margin2M
@@ -103,11 +204,15 @@ SmartPanel {
           RowLayout {
             NIcon {
               id: modeIcon
-              icon: panelViewMode === "wifi"
-                    ? (NetworkService.wifiEnabled ? "wifi" : "wifi-off")
-                    : panelViewMode === "ethernet"
-                      ? (NetworkService.ethernetAvailable ? "ethernet" : "ethernet-off")
-                      : (VPNService.hasActiveConnection ? "shield-lock" : "shield")
+              icon: {
+                if (panelViewMode === "wifi") {
+                  return NetworkService.wifiEnabled ? "wifi" : "wifi-off";
+                } else if (panelViewMode === "ethernet") {
+                  return NetworkService.ethernetAvailable ? "ethernet" : "ethernet-off";
+                } else {
+                  return VPNService.hasActiveConnection ? "shield-lock" : "shield";
+                }
+              }
               pointSize: Style.fontSizeXXL
               color: {
                 if (panelViewMode === "wifi") {
@@ -118,39 +223,29 @@ SmartPanel {
                   return VPNService.hasActiveConnection ? Color.mPrimary : Color.mOnSurfaceVariant;
                 }
               }
-
               MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
-
                 onClicked: {
                   if (panelViewMode === "wifi") {
-                    panelViewMode = "ethernet";
+                    if (NetworkService.ethernetAvailable) {
+                      panelViewMode = "ethernet";
+                    } else {
+                      TooltipService.show(parent, I18n.tr("wifi.panel.no-ethernet-devices"));
+                    }
                   } else if (panelViewMode === "ethernet") {
-                    panelViewMode = "vpn";
+                    panelViewMode = "wifi";
                   } else {
-                    panelViewMode = NetworkService.wifiAvailable ? "wifi" : "ethernet";
+                    panelViewMode = "wifi";
                   }
                 }
-
-                onEntered: TooltipService.show(
-                             parent,
-                             panelViewMode === "wifi"
-                             ? I18n.tr("common.wifi")
-                             : panelViewMode === "ethernet"
-                               ? I18n.tr("common.ethernet")
-                               : "VPN"
-                           )
+                onEntered: TooltipService.show(parent, panelViewMode === "wifi" ? I18n.tr("common.wifi") : panelViewMode === "ethernet" ? I18n.tr("common.ethernet") : "VPN")
                 onExited: TooltipService.hide()
               }
             }
 
             NLabel {
-              label: panelViewMode === "wifi"
-                     ? I18n.tr("common.wifi")
-                     : panelViewMode === "ethernet"
-                       ? I18n.tr("common.ethernet")
-                       : "VPN"
+              label: panelViewMode === "wifi" ? I18n.tr("common.wifi") : panelViewMode === "ethernet" ? I18n.tr("common.ethernet") : "VPN"
               Layout.fillWidth: true
             }
 
@@ -161,6 +256,17 @@ SmartPanel {
               enabled: !NetworkService.airplaneModeEnabled && NetworkService.wifiAvailable
               onToggled: checked => NetworkService.setWifiEnabled(checked)
               baseSize: Style.baseWidgetSize * 0.7
+            }
+
+
+
+            NIconButton {
+              icon: "refresh"
+              visible: panelViewMode === "vpn"
+              tooltipText: I18n.tr("common.refresh")
+              baseSize: Style.baseWidgetSize * 0.8
+              enabled: !VPNService.refreshing
+              onClicked: VPNService.refresh()
             }
 
             NIconButton {
@@ -178,15 +284,21 @@ SmartPanel {
             }
           }
 
+          // Mode switch (Wi‑Fi / Ethernet / VPN)
           NTabBar {
             id: modeTabBar
-            visible: true
+            visible: {
+              let count = 0;
+              if (NetworkService.wifiAvailable) count++;
+              if (NetworkService.ethernetAvailable) count++;
+              if (root.vpnAvailable) count++;
+              return count > 1;
+            }
             margins: Style.marginS
             Layout.fillWidth: true
             spacing: Style.marginM
             distributeEvenly: true
             currentIndex: root.panelViewMode === "wifi" ? 0 : root.panelViewMode === "ethernet" ? 1 : 2
-
             onCurrentIndexChanged: {
               root.panelViewMode = currentIndex === 0 ? "wifi" : currentIndex === 1 ? "ethernet" : "vpn";
             }
@@ -201,23 +313,27 @@ SmartPanel {
               text: I18n.tr("common.ethernet")
               tabIndex: 1
               checked: modeTabBar.currentIndex === 1
+              visible: NetworkService.ethernetAvailable
             }
 
             NTabButton {
               text: "VPN"
               tabIndex: 2
               checked: modeTabBar.currentIndex === 2
+              visible: root.vpnAvailable
             }
           }
         }
       }
 
+      // Unified scrollable content (Wi‑Fi or Ethernet view)
       ColumnLayout {
         id: wifiSectionContainer
         visible: true
         Layout.fillWidth: true
         spacing: Style.marginM
 
+        // Error message
         Rectangle {
           visible: panelViewMode === "wifi" && NetworkService.lastError.length > 0
           Layout.fillWidth: true
@@ -255,43 +371,7 @@ SmartPanel {
           }
         }
 
-        Rectangle {
-          visible: panelViewMode === "vpn" && VPNService.lastError.length > 0
-          Layout.fillWidth: true
-          Layout.preferredHeight: vpnErrorRow.implicitHeight + Style.margin2M
-          color: Qt.alpha(Color.mError, 0.1)
-          radius: Style.radiusS
-          border.width: Style.borderS
-          border.color: Color.mError
-
-          RowLayout {
-            id: vpnErrorRow
-            anchors.fill: parent
-            anchors.margins: Style.marginM
-            spacing: Style.marginS
-
-            NIcon {
-              icon: "warning"
-              pointSize: Style.fontSizeL
-              color: Color.mError
-            }
-
-            NText {
-              text: VPNService.lastError
-              color: Color.mError
-              pointSize: Style.fontSizeS
-              wrapMode: Text.Wrap
-              Layout.fillWidth: true
-            }
-
-            NIconButton {
-              icon: "close"
-              baseSize: Style.baseWidgetSize * 0.6
-              onClicked: VPNService.lastError = ""
-            }
-          }
-        }
-
+        // Unified scrollable content
         NScrollView {
           id: contentScroll
           Layout.fillWidth: true
@@ -306,6 +386,7 @@ SmartPanel {
             width: contentScroll.availableWidth
             spacing: Style.marginM
 
+            // Wi‑Fi disabled state
             NBox {
               id: disabledBox
               visible: panelViewMode === "wifi" && !NetworkService.wifiEnabled
@@ -318,7 +399,9 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
 
                 NIcon {
                   icon: "wifi-off"
@@ -343,10 +426,13 @@ SmartPanel {
                   wrapMode: Text.WordWrap
                 }
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
               }
             }
 
+            // Scanning state (show when no networks and we haven't had any yet)
             NBox {
               id: scanningBox
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && NetworkService.scanningActive
@@ -359,7 +445,9 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
 
                 NBusyIndicator {
                   running: visible && root.effectivelyVisible
@@ -375,10 +463,13 @@ SmartPanel {
                   Layout.alignment: Qt.AlignHCenter
                 }
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
               }
             }
 
+            // Empty state when no networks (only show after we've had networks before, meaning a real empty result)
             NBox {
               id: emptyBox
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && !NetworkService.scanningActive
@@ -391,7 +482,9 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
 
                 NIcon {
                   icon: "wifi-question"
@@ -407,10 +500,13 @@ SmartPanel {
                   Layout.alignment: Qt.AlignHCenter
                 }
 
-                Item { Layout.fillHeight: true }
+                Item {
+                  Layout.fillHeight: true
+                }
               }
             }
 
+            // Networks list container (Wi‑Fi)
             ColumnLayout {
               id: networksList
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length > 0
@@ -422,6 +518,7 @@ SmartPanel {
               }
             }
 
+            // Ethernet view
             NBox {
               id: ethernetSection
               visible: panelViewMode === "ethernet"
@@ -434,20 +531,25 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginM
 
+                // Section label
                 NLabel {
                   label: I18n.tr("wifi.panel.available-interfaces")
                   visible: (NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
                 }
 
+                // Empty state when no Ethernet devices
                 ColumnLayout {
                   id: emptyEthColumn
+
                   Layout.fillWidth: true
                   Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                   Layout.preferredHeight: emptyEthColumn.implicitHeight + Style.margin2M
                   visible: !(NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
                   spacing: Style.marginL
 
-                  Item { Layout.fillHeight: true }
+                  Item {
+                    Layout.fillHeight: true
+                  }
 
                   NIcon {
                     icon: "ethernet-off"
@@ -463,9 +565,12 @@ SmartPanel {
                     Layout.alignment: Qt.AlignHCenter
                   }
 
-                  Item { Layout.fillHeight: true }
+                  Item {
+                    Layout.fillHeight: true
+                  }
                 }
 
+                // Interfaces list
                 ColumnLayout {
                   id: ethIfacesList
                   visible: NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0
@@ -474,7 +579,6 @@ SmartPanel {
 
                   Repeater {
                     model: NetworkService.ethernetInterfaces || []
-
                     delegate: NBox {
                       id: ethItem
 
@@ -500,6 +604,9 @@ SmartPanel {
                         y: Style.marginM
                         spacing: Style.marginS
 
+                        // Main row matching Wi‑Fi card style
+                        // Click handling for the whole header row is provided by a sibling MouseArea
+                        // anchored to this row (defined right after this RowLayout).
                         RowLayout {
                           id: ethHeaderRow
                           Layout.fillWidth: true
@@ -550,6 +657,7 @@ SmartPanel {
                                 color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
                               }
 
+                              // Network speed indicators (visible when connected and speed > 0)
                               RowLayout {
                                 visible: (modelData.connected && NetworkService.networkConnectivity === "full") && (SystemStatService.rxSpeed > 0 || SystemStatService.txSpeed > 0)
                                 spacing: 2
@@ -595,6 +703,7 @@ SmartPanel {
                             }
                           }
 
+                          // Info button on the right
                           NIconButton {
                             icon: "info"
                             tooltipText: I18n.tr("common.info")
@@ -605,7 +714,6 @@ SmartPanel {
                             colorBorderHover: "transparent"
                             enabled: true
                             visible: NetworkService.ethernetConnected
-
                             onClicked: {
                               if (NetworkService.activeEthernetIf === modelData.ifname && ethernetInfoExpanded) {
                                 ethernetInfoExpanded = false;
@@ -621,6 +729,7 @@ SmartPanel {
                           }
                         }
 
+                        // Click handling without anchors in a Layout-managed item
                         TapHandler {
                           target: ethHeaderRow
                           onTapped: {
@@ -637,6 +746,7 @@ SmartPanel {
                           }
                         }
 
+                        // Inline Ethernet details
                         Rectangle {
                           id: ethInfoInline
                           visible: ethernetInfoExpanded && NetworkService.activeEthernetIf === modelData.ifname
@@ -649,6 +759,7 @@ SmartPanel {
                           clip: true
                           Layout.topMargin: Style.marginXS
 
+                          // Grid/List toggle
                           NIconButton {
                             anchors.top: parent.top
                             anchors.right: parent.right
@@ -673,7 +784,6 @@ SmartPanel {
                             columns: ethernetDetailsGrid ? 2 : 1
                             columnSpacing: Style.marginM
                             rowSpacing: Style.marginXS
-
                             onColumnsChanged: {
                               if (ethInfoGrid.forceLayout) {
                                 Qt.callLater(function () {
@@ -682,6 +792,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 1: Interface ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -708,8 +819,11 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
+
+                                // Click-to-copy Ethernet interface name
                                 MouseArea {
                                   anchors.fill: parent
+                                  // Guard against undefined by normalizing to empty strings
                                   enabled: ((NetworkService.activeEthernetDetails.ifname || "").length > 0) || ((NetworkService.activeEthernetIf || "").length > 0)
                                   hoverEnabled: true
                                   cursorShape: Qt.PointingHandCursor
@@ -726,6 +840,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 2: Hardware Address ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -752,6 +867,7 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
+
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: (NetworkService.activeEthernetDetails.hwAddr || "").length > 0
@@ -770,6 +886,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 3: Link speed ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -799,6 +916,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 4: IPv4 || IPv6 ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -829,6 +947,8 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
+
+                                // Click-to-copy Ethernet IP address
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "").length > 0 : (NetworkService.activeEthernetDetails.ipv6 || []).length > 0
@@ -847,6 +967,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 5: DNS ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -877,6 +998,8 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
+
+                                // Click-to-copy Ethernet DNS
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.dns4 || []).length > 0 : (NetworkService.activeEthernetDetails.dns6 || []).length > 0
@@ -895,6 +1018,7 @@ SmartPanel {
                               }
                             }
 
+                            // --- Item 6: Gateway ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -925,6 +1049,8 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
+
+                                // Click-to-copy Ethernet Gateway
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "").length > 0 : (NetworkService.activeEthernetDetails.gateway6 || []).length > 0
@@ -951,63 +1077,80 @@ SmartPanel {
               }
             }
 
-            NBox {
-              id: vpnSection
-              visible: panelViewMode === "vpn"
+            // VPN error message
+            Rectangle {
+              visible: panelViewMode === "vpn" && VPNService.lastError.length > 0
               Layout.fillWidth: true
-              Layout.preferredHeight: vpnColumn.implicitHeight + Style.margin2M
+              Layout.preferredHeight: vpnErrorRow.implicitHeight + Style.margin2M
+              color: Qt.alpha(Color.mError, 0.1)
+              radius: Style.radiusS
+              border.width: Style.borderS
+              border.color: Color.mError
+
+              RowLayout {
+                id: vpnErrorRow
+                anchors.fill: parent
+                anchors.margins: Style.marginM
+                spacing: Style.marginS
+
+                NIcon {
+                  icon: "warning"
+                  pointSize: Style.fontSizeL
+                  color: Color.mError
+                }
+
+                NText {
+                  text: VPNService.lastError
+                  color: Color.mError
+                  pointSize: Style.fontSizeS
+                  wrapMode: Text.Wrap
+                  Layout.fillWidth: true
+                }
+
+                NIconButton {
+                  icon: "close"
+                  baseSize: Style.baseWidgetSize * 0.6
+                  onClicked: VPNService.lastError = ""
+                }
+              }
+            }
+
+            // VPN Connected section
+            NBox {
+              visible: panelViewMode === "vpn" && VPNService.activeConnections.length > 0
+              Layout.fillWidth: true
+              Layout.preferredHeight: vpnConnectedColumn.implicitHeight + Style.margin2M
 
               ColumnLayout {
-                id: vpnColumn
+                id: vpnConnectedColumn
                 anchors.fill: parent
                 anchors.margins: Style.marginM
                 spacing: Style.marginM
 
-                ColumnLayout {
-                  visible: Object.keys(VPNService.connections).length === 0
-                  Layout.fillWidth: true
-                  spacing: Style.marginL
-
-                  NIcon {
-                    icon: "shield"
-                    pointSize: 48
-                    color: Color.mOnSurfaceVariant
-                    Layout.alignment: Qt.AlignHCenter
-                  }
-
-                  NText {
-                    text: "No VPN connections"
-                    pointSize: Style.fontSizeL
-                    color: Color.mOnSurfaceVariant
-                    Layout.alignment: Qt.AlignHCenter
-                  }
+                NLabel {
+                  label: I18n.tr("common.connected")
                 }
 
                 ColumnLayout {
-                  visible: VPNService.activeConnections.length > 0
                   Layout.fillWidth: true
-                  spacing: Style.marginS
-
-                  NLabel {
-                    label: I18n.tr("common.connected")
-                  }
+                  spacing: Style.marginXS
 
                   Repeater {
                     model: VPNService.activeConnections
 
                     delegate: NBox {
-                      id: activeVpnItem
                       Layout.fillWidth: true
-                      implicitHeight: activeVpnRow.implicitHeight + Style.margin2M
-                      radius: Style.radiusL
-                      forceOpaque: true
-                      color: Qt.alpha(Color.mPrimary, 0.18)
+                      Layout.leftMargin: Style.marginXS
+                      Layout.rightMargin: Style.marginXS
+                      implicitHeight: vpnActiveRow.implicitHeight + Style.marginXL
+                      color: Qt.alpha(Color.mPrimary, 0.15)
 
                       RowLayout {
-                        id: activeVpnRow
-                        anchors.fill: parent
-                        anchors.margins: Style.marginM
-                        spacing: Style.marginM
+                        id: vpnActiveRow
+                        width: parent.width - Style.marginXL
+                        x: Style.marginM
+                        y: Style.marginM
+                        spacing: Style.marginS
 
                         NIcon {
                           icon: "shield-lock"
@@ -1022,180 +1165,173 @@ SmartPanel {
 
                           NText {
                             text: modelData.name
-                            pointSize: Style.fontSizeL
-                            font.weight: Style.fontWeightBold
+                            pointSize: Style.fontSizeM
+                            font.weight: Style.fontWeightMedium
                             color: Color.mOnSurface
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                           }
 
                           RowLayout {
-                            spacing: Style.marginS
+                            spacing: Style.marginXS
 
                             NText {
-                              text: "VPN"
-                              pointSize: Style.fontSizeS
+                              text: modelData.type || "vpn"
+                              pointSize: Style.fontSizeXXS
                               color: Color.mOnSurfaceVariant
                             }
 
                             Rectangle {
-                              radius: 999
                               color: Color.mPrimary
-                              implicitHeight: connectedBadgeText.implicitHeight + Style.marginS
-                              implicitWidth: connectedBadgeText.implicitWidth + Style.marginM
+                              radius: height * 0.5
+                              width: Math.round(connectedBadgeText.implicitWidth + Style.marginS * 2)
+                              height: Math.round(connectedBadgeText.implicitHeight + Style.marginXS)
 
                               NText {
                                 id: connectedBadgeText
                                 anchors.centerIn: parent
-                                text: I18n.tr("common.connected")
-                                pointSize: Style.fontSizeS
+                                text: (VPNService.disconnecting && VPNService.disconnectingUuid === modelData.uuid) ? I18n.tr("common.disconnecting") : I18n.tr("common.connected")
+                                pointSize: Style.fontSizeXXS
                                 color: Color.mOnPrimary
                               }
                             }
                           }
                         }
 
-                        RowLayout {
-                          spacing: Style.marginS
-                          Layout.alignment: Qt.AlignVCenter
+                        NBusyIndicator {
+                          visible: VPNService.disconnecting && VPNService.disconnectingUuid === modelData.uuid
+                          running: visible && root.effectivelyVisible
+                          color: Color.mPrimary
+                          size: Style.baseWidgetSize * 0.5
+                        }
 
-                          NBusyIndicator {
-                            visible: VPNService.disconnectingUuid === modelData.uuid
-                            running: visible
-                            color: Color.mPrimary
-                            size: Math.round(Style.baseWidgetSize * 0.55)
-                          }
-
-                          Rectangle {
-                            id: disconnectButton
-                            radius: 999
-                            implicitHeight: disconnectLabel.implicitHeight + Style.marginM
-                            implicitWidth: disconnectLabel.implicitWidth + Style.marginL
-                            color: "transparent"
-                            border.width: Style.borderM
-                            border.color: Color.mError
-                            opacity: (!VPNService.connecting && !VPNService.disconnecting) ? 1.0 : 0.5
-
-                            NText {
-                              id: disconnectLabel
-                              anchors.centerIn: parent
-                              text: VPNService.disconnectingUuid === modelData.uuid
-                                    ? I18n.tr("common.disconnecting")
-                                    : I18n.tr("common.disconnect")
-                              pointSize: Style.fontSizeM
-                              color: Color.mError
-                              font.weight: Style.fontWeightBold
-                            }
-
-                            MouseArea {
-                              anchors.fill: parent
-                              enabled: !VPNService.connecting && !VPNService.disconnecting
-                              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                              onClicked: VPNService.disconnect(modelData.uuid)
-                            }
-                          }
+                        NButton {
+                          text: I18n.tr("common.disconnect")
+                          outlined: !hovered
+                          fontSize: Style.fontSizeS
+                          backgroundColor: Color.mError
+                          enabled: !VPNService.disconnecting
+                          onClicked: VPNService.disconnect(modelData.uuid)
                         }
                       }
                     }
                   }
                 }
+              }
+            }
 
-                ColumnLayout {
-                  visible: VPNService.inactiveConnections.length > 0
-                  Layout.fillWidth: true
-                  spacing: Style.marginS
+            // VPN Available (inactive) section
+            NBox {
+              visible: panelViewMode === "vpn" && VPNService.inactiveConnections.length > 0
+              Layout.fillWidth: true
+              Layout.preferredHeight: vpnAvailableColumn.implicitHeight + Style.margin2M
 
-                  NLabel {
-                    label: I18n.tr("common.disconnected")
-                  }
+              ColumnLayout {
+                id: vpnAvailableColumn
+                anchors.fill: parent
+                anchors.margins: Style.marginM
+                spacing: Style.marginM
 
-                  Repeater {
-                    model: VPNService.inactiveConnections
+                NLabel {
+                  label: I18n.tr("common.disconnected")
+                }
 
-                    delegate: NBox {
-                      id: inactiveVpnItem
-                      Layout.fillWidth: true
-                      implicitHeight: inactiveVpnRow.implicitHeight + Style.margin2M
-                      radius: Style.radiusL
-                      forceOpaque: true
-                      color: Color.mSurface
+                Repeater {
+                  model: VPNService.inactiveConnections
 
-                      RowLayout {
-                        id: inactiveVpnRow
-                        anchors.fill: parent
-                        anchors.margins: Style.marginM
-                        spacing: Style.marginM
+                  delegate: NBox {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Style.marginXS
+                    Layout.rightMargin: Style.marginXS
+                    implicitHeight: vpnInactiveRow.implicitHeight + Style.marginXL
+                    color: Color.mSurface
 
-                        NIcon {
-                          icon: "shield"
-                          pointSize: Style.fontSizeXXL
+                    RowLayout {
+                      id: vpnInactiveRow
+                      width: parent.width - Style.marginXL
+                      x: Style.marginM
+                      y: Style.marginM
+                      spacing: Style.marginS
+
+                      NIcon {
+                        icon: "shield"
+                        pointSize: Style.fontSizeXXL
+                        color: Color.mOnSurface
+                        Layout.alignment: Qt.AlignVCenter
+                      }
+
+                      ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 2
+
+                        NText {
+                          text: modelData.name
+                          pointSize: Style.fontSizeM
+                          font.weight: Style.fontWeightMedium
                           color: Color.mOnSurface
-                          Layout.alignment: Qt.AlignVCenter
-                        }
-
-                        ColumnLayout {
+                          elide: Text.ElideRight
                           Layout.fillWidth: true
-                          spacing: 2
-
-                          NText {
-                            text: modelData.name
-                            pointSize: Style.fontSizeL
-                            font.weight: Style.fontWeightBold
-                            color: Color.mOnSurface
-                            elide: Text.ElideRight
-                            Layout.fillWidth: true
-                          }
-
-                          NText {
-                            text: "VPN"
-                            pointSize: Style.fontSizeS
-                            color: Color.mOnSurfaceVariant
-                          }
                         }
 
-                        RowLayout {
-                          spacing: Style.marginS
-                          Layout.alignment: Qt.AlignVCenter
-
-                          NBusyIndicator {
-                            visible: VPNService.connectingUuid === modelData.uuid
-                            running: visible
-                            color: Color.mPrimary
-                            size: Math.round(Style.baseWidgetSize * 0.55)
-                          }
-
-                          Rectangle {
-                            id: connectButton
-                            radius: 999
-                            implicitHeight: connectLabel.implicitHeight + Style.marginM
-                            implicitWidth: connectLabel.implicitWidth + Style.marginL
-                            color: "transparent"
-                            border.width: Style.borderM
-                            border.color: Color.mPrimary
-                            opacity: (!VPNService.connecting && !VPNService.disconnecting) ? 1.0 : 0.5
-
-                            NText {
-                              id: connectLabel
-                              anchors.centerIn: parent
-                              text: VPNService.connectingUuid === modelData.uuid
-                                    ? I18n.tr("common.connecting")
-                                    : I18n.tr("common.connect")
-                              pointSize: Style.fontSizeM
-                              color: Color.mPrimary
-                              font.weight: Style.fontWeightBold
-                            }
-
-                            MouseArea {
-                              anchors.fill: parent
-                              enabled: !VPNService.connecting && !VPNService.disconnecting
-                              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                              onClicked: VPNService.connect(modelData.uuid)
-                            }
-                          }
+                        NText {
+                          text: modelData.type || "vpn"
+                          pointSize: Style.fontSizeXXS
+                          color: Color.mOnSurfaceVariant
                         }
+                      }
+
+                      NBusyIndicator {
+                        visible: VPNService.connecting && VPNService.connectingUuid === modelData.uuid
+                        running: visible && root.effectivelyVisible
+                        color: Color.mPrimary
+                        size: Style.baseWidgetSize * 0.5
+                      }
+
+                      NButton {
+                        text: (VPNService.connecting && VPNService.connectingUuid === modelData.uuid) ? I18n.tr("common.connecting") : I18n.tr("common.connect")
+                        outlined: !hovered
+                        fontSize: Style.fontSizeS
+                        enabled: !VPNService.connecting
+                        onClicked: VPNService.connect(modelData.uuid)
                       }
                     }
                   }
+                }
+              }
+            }
+
+            // VPN empty state
+            NBox {
+              visible: panelViewMode === "vpn" && Object.keys(VPNService.connections).length === 0
+              Layout.fillWidth: true
+              Layout.preferredHeight: emptyVpnColumn.implicitHeight + Style.margin2M
+
+              ColumnLayout {
+                id: emptyVpnColumn
+                anchors.fill: parent
+                anchors.margins: Style.marginM
+                spacing: Style.marginL
+
+                Item {
+                  Layout.fillHeight: true
+                }
+
+                NIcon {
+                  icon: "shield-off"
+                  pointSize: 48
+                  color: Color.mOnSurfaceVariant
+                  Layout.alignment: Qt.AlignHCenter
+                }
+
+                NText {
+                  text: I18n.tr("tooltips.manage-vpn")
+                  pointSize: Style.fontSizeL
+                  color: Color.mOnSurfaceVariant
+                  Layout.alignment: Qt.AlignHCenter
+                }
+
+                Item {
+                  Layout.fillHeight: true
                 }
               }
             }
@@ -1205,3 +1341,4 @@ SmartPanel {
     }
   }
 }
+

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -238,9 +238,8 @@ SmartPanel {
               if (VPNService.hasConnections) count++;
               return count > 1;
             }
-            margins: Style.marginS
             Layout.fillWidth: true
-            spacing: Style.marginM
+            margins: Style.marginS
             distributeEvenly: true
             currentIndex: (root.panelViewMode === "wifi") ? 0 : (root.panelViewMode === "ethernet") ? 1 : 2
             onCurrentIndexChanged: {
@@ -472,23 +471,26 @@ SmartPanel {
               ColumnLayout {
                 id: ethernetColumn
                 anchors.fill: parent
-                anchors.margins: Style.marginM
+                anchors.topMargin: Style.marginM
+                anchors.bottomMargin: Style.marginM
+                anchors.leftMargin: Style.marginL
+                anchors.rightMargin: Style.marginL
                 spacing: Style.marginM
 
                 // Section label
                 NLabel {
                   label: I18n.tr("wifi.panel.available-interfaces")
-                  visible: (NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
+                  visible: NetworkService.ethernetInterfaces.length > 0
+                  Layout.leftMargin: Style.marginS
                 }
 
                 // Empty state when no Ethernet devices
                 ColumnLayout {
                   id: emptyEthColumn
-
                   Layout.fillWidth: true
                   Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-                  Layout.preferredHeight: emptyEthColumn.implicitHeight + Style.margin2M
-                  visible: !(NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
+                  Layout.preferredHeight: emptyEthColumn.implicitHeight
+                  visible: NetworkService.ethernetInterfaces.length === 0
                   spacing: Style.marginL
 
                   Item {
@@ -515,168 +517,144 @@ SmartPanel {
                 }
 
                 // Interfaces list
-                ColumnLayout {
-                  id: ethIfacesList
-                  visible: NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0
-                  width: parent.width
-                  spacing: Style.marginXS
+                Repeater {
+                  visible: NetworkService.ethernetInterfaces.length > 0
+                  model: NetworkService.ethernetInterfaces
+                  delegate: NBox {
+                    id: ethItem
 
-                  Repeater {
-                    model: NetworkService.ethernetInterfaces || []
-                    delegate: NBox {
-                      id: ethItem
-
-                      function getContentColors(defaultColors = [Color.mSurface, Color.mOnSurface]) {
-                        if (modelData.connected) {
-                          return [Color.mPrimary, Color.mOnPrimary];
-                        }
-                        return defaultColors;
+                    function getContentColors(defaultColors = [Color.mSurface, Color.mOnSurface]) {
+                      if (modelData.connected) {
+                        return [Color.mPrimary, Color.mOnPrimary];
                       }
+                      return defaultColors;
+                    }
 
-                      Layout.fillWidth: true
-                      Layout.leftMargin: Style.marginXS
-                      Layout.rightMargin: Style.marginXS
-                      implicitHeight: ethItemColumn.implicitHeight + Style.margin2M
-                      radius: Style.radiusM
-                      forceOpaque: true
-                      color: ethItem.getContentColors()[0]
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: ethItemColumn.implicitHeight + Style.marginXL
+                    radius: Style.radiusM
+                    clip: true
+                    forceOpaque: true
+                    color: ethItem.getContentColors()[0]
 
-                      ColumnLayout {
-                        id: ethItemColumn
-                        width: parent.width - Style.margin2M
-                        x: Style.marginM
-                        y: Style.marginM
-                        spacing: Style.marginS
+                    ColumnLayout {
+                      id: ethItemColumn
+                      anchors.fill: parent
+                      anchors.margins: Style.marginM
+                      spacing: Style.marginS
 
-                        // Main row matching Wi‑Fi card style
-                        // Click handling for the whole header row is provided by a sibling MouseArea
-                        // anchored to this row (defined right after this RowLayout).
-                        RowLayout {
-                          id: ethHeaderRow
+                      // Main row matching Wi‑Fi card style
+                      // Click handling for the whole header row is provided by a sibling MouseArea
+                      // anchored to this row (defined right after this RowLayout).
+                      RowLayout {
+                        id: ethHeaderRow
+                        Layout.fillWidth: true
+                        spacing: Style.marginM
+                        Layout.alignment: Qt.AlignVCenter
+
+                        NIcon {
+                          Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                          horizontalAlignment: Text.AlignLeft
+                          icon: NetworkService.getIcon(true)
+                          pointSize: Style.fontSizeXXL
+                          color: ethItem.getContentColors()[1]
+                        }
+
+                        ColumnLayout {
                           Layout.fillWidth: true
-                          spacing: Style.marginS
+                          spacing: Style.marginXXS
 
-                          NIcon {
-                            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                            horizontalAlignment: Text.AlignLeft
-                            icon: NetworkService.getIcon(true)
-                            pointSize: Style.fontSizeXXL
+                          NText {
+                            text: modelData.connectionName || modelData.ifname
+                            pointSize: Style.fontSizeM
+                            font.weight: modelData.connected ? Style.fontWeightBold : Style.fontWeightMedium
                             color: ethItem.getContentColors()[1]
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
                           }
 
-                          ColumnLayout {
-                            Layout.fillWidth: true
-                            spacing: 2
+                          RowLayout {
+                            spacing: Style.marginXS
 
                             NText {
-                              text: modelData.connectionName || modelData.ifname
-                              pointSize: Style.fontSizeM
-                              font.weight: modelData.connected ? Style.fontWeightBold : Style.fontWeightMedium
-                              color: ethItem.getContentColors()[1]
-                              elide: Text.ElideRight
-                              Layout.fillWidth: true
+                              text: {
+                                if (modelData.connected) {
+                                  switch (NetworkService.networkConnectivity) {
+                                  case "full":
+                                    return I18n.tr("common.connected");
+                                  case "limited":
+                                  case "unknown":
+                                    return I18n.tr("wifi.panel.internet-limited");
+                                  case "portal":
+                                    return I18n.tr("wifi.panel.action-required");
+                                  default:
+                                    return NetworkService.networkConnectivity;
+                                  }
+                                }
+                                return I18n.tr("common.disconnected");
+                              }
+                              pointSize: Style.fontSizeXXS
+                              color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
                             }
 
+                            // Network speed indicators (visible when connected and speed > 0)
                             RowLayout {
-                              spacing: Style.marginXS
+                              visible: (modelData.connected && NetworkService.networkConnectivity === "full") && (SystemStatService.rxSpeed > 0 || SystemStatService.txSpeed > 0)
+                              spacing: 2
+                              Layout.leftMargin: Style.marginXS
+                              Layout.fillWidth: false
 
-                              NText {
-                                text: {
-                                  if (modelData.connected) {
-                                    switch (NetworkService.networkConnectivity) {
-                                    case "full":
-                                      return I18n.tr("common.connected");
-                                    case "limited":
-                                    case "unknown":
-                                      return I18n.tr("wifi.panel.internet-limited");
-                                    case "portal":
-                                      return I18n.tr("wifi.panel.action-required");
-                                    default:
-                                      return NetworkService.networkConnectivity;
-                                    }
-                                  }
-                                  return I18n.tr("common.disconnected");
-                                }
+                              NIcon {
+                                visible: SystemStatService.rxSpeed > 0
+                                icon: "arrow-down"
                                 pointSize: Style.fontSizeXXS
                                 color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
                               }
 
-                              // Network speed indicators (visible when connected and speed > 0)
-                              RowLayout {
-                                visible: (modelData.connected && NetworkService.networkConnectivity === "full") && (SystemStatService.rxSpeed > 0 || SystemStatService.txSpeed > 0)
-                                spacing: 2
-                                Layout.leftMargin: Style.marginXS
-                                Layout.fillWidth: false
-
-                                NIcon {
-                                  visible: SystemStatService.rxSpeed > 0
-                                  icon: "arrow-down"
-                                  pointSize: Style.fontSizeXXS
-                                  color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
-                                }
-
-                                NText {
-                                  visible: SystemStatService.rxSpeed > 0
-                                  text: SystemStatService.formatSpeed(SystemStatService.rxSpeed)
-                                  pointSize: Style.fontSizeXXS
-                                  color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
-                                  elide: Text.ElideNone
-                                }
-
-                                Item {
-                                  visible: SystemStatService.rxSpeed > 0 && SystemStatService.txSpeed > 0
-                                  width: Style.marginXS
-                                  height: 1
-                                }
-
-                                NIcon {
-                                  visible: SystemStatService.txSpeed > 0
-                                  icon: "arrow-up"
-                                  pointSize: Style.fontSizeXXS
-                                  color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
-                                }
-
-                                NText {
-                                  visible: SystemStatService.txSpeed > 0
-                                  text: SystemStatService.formatSpeed(SystemStatService.txSpeed)
-                                  pointSize: Style.fontSizeXXS
-                                  color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
-                                  elide: Text.ElideNone
-                                }
+                              NText {
+                                visible: SystemStatService.rxSpeed > 0
+                                text: SystemStatService.formatSpeed(SystemStatService.rxSpeed)
+                                pointSize: Style.fontSizeXXS
+                                color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
+                                elide: Text.ElideNone
                               }
-                            }
-                          }
 
-                          // Info button on the right
-                          NIconButton {
-                            icon: "info"
-                            tooltipText: I18n.tr("common.info")
-                            baseSize: Style.baseWidgetSize * 0.75
-                            colorBg: Color.mSurfaceVariant
-                            colorFg: Color.mOnSurface
-                            colorBorder: "transparent"
-                            colorBorderHover: "transparent"
-                            enabled: true
-                            visible: NetworkService.ethernetConnected
-                            onClicked: {
-                              if (NetworkService.activeEthernetIf === modelData.ifname && ethernetInfoExpanded) {
-                                ethernetInfoExpanded = false;
-                                return;
+                              Item {
+                                visible: SystemStatService.rxSpeed > 0 && SystemStatService.txSpeed > 0
+                                width: Style.marginXS
+                                height: 1
                               }
-                              if (NetworkService.activeEthernetIf !== modelData.ifname) {
-                                NetworkService.activeEthernetIf = modelData.ifname;
-                                NetworkService.activeEthernetDetailsTimestamp = 0;
+
+                              NIcon {
+                                visible: SystemStatService.txSpeed > 0
+                                icon: "arrow-up"
+                                pointSize: Style.fontSizeXXS
+                                color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
                               }
-                              ethernetInfoExpanded = true;
-                              NetworkService.refreshActiveEthernetDetails();
+
+                              NText {
+                                visible: SystemStatService.txSpeed > 0
+                                text: SystemStatService.formatSpeed(SystemStatService.txSpeed)
+                                pointSize: Style.fontSizeXXS
+                                color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
+                                elide: Text.ElideNone
+                              }
                             }
                           }
                         }
 
-                        // Click handling without anchors in a Layout-managed item
-                        TapHandler {
-                          target: ethHeaderRow
-                          onTapped: {
+                        // Info button on the right
+                        NIconButton {
+                          icon: "info"
+                          tooltipText: I18n.tr("common.info")
+                          baseSize: Style.baseWidgetSize * 0.75
+                          colorBg: Color.mSurfaceVariant
+                          colorFg: Color.mOnSurface
+                          colorBorder: "transparent"
+                          colorBorderHover: "transparent"
+                          enabled: true
+                          visible: NetworkService.ethernetConnected
+                          onClicked: {
                             if (NetworkService.activeEthernetIf === modelData.ifname && ethernetInfoExpanded) {
                               ethernetInfoExpanded = false;
                               return;
@@ -689,330 +667,348 @@ SmartPanel {
                             NetworkService.refreshActiveEthernetDetails();
                           }
                         }
+                      }
 
-                        // Inline Ethernet details
-                        Rectangle {
-                          id: ethInfoInline
-                          visible: ethernetInfoExpanded && NetworkService.activeEthernetIf === modelData.ifname
-                          Layout.fillWidth: true
-                          color: Color.mSurfaceVariant
-                          radius: Style.radiusXS
-                          border.width: Style.borderS
-                          border.color: Style.boxBorderColor
-                          implicitHeight: ethInfoGrid.implicitHeight + Style.margin2S
-                          clip: true
-                          Layout.topMargin: Style.marginXS
+                      // Click handling without anchors in a Layout-managed item
+                      TapHandler {
+                        target: ethHeaderRow
+                        onTapped: {
+                          if (NetworkService.activeEthernetIf === modelData.ifname && ethernetInfoExpanded) {
+                            ethernetInfoExpanded = false;
+                            return;
+                          }
+                          if (NetworkService.activeEthernetIf !== modelData.ifname) {
+                            NetworkService.activeEthernetIf = modelData.ifname;
+                            NetworkService.activeEthernetDetailsTimestamp = 0;
+                          }
+                          ethernetInfoExpanded = true;
+                          NetworkService.refreshActiveEthernetDetails();
+                        }
+                      }
 
-                          // Grid/List toggle
-                          NIconButton {
-                            anchors.top: parent.top
-                            anchors.right: parent.right
-                            anchors.margins: Style.marginS
-                            icon: ethernetDetailsGrid ? "layout-list" : "layout-grid"
-                            tooltipText: ethernetDetailsGrid ? I18n.tr("tooltips.list-view") : I18n.tr("tooltips.grid-view")
-                            baseSize: Style.baseWidgetSize * 0.65
-                            onClicked: {
-                              ethernetDetailsGrid = !ethernetDetailsGrid;
-                              Settings.data.network.wifiDetailsViewMode = ethernetDetailsGrid ? "grid" : "list";
+                      // Inline Ethernet details
+                      Rectangle {
+                        id: ethInfoInline
+                        visible: ethernetInfoExpanded && NetworkService.activeEthernetIf === modelData.ifname
+                        Layout.fillWidth: true
+                        color: Color.mSurfaceVariant
+                        radius: Style.radiusXS
+                        border.width: Style.borderS
+                        border.color: Style.boxBorderColor
+                        implicitHeight: ethInfoGrid.implicitHeight + Style.margin2S
+                        clip: true
+                        Layout.topMargin: Style.marginXS
+
+                        // Grid/List toggle
+                        NIconButton {
+                          anchors.top: parent.top
+                          anchors.right: parent.right
+                          anchors.margins: Style.marginS
+                          icon: ethernetDetailsGrid ? "layout-list" : "layout-grid"
+                          tooltipText: ethernetDetailsGrid ? I18n.tr("tooltips.list-view") : I18n.tr("tooltips.grid-view")
+                          baseSize: Style.baseWidgetSize * 0.65
+                          onClicked: {
+                            ethernetDetailsGrid = !ethernetDetailsGrid;
+                            Settings.data.network.wifiDetailsViewMode = ethernetDetailsGrid ? "grid" : "list";
+                          }
+                          z: 1
+                        }
+
+                        GridLayout {
+                          id: ethInfoGrid
+                          anchors.fill: parent
+                          anchors.margins: Style.marginS
+                          anchors.rightMargin: Style.baseWidgetSize
+                          flow: ethernetDetailsGrid ? GridLayout.TopToBottom : GridLayout.LeftToRight
+                          rows: ethernetDetailsGrid ? 3 : 6
+                          columns: ethernetDetailsGrid ? 2 : 1
+                          columnSpacing: Style.marginM
+                          rowSpacing: Style.marginXS
+                          onColumnsChanged: {
+                            if (ethInfoGrid.forceLayout) {
+                              Qt.callLater(function () {
+                                ethInfoGrid.forceLayout();
+                              });
                             }
-                            z: 1
                           }
 
-                          GridLayout {
-                            id: ethInfoGrid
-                            anchors.fill: parent
-                            anchors.margins: Style.marginS
-                            anchors.rightMargin: Style.baseWidgetSize
-                            flow: ethernetDetailsGrid ? GridLayout.TopToBottom : GridLayout.LeftToRight
-                            rows: ethernetDetailsGrid ? 3 : 6
-                            columns: ethernetDetailsGrid ? 2 : 1
-                            columnSpacing: Style.marginM
-                            rowSpacing: Style.marginXS
-                            onColumnsChanged: {
-                              if (ethInfoGrid.forceLayout) {
-                                Qt.callLater(function () {
-                                  ethInfoGrid.forceLayout();
-                                });
+                          // --- Item 1: Interface ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "ethernet"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.interface"))
+                                onExited: TooltipService.hide()
                               }
                             }
-
-                            // --- Item 1: Interface ---
-                            RowLayout {
+                            NText {
+                              text: (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "-")
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
                               Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "ethernet"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.interface"))
-                                  onExited: TooltipService.hide()
-                                }
-                              }
-                              NText {
-                                text: (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "-")
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
 
-                                // Click-to-copy Ethernet interface name
-                                MouseArea {
-                                  anchors.fill: parent
-                                  // Guard against undefined by normalizing to empty strings
-                                  enabled: ((NetworkService.activeEthernetDetails.ifname || "").length > 0) || ((NetworkService.activeEthernetIf || "").length > 0)
-                                  hoverEnabled: true
-                                  cursorShape: Qt.PointingHandCursor
-                                  onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    const value = (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "");
-                                    if (value.length > 0) {
-                                      Quickshell.execDetached(["wl-copy", value]);
-                                      ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
-                                    }
-                                  }
-                                }
-                              }
-                            }
-
-                            // --- Item 2: Hardware Address ---
-                            RowLayout {
-                              Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "hash"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, I18n.tr("bluetooth.panel.device-address"))
-                                  onExited: TooltipService.hide()
-                                }
-                              }
-                              NText {
-                                text: NetworkService.activeEthernetDetails.hwAddr || "-"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
-
-                                MouseArea {
-                                  anchors.fill: parent
-                                  enabled: (NetworkService.activeEthernetDetails.hwAddr || "").length > 0
-                                  hoverEnabled: true
-                                  cursorShape: Qt.PointingHandCursor
-                                  onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    const value = NetworkService.activeEthernetDetails.hwAddr || "";
-                                    if (value.length > 0) {
-                                      Quickshell.execDetached(["wl-copy", value]);
-                                      ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
-                                    }
-                                  }
-                                }
-                              }
-                            }
-
-                            // --- Item 3: Link speed ---
-                            RowLayout {
-                              Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "gauge"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.link-speed"))
-                                  onExited: TooltipService.hide()
-                                }
-                              }
-                              NText {
-                                text: (NetworkService.activeEthernetDetails.speed && NetworkService.activeEthernetDetails.speed.length > 0) ? NetworkService.activeEthernetDetails.speed : "-"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
-                              }
-                            }
-
-                            // --- Item 4: IPv4 || IPv6 ---
-                            RowLayout {
-                              Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "network"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    root.ipVersion = root.ipVersion === 4 ? 6 : 4;
-                                    TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"));
-                                  }
-                                }
-                              }
-                              NText {
-                                text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "-") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "-")
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
-
-                                // Click-to-copy Ethernet IP address
-                                MouseArea {
-                                  anchors.fill: parent
-                                  enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "").length > 0 : (NetworkService.activeEthernetDetails.ipv6 || []).length > 0
-                                  hoverEnabled: true
-                                  cursorShape: Qt.PointingHandCursor
-                                  onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "");
-                                    if (value.length > 0) {
-                                      Quickshell.execDetached(["wl-copy", value]);
-                                      ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
-                                    }
-                                  }
-                                }
-                              }
-                            }
-
-                            // --- Item 5: DNS ---
-                            RowLayout {
-                              Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "world"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    root.ipVersion = root.ipVersion === 4 ? 6 : 4;
-                                    TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
-                                  }
-                                }
-                              }
-                              NText {
-                                text: root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "-") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "-")
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
-
-                                // Click-to-copy Ethernet DNS
-                                MouseArea {
-                                  anchors.fill: parent
-                                  enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.dns4 || []).length > 0 : (NetworkService.activeEthernetDetails.dns6 || []).length > 0
-                                  hoverEnabled: true
-                                  cursorShape: Qt.PointingHandCursor
-                                  onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    const value = root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "");
-                                    if (value.length > 0) {
-                                      Quickshell.execDetached(["wl-copy", value]);
-                                      ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
-                                    }
-                                  }
-                                }
-                              }
-                            }
-
-                            // --- Item 6: Gateway ---
-                            RowLayout {
-                              Layout.fillWidth: true
-                              Layout.preferredWidth: 1
-                              spacing: Style.marginXS
-                              NIcon {
-                                icon: "router"
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.alignment: Qt.AlignVCenter
-                                MouseArea {
-                                  anchors.fill: parent
-                                  hoverEnabled: true
-                                  onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    root.ipVersion = root.ipVersion === 4 ? 6 : 4;
-                                    TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
-                                  }
-                                }
-                              }
-                              NText {
-                                text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "-") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "-")
-                                pointSize: Style.fontSizeXS
-                                color: Color.mOnSurface
-                                Layout.fillWidth: true
-                                Layout.alignment: Qt.AlignVCenter
-                                wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
-                                elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
-                                maximumLineCount: ethernetDetailsGrid ? 1 : 6
-                                clip: true
-
-                                // Click-to-copy Ethernet Gateway
-                                MouseArea {
-                                  anchors.fill: parent
-                                  enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "").length > 0 : (NetworkService.activeEthernetDetails.gateway6 || []).length > 0
-                                  hoverEnabled: true
-                                  cursorShape: Qt.PointingHandCursor
-                                  onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
-                                  onExited: TooltipService.hide()
-                                  onClicked: {
-                                    const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "");
-                                    if (value.length > 0) {
-                                      Quickshell.execDetached(["wl-copy", value]);
-                                      ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
-                                    }
+                              // Click-to-copy Ethernet interface name
+                              MouseArea {
+                                anchors.fill: parent
+                                // Guard against undefined by normalizing to empty strings
+                                enabled: ((NetworkService.activeEthernetDetails.ifname || "").length > 0) || ((NetworkService.activeEthernetIf || "").length > 0)
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  const value = (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "");
+                                  if (value.length > 0) {
+                                    Quickshell.execDetached(["wl-copy", value]);
+                                    ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
                                   }
                                 }
                               }
                             }
                           }
+
+                          // --- Item 2: Hardware Address ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "hash"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, I18n.tr("bluetooth.panel.device-address"))
+                                onExited: TooltipService.hide()
+                              }
+                            }
+                            NText {
+                              text: NetworkService.activeEthernetDetails.hwAddr || "-"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.fillWidth: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
+
+                              MouseArea {
+                                anchors.fill: parent
+                                enabled: (NetworkService.activeEthernetDetails.hwAddr || "").length > 0
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  const value = NetworkService.activeEthernetDetails.hwAddr || "";
+                                  if (value.length > 0) {
+                                    Quickshell.execDetached(["wl-copy", value]);
+                                    ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                                  }
+                                }
+                              }
+                            }
+                          }
+
+                          // --- Item 3: Link speed ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "gauge"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.link-speed"))
+                                onExited: TooltipService.hide()
+                              }
+                            }
+                            NText {
+                              text: (NetworkService.activeEthernetDetails.speed && NetworkService.activeEthernetDetails.speed.length > 0) ? NetworkService.activeEthernetDetails.speed : "-"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.fillWidth: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
+                            }
+                          }
+
+                          // --- Item 4: IPv4 || IPv6 ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "network"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                                  TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"));
+                                }
+                              }
+                            }
+                            NText {
+                              text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "-") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "-")
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.fillWidth: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
+
+                              // Click-to-copy Ethernet IP address
+                              MouseArea {
+                                anchors.fill: parent
+                                enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "").length > 0 : (NetworkService.activeEthernetDetails.ipv6 || []).length > 0
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "");
+                                  if (value.length > 0) {
+                                    Quickshell.execDetached(["wl-copy", value]);
+                                    ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                                  }
+                                }
+                              }
+                            }
+                          }
+
+                          // --- Item 5: DNS ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "world"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                                  TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
+                                }
+                              }
+                            }
+                            NText {
+                              text: root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "-") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "-")
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.fillWidth: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
+
+                              // Click-to-copy Ethernet DNS
+                              MouseArea {
+                                anchors.fill: parent
+                                enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.dns4 || []).length > 0 : (NetworkService.activeEthernetDetails.dns6 || []).length > 0
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  const value = root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "");
+                                  if (value.length > 0) {
+                                    Quickshell.execDetached(["wl-copy", value]);
+                                    ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                                  }
+                                }
+                              }
+                            }
+                          }
+
+                          // --- Item 6: Gateway ---
+                          RowLayout {
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 1
+                            spacing: Style.marginXS
+                            NIcon {
+                              icon: "router"
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.alignment: Qt.AlignVCenter
+                              MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                                  TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
+                                }
+                              }
+                            }
+                            NText {
+                              text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "-") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "-")
+                              pointSize: Style.fontSizeXS
+                              color: Color.mOnSurface
+                              Layout.fillWidth: true
+                              Layout.alignment: Qt.AlignVCenter
+                              wrapMode: ethernetDetailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                              elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
+                              maximumLineCount: ethernetDetailsGrid ? 1 : 6
+                              clip: true
+
+                              // Click-to-copy Ethernet Gateway
+                              MouseArea {
+                                anchors.fill: parent
+                                enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "").length > 0 : (NetworkService.activeEthernetDetails.gateway6 || []).length > 0
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                                onExited: TooltipService.hide()
+                                onClicked: {
+                                  const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "");
+                                  if (value.length > 0) {
+                                    Quickshell.execDetached(["wl-copy", value]);
+                                    ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                                  }
+                                }
+                              }
+                            }
+                          }
+
                         }
                       }
                     }
@@ -1068,92 +1064,89 @@ SmartPanel {
               ColumnLayout {
                 id: vpnConnectedColumn
                 anchors.fill: parent
-                anchors.margins: Style.marginM
+                anchors.topMargin: Style.marginM
+                anchors.bottomMargin: Style.marginM
+                anchors.leftMargin: Style.marginL
+                anchors.rightMargin: Style.marginL
                 spacing: Style.marginM
 
                 NLabel {
                   label: I18n.tr("common.connected")
+                  Layout.fillWidth: true
+                  Layout.leftMargin: Style.marginS
                 }
 
-                ColumnLayout {
-                  Layout.fillWidth: true
-                  spacing: Style.marginXS
+                Repeater {
+                  model: VPNService.activeConnections
 
-                  Repeater {
-                    model: VPNService.activeConnections
+                  delegate: NBox {
+                    id: vpnItem
 
-                    delegate: NBox {
-                      Layout.fillWidth: true
-                      Layout.leftMargin: Style.marginXS
-                      Layout.rightMargin: Style.marginXS
-                      implicitHeight: vpnActiveRow.implicitHeight + Style.marginXL
-                      color: Qt.alpha(Color.mPrimary, 0.15)
+                    function getContentColors(defaultColors = [Color.mPrimary, Color.mOnPrimary]) {
+                      if (VPNService.disconnectingUuid === modelData.uuid) {
+                        return [Color.mError, Color.mOnError];
+                      }
+                      return defaultColors;
+                    }
+
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: vpnActiveColumn.implicitHeight + Style.marginXL
+                    radius: Style.radiusM
+                    clip: true
+                    forceOpaque: true
+                    color: vpnItem.getContentColors()[0]
+
+                    ColumnLayout {
+                      id: vpnActiveColumn
+                      anchors.fill: parent
+                      anchors.margins: Style.marginM
+                      spacing: Style.marginS
 
                       RowLayout {
                         id: vpnActiveRow
-                        width: parent.width - Style.marginXL
-                        x: Style.marginM
-                        y: Style.marginM
-                        spacing: Style.marginS
+                        Layout.fillWidth: true
+                        spacing: Style.marginM
+                        Layout.alignment: Qt.AlignVCenter
 
                         NIcon {
                           icon: "shield-lock"
                           pointSize: Style.fontSizeXXL
-                          color: Color.mPrimary
+                          color: vpnItem.getContentColors()[1]
                           Layout.alignment: Qt.AlignVCenter
                         }
 
                         ColumnLayout {
                           Layout.fillWidth: true
-                          spacing: 2
+                          spacing: Style.marginXXS
 
                           NText {
                             text: modelData.name
                             pointSize: Style.fontSizeM
                             font.weight: Style.fontWeightMedium
-                            color: Color.mOnSurface
+                            color: vpnItem.getContentColors()[1]
                             elide: Text.ElideRight
                             Layout.fillWidth: true
                           }
 
-                          RowLayout {
-                            spacing: Style.marginXS
-
-                            NText {
-                              text: modelData.type || "vpn"
-                              pointSize: Style.fontSizeXXS
-                              color: Color.mOnSurfaceVariant
-                            }
-
-                            Rectangle {
-                              color: Color.mPrimary
-                              radius: height * 0.5
-                              width: Math.round(connectedBadgeText.implicitWidth + Style.marginS * 2)
-                              height: Math.round(connectedBadgeText.implicitHeight + Style.marginXS)
-
-                              NText {
-                                id: connectedBadgeText
-                                anchors.centerIn: parent
-                                text: (VPNService.disconnecting && VPNService.disconnectingUuid === modelData.uuid) ? I18n.tr("common.disconnecting") : I18n.tr("common.connected")
-                                pointSize: Style.fontSizeXXS
-                                color: Color.mOnPrimary
-                              }
-                            }
+                          NText {
+                            text: (VPNService.disconnecting && VPNService.disconnectingUuid === modelData.uuid) ? I18n.tr("common.disconnecting") : I18n.tr("common.connected")
+                            pointSize: Style.fontSizeXXS
+                            color: Qt.alpha(vpnItem.getContentColors()[1], Style.opacityHeavy)
                           }
                         }
 
                         NBusyIndicator {
                           visible: VPNService.disconnecting && VPNService.disconnectingUuid === modelData.uuid
                           running: visible && root.effectivelyVisible
-                          color: Color.mPrimary
+                          color: vpnItem.getContentColors()[1]
                           size: Style.baseWidgetSize * 0.5
                         }
 
                         NButton {
                           text: I18n.tr("common.disconnect")
-                          outlined: !hovered
                           fontSize: Style.fontSizeS
-                          backgroundColor: Color.mError
+                          backgroundColor: Color.mSurfaceVariant
+                          textColor: Color.mOnSurface
                           enabled: !VPNService.disconnecting
                           onClicked: VPNService.disconnect(modelData.uuid)
                         }
@@ -1173,70 +1166,92 @@ SmartPanel {
               ColumnLayout {
                 id: vpnAvailableColumn
                 anchors.fill: parent
-                anchors.margins: Style.marginM
+                anchors.topMargin: Style.marginM
+                anchors.bottomMargin: Style.marginM
+                anchors.leftMargin: Style.marginL
+                anchors.rightMargin: Style.marginL
                 spacing: Style.marginM
 
                 NLabel {
                   label: I18n.tr("common.disconnected")
+                  Layout.fillWidth: true
+                  Layout.leftMargin: Style.marginS
                 }
 
                 Repeater {
                   model: VPNService.inactiveConnections
 
                   delegate: NBox {
-                    Layout.fillWidth: true
-                    Layout.leftMargin: Style.marginXS
-                    Layout.rightMargin: Style.marginXS
-                    implicitHeight: vpnInactiveRow.implicitHeight + Style.marginXL
-                    color: Color.mSurface
+                    id: vpnItem
 
-                    RowLayout {
-                      id: vpnInactiveRow
-                      width: parent.width - Style.marginXL
-                      x: Style.marginM
-                      y: Style.marginM
+                    function getContentColors(defaultColors = [Color.mSurface, Color.mOnSurface]) {
+                      if (VPNService.connectingUuid === modelData.uuid) {
+                        return [Color.mPrimary, Color.mOnPrimary];
+                      }
+                      return defaultColors;
+                    }
+
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: vpnInactiveColumn.implicitHeight + Style.marginXL
+                    radius: Style.radiusM
+                    clip: true
+                    forceOpaque: true
+                    color: vpnItem.getContentColors()[0]
+
+                    ColumnLayout {
+                      id: vpnInactiveColumn
+                      anchors.fill: parent
+                      anchors.margins: Style.marginM
                       spacing: Style.marginS
 
-                      NIcon {
-                        icon: "shield"
-                        pointSize: Style.fontSizeXXL
-                        color: Color.mOnSurface
-                        Layout.alignment: Qt.AlignVCenter
-                      }
-
-                      ColumnLayout {
+                      RowLayout {
+                        id: vpnInactiveRow
                         Layout.fillWidth: true
-                        spacing: 2
+                        spacing: Style.marginM
+                        Layout.alignment: Qt.AlignVCenter
 
-                        NText {
-                          text: modelData.name
-                          pointSize: Style.fontSizeM
-                          font.weight: Style.fontWeightMedium
-                          color: Color.mOnSurface
-                          elide: Text.ElideRight
+                        NIcon {
+                          icon: "shield"
+                          pointSize: Style.fontSizeXXL
+                          color: vpnItem.getContentColors()[1]
+                          Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        ColumnLayout {
                           Layout.fillWidth: true
+                          spacing: Style.marginXXS
+
+                          NText {
+                            text: modelData.name
+                            pointSize: Style.fontSizeM
+                            font.weight: Style.fontWeightMedium
+                            color: vpnItem.getContentColors()[1]
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                          }
+
+                          NText {
+                            text: modelData.type || "vpn"
+                            pointSize: Style.fontSizeXXS
+                            color: Qt.alpha(vpnItem.getContentColors()[1], Style.opacityHeavy)
+                          }
                         }
 
-                        NText {
-                          text: modelData.type || "vpn"
-                          pointSize: Style.fontSizeXXS
-                          color: Color.mOnSurfaceVariant
+                        NBusyIndicator {
+                          visible: VPNService.connecting && VPNService.connectingUuid === modelData.uuid
+                          running: visible && root.effectivelyVisible
+                          color: vpnItem.getContentColors()[1]
+                          size: Style.baseWidgetSize * 0.5
                         }
-                      }
 
-                      NBusyIndicator {
-                        visible: VPNService.connecting && VPNService.connectingUuid === modelData.uuid
-                        running: visible && root.effectivelyVisible
-                        color: Color.mPrimary
-                        size: Style.baseWidgetSize * 0.5
-                      }
-
-                      NButton {
-                        text: (VPNService.connecting && VPNService.connectingUuid === modelData.uuid) ? I18n.tr("common.connecting") : I18n.tr("common.connect")
-                        outlined: !hovered
-                        fontSize: Style.fontSizeS
-                        enabled: !VPNService.connecting
-                        onClicked: VPNService.connect(modelData.uuid)
+                        NButton {
+                          text: I18n.tr("common.connect")
+                          fontSize: Style.fontSizeS
+                          backgroundColor: Color.mPrimary
+                          textColor: Color.mOnPrimary
+                          enabled: !VPNService.connecting
+                          onClicked: VPNService.connect(modelData.uuid)
+                        }
                       }
                     }
                   }

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -18,34 +18,35 @@ SmartPanel {
   preferredHeight: Math.round(500 * Style.uiScaleRatio)
 
   // Info panel collapsed by default, view mode persisted in settings
-  // Ethernet details UI state (mirrors Wi‑Fi info behavior)
+  // Ethernet details UI state (mirrors Wi-Fi info behavior)
   property bool ethernetInfoExpanded: false
   property bool ethernetDetailsGrid: (Settings.data.network.wifiDetailsViewMode === "grid")
   property int ipVersion: 4
 
-  // Unified panel view mode: "wifi" | "ethernet" (persisted)
+  // Unified panel view mode: "wifi" | "ethernet" | "vpn" (persisted)
   property string panelViewMode: "wifi"
   property bool panelViewPersistEnabled: false
 
   onPanelViewModeChanged: {
-    // Persist last view (only after restored the initial value)
     if (panelViewPersistEnabled) {
       Settings.data.network.networkPanelView = panelViewMode;
     }
+
     if (panelViewMode === "wifi") {
       ethernetInfoExpanded = false;
       if (NetworkService.wifiEnabled && !NetworkService.scanningActive) {
         NetworkService.scan();
         NetworkService.refreshActiveWifiDetails();
       }
-    } else {
+    } else if (panelViewMode === "ethernet") {
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
+    } else if (panelViewMode === "vpn") {
+      VPNService.refresh();
     }
   }
 
-  // Effectively visible tracking
   readonly property bool effectivelyVisible: root.visible && Window.window && Window.window.visible
 
   onEffectivelyVisibleChanged: {
@@ -58,27 +59,23 @@ SmartPanel {
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
+      VPNService.refresh();
     } else {
       SystemStatService.unregisterComponent("network-panel");
     }
   }
 
   onOpened: {
-    // Restore last view if valid, otherwise choose what's available (prefer Wi‑Fi when both exist)
-    if (Settings.data.network.networkPanelView) {
-      const last = Settings.data.network.networkPanelView;
-      if (last === "ethernet" && NetworkService.ethernetAvailable) {
-        panelViewMode = "ethernet";
-      } else {
-        panelViewMode = "wifi";
-      }
+    // Default opening logic:
+    // - If Wi-Fi is actively connected, open Wi-Fi first
+    // - Otherwise always open Ethernet first
+    // VPN is manual-only and should not be auto-selected
+    if (NetworkService.wifiConnected) {
+      panelViewMode = "wifi";
     } else {
-      if (!NetworkService.wifiEnabled && NetworkService.ethernetAvailable) {
-        panelViewMode = "ethernet";
-      } else {
-        panelViewMode = "wifi";
-      }
+      panelViewMode = "ethernet";
     }
+
     panelViewPersistEnabled = true;
   }
 
@@ -93,7 +90,6 @@ SmartPanel {
       anchors.margins: Style.marginL
       spacing: Style.marginM
 
-      // Header
       NBox {
         Layout.fillWidth: true
         Layout.preferredHeight: header.implicitHeight + Style.margin2M
@@ -107,36 +103,54 @@ SmartPanel {
           RowLayout {
             NIcon {
               id: modeIcon
-              icon: panelViewMode === "wifi" ? (NetworkService.wifiEnabled ? "wifi" : "wifi-off") : (NetworkService.ethernetAvailable ? (NetworkService.ethernetConnected ? "ethernet" : "ethernet") : "ethernet-off")
+              icon: panelViewMode === "wifi"
+                    ? (NetworkService.wifiEnabled ? "wifi" : "wifi-off")
+                    : panelViewMode === "ethernet"
+                      ? (NetworkService.ethernetAvailable ? "ethernet" : "ethernet-off")
+                      : (VPNService.hasActiveConnection ? "shield-lock" : "shield")
               pointSize: Style.fontSizeXXL
               color: {
                 if (panelViewMode === "wifi") {
                   return NetworkService.wifiEnabled ? Color.mPrimary : Color.mOnSurfaceVariant;
-                } else {
+                } else if (panelViewMode === "ethernet") {
                   return NetworkService.ethernetConnected ? Color.mPrimary : Color.mOnSurfaceVariant;
+                } else {
+                  return VPNService.hasActiveConnection ? Color.mPrimary : Color.mOnSurfaceVariant;
                 }
               }
+
               MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
+
                 onClicked: {
                   if (panelViewMode === "wifi") {
-                    if (NetworkService.ethernetAvailable) {
-                      panelViewMode = "ethernet";
-                    } else {
-                      TooltipService.show(parent, I18n.tr("wifi.panel.no-ethernet-devices"));
-                    }
+                    panelViewMode = "ethernet";
+                  } else if (panelViewMode === "ethernet") {
+                    panelViewMode = "vpn";
                   } else {
-                    panelViewMode = "wifi";
+                    panelViewMode = NetworkService.wifiAvailable ? "wifi" : "ethernet";
                   }
                 }
-                onEntered: TooltipService.show(parent, panelViewMode === "wifi" ? I18n.tr("common.wifi") : I18n.tr("common.ethernet"))
+
+                onEntered: TooltipService.show(
+                             parent,
+                             panelViewMode === "wifi"
+                             ? I18n.tr("common.wifi")
+                             : panelViewMode === "ethernet"
+                               ? I18n.tr("common.ethernet")
+                               : "VPN"
+                           )
                 onExited: TooltipService.hide()
               }
             }
 
             NLabel {
-              label: panelViewMode === "wifi" ? I18n.tr("common.wifi") : I18n.tr("common.ethernet")
+              label: panelViewMode === "wifi"
+                     ? I18n.tr("common.wifi")
+                     : panelViewMode === "ethernet"
+                       ? I18n.tr("common.ethernet")
+                       : "VPN"
               Layout.fillWidth: true
             }
 
@@ -146,7 +160,7 @@ SmartPanel {
               checked: NetworkService.wifiEnabled
               enabled: !NetworkService.airplaneModeEnabled && NetworkService.wifiAvailable
               onToggled: checked => NetworkService.setWifiEnabled(checked)
-              baseSize: Style.baseWidgetSize * 0.7 // Slightly smaller
+              baseSize: Style.baseWidgetSize * 0.7
             }
 
             NIconButton {
@@ -164,17 +178,17 @@ SmartPanel {
             }
           }
 
-          // Mode switch (Wi‑Fi / Ethernet)
           NTabBar {
             id: modeTabBar
-            visible: NetworkService.ethernetAvailable && NetworkService.wifiAvailable
+            visible: true
             margins: Style.marginS
             Layout.fillWidth: true
             spacing: Style.marginM
             distributeEvenly: true
-            currentIndex: root.panelViewMode === "wifi" ? 0 : 1
+            currentIndex: root.panelViewMode === "wifi" ? 0 : root.panelViewMode === "ethernet" ? 1 : 2
+
             onCurrentIndexChanged: {
-              root.panelViewMode = (currentIndex === 0) ? "wifi" : "ethernet";
+              root.panelViewMode = currentIndex === 0 ? "wifi" : currentIndex === 1 ? "ethernet" : "vpn";
             }
 
             NTabButton {
@@ -188,18 +202,22 @@ SmartPanel {
               tabIndex: 1
               checked: modeTabBar.currentIndex === 1
             }
+
+            NTabButton {
+              text: "VPN"
+              tabIndex: 2
+              checked: modeTabBar.currentIndex === 2
+            }
           }
         }
       }
 
-      // Unified scrollable content (Wi‑Fi or Ethernet view)
       ColumnLayout {
         id: wifiSectionContainer
         visible: true
         Layout.fillWidth: true
         spacing: Style.marginM
 
-        // Error message
         Rectangle {
           visible: panelViewMode === "wifi" && NetworkService.lastError.length > 0
           Layout.fillWidth: true
@@ -237,7 +255,43 @@ SmartPanel {
           }
         }
 
-        // Unified scrollable content
+        Rectangle {
+          visible: panelViewMode === "vpn" && VPNService.lastError.length > 0
+          Layout.fillWidth: true
+          Layout.preferredHeight: vpnErrorRow.implicitHeight + Style.margin2M
+          color: Qt.alpha(Color.mError, 0.1)
+          radius: Style.radiusS
+          border.width: Style.borderS
+          border.color: Color.mError
+
+          RowLayout {
+            id: vpnErrorRow
+            anchors.fill: parent
+            anchors.margins: Style.marginM
+            spacing: Style.marginS
+
+            NIcon {
+              icon: "warning"
+              pointSize: Style.fontSizeL
+              color: Color.mError
+            }
+
+            NText {
+              text: VPNService.lastError
+              color: Color.mError
+              pointSize: Style.fontSizeS
+              wrapMode: Text.Wrap
+              Layout.fillWidth: true
+            }
+
+            NIconButton {
+              icon: "close"
+              baseSize: Style.baseWidgetSize * 0.6
+              onClicked: VPNService.lastError = ""
+            }
+          }
+        }
+
         NScrollView {
           id: contentScroll
           Layout.fillWidth: true
@@ -252,7 +306,6 @@ SmartPanel {
             width: contentScroll.availableWidth
             spacing: Style.marginM
 
-            // Wi‑Fi disabled state
             NBox {
               id: disabledBox
               visible: panelViewMode === "wifi" && !NetworkService.wifiEnabled
@@ -265,9 +318,7 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
 
                 NIcon {
                   icon: "wifi-off"
@@ -292,13 +343,10 @@ SmartPanel {
                   wrapMode: Text.WordWrap
                 }
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
               }
             }
 
-            // Scanning state (show when no networks and we haven't had any yet)
             NBox {
               id: scanningBox
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && NetworkService.scanningActive
@@ -311,9 +359,7 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
 
                 NBusyIndicator {
                   running: visible && root.effectivelyVisible
@@ -329,13 +375,10 @@ SmartPanel {
                   Layout.alignment: Qt.AlignHCenter
                 }
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
               }
             }
 
-            // Empty state when no networks (only show after we've had networks before, meaning a real empty result)
             NBox {
               id: emptyBox
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length === 0 && !NetworkService.scanningActive
@@ -348,9 +391,7 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginL
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
 
                 NIcon {
                   icon: "wifi-question"
@@ -366,13 +407,10 @@ SmartPanel {
                   Layout.alignment: Qt.AlignHCenter
                 }
 
-                Item {
-                  Layout.fillHeight: true
-                }
+                Item { Layout.fillHeight: true }
               }
             }
 
-            // Networks list container (Wi‑Fi)
             ColumnLayout {
               id: networksList
               visible: panelViewMode === "wifi" && NetworkService.wifiEnabled && Object.keys(NetworkService.networks).length > 0
@@ -384,7 +422,6 @@ SmartPanel {
               }
             }
 
-            // Ethernet view
             NBox {
               id: ethernetSection
               visible: panelViewMode === "ethernet"
@@ -397,25 +434,20 @@ SmartPanel {
                 anchors.margins: Style.marginM
                 spacing: Style.marginM
 
-                // Section label
                 NLabel {
                   label: I18n.tr("wifi.panel.available-interfaces")
                   visible: (NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
                 }
 
-                // Empty state when no Ethernet devices
                 ColumnLayout {
                   id: emptyEthColumn
-
                   Layout.fillWidth: true
                   Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                   Layout.preferredHeight: emptyEthColumn.implicitHeight + Style.margin2M
                   visible: !(NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
                   spacing: Style.marginL
 
-                  Item {
-                    Layout.fillHeight: true
-                  }
+                  Item { Layout.fillHeight: true }
 
                   NIcon {
                     icon: "ethernet-off"
@@ -431,12 +463,9 @@ SmartPanel {
                     Layout.alignment: Qt.AlignHCenter
                   }
 
-                  Item {
-                    Layout.fillHeight: true
-                  }
+                  Item { Layout.fillHeight: true }
                 }
 
-                // Interfaces list
                 ColumnLayout {
                   id: ethIfacesList
                   visible: NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0
@@ -445,6 +474,7 @@ SmartPanel {
 
                   Repeater {
                     model: NetworkService.ethernetInterfaces || []
+
                     delegate: NBox {
                       id: ethItem
 
@@ -470,9 +500,6 @@ SmartPanel {
                         y: Style.marginM
                         spacing: Style.marginS
 
-                        // Main row matching Wi‑Fi card style
-                        // Click handling for the whole header row is provided by a sibling MouseArea
-                        // anchored to this row (defined right after this RowLayout).
                         RowLayout {
                           id: ethHeaderRow
                           Layout.fillWidth: true
@@ -523,7 +550,6 @@ SmartPanel {
                                 color: Qt.alpha(ethItem.getContentColors()[1], Style.opacityHeavy)
                               }
 
-                              // Network speed indicators (visible when connected and speed > 0)
                               RowLayout {
                                 visible: (modelData.connected && NetworkService.networkConnectivity === "full") && (SystemStatService.rxSpeed > 0 || SystemStatService.txSpeed > 0)
                                 spacing: 2
@@ -569,7 +595,6 @@ SmartPanel {
                             }
                           }
 
-                          // Info button on the right
                           NIconButton {
                             icon: "info"
                             tooltipText: I18n.tr("common.info")
@@ -580,6 +605,7 @@ SmartPanel {
                             colorBorderHover: "transparent"
                             enabled: true
                             visible: NetworkService.ethernetConnected
+
                             onClicked: {
                               if (NetworkService.activeEthernetIf === modelData.ifname && ethernetInfoExpanded) {
                                 ethernetInfoExpanded = false;
@@ -595,7 +621,6 @@ SmartPanel {
                           }
                         }
 
-                        // Click handling without anchors in a Layout-managed item
                         TapHandler {
                           target: ethHeaderRow
                           onTapped: {
@@ -612,7 +637,6 @@ SmartPanel {
                           }
                         }
 
-                        // Inline Ethernet details
                         Rectangle {
                           id: ethInfoInline
                           visible: ethernetInfoExpanded && NetworkService.activeEthernetIf === modelData.ifname
@@ -625,7 +649,6 @@ SmartPanel {
                           clip: true
                           Layout.topMargin: Style.marginXS
 
-                          // Grid/List toggle
                           NIconButton {
                             anchors.top: parent.top
                             anchors.right: parent.right
@@ -650,6 +673,7 @@ SmartPanel {
                             columns: ethernetDetailsGrid ? 2 : 1
                             columnSpacing: Style.marginM
                             rowSpacing: Style.marginXS
+
                             onColumnsChanged: {
                               if (ethInfoGrid.forceLayout) {
                                 Qt.callLater(function () {
@@ -658,7 +682,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 1: Interface ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -685,11 +708,8 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
-
-                                // Click-to-copy Ethernet interface name
                                 MouseArea {
                                   anchors.fill: parent
-                                  // Guard against undefined by normalizing to empty strings
                                   enabled: ((NetworkService.activeEthernetDetails.ifname || "").length > 0) || ((NetworkService.activeEthernetIf || "").length > 0)
                                   hoverEnabled: true
                                   cursorShape: Qt.PointingHandCursor
@@ -706,7 +726,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 2: Hardware Address ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -733,7 +752,6 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
-
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: (NetworkService.activeEthernetDetails.hwAddr || "").length > 0
@@ -752,7 +770,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 3: Link speed ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -782,7 +799,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 4: IPv4 || IPv6 ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -813,8 +829,6 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
-
-                                // Click-to-copy Ethernet IP address
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "").length > 0 : (NetworkService.activeEthernetDetails.ipv6 || []).length > 0
@@ -833,7 +847,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 5: DNS ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -864,8 +877,6 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
-
-                                // Click-to-copy Ethernet DNS
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.dns4 || []).length > 0 : (NetworkService.activeEthernetDetails.dns6 || []).length > 0
@@ -884,7 +895,6 @@ SmartPanel {
                               }
                             }
 
-                            // --- Item 6: Gateway ---
                             RowLayout {
                               Layout.fillWidth: true
                               Layout.preferredWidth: 1
@@ -915,8 +925,6 @@ SmartPanel {
                                 elide: ethernetDetailsGrid ? Text.ElideRight : Text.ElideNone
                                 maximumLineCount: ethernetDetailsGrid ? 1 : 6
                                 clip: true
-
-                                // Click-to-copy Ethernet Gateway
                                 MouseArea {
                                   anchors.fill: parent
                                   enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "").length > 0 : (NetworkService.activeEthernetDetails.gateway6 || []).length > 0
@@ -933,6 +941,255 @@ SmartPanel {
                                   }
                                 }
                               }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            NBox {
+              id: vpnSection
+              visible: panelViewMode === "vpn"
+              Layout.fillWidth: true
+              Layout.preferredHeight: vpnColumn.implicitHeight + Style.margin2M
+
+              ColumnLayout {
+                id: vpnColumn
+                anchors.fill: parent
+                anchors.margins: Style.marginM
+                spacing: Style.marginM
+
+                ColumnLayout {
+                  visible: Object.keys(VPNService.connections).length === 0
+                  Layout.fillWidth: true
+                  spacing: Style.marginL
+
+                  NIcon {
+                    icon: "shield"
+                    pointSize: 48
+                    color: Color.mOnSurfaceVariant
+                    Layout.alignment: Qt.AlignHCenter
+                  }
+
+                  NText {
+                    text: "No VPN connections"
+                    pointSize: Style.fontSizeL
+                    color: Color.mOnSurfaceVariant
+                    Layout.alignment: Qt.AlignHCenter
+                  }
+                }
+
+                ColumnLayout {
+                  visible: VPNService.activeConnections.length > 0
+                  Layout.fillWidth: true
+                  spacing: Style.marginS
+
+                  NLabel {
+                    label: I18n.tr("common.connected")
+                  }
+
+                  Repeater {
+                    model: VPNService.activeConnections
+
+                    delegate: NBox {
+                      id: activeVpnItem
+                      Layout.fillWidth: true
+                      implicitHeight: activeVpnRow.implicitHeight + Style.margin2M
+                      radius: Style.radiusL
+                      forceOpaque: true
+                      color: Qt.alpha(Color.mPrimary, 0.18)
+
+                      RowLayout {
+                        id: activeVpnRow
+                        anchors.fill: parent
+                        anchors.margins: Style.marginM
+                        spacing: Style.marginM
+
+                        NIcon {
+                          icon: "shield-lock"
+                          pointSize: Style.fontSizeXXL
+                          color: Color.mPrimary
+                          Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        ColumnLayout {
+                          Layout.fillWidth: true
+                          spacing: 2
+
+                          NText {
+                            text: modelData.name
+                            pointSize: Style.fontSizeL
+                            font.weight: Style.fontWeightBold
+                            color: Color.mOnSurface
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                          }
+
+                          RowLayout {
+                            spacing: Style.marginS
+
+                            NText {
+                              text: "VPN"
+                              pointSize: Style.fontSizeS
+                              color: Color.mOnSurfaceVariant
+                            }
+
+                            Rectangle {
+                              radius: 999
+                              color: Color.mPrimary
+                              implicitHeight: connectedBadgeText.implicitHeight + Style.marginS
+                              implicitWidth: connectedBadgeText.implicitWidth + Style.marginM
+
+                              NText {
+                                id: connectedBadgeText
+                                anchors.centerIn: parent
+                                text: I18n.tr("common.connected")
+                                pointSize: Style.fontSizeS
+                                color: Color.mOnPrimary
+                              }
+                            }
+                          }
+                        }
+
+                        RowLayout {
+                          spacing: Style.marginS
+                          Layout.alignment: Qt.AlignVCenter
+
+                          NBusyIndicator {
+                            visible: VPNService.disconnectingUuid === modelData.uuid
+                            running: visible
+                            color: Color.mPrimary
+                            size: Math.round(Style.baseWidgetSize * 0.55)
+                          }
+
+                          Rectangle {
+                            id: disconnectButton
+                            radius: 999
+                            implicitHeight: disconnectLabel.implicitHeight + Style.marginM
+                            implicitWidth: disconnectLabel.implicitWidth + Style.marginL
+                            color: "transparent"
+                            border.width: Style.borderM
+                            border.color: Color.mError
+                            opacity: (!VPNService.connecting && !VPNService.disconnecting) ? 1.0 : 0.5
+
+                            NText {
+                              id: disconnectLabel
+                              anchors.centerIn: parent
+                              text: VPNService.disconnectingUuid === modelData.uuid
+                                    ? I18n.tr("common.disconnecting")
+                                    : I18n.tr("common.disconnect")
+                              pointSize: Style.fontSizeM
+                              color: Color.mError
+                              font.weight: Style.fontWeightBold
+                            }
+
+                            MouseArea {
+                              anchors.fill: parent
+                              enabled: !VPNService.connecting && !VPNService.disconnecting
+                              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                              onClicked: VPNService.disconnect(modelData.uuid)
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                ColumnLayout {
+                  visible: VPNService.inactiveConnections.length > 0
+                  Layout.fillWidth: true
+                  spacing: Style.marginS
+
+                  NLabel {
+                    label: I18n.tr("common.disconnected")
+                  }
+
+                  Repeater {
+                    model: VPNService.inactiveConnections
+
+                    delegate: NBox {
+                      id: inactiveVpnItem
+                      Layout.fillWidth: true
+                      implicitHeight: inactiveVpnRow.implicitHeight + Style.margin2M
+                      radius: Style.radiusL
+                      forceOpaque: true
+                      color: Color.mSurface
+
+                      RowLayout {
+                        id: inactiveVpnRow
+                        anchors.fill: parent
+                        anchors.margins: Style.marginM
+                        spacing: Style.marginM
+
+                        NIcon {
+                          icon: "shield"
+                          pointSize: Style.fontSizeXXL
+                          color: Color.mOnSurface
+                          Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        ColumnLayout {
+                          Layout.fillWidth: true
+                          spacing: 2
+
+                          NText {
+                            text: modelData.name
+                            pointSize: Style.fontSizeL
+                            font.weight: Style.fontWeightBold
+                            color: Color.mOnSurface
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                          }
+
+                          NText {
+                            text: "VPN"
+                            pointSize: Style.fontSizeS
+                            color: Color.mOnSurfaceVariant
+                          }
+                        }
+
+                        RowLayout {
+                          spacing: Style.marginS
+                          Layout.alignment: Qt.AlignVCenter
+
+                          NBusyIndicator {
+                            visible: VPNService.connectingUuid === modelData.uuid
+                            running: visible
+                            color: Color.mPrimary
+                            size: Math.round(Style.baseWidgetSize * 0.55)
+                          }
+
+                          Rectangle {
+                            id: connectButton
+                            radius: 999
+                            implicitHeight: connectLabel.implicitHeight + Style.marginM
+                            implicitWidth: connectLabel.implicitWidth + Style.marginL
+                            color: "transparent"
+                            border.width: Style.borderM
+                            border.color: Color.mPrimary
+                            opacity: (!VPNService.connecting && !VPNService.disconnecting) ? 1.0 : 0.5
+
+                            NText {
+                              id: connectLabel
+                              anchors.centerIn: parent
+                              text: VPNService.connectingUuid === modelData.uuid
+                                    ? I18n.tr("common.connecting")
+                                    : I18n.tr("common.connect")
+                              pointSize: Style.fontSizeM
+                              color: Color.mPrimary
+                              font.weight: Style.fontWeightBold
+                            }
+
+                            MouseArea {
+                              anchors.fill: parent
+                              enabled: !VPNService.connecting && !VPNService.disconnecting
+                              cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                              onClicked: VPNService.connect(modelData.uuid)
                             }
                           }
                         }

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -17,14 +17,15 @@ SmartPanel {
   preferredWidth: Math.round(440 * Style.uiScaleRatio)
   preferredHeight: Math.round(500 * Style.uiScaleRatio)
 
-  // Info panel collapsed by default, view mode persisted in settings
   // Ethernet details UI state (mirrors Wi‑Fi info behavior)
   property bool ethernetInfoExpanded: false
   property bool ethernetDetailsGrid: (Settings.data.network.wifiDetailsViewMode === "grid")
   property int ipVersion: 4
 
-  // Unified panel view mode: "wifi" | "ethernet" (persisted)
+  // Panel view mode: "wifi" | "ethernet" | "vpn" (chosen dynamically on open)
   property string panelViewMode: "wifi"
+  // Reference set by modeTabBar after creation (avoids ReferenceError in onPanelViewModeChanged)
+  property var _modeTabBar: null
 
   // If VPN configs vanish while on VPN tab, switch away
   Connections {
@@ -51,79 +52,6 @@ SmartPanel {
     }
   }
 
-  // VPN connect toast workaround: VPNService's stdout handler doesn't fire
-  // for WireGuard (and possibly other types) because nmcli doesn't print
-  // "successfully activated". We track the pending connect and watch
-  // VPNService.connections (refreshed every 5s / 1s after connect) for
-  // the UUID becoming active.
-  property string _vpnPendingUuid: ""
-  property string _vpnPendingName: ""
-
-  Connections {
-    target: VPNService
-    function onConnectingUuidChanged() {
-      if (VPNService.connectingUuid) {
-        // A new connect started — capture UUID/name
-        root._vpnPendingUuid = VPNService.connectingUuid;
-        const conn = VPNService.connections[root._vpnPendingUuid];
-        root._vpnPendingName = conn ? conn.name : "";
-        _vpnConnectTimeout.restart();
-      }
-    }
-
-    function onConnectingChanged() {
-      if (!VPNService.connecting && root._vpnPendingUuid) {
-        // connecting went false — check why:
-        const conn = VPNService.connections[root._vpnPendingUuid];
-        if (conn && conn.active) {
-          // VPNService's stdout handler worked (OpenVPN etc.) and already
-          // showed a toast + set active. Just clean up.
-          root._vpnPendingUuid = "";
-          root._vpnPendingName = "";
-          _vpnConnectTimeout.stop();
-        } else if (VPNService.lastError) {
-          // stderr handler fired with an error and already showed a
-          // warning toast. Clean up.
-          root._vpnPendingUuid = "";
-          root._vpnPendingName = "";
-          _vpnConnectTimeout.stop();
-        }
-        // Otherwise (WireGuard success): connecting=false via empty stderr
-        // handler, but active not yet set — keep pending, let
-        // onConnectionsChanged pick it up after the next refresh.
-      }
-    }
-  }
-
-  Connections {
-    target: VPNService
-    function onConnectionsChanged() {
-      if (!root._vpnPendingUuid) return;
-      const conn = VPNService.connections[root._vpnPendingUuid];
-      if (conn && conn.active) {
-        ToastService.showNotice(root._vpnPendingName, I18n.tr("toast.vpn.connected", {
-                                                                  "name": root._vpnPendingName
-                                                                }), "shield-lock");
-        root._vpnPendingUuid = "";
-        root._vpnPendingName = "";
-        _vpnConnectTimeout.stop();
-      }
-    }
-  }
-
-  Timer {
-    id: _vpnConnectTimeout
-    interval: 15000
-    repeat: false
-    onTriggered: {
-      if (root._vpnPendingName) {
-        ToastService.showWarning(root._vpnPendingName, I18n.tr("toast.wifi.connection-timeout"), "shield-off");
-      }
-      root._vpnPendingUuid = "";
-      root._vpnPendingName = "";
-    }
-  }
-
   onPanelViewModeChanged: {
     // Sync tab bar (imperative – avoids declarative binding being broken by NTabButton clicks)
     let _tabIdx = 0;
@@ -132,23 +60,22 @@ SmartPanel {
     } else if (panelViewMode === "vpn") {
       _tabIdx = 2;
     }
-    if (modeTabBar && modeTabBar.currentIndex !== _tabIdx) {
-      modeTabBar.currentIndex = _tabIdx;
+    if (_modeTabBar && _modeTabBar.currentIndex !== _tabIdx) {
+      _modeTabBar.currentIndex = _tabIdx;
     }
 
+    ethernetInfoExpanded = false;
+
     if (panelViewMode === "wifi") {
-      ethernetInfoExpanded = false;
       if (NetworkService.wifiEnabled && !NetworkService.scanningActive) {
         NetworkService.scan();
         NetworkService.refreshActiveWifiDetails();
       }
     } else if (panelViewMode === "ethernet") {
-      ethernetInfoExpanded = false;
       if (NetworkService.ethernetConnected) {
         NetworkService.refreshActiveEthernetDetails();
       }
     } else if (panelViewMode === "vpn") {
-      ethernetInfoExpanded = false;
       VPNService.refresh();
     }
   }
@@ -303,6 +230,7 @@ SmartPanel {
           // Mode switch (Wi‑Fi / Ethernet / VPN)
           NTabBar {
             id: modeTabBar
+            Component.onCompleted: root._modeTabBar = modeTabBar
             visible: {
               let count = 0;
               if (NetworkService.wifiAvailable) count++;
@@ -346,7 +274,6 @@ SmartPanel {
       // Unified scrollable content (Wi‑Fi or Ethernet view)
       ColumnLayout {
         id: wifiSectionContainer
-        visible: true
         Layout.fillWidth: true
         spacing: Style.marginM
 

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -128,10 +128,14 @@ SmartPanel {
   onPanelViewModeChanged: {
     // Sync tab bar (imperative – avoids declarative binding being broken by NTabButton clicks)
     let _tabIdx = 0;
-    if (panelViewMode === "ethernet") _tabIdx = 1;
-    else if (panelViewMode === "vpn") _tabIdx = 2;
-    if (modeTabBar.currentIndex !== _tabIdx)
+    if (panelViewMode === "ethernet") {
+      _tabIdx = 1;
+    } else if (panelViewMode === "vpn") {
+      _tabIdx = 2;
+    }
+    if (modeTabBar.currentIndex !== _tabIdx) {
       modeTabBar.currentIndex = _tabIdx;
+    }
 
     // Persist last view (only after restored the initial value)
     if (panelViewPersistEnabled) {
@@ -264,10 +268,8 @@ SmartPanel {
               checked: NetworkService.wifiEnabled
               enabled: !NetworkService.airplaneModeEnabled && NetworkService.wifiAvailable
               onToggled: checked => NetworkService.setWifiEnabled(checked)
-              baseSize: Style.baseWidgetSize * 0.7
+              baseSize: Style.baseWidgetSize * 0.7 // Slightly smaller
             }
-
-
 
             NIconButton {
               icon: "refresh"
@@ -307,9 +309,9 @@ SmartPanel {
             Layout.fillWidth: true
             spacing: Style.marginM
             distributeEvenly: true
-            currentIndex: root.panelViewMode === "wifi" ? 0 : root.panelViewMode === "ethernet" ? 1 : 2
+            currentIndex: (root.panelViewMode === "wifi") ? 0 : (root.panelViewMode === "ethernet") ? 1 : 2
             onCurrentIndexChanged: {
-              root.panelViewMode = currentIndex === 0 ? "wifi" : currentIndex === 1 ? "ethernet" : "vpn";
+              root.panelViewMode = (currentIndex === 0) ? "wifi" : (currentIndex === 1) ? "ethernet" : "vpn";
             }
 
             NTabButton {

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -697,12 +697,19 @@ Singleton {
           newActiveWifiDetails.signal = signal;
         }
 
+        let wifiWasAvailable = root._wifiAvailable;
         root._wifiAvailable = wifiAvailable;
         root._ethernetAvailable = ethernetAvailable;
         root.ethernetConnected = (activeEthIf !== "");
         root.wifiConnected = (activeWifiIf !== "");
 
         Logger.d("Network", "Device sync: wifiAvailable: " + wifiAvailable + ", ethAvailable: " + ethernetAvailable + ", wifiConnected: " + root.wifiConnected + " (" + activeWifiIf + "), ethConnected: " + root.ethernetConnected + " (" + activeEthIf + ")");
+
+        // Adapter (re-)appeared: trigger a scan so the network list populates
+        if (wifiAvailable && !wifiWasAvailable && root.wifiEnabled && !root.scanningActive) {
+          delayedScanTimer.interval = 2000;
+          delayedScanTimer.restart();
+        }
 
         ethList.sort((a, b) => (a.connected !== b.connected) ? (a.connected ? -1 : 1) : a.ifname.localeCompare(b.ifname));
         root.ethernetInterfaces = ethList;
@@ -1151,11 +1158,26 @@ Singleton {
     stdout: SplitParser {
       onRead: data => {
         if (data.endsWith(": connected") || data.endsWith(": disconnected")) {
+          // High-priority state changes: refresh immediately
           Logger.d("Network", "State changed: " + data);
+          _monitorDebounce.stop();
           deviceStatusProcess.running = true;
           connectivityCheckProcess.running = true;
+        } else if (data.endsWith(": unavailable") || data.endsWith(": unmanaged") || data.indexOf(": device removed") !== -1 || data.indexOf(": device created") !== -1) {
+          // Adapter added/removed: debounce to avoid rapid-fire refreshes
+          Logger.d("Network", "Device event: " + data);
+          _monitorDebounce.restart();
         }
       }
+    }
+  }
+
+  Timer {
+    id: _monitorDebounce
+    interval: 500
+    repeat: false
+    onTriggered: {
+      deviceStatusProcess.running = true;
     }
   }
 }

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -1158,26 +1158,14 @@ Singleton {
     stdout: SplitParser {
       onRead: data => {
         if (data.endsWith(": connected") || data.endsWith(": disconnected")) {
-          // High-priority state changes: refresh immediately
           Logger.d("Network", "State changed: " + data);
-          _monitorDebounce.stop();
           deviceStatusProcess.running = true;
           connectivityCheckProcess.running = true;
-        } else if (data.endsWith(": unavailable") || data.endsWith(": unmanaged") || data.indexOf(": device removed") !== -1 || data.indexOf(": device created") !== -1) {
-          // Adapter added/removed: debounce to avoid rapid-fire refreshes
+        } else if (data.endsWith(": unavailable") || data.indexOf(": device removed") !== -1 || data.indexOf(": device created") !== -1) {
           Logger.d("Network", "Device event: " + data);
-          _monitorDebounce.restart();
+          deviceStatusProcess.running = true;
         }
       }
-    }
-  }
-
-  Timer {
-    id: _monitorDebounce
-    interval: 500
-    repeat: false
-    onTriggered: {
-      deviceStatusProcess.running = true;
     }
   }
 }

--- a/Services/Networking/VPNService.qml
+++ b/Services/Networking/VPNService.qml
@@ -88,6 +88,7 @@ Singleton {
     lastError = "";
     connectProcess.uuid = uuid;
     connectProcess.name = conn.name;
+    connectProcess._stderrText = "";
     connectProcess.running = true;
   }
 
@@ -104,6 +105,7 @@ Singleton {
     lastError = "";
     disconnectProcess.uuid = uuid;
     disconnectProcess.name = conn.name;
+    disconnectProcess._stderrText = "";
     disconnectProcess.running = true;
   }
 
@@ -177,6 +179,7 @@ Singleton {
           map[uuid] = {
             "uuid": uuid,
             "name": name,
+            "type": type,
             "device": device,
             "active": active
           };
@@ -211,39 +214,38 @@ Singleton {
     id: connectProcess
     property string uuid: ""
     property string name: ""
+    property string _stderrText: ""
     running: false
     command: ["nmcli", "connection", "up", "uuid", uuid]
 
-    stdout: StdioCollector {
-      onStreamFinished: {
-        const output = text.trim();
-        if (!output || (!output.includes("successfully activated") && !output.includes("Connection successfully"))) {
-          return;
-        }
+    onExited: function (exitCode) {
+      if (exitCode === 0) {
         setConnection(connectProcess.uuid, {
                         "active": true
                       });
-        connecting = false;
-        connectingUuid = "";
         lastError = "";
         Logger.i("VPN", "Connected to " + connectProcess.name);
         ToastService.showNotice(connectProcess.name, I18n.tr("toast.vpn.connected", {
-                                                               "name": connectProcess.name
-                                                             }), "shield-lock");
+                                                                "name": connectProcess.name
+                                                              }), "shield-lock");
         scheduleRefresh(1000);
+      } else {
+        const errText = connectProcess._stderrText.trim();
+        if (errText) {
+          lastError = errText.split("\n")[0].trim();
+        } else {
+          lastError = "Connection failed (exit code " + exitCode + ")";
+        }
+        Logger.w("VPN", "Connect error (exit " + exitCode + "): " + lastError);
+        ToastService.showWarning(connectProcess.name, lastError);
       }
+      connecting = false;
+      connectingUuid = "";
     }
 
     stderr: StdioCollector {
       onStreamFinished: {
-        const trimmed = text.trim();
-        if (trimmed) {
-          lastError = trimmed.split("\n")[0].trim();
-          Logger.w("VPN", "Connect error: " + trimmed);
-          ToastService.showWarning(connectProcess.name, lastError);
-        }
-        connecting = false;
-        connectingUuid = "";
+        connectProcess._stderrText = text;
       }
     }
   }
@@ -252,36 +254,39 @@ Singleton {
     id: disconnectProcess
     property string uuid: ""
     property string name: ""
+    property string _stderrText: ""
     running: false
     command: ["nmcli", "connection", "down", "uuid", uuid]
 
-    stdout: StdioCollector {
-      onStreamFinished: {
+    onExited: function (exitCode) {
+      if (exitCode === 0) {
         Logger.i("VPN", "Disconnected from " + disconnectProcess.name);
         setConnection(disconnectProcess.uuid, {
                         "active": false,
                         "device": ""
                       });
-        disconnecting = false;
-        disconnectingUuid = "";
         lastError = "";
         ToastService.showNotice(disconnectProcess.name, I18n.tr("toast.vpn.disconnected", {
-                                                                  "name": disconnectProcess.name
-                                                                }), "shield-off");
+                                                                   "name": disconnectProcess.name
+                                                                 }), "shield-off");
         scheduleRefresh(1000);
+      } else {
+        const errText = disconnectProcess._stderrText.trim();
+        if (errText) {
+          lastError = errText.split("\n")[0].trim();
+        } else {
+          lastError = "Disconnect failed (exit code " + exitCode + ")";
+        }
+        Logger.w("VPN", "Disconnect error (exit " + exitCode + "): " + lastError);
+        ToastService.showWarning(disconnectProcess.name, lastError);
       }
+      disconnecting = false;
+      disconnectingUuid = "";
     }
 
     stderr: StdioCollector {
       onStreamFinished: {
-        const trimmed = text.trim();
-        if (trimmed) {
-          lastError = trimmed.split("\n")[0].trim();
-          Logger.w("VPN", "Disconnect error: " + trimmed);
-          ToastService.showWarning(disconnectProcess.name, lastError);
-        }
-        disconnecting = false;
-        disconnectingUuid = "";
+        disconnectProcess._stderrText = text;
       }
     }
   }

--- a/Services/Networking/VPNService.qml
+++ b/Services/Networking/VPNService.qml
@@ -43,6 +43,7 @@ Singleton {
   }
 
   readonly property bool hasActiveConnection: activeConnections.length > 0
+  readonly property bool hasConnections: Object.keys(connections).length > 0
 
   Timer {
     id: refreshTimer


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Fix Ethernet connection not being displayed in the network widget after recent networking changes. The issue occurs even when a wired connection is active and working correctly.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2385

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="787" height="491" alt="obraz" src="https://github.com/user-attachments/assets/c62a43d2-b5cb-4afe-8d2c-09dab07fbc82" />
<img width="787" height="491" alt="obraz" src="https://github.com/user-attachments/assets/da2d09cd-964e-44a6-b580-f4a3fecb3d2d" />
<img width="1263" height="788" alt="obraz" src="https://github.com/user-attachments/assets/19f886d2-00a8-42df-92b0-2e5bc206a60a" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
This change restores Ethernet (wired) connection visibility in the network widget while keeping existing Wi-Fi behavior unchanged.
Handles wired connections from NetworkManager and ensures they are properly reflected in the widget state.
