### PR TITLE
Add option to not mark notifications as seen when opening the history

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1507,6 +1507,8 @@
       "settings-enabled-description": "Enable or disable the notification daemon, requires a restart of Noctalia shell.",
       "settings-enabled-label": "Enable notifications",
       "settings-location-description": "Where notifications appear on screen.",
+      "settings-mark-seen-on-open-label": "Mark notifications seen when opening history",
+      "settings-mark-seen-on-open-description": "Marks all notifications as seen when opening the history so they won't show up as new.",
       "settings-markdown-description": "Render notification content using Markdown formatting.",
       "settings-markdown-label": "Enable Markdown",
       "sounds-desc": "Configure notification sound effects and volume.",

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -441,6 +441,7 @@
   "notifications": {
     "enabled": true,
     "enableMarkdown": false,
+    "markSeenOnOpen": true,
     "density": "default",
     "monitors": [],
     "location": "top_right",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -671,6 +671,7 @@ Singleton {
     property JsonObject notifications: JsonObject {
       property bool enabled: true
       property bool enableMarkdown: false
+      property bool markSeenOnOpen: true
       property string density: "default" // "default", "compact"
       property list<string> monitors: [] // holds notifications visibility per monitor
       property string location: "top_right"

--- a/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
+++ b/Modules/Panels/NotificationHistory/NotificationHistoryPanel.qml
@@ -19,7 +19,9 @@ SmartPanel {
   preferredHeight: Math.round((Settings.data.notifications.enableMarkdown ? 640 : 540) * Style.uiScaleRatio)
 
   onOpened: {
-    NotificationService.updateLastSeenTs();
+      if (Settings.data.notifications.markSeenOnOpen === true) {
+          NotificationService.updateLastSeenTs();
+      }
   }
 
   panelContent: Rectangle {

--- a/Modules/Panels/Settings/Tabs/Notifications/HistorySubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Notifications/HistorySubTab.qml
@@ -19,6 +19,14 @@ ColumnLayout {
   }
 
   NToggle {
+    label: I18n.tr("panels.notifications.settings-mark-seen-on-open-label")
+    description: I18n.tr("panels.notifications.settings-mark-seen-on-open-description")
+    checked: Settings.data.notifications.markSeenOnOpen
+    onToggled: checked => Settings.data.notifications.markSeenOnOpen = checked
+    defaultValue: Settings.getDefaultValue("notifications.markSeenOnOpen")
+  }
+
+  NToggle {
     label: I18n.tr("panels.notifications.settings-markdown-label")
     description: I18n.tr("panels.notifications.settings-markdown-description")
     checked: Settings.data.notifications.enableMarkdown


### PR DESCRIPTION
## Motivation

I like to leave notifications on do not disturb for the most time. I still want to see when there's a new notification with the little dot on the bar icon but I don't want any pop-up notifications. When I check the new notifications by opening the history I may see some that are not actionable yet and that I want to deal with later. However, now the bar icon won't show that there are any new notifications (of course they are still in the history). This merge request adds an option to not mark notifications as seen anymore when opening the history.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing


- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

This is probably independent from all of the above.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes

There are two points that are worth discussing in my opinion:

* I could also see giving the option a name that describes that the dot on the bar icon shows that there are notifications in the history instead of unseen ones instead.
* I could also create a new plugin instead but that would be a lot of code duplication for a single added if clause and a feature toggle.