### PR TITLE
Revert "fix(notifications): prefer default actions for window focus"

### DIFF
--- a/Modules/Notification/Notification.qml
+++ b/Modules/Notification/Notification.qml
@@ -350,13 +350,12 @@ Variants {
 
             function runAction(actionId, isDismissed) {
               if (!isDismissed) {
-                if (NotificationService.invokeActionAndSuppressClose(notificationId, actionId))
-                  card.animateOut();
-              } else {
-                if (Settings.data.notifications.clearDismissed)
-                  NotificationService.removeFromHistory(notificationId);
-                card.animateOut();
+                NotificationService.focusSenderWindow(model.appName);
+                NotificationService.invokeActionAndSuppressClose(notificationId, actionId);
+              } else if (Settings.data.notifications.clearDismissed) {
+                NotificationService.removeFromHistory(notificationId);
               }
+              card.animateOut();
             }
 
             Timer {
@@ -528,11 +527,9 @@ Variants {
                               var hasDefault = actions.some(function (a) {
                                 return a.identifier === "default";
                               });
-                              if (hasDefault && NotificationService.invokeActionAndSuppressClose(notificationId, "default")) {
-                                card.animateOut();
+                              if (hasDefault) {
+                                card.runAction("default", false);
                               } else {
-                                // Without a default action, or if invoking it fails,
-                                // the best fallback is focusing the sender window by app identity.
                                 NotificationService.focusSenderWindow(model.appName);
                                 card.animateOut();
                               }

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -171,8 +171,7 @@ SmartPanel {
       if (actionIndex >= 0) {
         var actions = parseActions(item.actionsJson);
         if (actionIndex < actions.length) {
-          if (NotificationService.invokeAction(item.id, actions[actionIndex].identifier))
-            root.close();
+          NotificationService.invokeAction(item.id, actions[actionIndex].identifier);
         }
       } else {
         var delegate = notificationColumn.children[focusIndex];
@@ -792,18 +791,18 @@ SmartPanel {
                                       return;
                                     }
 
-                                    // Without a default action, or if invoking it fails,
-                                    // fall back to focusing the sender window by app identity.
+                                    // Focus sender window (and invoke default action if available)
                                     var actions = notificationDelegate.actionsList;
                                     var hasDefault = actions.some(function (a) {
                                       return a.identifier === "default";
                                     });
-                                    if (hasDefault && NotificationService.invokeAction(notificationDelegate.notificationId, "default")) {
-                                      root.close();
+                                    if (hasDefault) {
+                                      NotificationService.focusSenderWindow(notificationDelegate.appName);
+                                      NotificationService.invokeAction(notificationDelegate.notificationId, "default");
                                     } else {
                                       NotificationService.focusSenderWindow(notificationDelegate.appName);
-                                      root.close();
                                     }
+                                    root.close();
                                   }
                       onCanceled: {
                         notificationDelegate.isSwiping = false;
@@ -961,8 +960,9 @@ SmartPanel {
                                 // Capture modelData in a property to avoid reference errors
                                 property var actionData: modelData
                                 onClicked: {
-                                  if (NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier))
-                                    root.close();
+                                  NotificationService.focusSenderWindow(notificationDelegate.appName);
+                                  root.close();
+                                  NotificationService.invokeAction(notificationDelegate.notificationId, actionData.identifier);
                                 }
                               }
                             }

--- a/Services/System/NotificationService.qml
+++ b/Services/System/NotificationService.qml
@@ -923,29 +923,13 @@ Singleton {
 
   function invokeActionAndSuppressClose(id, actionId) {
     const notifData = popupState[id];
-    const notification = notifData?.notification;
-    const onClosed = notifData?.onClosed;
-    let restoreClosedHandler = false;
-
-    if (notification && onClosed) {
+    if (notifData && notifData.notification && notifData.onClosed) {
       try {
-        // A successful action may synchronously close the notification. Disconnect
-        // our close handler first so the popup is only dismissed by the action path.
-        notification.closed.disconnect(onClosed);
-        restoreClosedHandler = true;
+        notifData.notification.closed.disconnect(notifData.onClosed);
       } catch (e) {}
     }
 
-    const invoked = invokeAction(id, actionId);
-
-    if (!invoked && restoreClosedHandler && notification && onClosed) {
-      try {
-        // If invoking the action failed, restore normal close handling for this popup.
-        notification.closed.connect(onClosed);
-      } catch (e) {}
-    }
-
-    return invoked;
+    return invokeAction(id, actionId);
   }
 
   function invokeAction(id, actionId) {


### PR DESCRIPTION
This reverts commit ce8da4c51416f7fd8f7948f490f2587f43e92d1e (https://github.com/noctalia-dev/noctalia-shell/pull/2281).

## Motivation

 - ce8da4c was a rewrite, not a targeted fix - it broke click-to-focus entirely
 - ce8da4c didn't fix the multi-window issue it claimed to - when no default action is present, the same first-in-list matching is used
 - The revert restores working behavior
 - The real multi-window focus problem is acknowledged. I suggest reopening https://github.com/noctalia-dev/noctalia-shell/issues/2280. I will work on the solution.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [x] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
N/A

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
N/A
