### PR TITLE
Safeguard custom commands from trailing whitespaces

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -413,12 +413,12 @@ Item {
     try {
       const app = DesktopEntries.byId(appId);
 
-      if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix) {
+      if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix.trim() !== "") {
         // Use custom launch prefix
-        const prefix = Settings.data.appLauncher.customLaunchPrefix.split(" ");
+        const prefix = Settings.data.appLauncher.customLaunchPrefix.trim().split(" ");
 
-        if (app.runInTerminal) {
-          const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+        if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
+          const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
           const command = prefix.concat(terminal.concat(app.command));
           Quickshell.execDetached(command);
         } else {
@@ -426,9 +426,9 @@ Item {
           Quickshell.execDetached(command);
         }
       } else {
-        if (app.runInTerminal) {
+        if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
           Logger.d("Taskbar", "Executing terminal app manually: " + app.name);
-          const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+          const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
           const command = terminal.concat(app.command);
           CompositorService.spawn(command);
         } else if (app.command && app.command.length > 0) {

--- a/Modules/Dock/DockContent.qml
+++ b/Modules/Dock/DockContent.qml
@@ -145,11 +145,11 @@ Item {
           return;
         }
 
-        if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix) {
-          const prefix = Settings.data.appLauncher.customLaunchPrefix.split(" ");
+        if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix.trim() !== "") {
+          const prefix = Settings.data.appLauncher.customLaunchPrefix.trim().split(" ");
 
-          if (app.runInTerminal) {
-            const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+          if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
+            const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
             const command = prefix.concat(terminal.concat(app.command));
             Quickshell.execDetached(command);
           } else {
@@ -157,9 +157,9 @@ Item {
             Quickshell.execDetached(command);
           }
         } else {
-          if (app.runInTerminal) {
+          if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
             Logger.d("Dock", "Executing terminal app manually: " + app.name);
-            const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+            const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
             const command = terminal.concat(app.command);
             CompositorService.spawn(command);
           } else if (app.command && app.command.length > 0) {

--- a/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
+++ b/Modules/Panels/Launcher/Providers/ApplicationsProvider.qml
@@ -553,13 +553,13 @@ Item {
                          return;
                        }
 
-                       if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix) {
+                       if (Settings.data.appLauncher.customLaunchPrefixEnabled && Settings.data.appLauncher.customLaunchPrefix.trim() !== "") {
                          // Use custom launch prefix
-                         const prefix = Settings.data.appLauncher.customLaunchPrefix.split(" ");
-                         Logger.d("ApplicationsProvider", `Using custom launch prefix: ${Settings.data.appLauncher.customLaunchPrefix}`);
+                         const prefix = Settings.data.appLauncher.customLaunchPrefix.trim().split(" ");
+                         Logger.d("ApplicationsProvider", `Using custom launch prefix: ${Settings.data.appLauncher.customLaunchPrefix.trim()}`);
 
-                         if (app.runInTerminal) {
-                           const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+                         if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
+                           const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
                            const command = prefix.concat(terminal.concat(app.command));
                            Logger.d("ApplicationsProvider", `Executing command (with prefix and terminal): ${command.join(" ")}`);
                            Quickshell.execDetached(command);
@@ -569,9 +569,9 @@ Item {
                            Quickshell.execDetached(command);
                          }
                        } else {
-                         if (app.runInTerminal) {
+                         if (app.runInTerminal && Settings.data.appLauncher.terminalCommand.trim() !== "") {
                            Logger.d("ApplicationsProvider", "Executing terminal app manually: " + app.name);
-                           const terminal = Settings.data.appLauncher.terminalCommand.split(" ");
+                           const terminal = Settings.data.appLauncher.terminalCommand.trim().split(" ");
                            const command = terminal.concat(app.command);
                            Logger.d("ApplicationsProvider", "Executing command (manual terminal): " + command.join(" "));
                            CompositorService.spawn(command);

--- a/Modules/Panels/Launcher/Providers/ClipboardProvider.qml
+++ b/Modules/Panels/Launcher/Providers/ClipboardProvider.qml
@@ -385,12 +385,12 @@ Item {
     var actions = [];
 
     // Annotation tool for images
-    if (item.isImage && Settings.data.appLauncher.screenshotAnnotationTool !== "") {
+    if (item.isImage && Settings.data.appLauncher.screenshotAnnotationTool.trim() !== "") {
       actions.push({
                      "icon": "pencil",
                      "tooltip": I18n.tr("tooltips.open-annotation-tool"),
                      "action": function () {
-                       var tool = Settings.data.appLauncher.screenshotAnnotationTool;
+                       var tool = Settings.data.appLauncher.screenshotAnnotationTool.trim();
                        Quickshell.execDetached(["sh", "-c", "cliphist decode " + item.clipboardId + " | " + tool]);
                        if (launcher)
                          launcher.close();

--- a/Modules/Panels/Settings/Tabs/Launcher/ExecuteSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Launcher/ExecuteSubTab.qml
@@ -15,8 +15,7 @@ ColumnLayout {
     description: I18n.tr("panels.launcher.settings-terminal-command-description")
     Layout.fillWidth: true
     text: Settings.data.appLauncher.terminalCommand
-    onTextChanged: {
-      Settings.data.appLauncher.terminalCommand = text;
+    onTextChanged: Settings.data.appLauncher.terminalCommand = text
     }
   }
 


### PR DESCRIPTION
This PR removes trailing whitespaces from custom commands in the launcher settings since they can cause errors (see issue #2435)