### PR TITLE
fix(notifications): show fallback icon instead of checkerboard for missing theme icons

### DIFF
--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -770,6 +770,11 @@ Singleton {
       return "";
     if (icon.startsWith("/") || icon.startsWith("file://"))
       return icon;
+    // Verify the icon exists in the theme before returning its image:// URI.
+    // Without this check, missing icons render as the purple/black checkerboard
+    // from IconImageProvider::missingPixmap instead of the notification fallback icon.
+    if (!ThemeIcons.iconExists(icon))
+      return "";
     return ThemeIcons.iconFromName(icon);
   }
 

--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -770,9 +770,6 @@ Singleton {
       return "";
     if (icon.startsWith("/") || icon.startsWith("file://"))
       return icon;
-    // Verify the icon exists in the theme before returning its image:// URI.
-    // Without this check, missing icons render as the purple/black checkerboard
-    // from IconImageProvider::missingPixmap instead of the notification fallback icon.
     if (!ThemeIcons.iconExists(icon))
       return "";
     return ThemeIcons.iconFromName(icon);


### PR DESCRIPTION
## Summary
- When Qt cannot resolve a notification icon name from the theme (e.g. `audio-headset` from Blueman), `IconImageProvider` returns a purple/black checkerboard (`missingPixmap`) instead of a usable image
- This happens because `Quickshell.iconPath()` always returns an `image://icon/` URI regardless of whether the icon exists, and the image provider never errors — it returns a valid pixmap with the checkerboard pattern, so the fallback icon never triggers
- Added an `iconExists()` check in `NotificationService.getIcon()` so that unresolvable icon names return `""`, which lets `NImageRounded` display its fallback icon instead

## Root cause
Qt defaults to the `hicolor` icon theme when `QT_QPA_PLATFORMTHEME` is not set (common on Wayland compositors like Niri). Device icons like `audio-headset` only exist in themes like Adwaita or Tela, which `hicolor` does not inherit from. Users can fully fix this by setting `//@ pragma IconTheme <theme-name>` in `shell.qml` or exporting `QS_ICON_THEME`.