### PR TITLE
fix: stale data on wifi widget

### DIFF
--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -1171,8 +1171,10 @@ Singleton {
       onRead: data => {
         if (data.endsWith(": connected") || data.endsWith(": disconnected")) {
           Logger.d("Network", "State changed: " + data);
+          // Refresh status and trigger a scan to update SSID
           deviceStatusProcess.running = true;
           connectivityCheckProcess.running = true;
+          root.scan();
         }
       }
     }

--- a/Services/Networking/NetworkService.qml
+++ b/Services/Networking/NetworkService.qml
@@ -101,6 +101,17 @@ Singleton {
     }
   }
 
+  // Handle system resume to refresh network status and trigger a scan
+  Connections {
+    target: Time
+    function onResumed() {
+      Logger.i("Network", "System resumed - refreshing state");
+      deviceStatusProcess.running = true;
+      connectivityCheckProcess.running = true;
+      scan();
+    }
+  }
+
   // Start initial checks when nmcli becomes available
   Connections {
     target: ProgramCheckerService
@@ -196,6 +207,14 @@ Singleton {
     id: delayedScanTimer
     interval: 7000
     onTriggered: scan()
+  }
+
+  // Timer to restart the monitor process if it exits (e.g. after sleep or NM restart)
+  Timer {
+    id: monitorRestartTimer
+    interval: 2000
+    repeat: false
+    onTriggered: networkMonitorProcess.running = true
   }
 
   // Core functions
@@ -1156,6 +1175,10 @@ Singleton {
           connectivityCheckProcess.running = true;
         }
       }
+    }
+    onExited: {
+      Logger.w("Network", "Monitor process exited. Restarting in 2s...");
+      monitorRestartTimer.start();
     }
   }
 }


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
closes #2184 
I have noticed that when I am connected to a network and suspend my laptop, the Wi-Fi widget displays stale SSID data from the previous connection upon resuming in a new location. A similar issue occurs during automatic failover: if the primary connection drops and the system automatically connects to a saved hotspot, the SSID name in the status bar remains unchanged despite the successful reconnection.

This pull requests forces a scan to update the network list and reflect the latest changes when those events occur. I've also implemented a mechanism to start again `nmcli -t monitor` if the process for some reason hangs or exits

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)