### PR TITLE
feat(network): editable network settings (IPv4, IPv6, MTU)

### DIFF
--- a/Assets/Translations/cs.json
+++ b/Assets/Translations/cs.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Neplatný formát DNS",
       "error-invalid-gateway": "Neplatný formát brány",
       "error-invalid-ip": "Neplatný formát IP adresy",
+      "error-load-failed": "Nepodařilo se načíst nastavení",
       "gateway": "Brána",
       "gateway-placeholder-v4": "např. 192.168.1.1",
       "gateway-placeholder-v6": "např. fd00::1",

--- a/Assets/Translations/cs.json
+++ b/Assets/Translations/cs.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Časový limit připojení",
       "disconnected": "Odpojeno od '{ssid}'",
       "incorrect-password": "Nesprávné heslo",
-      "network-not-found": "Síť nenalezena"
+      "network-not-found": "Síť nenalezena",
+      "settings-applied": "Síťová nastavení byla použita",
+      "settings-apply-failed": "Nepodařilo se použít síťová nastavení"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Zástupný symbol"
   },
   "wifi": {
+    "edit": {
+      "address": "IP adresa",
+      "address-placeholder-v4": "např. 192.168.1.50/24",
+      "address-placeholder-v6": "např. fd00::1/64",
+      "apply": "Použít",
+      "applying": "Aplikování...",
+      "cancel": "Zrušit",
+      "dns": "DNS servery",
+      "dns-hint": "Oddělené čárkami",
+      "dns-placeholder-v4": "např. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "např. 2001:4860:4860::8888",
+      "error-apply-failed": "Nepodařilo se použít nastavení",
+      "error-invalid-dns": "Neplatný formát DNS",
+      "error-invalid-gateway": "Neplatný formát brány",
+      "error-invalid-ip": "Neplatný formát IP adresy",
+      "gateway": "Brána",
+      "gateway-placeholder-v4": "např. 192.168.1.1",
+      "gateway-placeholder-v6": "např. fd00::1",
+      "general": "Obecné",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metoda",
+      "method-auto": "Automaticky (DHCP)",
+      "method-disabled": "Vypnuto",
+      "method-link-local": "Pouze místní spojení",
+      "method-manual": "Ručně",
+      "mtu": "MTU",
+      "mtu-description": "0 = automaticky",
+      "title": "Upravit připojení"
+    },
     "enterprise": {
       "anonymous-identity": "Anonymní identita",
       "ca-cert": "Certifikát CA",

--- a/Assets/Translations/cs.json
+++ b/Assets/Translations/cs.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Neplatný formát brány",
       "error-invalid-ip": "Neplatný formát IP adresy",
       "error-load-failed": "Nepodařilo se načíst nastavení",
+      "error-invalid-mtu": "MTU musí být 0 (auto) nebo 68–9216",
       "gateway": "Brána",
       "gateway-placeholder-v4": "např. 192.168.1.1",
       "gateway-placeholder-v6": "např. fd00::1",

--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Ungültiges DNS-Format",
       "error-invalid-gateway": "Ungültiges Gateway-Format",
       "error-invalid-ip": "Ungültiges IP-Adressformat",
+      "error-load-failed": "Einstellungen konnten nicht geladen werden",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "z.B. 192.168.1.1",
       "gateway-placeholder-v6": "z.B. fd00::1",

--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Ungültiges Gateway-Format",
       "error-invalid-ip": "Ungültiges IP-Adressformat",
       "error-load-failed": "Einstellungen konnten nicht geladen werden",
+      "error-invalid-mtu": "MTU muss 0 (auto) oder 68–9216 sein",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "z.B. 192.168.1.1",
       "gateway-placeholder-v6": "z.B. fd00::1",

--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Zeitüberschreitung bei der Verbindung",
       "disconnected": "Getrennt von '{ssid}'",
       "incorrect-password": "Falsches Passwort",
-      "network-not-found": "Netzwerk nicht gefunden"
+      "network-not-found": "Netzwerk nicht gefunden",
+      "settings-applied": "Netzwerkeinstellungen angewendet",
+      "settings-apply-failed": "Netzwerkeinstellungen konnten nicht angewendet werden"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Platzhalter"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-Adresse",
+      "address-placeholder-v4": "z.B. 192.168.1.50/24",
+      "address-placeholder-v6": "z.B. fd00::1/64",
+      "apply": "Anwenden",
+      "applying": "Wird angewendet...",
+      "cancel": "Abbrechen",
+      "dns": "DNS-Server",
+      "dns-hint": "Kommagetrennt",
+      "dns-placeholder-v4": "z.B. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "z.B. 2001:4860:4860::8888",
+      "error-apply-failed": "Einstellungen konnten nicht angewendet werden",
+      "error-invalid-dns": "Ungültiges DNS-Format",
+      "error-invalid-gateway": "Ungültiges Gateway-Format",
+      "error-invalid-ip": "Ungültiges IP-Adressformat",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "z.B. 192.168.1.1",
+      "gateway-placeholder-v6": "z.B. fd00::1",
+      "general": "Allgemein",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Methode",
+      "method-auto": "Automatisch (DHCP)",
+      "method-disabled": "Deaktiviert",
+      "method-link-local": "Nur Link-Local",
+      "method-manual": "Manuell",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatisch",
+      "title": "Verbindung bearbeiten"
+    },
     "enterprise": {
       "anonymous-identity": "Anonyme Identität",
       "ca-cert": "CA-Zertifikat",

--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Connection timeout",
       "disconnected": "Disconnected from '{ssid}'",
       "incorrect-password": "Incorrect password",
-      "network-not-found": "Network not found"
+      "network-not-found": "Network not found",
+      "settings-applied": "Network settings applied",
+      "settings-apply-failed": "Failed to apply network settings"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Placeholder"
   },
   "wifi": {
+    "edit": {
+      "address": "IP Address",
+      "address-placeholder-v4": "e.g. 192.168.1.50/24",
+      "address-placeholder-v6": "e.g. fd00::1/64",
+      "apply": "Apply",
+      "applying": "Applying...",
+      "cancel": "Cancel",
+      "dns": "DNS Servers",
+      "dns-hint": "Comma-separated",
+      "dns-placeholder-v4": "e.g. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "e.g. 2001:4860:4860::8888",
+      "error-apply-failed": "Failed to apply settings",
+      "error-invalid-dns": "Invalid DNS format",
+      "error-invalid-gateway": "Invalid gateway format",
+      "error-invalid-ip": "Invalid IP address format",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "e.g. 192.168.1.1",
+      "gateway-placeholder-v6": "e.g. fd00::1",
+      "general": "General",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Method",
+      "method-auto": "Automatic (DHCP)",
+      "method-disabled": "Disabled",
+      "method-link-local": "Link-Local only",
+      "method-manual": "Manual",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatic",
+      "title": "Edit connection"
+    },
     "enterprise": {
       "anonymous-identity": "Anonymous Identity",
       "ca-cert": "CA Certificate",

--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Invalid gateway format",
       "error-invalid-ip": "Invalid IP address format",
       "error-load-failed": "Failed to load settings",
+      "error-invalid-mtu": "MTU must be 0 (auto) or 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "e.g. 192.168.1.1",
       "gateway-placeholder-v6": "e.g. fd00::1",

--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Invalid DNS format",
       "error-invalid-gateway": "Invalid gateway format",
       "error-invalid-ip": "Invalid IP address format",
+      "error-load-failed": "Failed to load settings",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "e.g. 192.168.1.1",
       "gateway-placeholder-v6": "e.g. fd00::1",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Connection timeout",
       "disconnected": "Disconnected from '{ssid}'",
       "incorrect-password": "Incorrect password",
-      "network-not-found": "Network not found"
+      "network-not-found": "Network not found",
+      "settings-applied": "Network settings applied",
+      "settings-apply-failed": "Failed to apply network settings"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Placeholder"
   },
   "wifi": {
+    "edit": {
+      "address": "IP Address",
+      "address-placeholder-v4": "e.g. 192.168.1.50/24",
+      "address-placeholder-v6": "e.g. fd00::1/64",
+      "apply": "Apply",
+      "applying": "Applying...",
+      "cancel": "Cancel",
+      "dns": "DNS Servers",
+      "dns-hint": "Comma-separated",
+      "dns-placeholder-v4": "e.g. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "e.g. 2001:4860:4860::8888",
+      "error-apply-failed": "Failed to apply settings",
+      "error-invalid-dns": "Invalid DNS format",
+      "error-invalid-gateway": "Invalid gateway format",
+      "error-invalid-ip": "Invalid IP address format",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "e.g. 192.168.1.1",
+      "gateway-placeholder-v6": "e.g. fd00::1",
+      "general": "General",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Method",
+      "method-auto": "Automatic (DHCP)",
+      "method-disabled": "Disabled",
+      "method-link-local": "Link-Local only",
+      "method-manual": "Manual",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatic",
+      "title": "Edit connection"
+    },
     "enterprise": {
       "anonymous-identity": "Anonymous Identity",
       "ca-cert": "CA Certificate",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Invalid gateway format",
       "error-invalid-ip": "Invalid IP address format",
       "error-load-failed": "Failed to load settings",
+      "error-invalid-mtu": "MTU must be 0 (auto) or 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "e.g. 192.168.1.1",
       "gateway-placeholder-v6": "e.g. fd00::1",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Invalid DNS format",
       "error-invalid-gateway": "Invalid gateway format",
       "error-invalid-ip": "Invalid IP address format",
+      "error-load-failed": "Failed to load settings",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "e.g. 192.168.1.1",
       "gateway-placeholder-v6": "e.g. fd00::1",

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Formato de puerta de enlace no válido",
       "error-invalid-ip": "Formato de dirección IP no válido",
       "error-load-failed": "Error al cargar la configuración",
+      "error-invalid-mtu": "MTU debe ser 0 (auto) o 68–9216",
       "gateway": "Puerta de enlace",
       "gateway-placeholder-v4": "ej. 192.168.1.1",
       "gateway-placeholder-v6": "ej. fd00::1",

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Tiempo de conexión agotado",
       "disconnected": "Desconectado de '{ssid}'",
       "incorrect-password": "Contraseña incorrecta",
-      "network-not-found": "Red no encontrada"
+      "network-not-found": "Red no encontrada",
+      "settings-applied": "Configuración de red aplicada",
+      "settings-apply-failed": "Error al aplicar la configuración de red"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Marcador de posición"
   },
   "wifi": {
+    "edit": {
+      "address": "Dirección IP",
+      "address-placeholder-v4": "ej. 192.168.1.50/24",
+      "address-placeholder-v6": "ej. fd00::1/64",
+      "apply": "Aplicar",
+      "applying": "Aplicando...",
+      "cancel": "Cancelar",
+      "dns": "Servidores DNS",
+      "dns-hint": "Separados por comas",
+      "dns-placeholder-v4": "ej. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "ej. 2001:4860:4860::8888",
+      "error-apply-failed": "Error al aplicar la configuración",
+      "error-invalid-dns": "Formato de DNS no válido",
+      "error-invalid-gateway": "Formato de puerta de enlace no válido",
+      "error-invalid-ip": "Formato de dirección IP no válido",
+      "gateway": "Puerta de enlace",
+      "gateway-placeholder-v4": "ej. 192.168.1.1",
+      "gateway-placeholder-v6": "ej. fd00::1",
+      "general": "General",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Método",
+      "method-auto": "Automático (DHCP)",
+      "method-disabled": "Desactivado",
+      "method-link-local": "Solo enlace local",
+      "method-manual": "Manual",
+      "mtu": "MTU",
+      "mtu-description": "0 = automático",
+      "title": "Editar conexión"
+    },
     "enterprise": {
       "anonymous-identity": "Identidad Anónima",
       "ca-cert": "Certificado CA",

--- a/Assets/Translations/es.json
+++ b/Assets/Translations/es.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Formato de DNS no válido",
       "error-invalid-gateway": "Formato de puerta de enlace no válido",
       "error-invalid-ip": "Formato de dirección IP no válido",
+      "error-load-failed": "Error al cargar la configuración",
       "gateway": "Puerta de enlace",
       "gateway-placeholder-v4": "ej. 192.168.1.1",
       "gateway-placeholder-v6": "ej. fd00::1",

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Format DNS invalide",
       "error-invalid-gateway": "Format de passerelle invalide",
       "error-invalid-ip": "Format d'adresse IP invalide",
+      "error-load-failed": "Échec du chargement des paramètres",
       "gateway": "Passerelle",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Format de passerelle invalide",
       "error-invalid-ip": "Format d'adresse IP invalide",
       "error-load-failed": "Échec du chargement des paramètres",
+      "error-invalid-mtu": "MTU doit être 0 (auto) ou 68–9216",
       "gateway": "Passerelle",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/fr.json
+++ b/Assets/Translations/fr.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Délai de connexion dépassé",
       "disconnected": "Déconnecté de '{ssid}'",
       "incorrect-password": "Mot de passe incorrect",
-      "network-not-found": "Réseau introuvable"
+      "network-not-found": "Réseau introuvable",
+      "settings-applied": "Paramètres réseau appliqués",
+      "settings-apply-failed": "Échec de l'application des paramètres réseau"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Espace réservé"
   },
   "wifi": {
+    "edit": {
+      "address": "Adresse IP",
+      "address-placeholder-v4": "ex. 192.168.1.50/24",
+      "address-placeholder-v6": "ex. fd00::1/64",
+      "apply": "Appliquer",
+      "applying": "Application...",
+      "cancel": "Annuler",
+      "dns": "Serveurs DNS",
+      "dns-hint": "Séparés par des virgules",
+      "dns-placeholder-v4": "ex. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "ex. 2001:4860:4860::8888",
+      "error-apply-failed": "Échec de l'application des paramètres",
+      "error-invalid-dns": "Format DNS invalide",
+      "error-invalid-gateway": "Format de passerelle invalide",
+      "error-invalid-ip": "Format d'adresse IP invalide",
+      "gateway": "Passerelle",
+      "gateway-placeholder-v4": "ex. 192.168.1.1",
+      "gateway-placeholder-v6": "ex. fd00::1",
+      "general": "Général",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Méthode",
+      "method-auto": "Automatique (DHCP)",
+      "method-disabled": "Désactivé",
+      "method-link-local": "Lien local uniquement",
+      "method-manual": "Manuel",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatique",
+      "title": "Modifier la connexion"
+    },
     "enterprise": {
       "anonymous-identity": "Identité Anonyme",
       "ca-cert": "Certificat CA",

--- a/Assets/Translations/hu.json
+++ b/Assets/Translations/hu.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Érvénytelen átjáró formátum",
       "error-invalid-ip": "Érvénytelen IP-cím formátum",
       "error-load-failed": "Nem sikerült betölteni a beállításokat",
+      "error-invalid-mtu": "MTU értéke 0 (automatikus) vagy 68–9216 legyen",
       "gateway": "Átjáró",
       "gateway-placeholder-v4": "pl. 192.168.1.1",
       "gateway-placeholder-v6": "pl. fd00::1",

--- a/Assets/Translations/hu.json
+++ b/Assets/Translations/hu.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Csatlakozási időtúllépés",
       "disconnected": "Kapcsolat megszakadt a(z) „{ssid}” hálózattal",
       "incorrect-password": "Helytelen jelszó.",
-      "network-not-found": "Hálózat nem található"
+      "network-not-found": "Hálózat nem található",
+      "settings-applied": "Hálózati beállítások alkalmazva",
+      "settings-apply-failed": "Nem sikerült alkalmazni a hálózati beállításokat"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Helyőrző"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-cím",
+      "address-placeholder-v4": "pl. 192.168.1.50/24",
+      "address-placeholder-v6": "pl. fd00::1/64",
+      "apply": "Alkalmaz",
+      "applying": "Alkalmazás...",
+      "cancel": "Mégse",
+      "dns": "DNS-kiszolgálók",
+      "dns-hint": "Vesszővel elválasztva",
+      "dns-placeholder-v4": "pl. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "pl. 2001:4860:4860::8888",
+      "error-apply-failed": "Nem sikerült alkalmazni a beállításokat",
+      "error-invalid-dns": "Érvénytelen DNS-formátum",
+      "error-invalid-gateway": "Érvénytelen átjáró formátum",
+      "error-invalid-ip": "Érvénytelen IP-cím formátum",
+      "gateway": "Átjáró",
+      "gateway-placeholder-v4": "pl. 192.168.1.1",
+      "gateway-placeholder-v6": "pl. fd00::1",
+      "general": "Általános",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Módszer",
+      "method-auto": "Automatikus (DHCP)",
+      "method-disabled": "Letiltva",
+      "method-link-local": "Csak helyi kapcsolat",
+      "method-manual": "Kézi",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatikus",
+      "title": "Kapcsolat szerkesztése"
+    },
     "enterprise": {
       "anonymous-identity": "Anonim Identitás",
       "ca-cert": "CA tanúsítvány",

--- a/Assets/Translations/hu.json
+++ b/Assets/Translations/hu.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Érvénytelen DNS-formátum",
       "error-invalid-gateway": "Érvénytelen átjáró formátum",
       "error-invalid-ip": "Érvénytelen IP-cím formátum",
+      "error-load-failed": "Nem sikerült betölteni a beállításokat",
       "gateway": "Átjáró",
       "gateway-placeholder-v4": "pl. 192.168.1.1",
       "gateway-placeholder-v6": "pl. fd00::1",

--- a/Assets/Translations/it.json
+++ b/Assets/Translations/it.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Connection timeout",
       "disconnected": "Disconnected from '{ssid}'",
       "incorrect-password": "Incorrect password",
-      "network-not-found": "Network not found"
+      "network-not-found": "Network not found",
+      "settings-applied": "Impostazioni di rete applicate",
+      "settings-apply-failed": "Impossibile applicare le impostazioni di rete"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Segnaposto"
   },
   "wifi": {
+    "edit": {
+      "address": "Indirizzo IP",
+      "address-placeholder-v4": "es. 192.168.1.50/24",
+      "address-placeholder-v6": "es. fd00::1/64",
+      "apply": "Applica",
+      "applying": "Applicazione...",
+      "cancel": "Annulla",
+      "dns": "Server DNS",
+      "dns-hint": "Separati da virgole",
+      "dns-placeholder-v4": "es. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "es. 2001:4860:4860::8888",
+      "error-apply-failed": "Impossibile applicare le impostazioni",
+      "error-invalid-dns": "Formato DNS non valido",
+      "error-invalid-gateway": "Formato gateway non valido",
+      "error-invalid-ip": "Formato indirizzo IP non valido",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "es. 192.168.1.1",
+      "gateway-placeholder-v6": "es. fd00::1",
+      "general": "Generale",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metodo",
+      "method-auto": "Automatico (DHCP)",
+      "method-disabled": "Disabilitato",
+      "method-link-local": "Solo link locale",
+      "method-manual": "Manuale",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatico",
+      "title": "Modifica connessione"
+    },
     "enterprise": {
       "anonymous-identity": "Identità Anonima",
       "ca-cert": "Certificato CA",

--- a/Assets/Translations/it.json
+++ b/Assets/Translations/it.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Formato DNS non valido",
       "error-invalid-gateway": "Formato gateway non valido",
       "error-invalid-ip": "Formato indirizzo IP non valido",
+      "error-load-failed": "Impossibile caricare le impostazioni",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "es. 192.168.1.1",
       "gateway-placeholder-v6": "es. fd00::1",

--- a/Assets/Translations/it.json
+++ b/Assets/Translations/it.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Formato gateway non valido",
       "error-invalid-ip": "Formato indirizzo IP non valido",
       "error-load-failed": "Impossibile caricare le impostazioni",
+      "error-invalid-mtu": "MTU deve essere 0 (auto) o 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "es. 192.168.1.1",
       "gateway-placeholder-v6": "es. fd00::1",

--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "無効なゲートウェイ形式",
       "error-invalid-ip": "無効なIPアドレス形式",
       "error-load-failed": "設定の読み込みに失敗しました",
+      "error-invalid-mtu": "MTU は 0（自動）または 68〜9216 にしてください",
       "gateway": "ゲートウェイ",
       "gateway-placeholder-v4": "例: 192.168.1.1",
       "gateway-placeholder-v6": "例: fd00::1",

--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "無効なDNS形式",
       "error-invalid-gateway": "無効なゲートウェイ形式",
       "error-invalid-ip": "無効なIPアドレス形式",
+      "error-load-failed": "設定の読み込みに失敗しました",
       "gateway": "ゲートウェイ",
       "gateway-placeholder-v4": "例: 192.168.1.1",
       "gateway-placeholder-v6": "例: fd00::1",

--- a/Assets/Translations/ja.json
+++ b/Assets/Translations/ja.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "接続タイムアウト",
       "disconnected": "{ssid} から切断しました",
       "incorrect-password": "パスワードが違います",
-      "network-not-found": "ネットワークが見つかりません"
+      "network-not-found": "ネットワークが見つかりません",
+      "settings-applied": "ネットワーク設定が適用されました",
+      "settings-apply-failed": "ネットワーク設定の適用に失敗しました"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "プレースホルダー"
   },
   "wifi": {
+    "edit": {
+      "address": "IPアドレス",
+      "address-placeholder-v4": "例: 192.168.1.50/24",
+      "address-placeholder-v6": "例: fd00::1/64",
+      "apply": "適用",
+      "applying": "適用中...",
+      "cancel": "キャンセル",
+      "dns": "DNSサーバー",
+      "dns-hint": "カンマ区切り",
+      "dns-placeholder-v4": "例: 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "例: 2001:4860:4860::8888",
+      "error-apply-failed": "設定の適用に失敗しました",
+      "error-invalid-dns": "無効なDNS形式",
+      "error-invalid-gateway": "無効なゲートウェイ形式",
+      "error-invalid-ip": "無効なIPアドレス形式",
+      "gateway": "ゲートウェイ",
+      "gateway-placeholder-v4": "例: 192.168.1.1",
+      "gateway-placeholder-v6": "例: fd00::1",
+      "general": "一般",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "方式",
+      "method-auto": "自動 (DHCP)",
+      "method-disabled": "無効",
+      "method-link-local": "リンクローカルのみ",
+      "method-manual": "手動",
+      "mtu": "MTU",
+      "mtu-description": "0 = 自動",
+      "title": "接続を編集"
+    },
     "enterprise": {
       "anonymous-identity": "匿名ID",
       "ca-cert": "CA証明書",

--- a/Assets/Translations/ko-KR.json
+++ b/Assets/Translations/ko-KR.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "잘못된 DNS 형식",
       "error-invalid-gateway": "잘못된 게이트웨이 형식",
       "error-invalid-ip": "잘못된 IP 주소 형식",
+      "error-load-failed": "설정 불러오기 실패",
       "gateway": "게이트웨이",
       "gateway-placeholder-v4": "예: 192.168.1.1",
       "gateway-placeholder-v6": "예: fd00::1",

--- a/Assets/Translations/ko-KR.json
+++ b/Assets/Translations/ko-KR.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "잘못된 게이트웨이 형식",
       "error-invalid-ip": "잘못된 IP 주소 형식",
       "error-load-failed": "설정 불러오기 실패",
+      "error-invalid-mtu": "MTU는 0(자동) 또는 68–9216이어야 합니다",
       "gateway": "게이트웨이",
       "gateway-placeholder-v4": "예: 192.168.1.1",
       "gateway-placeholder-v6": "예: fd00::1",

--- a/Assets/Translations/ko-KR.json
+++ b/Assets/Translations/ko-KR.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "연결 시간 초과",
       "disconnected": "'{ssid}' 연결 끊김",
       "incorrect-password": "잘못된 비밀번호",
-      "network-not-found": "네트워크를 찾을 수 없음"
+      "network-not-found": "네트워크를 찾을 수 없음",
+      "settings-applied": "네트워크 설정이 적용되었습니다",
+      "settings-apply-failed": "네트워크 설정 적용에 실패했습니다"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "플레이스홀더"
   },
   "wifi": {
+    "edit": {
+      "address": "IP 주소",
+      "address-placeholder-v4": "예: 192.168.1.50/24",
+      "address-placeholder-v6": "예: fd00::1/64",
+      "apply": "적용",
+      "applying": "적용 중...",
+      "cancel": "취소",
+      "dns": "DNS 서버",
+      "dns-hint": "쉼표로 구분",
+      "dns-placeholder-v4": "예: 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "예: 2001:4860:4860::8888",
+      "error-apply-failed": "설정 적용 실패",
+      "error-invalid-dns": "잘못된 DNS 형식",
+      "error-invalid-gateway": "잘못된 게이트웨이 형식",
+      "error-invalid-ip": "잘못된 IP 주소 형식",
+      "gateway": "게이트웨이",
+      "gateway-placeholder-v4": "예: 192.168.1.1",
+      "gateway-placeholder-v6": "예: fd00::1",
+      "general": "일반",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "방식",
+      "method-auto": "자동 (DHCP)",
+      "method-disabled": "비활성화",
+      "method-link-local": "링크 로컬만",
+      "method-manual": "수동",
+      "mtu": "MTU",
+      "mtu-description": "0 = 자동",
+      "title": "연결 편집"
+    },
     "enterprise": {
       "anonymous-identity": "익명 ID",
       "ca-cert": "CA 인증서",

--- a/Assets/Translations/ku.json
+++ b/Assets/Translations/ku.json
@@ -1842,6 +1842,7 @@
       "error-invalid-gateway": "Forma dergehê ne derbasdar e",
       "error-invalid-ip": "Forma navnîşana IP ne derbasdar e",
       "error-load-failed": "Mîheng nehatin barkirin",
+      "error-invalid-mtu": "MTU divê 0 (otomatîk) an 68–9216 be",
       "gateway": "Dergeh",
       "gateway-placeholder-v4": "wek 192.168.1.1",
       "gateway-placeholder-v6": "wek fd00::1",

--- a/Assets/Translations/ku.json
+++ b/Assets/Translations/ku.json
@@ -1638,7 +1638,9 @@
       "connection-timeout": "Dema girêdanê qediya",
       "disconnected": "Ji '{ssid}' qut bû",
       "incorrect-password": "Borînpeyva şaş e",
-      "network-not-found": "Tor nehat dîtin"
+      "network-not-found": "Tor nehat dîtin",
+      "settings-applied": "Mîhengên torê hatin bicîhkirin",
+      "settings-apply-failed": "Mîhengên torê nehatin bicîhkirin"
     }
   },
   "tooltips": {
@@ -1824,6 +1826,36 @@
     "tooltip-placeholder": "Cihgir"
   },
   "wifi": {
+    "edit": {
+      "address": "Navnîşana IP",
+      "address-placeholder-v4": "wek 192.168.1.50/24",
+      "address-placeholder-v6": "wek fd00::1/64",
+      "apply": "Bicîh bike",
+      "applying": "Tê bicîhkirin...",
+      "cancel": "Betal bike",
+      "dns": "Pêşkêşkerên DNS",
+      "dns-hint": "Bi vîrgulê veqetandî",
+      "dns-placeholder-v4": "wek 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "wek 2001:4860:4860::8888",
+      "error-apply-failed": "Mîheng nehatin bicîhkirin",
+      "error-invalid-dns": "Forma DNS ne derbasdar e",
+      "error-invalid-gateway": "Forma dergehê ne derbasdar e",
+      "error-invalid-ip": "Forma navnîşana IP ne derbasdar e",
+      "gateway": "Dergeh",
+      "gateway-placeholder-v4": "wek 192.168.1.1",
+      "gateway-placeholder-v6": "wek fd00::1",
+      "general": "Giştî",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Rêbaz",
+      "method-auto": "Otomatîk (DHCP)",
+      "method-disabled": "Neçalak",
+      "method-link-local": "Tenê girêdana herêmî",
+      "method-manual": "Bi destan",
+      "mtu": "MTU",
+      "mtu-description": "0 = otomatîk",
+      "title": "Girêdanê biguherîne"
+    },
     "panel": {
       "action-required": "Çalakî pêwîst e",
       "available-interfaces": "Navrûyên heyî",

--- a/Assets/Translations/ku.json
+++ b/Assets/Translations/ku.json
@@ -1841,6 +1841,7 @@
       "error-invalid-dns": "Forma DNS ne derbasdar e",
       "error-invalid-gateway": "Forma dergehê ne derbasdar e",
       "error-invalid-ip": "Forma navnîşana IP ne derbasdar e",
+      "error-load-failed": "Mîheng nehatin barkirin",
       "gateway": "Dergeh",
       "gateway-placeholder-v4": "wek 192.168.1.1",
       "gateway-placeholder-v6": "wek fd00::1",

--- a/Assets/Translations/nl.json
+++ b/Assets/Translations/nl.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Ongeldig gatewayformaat",
       "error-invalid-ip": "Ongeldig IP-adresformaat",
       "error-load-failed": "Instellingen konden niet worden geladen",
+      "error-invalid-mtu": "MTU moet 0 (auto) of 68–9216 zijn",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "bijv. 192.168.1.1",
       "gateway-placeholder-v6": "bijv. fd00::1",

--- a/Assets/Translations/nl.json
+++ b/Assets/Translations/nl.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Time-out bij verbinding",
       "disconnected": "Verbinding met '{ssid}' verbroken",
       "incorrect-password": "Onjuist wachtwoord",
-      "network-not-found": "Netwerk niet gevonden"
+      "network-not-found": "Netwerk niet gevonden",
+      "settings-applied": "Netwerkinstellingen toegepast",
+      "settings-apply-failed": "Netwerkinstellingen konden niet worden toegepast"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Plaatshouder"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-adres",
+      "address-placeholder-v4": "bijv. 192.168.1.50/24",
+      "address-placeholder-v6": "bijv. fd00::1/64",
+      "apply": "Toepassen",
+      "applying": "Toepassen...",
+      "cancel": "Annuleren",
+      "dns": "DNS-servers",
+      "dns-hint": "Kommagescheiden",
+      "dns-placeholder-v4": "bijv. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "bijv. 2001:4860:4860::8888",
+      "error-apply-failed": "Instellingen konden niet worden toegepast",
+      "error-invalid-dns": "Ongeldig DNS-formaat",
+      "error-invalid-gateway": "Ongeldig gatewayformaat",
+      "error-invalid-ip": "Ongeldig IP-adresformaat",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "bijv. 192.168.1.1",
+      "gateway-placeholder-v6": "bijv. fd00::1",
+      "general": "Algemeen",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Methode",
+      "method-auto": "Automatisch (DHCP)",
+      "method-disabled": "Uitgeschakeld",
+      "method-link-local": "Alleen lokale verbinding",
+      "method-manual": "Handmatig",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatisch",
+      "title": "Verbinding bewerken"
+    },
     "enterprise": {
       "anonymous-identity": "Anonieme Identiteit",
       "ca-cert": "CA-certificaat",

--- a/Assets/Translations/nl.json
+++ b/Assets/Translations/nl.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Ongeldig DNS-formaat",
       "error-invalid-gateway": "Ongeldig gatewayformaat",
       "error-invalid-ip": "Ongeldig IP-adresformaat",
+      "error-load-failed": "Instellingen konden niet worden geladen",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "bijv. 192.168.1.1",
       "gateway-placeholder-v6": "bijv. fd00::1",

--- a/Assets/Translations/nn-HN.json
+++ b/Assets/Translations/nn-HN.json
@@ -236,5 +236,43 @@
   },
   "system": {
     "welcome-back": "Velkomen attende,"
+  },
+  "toast": {
+    "wifi": {
+      "settings-applied": "Nettverksinnstillingar brukte",
+      "settings-apply-failed": "Klarte ikkje å bruka nettverksinnstillingane"
+    }
+  },
+  "wifi": {
+    "edit": {
+      "address": "IP-adresse",
+      "address-placeholder-v4": "t.d. 192.168.1.50/24",
+      "address-placeholder-v6": "t.d. fd00::1/64",
+      "apply": "Bruk",
+      "applying": "Brukar...",
+      "cancel": "Avbryt",
+      "dns": "DNS-tenarar",
+      "dns-hint": "Skilde med komma",
+      "dns-placeholder-v4": "t.d. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "t.d. 2001:4860:4860::8888",
+      "error-apply-failed": "Klarte ikkje å bruka innstillingane",
+      "error-invalid-dns": "Ugyldig DNS-format",
+      "error-invalid-gateway": "Ugyldig gateway-format",
+      "error-invalid-ip": "Ugyldig IP-adresseformat",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "t.d. 192.168.1.1",
+      "gateway-placeholder-v6": "t.d. fd00::1",
+      "general": "Generelt",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metode",
+      "method-auto": "Automatisk (DHCP)",
+      "method-disabled": "Deaktivert",
+      "method-link-local": "Berre lokal lenkje",
+      "method-manual": "Manuell",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatisk",
+      "title": "Rediger tilkopling"
+    }
   }
 }

--- a/Assets/Translations/nn-HN.json
+++ b/Assets/Translations/nn-HN.json
@@ -260,6 +260,7 @@
       "error-invalid-gateway": "Ugyldig gateway-format",
       "error-invalid-ip": "Ugyldig IP-adresseformat",
       "error-load-failed": "Klarte ikkje å lasta innstillingane",
+      "error-invalid-mtu": "MTU må vera 0 (automatisk) eller 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.d. 192.168.1.1",
       "gateway-placeholder-v6": "t.d. fd00::1",

--- a/Assets/Translations/nn-HN.json
+++ b/Assets/Translations/nn-HN.json
@@ -259,6 +259,7 @@
       "error-invalid-dns": "Ugyldig DNS-format",
       "error-invalid-gateway": "Ugyldig gateway-format",
       "error-invalid-ip": "Ugyldig IP-adresseformat",
+      "error-load-failed": "Klarte ikkje å lasta innstillingane",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.d. 192.168.1.1",
       "gateway-placeholder-v6": "t.d. fd00::1",

--- a/Assets/Translations/nn-NO.json
+++ b/Assets/Translations/nn-NO.json
@@ -2022,6 +2022,7 @@
       "error-invalid-gateway": "Ugyldig gateway-format",
       "error-invalid-ip": "Ugyldig IP-adresseformat",
       "error-load-failed": "Klarte ikkje å lasta innstillingane",
+      "error-invalid-mtu": "MTU må vera 0 (automatisk) eller 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.d. 192.168.1.1",
       "gateway-placeholder-v6": "t.d. fd00::1",

--- a/Assets/Translations/nn-NO.json
+++ b/Assets/Translations/nn-NO.json
@@ -2021,6 +2021,7 @@
       "error-invalid-dns": "Ugyldig DNS-format",
       "error-invalid-gateway": "Ugyldig gateway-format",
       "error-invalid-ip": "Ugyldig IP-adresseformat",
+      "error-load-failed": "Klarte ikkje å lasta innstillingane",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.d. 192.168.1.1",
       "gateway-placeholder-v6": "t.d. fd00::1",

--- a/Assets/Translations/nn-NO.json
+++ b/Assets/Translations/nn-NO.json
@@ -1813,7 +1813,9 @@
       "connection-timeout": "Tidsavbrot med kopling",
       "disconnected": "Kopla frå '{ssid}'",
       "incorrect-password": "Gale passord",
-      "network-not-found": "Nettverk ikkje funne"
+      "network-not-found": "Nettverk ikkje funne",
+      "settings-applied": "Nettverksinnstillingar brukte",
+      "settings-apply-failed": "Klarte ikkje å bruka nettverksinnstillingane"
     }
   },
   "tooltips": {
@@ -2004,6 +2006,36 @@
     "tooltip-placeholder": "Plasshaldar"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-adresse",
+      "address-placeholder-v4": "t.d. 192.168.1.50/24",
+      "address-placeholder-v6": "t.d. fd00::1/64",
+      "apply": "Bruk",
+      "applying": "Brukar...",
+      "cancel": "Avbryt",
+      "dns": "DNS-tenarar",
+      "dns-hint": "Skilde med komma",
+      "dns-placeholder-v4": "t.d. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "t.d. 2001:4860:4860::8888",
+      "error-apply-failed": "Klarte ikkje å bruka innstillingane",
+      "error-invalid-dns": "Ugyldig DNS-format",
+      "error-invalid-gateway": "Ugyldig gateway-format",
+      "error-invalid-ip": "Ugyldig IP-adresseformat",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "t.d. 192.168.1.1",
+      "gateway-placeholder-v6": "t.d. fd00::1",
+      "general": "Generelt",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metode",
+      "method-auto": "Automatisk (DHCP)",
+      "method-disabled": "Deaktivert",
+      "method-link-local": "Berre lokal lenkje",
+      "method-manual": "Manuell",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatisk",
+      "title": "Rediger tilkopling"
+    },
     "panel": {
       "action-required": "Krev handling",
       "available-interfaces": "Tilgjengelege grensesnitt",

--- a/Assets/Translations/pl.json
+++ b/Assets/Translations/pl.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Przekroczenie czasu połączenia",
       "disconnected": "Rozłączono z '{ssid}'",
       "incorrect-password": "Nieprawidłowe hasło",
-      "network-not-found": "Nie znaleziono sieci"
+      "network-not-found": "Nie znaleziono sieci",
+      "settings-applied": "Ustawienia sieciowe zastosowane",
+      "settings-apply-failed": "Nie udało się zastosować ustawień sieciowych"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Miejsce na tekst"
   },
   "wifi": {
+    "edit": {
+      "address": "Adres IP",
+      "address-placeholder-v4": "np. 192.168.1.50/24",
+      "address-placeholder-v6": "np. fd00::1/64",
+      "apply": "Zastosuj",
+      "applying": "Stosowanie...",
+      "cancel": "Anuluj",
+      "dns": "Serwery DNS",
+      "dns-hint": "Oddzielone przecinkami",
+      "dns-placeholder-v4": "np. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "np. 2001:4860:4860::8888",
+      "error-apply-failed": "Nie udało się zastosować ustawień",
+      "error-invalid-dns": "Nieprawidłowy format DNS",
+      "error-invalid-gateway": "Nieprawidłowy format bramy",
+      "error-invalid-ip": "Nieprawidłowy format adresu IP",
+      "gateway": "Brama",
+      "gateway-placeholder-v4": "np. 192.168.1.1",
+      "gateway-placeholder-v6": "np. fd00::1",
+      "general": "Ogólne",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metoda",
+      "method-auto": "Automatycznie (DHCP)",
+      "method-disabled": "Wyłączony",
+      "method-link-local": "Tylko łącze lokalne",
+      "method-manual": "Ręcznie",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatycznie",
+      "title": "Edytuj połączenie"
+    },
     "enterprise": {
       "anonymous-identity": "Anonimowa Tożsamość",
       "ca-cert": "Certyfikat CA",

--- a/Assets/Translations/pl.json
+++ b/Assets/Translations/pl.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Nieprawidłowy format bramy",
       "error-invalid-ip": "Nieprawidłowy format adresu IP",
       "error-load-failed": "Nie udało się załadować ustawień",
+      "error-invalid-mtu": "MTU musi wynosić 0 (auto) lub 68–9216",
       "gateway": "Brama",
       "gateway-placeholder-v4": "np. 192.168.1.1",
       "gateway-placeholder-v6": "np. fd00::1",

--- a/Assets/Translations/pl.json
+++ b/Assets/Translations/pl.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Nieprawidłowy format DNS",
       "error-invalid-gateway": "Nieprawidłowy format bramy",
       "error-invalid-ip": "Nieprawidłowy format adresu IP",
+      "error-load-failed": "Nie udało się załadować ustawień",
       "gateway": "Brama",
       "gateway-placeholder-v4": "np. 192.168.1.1",
       "gateway-placeholder-v6": "np. fd00::1",

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Formato de gateway inválido",
       "error-invalid-ip": "Formato de endereço IP inválido",
       "error-load-failed": "Falha ao carregar as configurações",
+      "error-invalid-mtu": "MTU deve ser 0 (auto) ou 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Tempo de conexão esgotado",
       "disconnected": "Desconectado de '{ssid}'",
       "incorrect-password": "Senha incorreta",
-      "network-not-found": "Rede não encontrada"
+      "network-not-found": "Rede não encontrada",
+      "settings-applied": "Configurações de rede aplicadas",
+      "settings-apply-failed": "Falha ao aplicar as configurações de rede"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Espaço reservado"
   },
   "wifi": {
+    "edit": {
+      "address": "Endereço IP",
+      "address-placeholder-v4": "ex. 192.168.1.50/24",
+      "address-placeholder-v6": "ex. fd00::1/64",
+      "apply": "Aplicar",
+      "applying": "Aplicando...",
+      "cancel": "Cancelar",
+      "dns": "Servidores DNS",
+      "dns-hint": "Separados por vírgulas",
+      "dns-placeholder-v4": "ex. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "ex. 2001:4860:4860::8888",
+      "error-apply-failed": "Falha ao aplicar as configurações",
+      "error-invalid-dns": "Formato de DNS inválido",
+      "error-invalid-gateway": "Formato de gateway inválido",
+      "error-invalid-ip": "Formato de endereço IP inválido",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "ex. 192.168.1.1",
+      "gateway-placeholder-v6": "ex. fd00::1",
+      "general": "Geral",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Método",
+      "method-auto": "Automático (DHCP)",
+      "method-disabled": "Desativado",
+      "method-link-local": "Apenas link local",
+      "method-manual": "Manual",
+      "mtu": "MTU",
+      "mtu-description": "0 = automático",
+      "title": "Editar conexão"
+    },
     "enterprise": {
       "anonymous-identity": "Identidade Anônima",
       "ca-cert": "Certificado CA",

--- a/Assets/Translations/pt.json
+++ b/Assets/Translations/pt.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Formato de DNS inválido",
       "error-invalid-gateway": "Formato de gateway inválido",
       "error-invalid-ip": "Formato de endereço IP inválido",
+      "error-load-failed": "Falha ao carregar as configurações",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/ro.json
+++ b/Assets/Translations/ro.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Timp de expirare a conexiunii",
       "disconnected": "Deconectat de la '{ssid}'",
       "incorrect-password": "Parolă incorectă",
-      "network-not-found": "Rețeaua nu a fost găsită"
+      "network-not-found": "Rețeaua nu a fost găsită",
+      "settings-applied": "Setări de rețea aplicate",
+      "settings-apply-failed": "Nu s-au putut aplica setările de rețea"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Spațiu rezervat"
   },
   "wifi": {
+    "edit": {
+      "address": "Adresă IP",
+      "address-placeholder-v4": "ex. 192.168.1.50/24",
+      "address-placeholder-v6": "ex. fd00::1/64",
+      "apply": "Aplică",
+      "applying": "Se aplică...",
+      "cancel": "Anulează",
+      "dns": "Servere DNS",
+      "dns-hint": "Separate prin virgulă",
+      "dns-placeholder-v4": "ex. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "ex. 2001:4860:4860::8888",
+      "error-apply-failed": "Nu s-au putut aplica setările",
+      "error-invalid-dns": "Format DNS invalid",
+      "error-invalid-gateway": "Format gateway invalid",
+      "error-invalid-ip": "Format adresă IP invalid",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "ex. 192.168.1.1",
+      "gateway-placeholder-v6": "ex. fd00::1",
+      "general": "General",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metodă",
+      "method-auto": "Automat (DHCP)",
+      "method-disabled": "Dezactivat",
+      "method-link-local": "Doar legătură locală",
+      "method-manual": "Manual",
+      "mtu": "MTU",
+      "mtu-description": "0 = automat",
+      "title": "Editare conexiune"
+    },
     "enterprise": {
       "anonymous-identity": "Identitate Anonimă",
       "ca-cert": "Certificat CA",

--- a/Assets/Translations/ro.json
+++ b/Assets/Translations/ro.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Format gateway invalid",
       "error-invalid-ip": "Format adresă IP invalid",
       "error-load-failed": "Nu s-au putut încărca setările",
+      "error-invalid-mtu": "MTU trebuie să fie 0 (auto) sau 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/ro.json
+++ b/Assets/Translations/ro.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Format DNS invalid",
       "error-invalid-gateway": "Format gateway invalid",
       "error-invalid-ip": "Format adresă IP invalid",
+      "error-load-failed": "Nu s-au putut încărca setările",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "ex. 192.168.1.1",
       "gateway-placeholder-v6": "ex. fd00::1",

--- a/Assets/Translations/ru.json
+++ b/Assets/Translations/ru.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Неверный формат DNS",
       "error-invalid-gateway": "Неверный формат шлюза",
       "error-invalid-ip": "Неверный формат IP-адреса",
+      "error-load-failed": "Не удалось загрузить настройки",
       "gateway": "Шлюз",
       "gateway-placeholder-v4": "напр. 192.168.1.1",
       "gateway-placeholder-v6": "напр. fd00::1",

--- a/Assets/Translations/ru.json
+++ b/Assets/Translations/ru.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Неверный формат шлюза",
       "error-invalid-ip": "Неверный формат IP-адреса",
       "error-load-failed": "Не удалось загрузить настройки",
+      "error-invalid-mtu": "MTU должен быть 0 (авто) или 68–9216",
       "gateway": "Шлюз",
       "gateway-placeholder-v4": "напр. 192.168.1.1",
       "gateway-placeholder-v6": "напр. fd00::1",

--- a/Assets/Translations/ru.json
+++ b/Assets/Translations/ru.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Превышено время ожидания соединения",
       "disconnected": "Отключено от '{ssid}'",
       "incorrect-password": "Неверный пароль",
-      "network-not-found": "Сеть не найдена"
+      "network-not-found": "Сеть не найдена",
+      "settings-applied": "Сетевые настройки применены",
+      "settings-apply-failed": "Не удалось применить сетевые настройки"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Заполнитель"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-адрес",
+      "address-placeholder-v4": "напр. 192.168.1.50/24",
+      "address-placeholder-v6": "напр. fd00::1/64",
+      "apply": "Применить",
+      "applying": "Применение...",
+      "cancel": "Отмена",
+      "dns": "DNS-серверы",
+      "dns-hint": "Через запятую",
+      "dns-placeholder-v4": "напр. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "напр. 2001:4860:4860::8888",
+      "error-apply-failed": "Не удалось применить настройки",
+      "error-invalid-dns": "Неверный формат DNS",
+      "error-invalid-gateway": "Неверный формат шлюза",
+      "error-invalid-ip": "Неверный формат IP-адреса",
+      "gateway": "Шлюз",
+      "gateway-placeholder-v4": "напр. 192.168.1.1",
+      "gateway-placeholder-v6": "напр. fd00::1",
+      "general": "Общие",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Метод",
+      "method-auto": "Автоматически (DHCP)",
+      "method-disabled": "Отключено",
+      "method-link-local": "Только локальная связь",
+      "method-manual": "Вручную",
+      "mtu": "MTU",
+      "mtu-description": "0 = автоматически",
+      "title": "Редактировать подключение"
+    },
     "enterprise": {
       "anonymous-identity": "Анонимная Личность",
       "ca-cert": "Сертификат CA",

--- a/Assets/Translations/sv.json
+++ b/Assets/Translations/sv.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Ogiltigt DNS-format",
       "error-invalid-gateway": "Ogiltigt gatewayformat",
       "error-invalid-ip": "Ogiltigt IP-adressformat",
+      "error-load-failed": "Kunde inte läsa in inställningarna",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.ex. 192.168.1.1",
       "gateway-placeholder-v6": "t.ex. fd00::1",

--- a/Assets/Translations/sv.json
+++ b/Assets/Translations/sv.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Ogiltigt gatewayformat",
       "error-invalid-ip": "Ogiltigt IP-adressformat",
       "error-load-failed": "Kunde inte läsa in inställningarna",
+      "error-invalid-mtu": "MTU måste vara 0 (auto) eller 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "t.ex. 192.168.1.1",
       "gateway-placeholder-v6": "t.ex. fd00::1",

--- a/Assets/Translations/sv.json
+++ b/Assets/Translations/sv.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Anslutningstidsgräns",
       "disconnected": "Kopplade från '{ssid}'",
       "incorrect-password": "Felaktigt lösenord",
-      "network-not-found": "Nätverket hittades inte"
+      "network-not-found": "Nätverket hittades inte",
+      "settings-applied": "Nätverksinställningar tillämpade",
+      "settings-apply-failed": "Kunde inte tillämpa nätverksinställningarna"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Platshållare"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-adress",
+      "address-placeholder-v4": "t.ex. 192.168.1.50/24",
+      "address-placeholder-v6": "t.ex. fd00::1/64",
+      "apply": "Tillämpa",
+      "applying": "Tillämpar...",
+      "cancel": "Avbryt",
+      "dns": "DNS-servrar",
+      "dns-hint": "Kommaseparerade",
+      "dns-placeholder-v4": "t.ex. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "t.ex. 2001:4860:4860::8888",
+      "error-apply-failed": "Kunde inte tillämpa inställningarna",
+      "error-invalid-dns": "Ogiltigt DNS-format",
+      "error-invalid-gateway": "Ogiltigt gatewayformat",
+      "error-invalid-ip": "Ogiltigt IP-adressformat",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "t.ex. 192.168.1.1",
+      "gateway-placeholder-v6": "t.ex. fd00::1",
+      "general": "Allmänt",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Metod",
+      "method-auto": "Automatisk (DHCP)",
+      "method-disabled": "Inaktiverad",
+      "method-link-local": "Endast lokal länk",
+      "method-manual": "Manuell",
+      "mtu": "MTU",
+      "mtu-description": "0 = automatisk",
+      "title": "Redigera anslutning"
+    },
     "enterprise": {
       "anonymous-identity": "Anonym Identitet",
       "ca-cert": "CA-certifikat",

--- a/Assets/Translations/tr.json
+++ b/Assets/Translations/tr.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Bağlantı zaman aşımı",
       "disconnected": "'{ssid}' bağlantısı kesildi",
       "incorrect-password": "Yanlış şifre",
-      "network-not-found": "Ağ bulunamadı"
+      "network-not-found": "Ağ bulunamadı",
+      "settings-applied": "Ağ ayarları uygulandı",
+      "settings-apply-failed": "Ağ ayarları uygulanamadı"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Yer tutucu"
   },
   "wifi": {
+    "edit": {
+      "address": "IP Adresi",
+      "address-placeholder-v4": "ör. 192.168.1.50/24",
+      "address-placeholder-v6": "ör. fd00::1/64",
+      "apply": "Uygula",
+      "applying": "Uygulanıyor...",
+      "cancel": "İptal",
+      "dns": "DNS Sunucuları",
+      "dns-hint": "Virgülle ayrılmış",
+      "dns-placeholder-v4": "ör. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "ör. 2001:4860:4860::8888",
+      "error-apply-failed": "Ayarlar uygulanamadı",
+      "error-invalid-dns": "Geçersiz DNS biçimi",
+      "error-invalid-gateway": "Geçersiz ağ geçidi biçimi",
+      "error-invalid-ip": "Geçersiz IP adresi biçimi",
+      "gateway": "Ağ Geçidi",
+      "gateway-placeholder-v4": "ör. 192.168.1.1",
+      "gateway-placeholder-v6": "ör. fd00::1",
+      "general": "Genel",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Yöntem",
+      "method-auto": "Otomatik (DHCP)",
+      "method-disabled": "Devre dışı",
+      "method-link-local": "Yalnızca yerel bağlantı",
+      "method-manual": "Manuel",
+      "mtu": "MTU",
+      "mtu-description": "0 = otomatik",
+      "title": "Bağlantıyı düzenle"
+    },
     "enterprise": {
       "anonymous-identity": "Anonim Kimlik",
       "ca-cert": "CA Sertifikası",

--- a/Assets/Translations/tr.json
+++ b/Assets/Translations/tr.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Geçersiz ağ geçidi biçimi",
       "error-invalid-ip": "Geçersiz IP adresi biçimi",
       "error-load-failed": "Ayarlar yüklenemedi",
+      "error-invalid-mtu": "MTU 0 (otomatik) veya 68–9216 olmalıdır",
       "gateway": "Ağ Geçidi",
       "gateway-placeholder-v4": "ör. 192.168.1.1",
       "gateway-placeholder-v6": "ör. fd00::1",

--- a/Assets/Translations/tr.json
+++ b/Assets/Translations/tr.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Geçersiz DNS biçimi",
       "error-invalid-gateway": "Geçersiz ağ geçidi biçimi",
       "error-invalid-ip": "Geçersiz IP adresi biçimi",
+      "error-load-failed": "Ayarlar yüklenemedi",
       "gateway": "Ağ Geçidi",
       "gateway-placeholder-v4": "ör. 192.168.1.1",
       "gateway-placeholder-v6": "ör. fd00::1",

--- a/Assets/Translations/uk-UA.json
+++ b/Assets/Translations/uk-UA.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Час очікування з'єднання вичерпано",
       "disconnected": "Відключено від '{ssid}'",
       "incorrect-password": "Неправильний пароль",
-      "network-not-found": "Мережу не знайдено"
+      "network-not-found": "Мережу не знайдено",
+      "settings-applied": "Мережеві налаштування застосовано",
+      "settings-apply-failed": "Не вдалося застосувати мережеві налаштування"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Заповнювач"
   },
   "wifi": {
+    "edit": {
+      "address": "IP-адреса",
+      "address-placeholder-v4": "напр. 192.168.1.50/24",
+      "address-placeholder-v6": "напр. fd00::1/64",
+      "apply": "Застосувати",
+      "applying": "Застосування...",
+      "cancel": "Скасувати",
+      "dns": "DNS-сервери",
+      "dns-hint": "Через кому",
+      "dns-placeholder-v4": "напр. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "напр. 2001:4860:4860::8888",
+      "error-apply-failed": "Не вдалося застосувати налаштування",
+      "error-invalid-dns": "Невірний формат DNS",
+      "error-invalid-gateway": "Невірний формат шлюзу",
+      "error-invalid-ip": "Невірний формат IP-адреси",
+      "gateway": "Шлюз",
+      "gateway-placeholder-v4": "напр. 192.168.1.1",
+      "gateway-placeholder-v6": "напр. fd00::1",
+      "general": "Загальне",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Метод",
+      "method-auto": "Автоматично (DHCP)",
+      "method-disabled": "Вимкнено",
+      "method-link-local": "Лише локальне з'єднання",
+      "method-manual": "Вручну",
+      "mtu": "MTU",
+      "mtu-description": "0 = автоматично",
+      "title": "Редагувати з'єднання"
+    },
     "enterprise": {
       "anonymous-identity": "Анонімна Ідентичність",
       "ca-cert": "Сертифікат CA",

--- a/Assets/Translations/uk-UA.json
+++ b/Assets/Translations/uk-UA.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Невірний формат шлюзу",
       "error-invalid-ip": "Невірний формат IP-адреси",
       "error-load-failed": "Не вдалося завантажити налаштування",
+      "error-invalid-mtu": "MTU має бути 0 (авто) або 68–9216",
       "gateway": "Шлюз",
       "gateway-placeholder-v4": "напр. 192.168.1.1",
       "gateway-placeholder-v6": "напр. fd00::1",

--- a/Assets/Translations/uk-UA.json
+++ b/Assets/Translations/uk-UA.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Невірний формат DNS",
       "error-invalid-gateway": "Невірний формат шлюзу",
       "error-invalid-ip": "Невірний формат IP-адреси",
+      "error-load-failed": "Не вдалося завантажити налаштування",
       "gateway": "Шлюз",
       "gateway-placeholder-v4": "напр. 192.168.1.1",
       "gateway-placeholder-v6": "напр. fd00::1",

--- a/Assets/Translations/vi.json
+++ b/Assets/Translations/vi.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "Định dạng gateway không hợp lệ",
       "error-invalid-ip": "Định dạng địa chỉ IP không hợp lệ",
       "error-load-failed": "Không thể tải cài đặt",
+      "error-invalid-mtu": "MTU phải là 0 (tự động) hoặc 68–9216",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "vd. 192.168.1.1",
       "gateway-placeholder-v6": "vd. fd00::1",

--- a/Assets/Translations/vi.json
+++ b/Assets/Translations/vi.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "Định dạng DNS không hợp lệ",
       "error-invalid-gateway": "Định dạng gateway không hợp lệ",
       "error-invalid-ip": "Định dạng địa chỉ IP không hợp lệ",
+      "error-load-failed": "Không thể tải cài đặt",
       "gateway": "Gateway",
       "gateway-placeholder-v4": "vd. 192.168.1.1",
       "gateway-placeholder-v6": "vd. fd00::1",

--- a/Assets/Translations/vi.json
+++ b/Assets/Translations/vi.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "Hết thời gian chờ kết nối",
       "disconnected": "Đã ngắt kết nối khỏi '{ssid}'",
       "incorrect-password": "Mật khẩu không đúng",
-      "network-not-found": "Không tìm thấy mạng"
+      "network-not-found": "Không tìm thấy mạng",
+      "settings-applied": "Đã áp dụng cài đặt mạng",
+      "settings-apply-failed": "Không thể áp dụng cài đặt mạng"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "Giữ chỗ"
   },
   "wifi": {
+    "edit": {
+      "address": "Địa chỉ IP",
+      "address-placeholder-v4": "vd. 192.168.1.50/24",
+      "address-placeholder-v6": "vd. fd00::1/64",
+      "apply": "Áp dụng",
+      "applying": "Đang áp dụng...",
+      "cancel": "Hủy",
+      "dns": "Máy chủ DNS",
+      "dns-hint": "Phân cách bằng dấu phẩy",
+      "dns-placeholder-v4": "vd. 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "vd. 2001:4860:4860::8888",
+      "error-apply-failed": "Không thể áp dụng cài đặt",
+      "error-invalid-dns": "Định dạng DNS không hợp lệ",
+      "error-invalid-gateway": "Định dạng gateway không hợp lệ",
+      "error-invalid-ip": "Định dạng địa chỉ IP không hợp lệ",
+      "gateway": "Gateway",
+      "gateway-placeholder-v4": "vd. 192.168.1.1",
+      "gateway-placeholder-v6": "vd. fd00::1",
+      "general": "Chung",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "Phương thức",
+      "method-auto": "Tự động (DHCP)",
+      "method-disabled": "Tắt",
+      "method-link-local": "Chỉ liên kết cục bộ",
+      "method-manual": "Thủ công",
+      "mtu": "MTU",
+      "mtu-description": "0 = tự động",
+      "title": "Chỉnh sửa kết nối"
+    },
     "enterprise": {
       "anonymous-identity": "Danh tính Ẩn danh",
       "ca-cert": "Chứng chỉ CA",

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "连接超时",
       "disconnected": "已断开与 '{ssid}' 的连接",
       "incorrect-password": "密码错误",
-      "network-not-found": "未找到网络"
+      "network-not-found": "未找到网络",
+      "settings-applied": "网络设置已应用",
+      "settings-apply-failed": "应用网络设置失败"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "占位符"
   },
   "wifi": {
+    "edit": {
+      "address": "IP 地址",
+      "address-placeholder-v4": "例如 192.168.1.50/24",
+      "address-placeholder-v6": "例如 fd00::1/64",
+      "apply": "应用",
+      "applying": "正在应用...",
+      "cancel": "取消",
+      "dns": "DNS 服务器",
+      "dns-hint": "以逗号分隔",
+      "dns-placeholder-v4": "例如 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "例如 2001:4860:4860::8888",
+      "error-apply-failed": "应用设置失败",
+      "error-invalid-dns": "无效的 DNS 格式",
+      "error-invalid-gateway": "无效的网关格式",
+      "error-invalid-ip": "无效的 IP 地址格式",
+      "gateway": "网关",
+      "gateway-placeholder-v4": "例如 192.168.1.1",
+      "gateway-placeholder-v6": "例如 fd00::1",
+      "general": "常规",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "方式",
+      "method-auto": "自动 (DHCP)",
+      "method-disabled": "已禁用",
+      "method-link-local": "仅本地链路",
+      "method-manual": "手动",
+      "mtu": "MTU",
+      "mtu-description": "0 = 自动",
+      "title": "编辑连接"
+    },
     "enterprise": {
       "anonymous-identity": "匿名身份",
       "ca-cert": "CA 证书",

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "无效的 DNS 格式",
       "error-invalid-gateway": "无效的网关格式",
       "error-invalid-ip": "无效的 IP 地址格式",
+      "error-load-failed": "加载设置失败",
       "gateway": "网关",
       "gateway-placeholder-v4": "例如 192.168.1.1",
       "gateway-placeholder-v6": "例如 fd00::1",

--- a/Assets/Translations/zh-CN.json
+++ b/Assets/Translations/zh-CN.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "无效的网关格式",
       "error-invalid-ip": "无效的 IP 地址格式",
       "error-load-failed": "加载设置失败",
+      "error-invalid-mtu": "MTU 必须为 0（自动）或 68–9216",
       "gateway": "网关",
       "gateway-placeholder-v4": "例如 192.168.1.1",
       "gateway-placeholder-v6": "例如 fd00::1",

--- a/Assets/Translations/zh-TW.json
+++ b/Assets/Translations/zh-TW.json
@@ -1999,7 +1999,9 @@
       "connection-timeout": "連線逾時",
       "disconnected": "已自 '{ssid}' 斷開連線",
       "incorrect-password": "密碼錯誤",
-      "network-not-found": "找不到網路"
+      "network-not-found": "找不到網路",
+      "settings-applied": "網路設定已套用",
+      "settings-apply-failed": "套用網路設定失敗"
     }
   },
   "tooltips": {
@@ -2206,6 +2208,36 @@
     "tooltip-placeholder": "暫用文字"
   },
   "wifi": {
+    "edit": {
+      "address": "IP 位址",
+      "address-placeholder-v4": "例如 192.168.1.50/24",
+      "address-placeholder-v6": "例如 fd00::1/64",
+      "apply": "套用",
+      "applying": "正在套用...",
+      "cancel": "取消",
+      "dns": "DNS 伺服器",
+      "dns-hint": "以逗號分隔",
+      "dns-placeholder-v4": "例如 8.8.8.8, 8.8.4.4",
+      "dns-placeholder-v6": "例如 2001:4860:4860::8888",
+      "error-apply-failed": "套用設定失敗",
+      "error-invalid-dns": "無效的 DNS 格式",
+      "error-invalid-gateway": "無效的閘道器格式",
+      "error-invalid-ip": "無效的 IP 位址格式",
+      "gateway": "閘道器",
+      "gateway-placeholder-v4": "例如 192.168.1.1",
+      "gateway-placeholder-v6": "例如 fd00::1",
+      "general": "一般",
+      "ipv4": "IPv4",
+      "ipv6": "IPv6",
+      "method": "方式",
+      "method-auto": "自動 (DHCP)",
+      "method-disabled": "已停用",
+      "method-link-local": "僅本機連結",
+      "method-manual": "手動",
+      "mtu": "MTU",
+      "mtu-description": "0 = 自動",
+      "title": "編輯連線"
+    },
     "enterprise": {
       "anonymous-identity": "匿名身份",
       "ca-cert": "CA 憑證",

--- a/Assets/Translations/zh-TW.json
+++ b/Assets/Translations/zh-TW.json
@@ -2223,6 +2223,7 @@
       "error-invalid-dns": "無效的 DNS 格式",
       "error-invalid-gateway": "無效的閘道器格式",
       "error-invalid-ip": "無效的 IP 位址格式",
+      "error-load-failed": "載入設定失敗",
       "gateway": "閘道器",
       "gateway-placeholder-v4": "例如 192.168.1.1",
       "gateway-placeholder-v6": "例如 fd00::1",

--- a/Assets/Translations/zh-TW.json
+++ b/Assets/Translations/zh-TW.json
@@ -2224,6 +2224,7 @@
       "error-invalid-gateway": "無效的閘道器格式",
       "error-invalid-ip": "無效的 IP 位址格式",
       "error-load-failed": "載入設定失敗",
+      "error-invalid-mtu": "MTU 必須為 0（自動）或 68–9216",
       "gateway": "閘道器",
       "gateway-placeholder-v4": "例如 192.168.1.1",
       "gateway-placeholder-v6": "例如 fd00::1",

--- a/Modules/Bar/Widgets/Bluetooth.qml
+++ b/Modules/Bar/Widgets/Bluetooth.qml
@@ -70,7 +70,7 @@ Item {
                    if (action === "toggle-bluetooth") {
                      BluetoothService.setBluetoothEnabled(!BluetoothService.enabled);
                    } else if (action === "bluetooth-settings") {
-                     SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 1, screen);
+                     SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 2, screen);
                    } else if (action === "widget-settings") {
                      BarService.openWidgetSettings(screen, section, sectionWidgetIndex, widgetId, widgetSettings);
                    }

--- a/Modules/Panels/Bluetooth/BluetoothPanel.qml
+++ b/Modules/Panels/Bluetooth/BluetoothPanel.qml
@@ -71,7 +71,7 @@ SmartPanel {
             icon: "settings"
             tooltipText: I18n.tr("tooltips.open-settings")
             baseSize: Style.baseWidgetSize * 0.8
-            onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 1, screen)
+            onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 2, screen)
           }
 
           NIconButton {
@@ -185,7 +185,7 @@ SmartPanel {
                 text: I18n.tr("common.settings")
                 icon: "settings"
                 Layout.alignment: Qt.AlignHCenter
-                onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 1, screen)
+                onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 2, screen)
               }
 
               Item {

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -647,6 +647,7 @@ SmartPanel {
 
                           // Edit connection button
                           NIconButton {
+                            visible: (NetworkService.activeEthernetDetails.connectionName || "").length > 0
                             anchors.top: parent.top
                             anchors.right: parent.right
                             anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
@@ -654,12 +655,7 @@ SmartPanel {
                             icon: "settings"
                             tooltipText: I18n.tr("wifi.edit.title")
                             baseSize: Style.baseWidgetSize * 0.65
-                            onClicked: {
-                              var connName = NetworkService.activeEthernetDetails.connectionName || "";
-                              if (connName) {
-                                networkEditPopup.openEdit(connName, true, false);
-                              }
-                            }
+                            onClicked: networkEditPopup.openEdit(NetworkService.activeEthernetDetails.connectionName, true, false)
                             z: 1
                           }
 

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -158,7 +158,7 @@ SmartPanel {
               icon: "settings"
               tooltipText: I18n.tr("tooltips.open-settings")
               baseSize: Style.baseWidgetSize * 0.8
-              onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, 0, screen)
+              onClicked: SettingsPanelService.openToTab(SettingsPanel.Tab.Connections, panelViewMode === "ethernet" ? 1 : 0, screen)
             }
 
             NIconButton {

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -27,6 +27,11 @@ SmartPanel {
   property string panelViewMode: "wifi"
   property bool panelViewPersistEnabled: false
 
+  WifiPrefs.NetworkEditPopup {
+    id: networkEditPopup
+    parent: Overlay.overlay
+  }
+
   onPanelViewModeChanged: {
     // Persist last view (only after restored the initial value)
     if (panelViewPersistEnabled) {
@@ -636,6 +641,24 @@ SmartPanel {
                             onClicked: {
                               ethernetDetailsGrid = !ethernetDetailsGrid;
                               Settings.data.network.wifiDetailsViewMode = ethernetDetailsGrid ? "grid" : "list";
+                            }
+                            z: 1
+                          }
+
+                          // Edit connection button
+                          NIconButton {
+                            anchors.top: parent.top
+                            anchors.right: parent.right
+                            anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
+                            anchors.topMargin: Style.marginS
+                            icon: "settings"
+                            tooltipText: I18n.tr("wifi.edit.title")
+                            baseSize: Style.baseWidgetSize * 0.65
+                            onClicked: {
+                              var connName = NetworkService.activeEthernetDetails.connectionName || "";
+                              if (connName) {
+                                networkEditPopup.openEdit(connName, true, false);
+                              }
                             }
                             z: 1
                           }

--- a/Modules/Panels/Network/NetworkPanel.qml
+++ b/Modules/Panels/Network/NetworkPanel.qml
@@ -647,7 +647,6 @@ SmartPanel {
 
                           // Edit connection button
                           NIconButton {
-                            visible: (NetworkService.activeEthernetDetails.connectionName || "").length > 0
                             anchors.top: parent.top
                             anchors.right: parent.right
                             anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
@@ -655,7 +654,12 @@ SmartPanel {
                             icon: "settings"
                             tooltipText: I18n.tr("wifi.edit.title")
                             baseSize: Style.baseWidgetSize * 0.65
-                            onClicked: networkEditPopup.openEdit(NetworkService.activeEthernetDetails.connectionName, true, false)
+                            onClicked: {
+                              var connName = NetworkService.activeEthernetDetails.connectionName || "";
+                              if (connName) {
+                                networkEditPopup.openEdit(connName, true, false);
+                              }
+                            }
                             z: 1
                           }
 

--- a/Modules/Panels/Settings/Tabs/Connections/ConnectionsTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/ConnectionsTab.qml
@@ -22,9 +22,14 @@ ColumnLayout {
       checked: subTabBar.currentIndex === 0
     }
     NTabButton {
-      text: I18n.tr("common.bluetooth")
+      text: I18n.tr("common.ethernet")
       tabIndex: 1
       checked: subTabBar.currentIndex === 1
+    }
+    NTabButton {
+      text: I18n.tr("common.bluetooth")
+      tabIndex: 2
+      checked: subTabBar.currentIndex === 2
     }
   }
 
@@ -38,6 +43,7 @@ ColumnLayout {
     currentIndex: subTabBar.currentIndex
 
     WifiSubTab {}
+    EthernetSubTab {}
     BluetoothSubTab {}
   }
 }

--- a/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
@@ -275,6 +275,7 @@ Item {
             }
 
             NIconButton {
+              visible: (NetworkService.activeEthernetDetails.connectionName || "").length > 0
               anchors.top: parent.top
               anchors.right: parent.right
               anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
@@ -282,12 +283,7 @@ Item {
               icon: "settings"
               tooltipText: I18n.tr("wifi.edit.title")
               baseSize: Style.baseWidgetSize * 0.65
-              onClicked: {
-                var connName = NetworkService.activeEthernetDetails.connectionName || "";
-                if (connName) {
-                  networkEditPopup.openEdit(connName, true, false);
-                }
-              }
+              onClicked: networkEditPopup.openEdit(NetworkService.activeEthernetDetails.connectionName, true, false)
               z: 1
             }
 

--- a/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
@@ -1,0 +1,554 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import Quickshell
+
+import qs.Commons
+import qs.Services.Networking
+import qs.Services.System
+import qs.Services.UI
+import qs.Widgets
+
+Item {
+  id: root
+  Layout.fillWidth: true
+  implicitHeight: mainLayout.implicitHeight
+
+  NetworkEditPopup {
+    id: networkEditPopup
+    parent: Overlay.overlay
+  }
+
+  property string expandedIf: ""
+  property int ipVersion: 4
+  property bool detailsGrid: (Settings.data && Settings.data.network && Settings.data.network.wifiDetailsViewMode === "grid")
+
+  readonly property bool effectivelyVisible: root.visible && Window.window && Window.window.visible
+
+  onEffectivelyVisibleChanged: {
+    if (effectivelyVisible) {
+      SystemStatService.registerComponent("ethernet-subtab");
+      if (NetworkService.ethernetConnected) {
+        NetworkService.refreshActiveEthernetDetails();
+      }
+    } else {
+      SystemStatService.unregisterComponent("ethernet-subtab");
+    }
+  }
+
+  Component.onDestruction: {
+    SystemStatService.unregisterComponent("ethernet-subtab");
+  }
+
+  ColumnLayout {
+    id: mainLayout
+    width: root.width
+    spacing: Style.marginM
+
+    // === Header ===
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: Style.marginS
+
+      NText {
+        text: I18n.tr("wifi.panel.available-interfaces")
+        pointSize: Style.fontSizeM
+        font.weight: Style.fontWeightSemiBold
+        color: Color.mOnSurface
+        visible: NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0
+      }
+    }
+
+    // === Empty state ===
+    ColumnLayout {
+      Layout.fillWidth: true
+      Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+      Layout.preferredHeight: implicitHeight + Style.margin2L
+      visible: !(NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0)
+      spacing: Style.marginL
+
+      Item { Layout.fillHeight: true }
+
+      NIcon {
+        icon: "ethernet-off"
+        pointSize: 48
+        color: Color.mOnSurfaceVariant
+        Layout.alignment: Qt.AlignHCenter
+      }
+
+      NText {
+        text: I18n.tr("wifi.panel.no-ethernet-devices")
+        pointSize: Style.fontSizeL
+        color: Color.mOnSurfaceVariant
+        Layout.alignment: Qt.AlignHCenter
+      }
+
+      Item { Layout.fillHeight: true }
+    }
+
+    // === Interfaces list ===
+    ColumnLayout {
+      Layout.fillWidth: true
+      visible: NetworkService.ethernetInterfaces && NetworkService.ethernetInterfaces.length > 0
+      spacing: Style.marginXS
+
+      Repeater {
+        model: NetworkService.ethernetInterfaces || []
+        delegate: ColumnLayout {
+          id: ethDelegate
+          Layout.fillWidth: true
+          spacing: 0
+
+          required property int index
+          required property var modelData
+
+          property bool isExpanded: root.expandedIf === modelData.ifname
+
+          function getContentColors(defaultColors) {
+            if (!defaultColors) defaultColors = [Color.mSurface, Color.mOnSurface];
+            if (modelData.connected) {
+              return [Color.mPrimary, Color.mOnPrimary];
+            }
+            return defaultColors;
+          }
+
+          // Interface card
+          NBox {
+            Layout.fillWidth: true
+            implicitHeight: cardColumn.implicitHeight + Style.margin2M
+            radius: Style.radiusM
+            forceOpaque: true
+            color: ethDelegate.getContentColors()[0]
+
+            ColumnLayout {
+              id: cardColumn
+              width: parent.width - Style.margin2M
+              x: Style.marginM
+              y: Style.marginM
+              spacing: Style.marginS
+
+              RowLayout {
+                Layout.fillWidth: true
+                spacing: Style.marginS
+
+                NIcon {
+                  Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                  icon: NetworkService.getIcon(true)
+                  pointSize: Style.fontSizeXXL
+                  color: ethDelegate.getContentColors()[1]
+                }
+
+                ColumnLayout {
+                  Layout.fillWidth: true
+                  spacing: 2
+
+                  NText {
+                    text: modelData.connectionName || modelData.ifname
+                    pointSize: Style.fontSizeM
+                    font.weight: modelData.connected ? Style.fontWeightBold : Style.fontWeightMedium
+                    color: ethDelegate.getContentColors()[1]
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                  }
+
+                  RowLayout {
+                    spacing: Style.marginXS
+
+                    NText {
+                      text: {
+                        if (modelData.connected) {
+                          switch (NetworkService.networkConnectivity) {
+                          case "full":
+                            return I18n.tr("common.connected");
+                          case "limited":
+                          case "unknown":
+                            return I18n.tr("wifi.panel.internet-limited");
+                          case "portal":
+                            return I18n.tr("wifi.panel.action-required");
+                          default:
+                            return NetworkService.networkConnectivity;
+                          }
+                        }
+                        return I18n.tr("common.disconnected");
+                      }
+                      pointSize: Style.fontSizeXXS
+                      color: Qt.alpha(ethDelegate.getContentColors()[1], Style.opacityHeavy)
+                    }
+
+                    RowLayout {
+                      visible: (modelData.connected && NetworkService.networkConnectivity === "full") && (SystemStatService.rxSpeed > 0 || SystemStatService.txSpeed > 0)
+                      spacing: 2
+                      Layout.leftMargin: Style.marginXS
+
+                      NIcon {
+                        visible: SystemStatService.rxSpeed > 0
+                        icon: "arrow-down"
+                        pointSize: Style.fontSizeXXS
+                        color: Qt.alpha(ethDelegate.getContentColors()[1], Style.opacityHeavy)
+                      }
+                      NText {
+                        visible: SystemStatService.rxSpeed > 0
+                        text: SystemStatService.formatSpeed(SystemStatService.rxSpeed)
+                        pointSize: Style.fontSizeXXS
+                        color: Qt.alpha(ethDelegate.getContentColors()[1], Style.opacityHeavy)
+                      }
+
+                      Item {
+                        visible: SystemStatService.rxSpeed > 0 && SystemStatService.txSpeed > 0
+                        width: Style.marginXS
+                        height: 1
+                      }
+
+                      NIcon {
+                        visible: SystemStatService.txSpeed > 0
+                        icon: "arrow-up"
+                        pointSize: Style.fontSizeXXS
+                        color: Qt.alpha(ethDelegate.getContentColors()[1], Style.opacityHeavy)
+                      }
+                      NText {
+                        visible: SystemStatService.txSpeed > 0
+                        text: SystemStatService.formatSpeed(SystemStatService.txSpeed)
+                        pointSize: Style.fontSizeXXS
+                        color: Qt.alpha(ethDelegate.getContentColors()[1], Style.opacityHeavy)
+                      }
+                    }
+                  }
+                }
+
+                // Info toggle
+                NIconButton {
+                  icon: "info"
+                  tooltipText: I18n.tr("common.info")
+                  baseSize: Style.baseWidgetSize * 0.75
+                  colorBg: Color.mSurfaceVariant
+                  colorFg: Color.mOnSurface
+                  colorBorder: "transparent"
+                  colorBorderHover: "transparent"
+                  visible: modelData.connected
+                  onClicked: {
+                    if (ethDelegate.isExpanded) {
+                      root.expandedIf = "";
+                      return;
+                    }
+                    if (NetworkService.activeEthernetIf !== modelData.ifname) {
+                      NetworkService.activeEthernetIf = modelData.ifname;
+                      NetworkService.activeEthernetDetailsTimestamp = 0;
+                    }
+                    root.expandedIf = modelData.ifname;
+                    NetworkService.refreshActiveEthernetDetails();
+                  }
+                }
+              }
+            }
+          }
+
+          // Connection info details
+          Rectangle {
+            visible: ethDelegate.isExpanded
+            Layout.fillWidth: true
+            implicitHeight: infoColumn.implicitHeight + Style.margin2S
+            radius: Style.radiusXS
+            color: Color.mSurfaceVariant
+            border.width: Style.borderS
+            border.color: Style.boxBorderColor
+            clip: true
+
+            onVisibleChanged: {
+              if (visible && infoColumn && infoColumn.forceLayout) {
+                Qt.callLater(function () { infoColumn.forceLayout(); });
+              }
+            }
+
+            NIconButton {
+              anchors.top: parent.top
+              anchors.right: parent.right
+              anchors.margins: Style.marginS
+              icon: root.detailsGrid ? "layout-list" : "layout-grid"
+              tooltipText: root.detailsGrid ? I18n.tr("tooltips.list-view") : I18n.tr("tooltips.grid-view")
+              baseSize: Style.baseWidgetSize * 0.65
+              onClicked: {
+                root.detailsGrid = !root.detailsGrid;
+                Settings.data.network.wifiDetailsViewMode = root.detailsGrid ? "grid" : "list";
+              }
+              z: 1
+            }
+
+            NIconButton {
+              anchors.top: parent.top
+              anchors.right: parent.right
+              anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
+              anchors.topMargin: Style.marginS
+              icon: "settings"
+              tooltipText: I18n.tr("wifi.edit.title")
+              baseSize: Style.baseWidgetSize * 0.65
+              onClicked: {
+                var connName = NetworkService.activeEthernetDetails.connectionName || "";
+                if (connName) {
+                  networkEditPopup.openEdit(connName, true, false);
+                }
+              }
+              z: 1
+            }
+
+            GridLayout {
+              id: infoColumn
+              anchors.fill: parent
+              anchors.margins: Style.marginS
+              anchors.rightMargin: Style.baseWidgetSize
+              flow: root.detailsGrid ? GridLayout.TopToBottom : GridLayout.LeftToRight
+              rows: root.detailsGrid ? 3 : 6
+              columns: root.detailsGrid ? 2 : 1
+              columnSpacing: Style.marginM
+              rowSpacing: Style.marginXS
+              onColumnsChanged: {
+                if (infoColumn.forceLayout) {
+                  Qt.callLater(function () { infoColumn.forceLayout(); });
+                }
+              }
+
+              // --- Item 1: Interface ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "ethernet"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.interface"))
+                    onExited: TooltipService.hide()
+                  }
+                }
+                NText {
+                  text: (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "-")
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                  wrapMode: root.detailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                  elide: root.detailsGrid ? Text.ElideRight : Text.ElideNone
+                  maximumLineCount: root.detailsGrid ? 1 : 6
+                  clip: true
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: ((NetworkService.activeEthernetDetails.ifname || "").length > 0) || ((NetworkService.activeEthernetIf || "").length > 0)
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      const value = (NetworkService.activeEthernetDetails.ifname && NetworkService.activeEthernetDetails.ifname.length > 0) ? NetworkService.activeEthernetDetails.ifname : (NetworkService.activeEthernetIf || "");
+                      if (value.length > 0) {
+                        Quickshell.execDetached(["wl-copy", value]);
+                        ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                      }
+                    }
+                  }
+                }
+              }
+
+              // --- Item 2: Hardware Address ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "hash"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, I18n.tr("bluetooth.panel.device-address"))
+                    onExited: TooltipService.hide()
+                  }
+                }
+                NText {
+                  text: NetworkService.activeEthernetDetails.hwAddr || "-"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                  wrapMode: root.detailsGrid ? Text.NoWrap : Text.WrapAtWordBoundaryOrAnywhere
+                  elide: root.detailsGrid ? Text.ElideRight : Text.ElideNone
+                  maximumLineCount: root.detailsGrid ? 1 : 6
+                  clip: true
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: (NetworkService.activeEthernetDetails.hwAddr || "").length > 0
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      const value = NetworkService.activeEthernetDetails.hwAddr || "";
+                      if (value.length > 0) {
+                        Quickshell.execDetached(["wl-copy", value]);
+                        ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                      }
+                    }
+                  }
+                }
+              }
+
+              // --- Item 3: Link speed ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "gauge"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, I18n.tr("wifi.panel.link-speed"))
+                    onExited: TooltipService.hide()
+                  }
+                }
+                NText {
+                  text: (NetworkService.activeEthernetDetails.speed && NetworkService.activeEthernetDetails.speed.length > 0) ? NetworkService.activeEthernetDetails.speed : "-"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                }
+              }
+
+              // --- Item 4: IPv4 || IPv6 ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "network"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                      TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.ipv4") : I18n.tr("wifi.panel.ipv6"));
+                    }
+                  }
+                }
+                NText {
+                  text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "-") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "-")
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "").length > 0 : (NetworkService.activeEthernetDetails.ipv6 || []).length > 0
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.ipv4 || "") : ((NetworkService.activeEthernetDetails.ipv6 || []).join(", ") || "");
+                      if (value.length > 0) {
+                        Quickshell.execDetached(["wl-copy", value]);
+                        ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                      }
+                    }
+                  }
+                }
+              }
+
+              // --- Item 5: DNS ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "world"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                      TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("wifi.panel.dns") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
+                    }
+                  }
+                }
+                NText {
+                  text: root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "-") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "-")
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.dns4 || []).length > 0 : (NetworkService.activeEthernetDetails.dns6 || []).length > 0
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      const value = root.ipVersion === 4 ? ((NetworkService.activeEthernetDetails.dns4 || []).join(", ") || "") : ((NetworkService.activeEthernetDetails.dns6 || []).join(", ") || "");
+                      if (value.length > 0) {
+                        Quickshell.execDetached(["wl-copy", value]);
+                        ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                      }
+                    }
+                  }
+                }
+              }
+
+              // --- Item 6: Gateway ---
+              RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredWidth: 1
+                spacing: Style.marginXS
+                NIcon {
+                  icon: "router"
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")")
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      root.ipVersion = root.ipVersion === 4 ? 6 : 4;
+                      TooltipService.show(parent, root.ipVersion === 4 ? I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv4") + ")" : I18n.tr("common.gateway") + " (" + I18n.tr("wifi.panel.ipv6") + ")");
+                    }
+                  }
+                }
+                NText {
+                  text: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "-") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "-")
+                  pointSize: Style.fontSizeXS
+                  color: Color.mOnSurface
+                  Layout.fillWidth: true
+                  MouseArea {
+                    anchors.fill: parent
+                    enabled: root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "").length > 0 : (NetworkService.activeEthernetDetails.gateway6 || []).length > 0
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: TooltipService.show(parent, I18n.tr("tooltips.copy-address"))
+                    onExited: TooltipService.hide()
+                    onClicked: {
+                      const value = root.ipVersion === 4 ? (NetworkService.activeEthernetDetails.gateway4 || "") : ((NetworkService.activeEthernetDetails.gateway6 || []).join(", ") || "");
+                      if (value.length > 0) {
+                        Quickshell.execDetached(["wl-copy", value]);
+                        ToastService.showNotice(I18n.tr("common.ethernet"), I18n.tr("common.copied-to-clipboard"), "ethernet");
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml
@@ -275,7 +275,6 @@ Item {
             }
 
             NIconButton {
-              visible: (NetworkService.activeEthernetDetails.connectionName || "").length > 0
               anchors.top: parent.top
               anchors.right: parent.right
               anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
@@ -283,7 +282,12 @@ Item {
               icon: "settings"
               tooltipText: I18n.tr("wifi.edit.title")
               baseSize: Style.baseWidgetSize * 0.65
-              onClicked: networkEditPopup.openEdit(NetworkService.activeEthernetDetails.connectionName, true, false)
+              onClicked: {
+                var connName = NetworkService.activeEthernetDetails.connectionName || "";
+                if (connName) {
+                  networkEditPopup.openEdit(connName, true, false);
+                }
+              }
               z: 1
             }
 

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -14,7 +14,6 @@ Popup {
   anchors.centerIn: parent
 
   width: Math.min(550 * Style.uiScaleRatio, parent.width * 0.9)
-  height: Math.min(contentLayout.implicitHeight + padding * 2, parent.height * 0.85)
   padding: Style.marginL
 
   // Input properties
@@ -170,193 +169,229 @@ Popup {
     try { NetworkService.connectionModified.disconnect(root._modifiedSlot); } catch (e) {}
   }
 
-  contentItem: ColumnLayout {
-    id: contentLayout
-    spacing: Style.marginL
+  contentItem: Flickable {
+    id: flickable
+    implicitHeight: Math.min(contentColumn.implicitHeight, root.parent ? root.parent.height * 0.8 : 600)
+    contentHeight: contentColumn.implicitHeight
+    clip: true
+    boundsBehavior: Flickable.StopAtBounds
 
-    // Header
-    RowLayout {
-      Layout.fillWidth: true
-      NText {
-        text: I18n.tr("wifi.edit.title") + " — " + root.connectionName
-        font.weight: Style.fontWeightBold
-        pointSize: Style.fontSizeL
+    ColumnLayout {
+      id: contentColumn
+      width: flickable.width
+      spacing: Style.marginL
+
+      // Header
+      RowLayout {
         Layout.fillWidth: true
-        elide: Text.ElideRight
+        NText {
+          text: I18n.tr("wifi.edit.title") + " — " + root.connectionName
+          font.weight: Style.fontWeightBold
+          pointSize: Style.fontSizeL
+          Layout.fillWidth: true
+          elide: Text.ElideRight
+        }
+        NIconButton {
+          icon: "close"
+          onClicked: root.close()
+        }
       }
-      NIconButton {
-        icon: "close"
-        onClicked: root.close()
+
+      // Loading indicator
+      NText {
+        visible: root.loading
+        text: "..."
+        color: Color.mOnSurfaceVariant
+        Layout.alignment: Qt.AlignHCenter
       }
-    }
 
-    // Loading indicator
-    NText {
-      visible: root.loading
-      text: "..."
-      color: Color.mOnSurfaceVariant
-      Layout.alignment: Qt.AlignHCenter
-    }
-
-    // Form content
-    NScrollView {
-      visible: !root.loading
-      Layout.fillWidth: true
-      Layout.fillHeight: true
-      Layout.maximumHeight: root.height - 160 * Style.uiScaleRatio
-
+      // === IPv4 Section ===
       ColumnLayout {
-        width: parent.width
+        visible: !root.loading
+        Layout.fillWidth: true
         spacing: Style.marginM
 
-        // === IPv4 Section ===
-        NCollapsible {
-          label: I18n.tr("wifi.edit.ipv4")
-          expanded: true
-          Layout.fillWidth: true
-
-          NComboBox {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.method")
-            model: [
-              { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
-              { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
-              { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
-            ]
-            currentKey: root.ipv4Method
-            onSelected: key => root.ipv4Method = key
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.address")
-            placeholderText: I18n.tr("wifi.edit.address-placeholder-v4")
-            text: root.ipv4Address
-            onTextChanged: root.ipv4Address = text
-            enabled: root.ipv4Method === "manual"
-            readOnly: root.ipv4Method !== "manual"
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.gateway")
-            placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v4")
-            text: root.ipv4Gateway
-            onTextChanged: root.ipv4Gateway = text
-            enabled: root.ipv4Method === "manual"
-            readOnly: root.ipv4Method !== "manual"
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
-            placeholderText: I18n.tr("wifi.edit.dns-placeholder-v4")
-            text: root.ipv4Dns
-            onTextChanged: root.ipv4Dns = text
-            enabled: root.ipv4Method !== "disabled"
-            readOnly: root.ipv4Method === "disabled"
-          }
+        NText {
+          text: I18n.tr("wifi.edit.ipv4")
+          pointSize: Style.fontSizeM
+          font.weight: Style.fontWeightSemiBold
+          color: Color.mPrimary
         }
 
-        // === IPv6 Section ===
-        NCollapsible {
-          label: I18n.tr("wifi.edit.ipv6")
-          expanded: false
+        NComboBox {
+          id: ipv4MethodCombo
           Layout.fillWidth: true
-
-          NComboBox {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.method")
-            model: [
-              { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
-              { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
-              { key: "link-local", name: I18n.tr("wifi.edit.method-link-local") },
-              { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
-            ]
-            currentKey: root.ipv6Method
-            onSelected: key => root.ipv6Method = key
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.address")
-            placeholderText: I18n.tr("wifi.edit.address-placeholder-v6")
-            text: root.ipv6Address
-            onTextChanged: root.ipv6Address = text
-            enabled: root.ipv6Method === "manual"
-            readOnly: root.ipv6Method !== "manual"
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.gateway")
-            placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v6")
-            text: root.ipv6Gateway
-            onTextChanged: root.ipv6Gateway = text
-            enabled: root.ipv6Method === "manual"
-            readOnly: root.ipv6Method !== "manual"
-          }
-
-          NTextInput {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
-            placeholderText: I18n.tr("wifi.edit.dns-placeholder-v6")
-            text: root.ipv6Dns
-            onTextChanged: root.ipv6Dns = text
-            enabled: root.ipv6Method !== "disabled"
-            readOnly: root.ipv6Method === "disabled"
-          }
+          label: I18n.tr("wifi.edit.method")
+          model: [
+            { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
+            { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
+            { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
+          ]
+          currentKey: root.ipv4Method
+          onSelected: key => root.ipv4Method = key
         }
 
-        // === General Section ===
-        NCollapsible {
-          label: I18n.tr("wifi.edit.general")
-          expanded: false
+        NTextInput {
+          id: ipv4AddressInput
           Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.address")
+          placeholderText: I18n.tr("wifi.edit.address-placeholder-v4")
+          text: root.ipv4Address
+          onTextChanged: root.ipv4Address = text
+          visible: root.ipv4Method === "manual"
+        }
 
-          NSpinBox {
-            Layout.fillWidth: true
-            label: I18n.tr("wifi.edit.mtu")
-            description: I18n.tr("wifi.edit.mtu-description")
-            value: root.mtu
-            from: 0
-            to: 9000
-            stepSize: 1
-            onValueChanged: root.mtu = value
-          }
+        NTextInput {
+          id: ipv4GatewayInput
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.gateway")
+          placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v4")
+          text: root.ipv4Gateway
+          onTextChanged: root.ipv4Gateway = text
+          visible: root.ipv4Method === "manual"
+        }
+
+        NTextInput {
+          id: ipv4DnsInput
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
+          placeholderText: I18n.tr("wifi.edit.dns-placeholder-v4")
+          text: root.ipv4Dns
+          onTextChanged: root.ipv4Dns = text
+          visible: root.ipv4Method !== "disabled"
         }
       }
-    }
 
-    // Error message
-    NText {
-      visible: root.errorMsg.length > 0
-      text: root.errorMsg
-      color: Color.mError
-      wrapMode: Text.WordWrap
-      Layout.fillWidth: true
-    }
-
-    // Footer buttons
-    RowLayout {
-      Layout.fillWidth: true
-      spacing: Style.marginM
-
-      Item { Layout.fillWidth: true }
-
-      NButton {
-        text: I18n.tr("wifi.edit.cancel")
-        outlined: true
-        onClicked: root.close()
+      // Separator
+      Rectangle {
+        visible: !root.loading
+        Layout.fillWidth: true
+        height: Style.borderS
+        color: Color.mOutline
       }
 
-      NButton {
-        text: NetworkService.modifyingConnection ? I18n.tr("wifi.edit.applying") : I18n.tr("wifi.edit.apply")
-        icon: "check"
-        backgroundColor: Color.mPrimary
-        textColor: Color.mOnPrimary
-        enabled: root.canApply()
-        onClicked: root.applySettings()
+      // === IPv6 Section ===
+      ColumnLayout {
+        visible: !root.loading
+        Layout.fillWidth: true
+        spacing: Style.marginM
+
+        NText {
+          text: I18n.tr("wifi.edit.ipv6")
+          pointSize: Style.fontSizeM
+          font.weight: Style.fontWeightSemiBold
+          color: Color.mPrimary
+        }
+
+        NComboBox {
+          id: ipv6MethodCombo
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.method")
+          model: [
+            { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
+            { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
+            { key: "link-local", name: I18n.tr("wifi.edit.method-link-local") },
+            { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
+          ]
+          currentKey: root.ipv6Method
+          onSelected: key => root.ipv6Method = key
+        }
+
+        NTextInput {
+          id: ipv6AddressInput
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.address")
+          placeholderText: I18n.tr("wifi.edit.address-placeholder-v6")
+          text: root.ipv6Address
+          onTextChanged: root.ipv6Address = text
+          visible: root.ipv6Method === "manual"
+        }
+
+        NTextInput {
+          id: ipv6GatewayInput
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.gateway")
+          placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v6")
+          text: root.ipv6Gateway
+          onTextChanged: root.ipv6Gateway = text
+          visible: root.ipv6Method === "manual"
+        }
+
+        NTextInput {
+          id: ipv6DnsInput
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
+          placeholderText: I18n.tr("wifi.edit.dns-placeholder-v6")
+          text: root.ipv6Dns
+          onTextChanged: root.ipv6Dns = text
+          visible: root.ipv6Method !== "disabled"
+        }
+      }
+
+      // Separator
+      Rectangle {
+        visible: !root.loading
+        Layout.fillWidth: true
+        height: Style.borderS
+        color: Color.mOutline
+      }
+
+      // === General Section ===
+      ColumnLayout {
+        visible: !root.loading
+        Layout.fillWidth: true
+        spacing: Style.marginM
+
+        NText {
+          text: I18n.tr("wifi.edit.general")
+          pointSize: Style.fontSizeM
+          font.weight: Style.fontWeightSemiBold
+          color: Color.mPrimary
+        }
+
+        NSpinBox {
+          id: mtuSpinBox
+          Layout.fillWidth: true
+          label: I18n.tr("wifi.edit.mtu")
+          description: I18n.tr("wifi.edit.mtu-description")
+          value: root.mtu
+          from: 0
+          to: 9000
+          stepSize: 1
+          onValueChanged: root.mtu = value
+        }
+      }
+
+      // Error message
+      NText {
+        visible: root.errorMsg.length > 0
+        text: root.errorMsg
+        color: Color.mError
+        wrapMode: Text.WordWrap
+        Layout.fillWidth: true
+      }
+
+      // Footer buttons
+      RowLayout {
+        Layout.fillWidth: true
+        spacing: Style.marginM
+
+        Item { Layout.fillWidth: true }
+
+        NButton {
+          text: I18n.tr("wifi.edit.cancel")
+          outlined: true
+          onClicked: root.close()
+        }
+
+        NButton {
+          text: NetworkService.modifyingConnection ? I18n.tr("wifi.edit.applying") : I18n.tr("wifi.edit.apply")
+          icon: "check"
+          backgroundColor: Color.mPrimary
+          textColor: Color.mOnPrimary
+          enabled: root.canApply()
+          onClicked: root.applySettings()
+        }
       }
     }
   }

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -151,13 +151,19 @@ Popup {
     var v4dns = ipv4Dns.split(",").map(function(s) { return s.trim(); }).filter(function(s) { return s; }).join(" ");
     var v6dns = ipv6Dns.split(",").map(function(s) { return s.trim(); }).filter(function(s) { return s; }).join(" ");
 
+    // Default prefix if user omits it: /24 for IPv4, /64 for IPv6
+    var v4addr = ipv4Address;
+    if (v4addr && v4addr.indexOf("/") === -1) v4addr += "/24";
+    var v6addr = ipv6Address;
+    if (v6addr && v6addr.indexOf("/") === -1) v6addr += "/64";
+
     NetworkService.modifyConnection(connectionName, {
       ipv4Method: ipv4Method,
-      ipv4Address: ipv4Method === "manual" ? ipv4Address : "",
+      ipv4Address: ipv4Method === "manual" ? v4addr : "",
       ipv4Gateway: ipv4Method === "manual" ? ipv4Gateway : "",
       ipv4Dns: v4dns,
       ipv6Method: ipv6Method,
-      ipv6Address: ipv6Method === "manual" ? ipv6Address : "",
+      ipv6Address: ipv6Method === "manual" ? v6addr : "",
       ipv6Gateway: ipv6Method === "manual" ? ipv6Gateway : "",
       ipv6Dns: v6dns,
       mtu: mtu

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -408,7 +408,7 @@ Popup {
           }
         }
         NText {
-          visible: mtuInput.text.length > 0 && !root.isValidMtu(parseInt(mtuInput.text) || -1)
+          visible: mtuInput.text.length > 0 && !root.isValidMtu(isNaN(parseInt(mtuInput.text)) ? -1 : parseInt(mtuInput.text))
           text: I18n.tr("wifi.edit.error-invalid-mtu")
           pointSize: Style.fontSizeXS
           color: Color.mError

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -129,6 +129,10 @@ Popup {
     return true;
   }
 
+  function isValidMtu(val) {
+    return val === 0 || (val >= 68 && val <= 9216);
+  }
+
   function canApply() {
     if (loading || NetworkService.modifyingConnection) return false;
     if (ipv4Method === "manual") {
@@ -141,6 +145,7 @@ Popup {
       if (ipv6Gateway && !isValidIpv6(ipv6Gateway)) return false;
     }
     if (!isValidDnsList(ipv6Dns, true)) return false;
+    if (!isValidMtu(mtu)) return false;
     return true;
   }
 
@@ -391,16 +396,22 @@ Popup {
           color: Color.mPrimary
         }
 
-        NSpinBox {
-          id: mtuSpinBox
+        NTextInput {
+          id: mtuInput
           Layout.fillWidth: true
-          label: I18n.tr("wifi.edit.mtu")
-          description: I18n.tr("wifi.edit.mtu-description")
-          value: root.mtu
-          from: 0
-          to: 9000
-          stepSize: 1
-          onValueChanged: root.mtu = value
+          label: I18n.tr("wifi.edit.mtu") + " (" + I18n.tr("wifi.edit.mtu-description") + ")"
+          placeholderText: "1500"
+          text: root.mtu > 0 ? String(root.mtu) : ""
+          onTextChanged: {
+            var val = parseInt(text);
+            root.mtu = (!text || isNaN(val)) ? 0 : val;
+          }
+        }
+        NText {
+          visible: mtuInput.text.length > 0 && !root.isValidMtu(parseInt(mtuInput.text) || -1)
+          text: I18n.tr("wifi.edit.error-invalid-mtu")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
         }
       }
 

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -1,0 +1,363 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Services.Networking
+import qs.Services.UI
+import qs.Widgets
+
+Popup {
+  id: root
+  modal: true
+  closePolicy: Popup.NoAutoClose
+  dim: true
+  anchors.centerIn: parent
+
+  width: Math.min(550 * Style.uiScaleRatio, parent.width * 0.9)
+  height: Math.min(contentLayout.implicitHeight + padding * 2, parent.height * 0.85)
+  padding: Style.marginL
+
+  // Input properties
+  property string connectionName: ""
+  property bool isActive: false
+  property bool isWifi: true
+
+  // Internal state
+  property bool loading: true
+  property string errorMsg: ""
+
+  // IPv4 fields
+  property string ipv4Method: "auto"
+  property string ipv4Address: ""
+  property string ipv4Gateway: ""
+  property string ipv4Dns: ""
+
+  // IPv6 fields
+  property string ipv6Method: "auto"
+  property string ipv6Address: ""
+  property string ipv6Gateway: ""
+  property string ipv6Dns: ""
+
+  // General fields
+  property int mtu: 0
+
+  signal applied()
+
+  property var _settingsSlot: null
+  property var _modifiedSlot: null
+
+  background: Rectangle {
+    color: Color.mSurface
+    radius: Style.radiusL
+    border.color: Color.mOutline
+    border.width: Style.borderS
+  }
+
+  function openEdit(connName, active, wifi) {
+    connectionName = connName;
+    isActive = active;
+    isWifi = wifi;
+    loading = true;
+    errorMsg = "";
+
+    // Clean up old signal connections
+    try { NetworkService.connectionSettingsLoaded.disconnect(root._settingsSlot); } catch (e) {}
+    try { NetworkService.connectionModified.disconnect(root._modifiedSlot); } catch (e) {}
+
+    // Connect settings loaded handler
+    root._settingsSlot = function(settings) {
+      try { NetworkService.connectionSettingsLoaded.disconnect(root._settingsSlot); } catch (e) {}
+      if (!settings) {
+        root.errorMsg = I18n.tr("wifi.edit.error-apply-failed");
+        root.loading = false;
+        return;
+      }
+      root.ipv4Method = settings.ipv4Method || "auto";
+      root.ipv4Address = settings.ipv4Address || "";
+      root.ipv4Gateway = settings.ipv4Gateway || "";
+      root.ipv4Dns = settings.ipv4Dns || "";
+      root.ipv6Method = settings.ipv6Method || "auto";
+      root.ipv6Address = settings.ipv6Address || "";
+      root.ipv6Gateway = settings.ipv6Gateway || "";
+      root.ipv6Dns = settings.ipv6Dns || "";
+      root.mtu = settings.mtu || 0;
+      root.loading = false;
+    };
+    NetworkService.connectionSettingsLoaded.connect(root._settingsSlot);
+
+    // Connect modify result handler
+    root._modifiedSlot = function(success, err) {
+      try { NetworkService.connectionModified.disconnect(root._modifiedSlot); } catch (e) {}
+      if (success) {
+        root.close();
+        root.applied();
+      } else {
+        root.errorMsg = err || I18n.tr("wifi.edit.error-apply-failed");
+      }
+    };
+    NetworkService.connectionModified.connect(root._modifiedSlot);
+
+    root.open();
+    NetworkService.getConnectionSettings(connName);
+  }
+
+  // Validation helpers
+  function isValidIpv4(ip) {
+    if (!ip) return true;
+    var re = /^(\d{1,3}\.){3}\d{1,3}(\/\d{1,2})?$/;
+    if (!re.test(ip)) return false;
+    var parts = ip.split("/")[0].split(".");
+    for (var i = 0; i < parts.length; i++) {
+      if (parseInt(parts[i]) > 255) return false;
+    }
+    return true;
+  }
+
+  function isValidIpv6(ip) {
+    if (!ip) return true;
+    var addr = ip.split("/")[0];
+    return /^[0-9a-fA-F:]+$/.test(addr) && addr.indexOf(":") !== -1;
+  }
+
+  function isValidDnsList(dns, isV6) {
+    if (!dns) return true;
+    var servers = dns.split(",");
+    for (var i = 0; i < servers.length; i++) {
+      var s = servers[i].trim();
+      if (!s) continue;
+      if (isV6 ? !isValidIpv6(s) : !isValidIpv4(s)) return false;
+    }
+    return true;
+  }
+
+  function canApply() {
+    if (loading || NetworkService.modifyingConnection) return false;
+    if (ipv4Method === "manual") {
+      if (!ipv4Address || !isValidIpv4(ipv4Address)) return false;
+      if (ipv4Gateway && !isValidIpv4(ipv4Gateway)) return false;
+    }
+    if (!isValidDnsList(ipv4Dns, false)) return false;
+    if (ipv6Method === "manual") {
+      if (!ipv6Address || !isValidIpv6(ipv6Address)) return false;
+      if (ipv6Gateway && !isValidIpv6(ipv6Gateway)) return false;
+    }
+    if (!isValidDnsList(ipv6Dns, true)) return false;
+    return true;
+  }
+
+  function applySettings() {
+    if (!canApply()) return;
+    errorMsg = "";
+
+    var v4dns = ipv4Dns.split(",").map(function(s) { return s.trim(); }).filter(function(s) { return s; }).join(" ");
+    var v6dns = ipv6Dns.split(",").map(function(s) { return s.trim(); }).filter(function(s) { return s; }).join(" ");
+
+    NetworkService.modifyConnection(connectionName, {
+      ipv4Method: ipv4Method,
+      ipv4Address: ipv4Method === "manual" ? ipv4Address : "",
+      ipv4Gateway: ipv4Method === "manual" ? ipv4Gateway : "",
+      ipv4Dns: v4dns,
+      ipv6Method: ipv6Method,
+      ipv6Address: ipv6Method === "manual" ? ipv6Address : "",
+      ipv6Gateway: ipv6Method === "manual" ? ipv6Gateway : "",
+      ipv6Dns: v6dns,
+      mtu: mtu
+    }, isActive);
+  }
+
+  onClosed: {
+    try { NetworkService.connectionSettingsLoaded.disconnect(root._settingsSlot); } catch (e) {}
+    try { NetworkService.connectionModified.disconnect(root._modifiedSlot); } catch (e) {}
+  }
+
+  contentItem: ColumnLayout {
+    id: contentLayout
+    spacing: Style.marginL
+
+    // Header
+    RowLayout {
+      Layout.fillWidth: true
+      NText {
+        text: I18n.tr("wifi.edit.title") + " — " + root.connectionName
+        font.weight: Style.fontWeightBold
+        pointSize: Style.fontSizeL
+        Layout.fillWidth: true
+        elide: Text.ElideRight
+      }
+      NIconButton {
+        icon: "close"
+        onClicked: root.close()
+      }
+    }
+
+    // Loading indicator
+    NText {
+      visible: root.loading
+      text: "..."
+      color: Color.mOnSurfaceVariant
+      Layout.alignment: Qt.AlignHCenter
+    }
+
+    // Form content
+    NScrollView {
+      visible: !root.loading
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      Layout.maximumHeight: root.height - 160 * Style.uiScaleRatio
+
+      ColumnLayout {
+        width: parent.width
+        spacing: Style.marginM
+
+        // === IPv4 Section ===
+        NCollapsible {
+          label: I18n.tr("wifi.edit.ipv4")
+          expanded: true
+          Layout.fillWidth: true
+
+          NComboBox {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.method")
+            model: [
+              { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
+              { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
+              { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
+            ]
+            currentKey: root.ipv4Method
+            onSelected: key => root.ipv4Method = key
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.address")
+            placeholderText: I18n.tr("wifi.edit.address-placeholder-v4")
+            text: root.ipv4Address
+            onTextChanged: root.ipv4Address = text
+            enabled: root.ipv4Method === "manual"
+            readOnly: root.ipv4Method !== "manual"
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.gateway")
+            placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v4")
+            text: root.ipv4Gateway
+            onTextChanged: root.ipv4Gateway = text
+            enabled: root.ipv4Method === "manual"
+            readOnly: root.ipv4Method !== "manual"
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
+            placeholderText: I18n.tr("wifi.edit.dns-placeholder-v4")
+            text: root.ipv4Dns
+            onTextChanged: root.ipv4Dns = text
+            enabled: root.ipv4Method !== "disabled"
+            readOnly: root.ipv4Method === "disabled"
+          }
+        }
+
+        // === IPv6 Section ===
+        NCollapsible {
+          label: I18n.tr("wifi.edit.ipv6")
+          expanded: false
+          Layout.fillWidth: true
+
+          NComboBox {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.method")
+            model: [
+              { key: "auto", name: I18n.tr("wifi.edit.method-auto") },
+              { key: "manual", name: I18n.tr("wifi.edit.method-manual") },
+              { key: "link-local", name: I18n.tr("wifi.edit.method-link-local") },
+              { key: "disabled", name: I18n.tr("wifi.edit.method-disabled") }
+            ]
+            currentKey: root.ipv6Method
+            onSelected: key => root.ipv6Method = key
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.address")
+            placeholderText: I18n.tr("wifi.edit.address-placeholder-v6")
+            text: root.ipv6Address
+            onTextChanged: root.ipv6Address = text
+            enabled: root.ipv6Method === "manual"
+            readOnly: root.ipv6Method !== "manual"
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.gateway")
+            placeholderText: I18n.tr("wifi.edit.gateway-placeholder-v6")
+            text: root.ipv6Gateway
+            onTextChanged: root.ipv6Gateway = text
+            enabled: root.ipv6Method === "manual"
+            readOnly: root.ipv6Method !== "manual"
+          }
+
+          NTextInput {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.dns") + " (" + I18n.tr("wifi.edit.dns-hint") + ")"
+            placeholderText: I18n.tr("wifi.edit.dns-placeholder-v6")
+            text: root.ipv6Dns
+            onTextChanged: root.ipv6Dns = text
+            enabled: root.ipv6Method !== "disabled"
+            readOnly: root.ipv6Method === "disabled"
+          }
+        }
+
+        // === General Section ===
+        NCollapsible {
+          label: I18n.tr("wifi.edit.general")
+          expanded: false
+          Layout.fillWidth: true
+
+          NSpinBox {
+            Layout.fillWidth: true
+            label: I18n.tr("wifi.edit.mtu")
+            description: I18n.tr("wifi.edit.mtu-description")
+            value: root.mtu
+            from: 0
+            to: 9000
+            stepSize: 1
+            onValueChanged: root.mtu = value
+          }
+        }
+      }
+    }
+
+    // Error message
+    NText {
+      visible: root.errorMsg.length > 0
+      text: root.errorMsg
+      color: Color.mError
+      wrapMode: Text.WordWrap
+      Layout.fillWidth: true
+    }
+
+    // Footer buttons
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.marginM
+
+      Item { Layout.fillWidth: true }
+
+      NButton {
+        text: I18n.tr("wifi.edit.cancel")
+        outlined: true
+        onClicked: root.close()
+      }
+
+      NButton {
+        text: NetworkService.modifyingConnection ? I18n.tr("wifi.edit.applying") : I18n.tr("wifi.edit.apply")
+        icon: "check"
+        backgroundColor: Color.mPrimary
+        textColor: Color.mOnPrimary
+        enabled: root.canApply()
+        onClicked: root.applySettings()
+      }
+    }
+  }
+}

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -67,7 +67,7 @@ Popup {
     root._settingsSlot = function(settings) {
       try { NetworkService.connectionSettingsLoaded.disconnect(root._settingsSlot); } catch (e) {}
       if (!settings) {
-        root.errorMsg = I18n.tr("wifi.edit.error-apply-failed");
+        root.errorMsg = I18n.tr("wifi.edit.error-load-failed");
         root.loading = false;
         return;
       }
@@ -246,6 +246,12 @@ Popup {
           onTextChanged: root.ipv4Address = text
           visible: root.ipv4Method === "manual"
         }
+        NText {
+          visible: ipv4AddressInput.visible && root.ipv4Address && !root.isValidIpv4(root.ipv4Address)
+          text: I18n.tr("wifi.edit.error-invalid-ip")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
+        }
 
         NTextInput {
           id: ipv4GatewayInput
@@ -256,6 +262,12 @@ Popup {
           onTextChanged: root.ipv4Gateway = text
           visible: root.ipv4Method === "manual"
         }
+        NText {
+          visible: ipv4GatewayInput.visible && root.ipv4Gateway && !root.isValidIpv4(root.ipv4Gateway)
+          text: I18n.tr("wifi.edit.error-invalid-gateway")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
+        }
 
         NTextInput {
           id: ipv4DnsInput
@@ -265,6 +277,12 @@ Popup {
           text: root.ipv4Dns
           onTextChanged: root.ipv4Dns = text
           visible: root.ipv4Method !== "disabled"
+        }
+        NText {
+          visible: ipv4DnsInput.visible && root.ipv4Dns && !root.isValidDnsList(root.ipv4Dns, false)
+          text: I18n.tr("wifi.edit.error-invalid-dns")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
         }
       }
 
@@ -312,6 +330,12 @@ Popup {
           onTextChanged: root.ipv6Address = text
           visible: root.ipv6Method === "manual"
         }
+        NText {
+          visible: ipv6AddressInput.visible && root.ipv6Address && !root.isValidIpv6(root.ipv6Address)
+          text: I18n.tr("wifi.edit.error-invalid-ip")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
+        }
 
         NTextInput {
           id: ipv6GatewayInput
@@ -322,6 +346,12 @@ Popup {
           onTextChanged: root.ipv6Gateway = text
           visible: root.ipv6Method === "manual"
         }
+        NText {
+          visible: ipv6GatewayInput.visible && root.ipv6Gateway && !root.isValidIpv6(root.ipv6Gateway)
+          text: I18n.tr("wifi.edit.error-invalid-gateway")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
+        }
 
         NTextInput {
           id: ipv6DnsInput
@@ -331,6 +361,12 @@ Popup {
           text: root.ipv6Dns
           onTextChanged: root.ipv6Dns = text
           visible: root.ipv6Method !== "disabled"
+        }
+        NText {
+          visible: ipv6DnsInput.visible && root.ipv6Dns && !root.isValidDnsList(root.ipv6Dns, true)
+          text: I18n.tr("wifi.edit.error-invalid-dns")
+          pointSize: Style.fontSizeXS
+          color: Color.mError
         }
       }
 

--- a/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml
@@ -98,7 +98,7 @@ Popup {
     NetworkService.connectionModified.connect(root._modifiedSlot);
 
     root.open();
-    NetworkService.getConnectionSettings(connName);
+    NetworkService.getConnectionSettings(connName, wifi);
   }
 
   // Validation helpers
@@ -162,7 +162,7 @@ Popup {
       ipv6Gateway: ipv6Method === "manual" ? ipv6Gateway : "",
       ipv6Dns: v6dns,
       mtu: mtu
-    }, isActive);
+    }, isActive, isWifi);
   }
 
   onClosed: {

--- a/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
@@ -905,7 +905,7 @@ Item {
             tooltipText: I18n.tr("wifi.edit.title")
             baseSize: Style.baseWidgetSize * 0.65
             onClicked: {
-              var connName = modelData.ssid;
+              var connName = (modelData.connected && NetworkService.activeWifiDetails.connectionName) ? NetworkService.activeWifiDetails.connectionName : modelData.ssid;
               var isActive = modelData.connected;
               networkEditPopup.openEdit(connName, isActive, true);
             }

--- a/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml
@@ -13,6 +13,11 @@ import qs.Widgets
 
 Item {
   id: root
+
+  NetworkEditPopup {
+    id: networkEditPopup
+    parent: Overlay.overlay
+  }
   Layout.fillWidth: true
   implicitHeight: mainLayout.implicitHeight
 
@@ -887,6 +892,22 @@ Item {
             onClicked: {
               root.detailsGrid = !root.detailsGrid;
               Settings.data.network.wifiDetailsViewMode = root.detailsGrid ? "grid" : "list";
+            }
+            z: 1
+          }
+
+          NIconButton {
+            anchors.top: parent.top
+            anchors.right: parent.right
+            anchors.rightMargin: Style.marginS + (Style.baseWidgetSize * 0.65) + Style.marginS
+            anchors.topMargin: Style.marginS
+            icon: "settings"
+            tooltipText: I18n.tr("wifi.edit.title")
+            baseSize: Style.baseWidgetSize * 0.65
+            onClicked: {
+              var connName = modelData.ssid;
+              var isActive = modelData.connected;
+              networkEditPopup.openEdit(connName, isActive, true);
             }
             z: 1
           }

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -1321,6 +1321,14 @@ Singleton {
     }
   }
 
+  Timer {
+    id: postReapplyRefreshTimer
+    interval: 5000
+    onTriggered: {
+      deviceStatusProcess.running = true;
+    }
+  }
+
   // Reapply connection after modify (bring it up with new settings)
   Process {
     id: reapplyProcess
@@ -1336,11 +1344,10 @@ Singleton {
         root.connectionModified(true, "");
         ToastService.showNotice(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-applied"), "settings");
 
-        // Invalidate cache and schedule scan (same pattern as connectProcess)
+        // Invalidate cache and schedule delayed refresh
         root.activeWifiDetailsTimestamp = 0;
         root.activeEthernetDetailsTimestamp = 0;
-        delayedScanTimer.interval = 5000;
-        delayedScanTimer.restart();
+        postReapplyRefreshTimer.restart();
       }
     }
     stderr: StdioCollector {

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -351,6 +351,8 @@ Singleton {
     }
     if (settings.ipv4Dns !== undefined) {
       args.push("ipv4.dns", settings.ipv4Dns || "");
+      var ignoreV4Dns = (settings.ipv4Method === "auto" && settings.ipv4Dns) ? "yes" : "no";
+      args.push("ipv4.ignore-auto-dns", ignoreV4Dns);
     }
 
     // IPv6
@@ -366,6 +368,8 @@ Singleton {
     }
     if (settings.ipv6Dns !== undefined) {
       args.push("ipv6.dns", settings.ipv6Dns || "");
+      var ignoreV6Dns = (settings.ipv6Method === "auto" && settings.ipv6Dns) ? "yes" : "no";
+      args.push("ipv6.ignore-auto-dns", ignoreV6Dns);
     }
 
     // MTU

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -1336,11 +1336,11 @@ Singleton {
         root.connectionModified(true, "");
         ToastService.showNotice(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-applied"), "settings");
 
-        // Refresh details after reapply
+        // Invalidate cache and schedule scan (same pattern as connectProcess)
         root.activeWifiDetailsTimestamp = 0;
         root.activeEthernetDetailsTimestamp = 0;
-        root.refreshActiveWifiDetails();
-        root.refreshActiveEthernetDetails();
+        delayedScanTimer.interval = 5000;
+        delayedScanTimer.restart();
       }
     }
     stderr: StdioCollector {

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -91,6 +91,13 @@ Singleton {
   property bool airplaneModeEnabled: false
   property bool airplaneModeToggled: false
 
+  // Edit connection state
+  property bool modifyingConnection: false
+  property var pendingConnectionSettings: ({})
+
+  signal connectionSettingsLoaded(var settings)
+  signal connectionModified(bool success, string errorMsg)
+
   Connections {
     target: root
     function onWifiEnabledChanged() {
@@ -308,6 +315,64 @@ Singleton {
       ethernetDetailsLoading = true;
       deviceStatusProcess.running = true;
     }
+  }
+
+  // Fetch saved profile settings for editing
+  function getConnectionSettings(connName) {
+    if (!ProgramCheckerService.nmcliAvailable || !connName) {
+      return;
+    }
+    getSettingsProcess.connName = connName;
+    getSettingsProcess.running = true;
+  }
+
+  // Modify connection profile and optionally reapply
+  function modifyConnection(connName, settings, isActive) {
+    if (!ProgramCheckerService.nmcliAvailable || !connName || modifyingConnection) {
+      return;
+    }
+    modifyingConnection = true;
+    pendingConnectionSettings = { connName: connName, isActive: isActive };
+
+    var args = ["nmcli", "connection", "modify", connName];
+
+    // IPv4
+    if (settings.ipv4Method !== undefined) {
+      args.push("ipv4.method", settings.ipv4Method);
+    }
+    if (settings.ipv4Method === "manual") {
+      args.push("ipv4.addresses", settings.ipv4Address || "");
+      args.push("ipv4.gateway", settings.ipv4Gateway || "");
+    } else if (settings.ipv4Method === "auto" || settings.ipv4Method === "disabled") {
+      args.push("ipv4.addresses", "");
+      args.push("ipv4.gateway", "");
+    }
+    if (settings.ipv4Dns !== undefined) {
+      args.push("ipv4.dns", settings.ipv4Dns || "");
+    }
+
+    // IPv6
+    if (settings.ipv6Method !== undefined) {
+      args.push("ipv6.method", settings.ipv6Method);
+    }
+    if (settings.ipv6Method === "manual") {
+      args.push("ipv6.addresses", settings.ipv6Address || "");
+      args.push("ipv6.gateway", settings.ipv6Gateway || "");
+    } else if (settings.ipv6Method !== "manual") {
+      args.push("ipv6.addresses", "");
+      args.push("ipv6.gateway", "");
+    }
+    if (settings.ipv6Dns !== undefined) {
+      args.push("ipv6.dns", settings.ipv6Dns || "");
+    }
+
+    // MTU
+    if (settings.mtu !== undefined) {
+      args.push("802-3-ethernet.mtu", String(settings.mtu));
+    }
+
+    modifyProcess.command = args;
+    modifyProcess.running = true;
   }
 
   // Helper function to immediately update network status
@@ -1154,6 +1219,133 @@ Singleton {
           Logger.d("Network", "State changed: " + data);
           deviceStatusProcess.running = true;
           connectivityCheckProcess.running = true;
+        }
+      }
+    }
+  }
+
+  // Fetch connection profile settings for editing
+  Process {
+    id: getSettingsProcess
+    property string connName: ""
+    running: false
+    command: ["nmcli", "-t", "-f", "ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns,ipv6.method,ipv6.addresses,ipv6.gateway,ipv6.dns,802-3-ethernet.mtu", "connection", "show", connName]
+    environment: ({ "LC_ALL": "C" })
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var settings = {
+          ipv4Method: "auto",
+          ipv4Address: "",
+          ipv4Gateway: "",
+          ipv4Dns: "",
+          ipv6Method: "auto",
+          ipv6Address: "",
+          ipv6Gateway: "",
+          ipv6Dns: "",
+          mtu: 0
+        };
+
+        var lines = text.split("\n");
+        for (var i = 0; i < lines.length; i++) {
+          var line = lines[i].trim();
+          if (!line) continue;
+          var idx = line.indexOf(":");
+          if (idx === -1) continue;
+          var key = line.substring(0, idx);
+          var val = line.substring(idx + 1).trim();
+
+          switch (key) {
+            case "ipv4.method": settings.ipv4Method = val; break;
+            case "ipv4.addresses": settings.ipv4Address = val || ""; break;
+            case "ipv4.gateway": settings.ipv4Gateway = val || ""; break;
+            case "ipv4.dns": settings.ipv4Dns = val || ""; break;
+            case "ipv6.method": settings.ipv6Method = val; break;
+            case "ipv6.addresses": settings.ipv6Address = val || ""; break;
+            case "ipv6.gateway": settings.ipv6Gateway = val || ""; break;
+            case "ipv6.dns": settings.ipv6Dns = val || ""; break;
+            case "802-3-ethernet.mtu": settings.mtu = parseInt(val) || 0; break;
+          }
+        }
+
+        // Clean up double dashes (nmcli outputs "--" for empty values)
+        for (var k in settings) {
+          if (settings[k] === "--") settings[k] = "";
+        }
+
+        root.connectionSettingsLoaded(settings);
+      }
+    }
+    stderr: StdioCollector {
+      onStreamFinished: {
+        if (text.trim()) {
+          Logger.w("Network", "Get settings error: " + text.trim());
+          root.connectionSettingsLoaded(null);
+        }
+      }
+    }
+  }
+
+  // Modify connection profile
+  Process {
+    id: modifyProcess
+    running: false
+    environment: ({ "LC_ALL": "C" })
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        Logger.i("Network", "Connection modified: " + root.pendingConnectionSettings.connName);
+        if (root.pendingConnectionSettings.isActive) {
+          reapplyProcess.connName = root.pendingConnectionSettings.connName;
+          reapplyProcess.running = true;
+        } else {
+          root.modifyingConnection = false;
+          root.connectionModified(true, "");
+          ToastService.showNotice(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-applied"), "settings");
+        }
+      }
+    }
+    stderr: StdioCollector {
+      onStreamFinished: {
+        if (text.trim()) {
+          Logger.w("Network", "Modify error: " + text.trim());
+          root.modifyingConnection = false;
+          root.connectionModified(false, text.trim());
+          ToastService.showWarning(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-apply-failed"), "settings");
+        }
+      }
+    }
+  }
+
+  // Reapply connection after modify (bring it up with new settings)
+  Process {
+    id: reapplyProcess
+    property string connName: ""
+    running: false
+    command: ["nmcli", "connection", "up", connName]
+    environment: ({ "LC_ALL": "C" })
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        Logger.i("Network", "Connection reapplied: " + reapplyProcess.connName);
+        root.modifyingConnection = false;
+        root.connectionModified(true, "");
+        ToastService.showNotice(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-applied"), "settings");
+
+        // Refresh details after reapply
+        root.activeWifiDetailsTimestamp = 0;
+        root.activeEthernetDetailsTimestamp = 0;
+        root.refreshActiveWifiDetails();
+        root.refreshActiveEthernetDetails();
+      }
+    }
+    stderr: StdioCollector {
+      onStreamFinished: {
+        if (text.trim()) {
+          Logger.w("Network", "Reapply error: " + text.trim());
+          root.modifyingConnection = false;
+          root.connectionModified(false, text.trim());
+          ToastService.showWarning(I18n.tr("common.network"), I18n.tr("toast.wifi.settings-apply-failed"), "settings");
         }
       }
     }

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -318,16 +318,18 @@ Singleton {
   }
 
   // Fetch saved profile settings for editing
-  function getConnectionSettings(connName) {
+  function getConnectionSettings(connName, isWifi) {
     if (!ProgramCheckerService.nmcliAvailable || !connName) {
       return;
     }
     getSettingsProcess.connName = connName;
+    var mtuField = isWifi ? "802-11-wireless.mtu" : "802-3-ethernet.mtu";
+    getSettingsProcess.command = ["nmcli", "-t", "-f", "ipv4.method,ipv4.addresses,ipv4.gateway,ipv4.dns,ipv6.method,ipv6.addresses,ipv6.gateway,ipv6.dns," + mtuField, "connection", "show", connName];
     getSettingsProcess.running = true;
   }
 
   // Modify connection profile and optionally reapply
-  function modifyConnection(connName, settings, isActive) {
+  function modifyConnection(connName, settings, isActive, isWifi) {
     if (!ProgramCheckerService.nmcliAvailable || !connName || modifyingConnection) {
       return;
     }
@@ -358,7 +360,7 @@ Singleton {
     if (settings.ipv6Method === "manual") {
       args.push("ipv6.addresses", settings.ipv6Address || "");
       args.push("ipv6.gateway", settings.ipv6Gateway || "");
-    } else if (settings.ipv6Method !== "manual") {
+    } else if (settings.ipv6Method === "auto" || settings.ipv6Method === "disabled" || settings.ipv6Method === "link-local") {
       args.push("ipv6.addresses", "");
       args.push("ipv6.gateway", "");
     }
@@ -368,7 +370,8 @@ Singleton {
 
     // MTU
     if (settings.mtu !== undefined) {
-      args.push("802-3-ethernet.mtu", String(settings.mtu));
+      var mtuKey = isWifi ? "802-11-wireless.mtu" : "802-3-ethernet.mtu";
+      args.push(mtuKey, String(settings.mtu));
     }
 
     modifyProcess.command = args;
@@ -1264,7 +1267,8 @@ Singleton {
             case "ipv6.addresses": settings.ipv6Address = val || ""; break;
             case "ipv6.gateway": settings.ipv6Gateway = val || ""; break;
             case "ipv6.dns": settings.ipv6Dns = val || ""; break;
-            case "802-3-ethernet.mtu": settings.mtu = parseInt(val) || 0; break;
+            case "802-3-ethernet.mtu":
+            case "802-11-wireless.mtu": settings.mtu = parseInt(val) || 0; break;
           }
         }
 


### PR DESCRIPTION
## Summary

- Add ability to edit network configuration (IPv4, IPv6, MTU) for both WiFi and Ethernet connections
- New `EthernetSubTab` in Settings → Connections (between WiFi and Bluetooth)
- New shared `NetworkEditPopup` with inline validation, immediate apply via `nmcli connection modify` + `nmcli connection up`
- Default `/24` prefix for IPv4 and `/64` for IPv6 when user omits it
- Ignore DHCP DNS when user sets custom DNS in auto mode (`ipv4.ignore-auto-dns`)
- Translations for all 24 supported languages

## Changes

- **New:** `Modules/Panels/Settings/Tabs/Connections/NetworkEditPopup.qml` — shared edit popup for WiFi/Ethernet
- **New:** `Modules/Panels/Settings/Tabs/Connections/EthernetSubTab.qml` — Ethernet tab in Settings → Connections
- **Modified:** `Services/Networking/NetworkService.qml` — `getConnectionSettings()`, `modifyConnection()`, 3 new Process objects, post-reapply refresh timer
- **Modified:** `Modules/Panels/Settings/Tabs/Connections/ConnectionsTab.qml` — added Ethernet tab (WiFi | Ethernet | Bluetooth)
- **Modified:** `Modules/Panels/Settings/Tabs/Connections/WifiSubTab.qml` — edit button on WiFi details
- **Modified:** `Modules/Panels/Network/NetworkPanel.qml` — edit button on Ethernet details, settings button routes to correct subtab
- **Modified:** `Modules/Bar/Widgets/Bluetooth.qml` — updated Bluetooth subtab index (1 → 2)
- **Modified:** `Modules/Panels/Bluetooth/BluetoothPanel.qml` — updated Bluetooth subtab index (1 → 2)
- **Modified:** `Assets/Translations/*.json` — 31 new i18n keys across all 24 languages