### PR TITLE
fix(tray): change the order in which the identifier for `blacklist` and `pinned` items is taken

### DIFF
--- a/Modules/Bar/Extras/TrayMenu.qml
+++ b/Modules/Bar/Extras/TrayMenu.qml
@@ -22,6 +22,23 @@ PopupWindow {
   // Derive menu from trayItem (only used for non-submenus)
   readonly property QsMenuHandle menu: isSubMenu ? null : (trayItem ? trayItem.menu : null)
 
+  // Helper functions
+  function wildCardMatch(str, rule) {
+    if (!str || !rule)
+      return false;
+    if (str === rule)
+      return true;
+    const placeholder = '\uE000';
+    let processedRule = rule.replace(/\*/g, placeholder);
+    let escaped = processedRule.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    let pattern = '^' + escaped.replace(new RegExp(placeholder, 'g'), '.*') + '$';
+    try {
+      return new RegExp(pattern, 'i').test(str);
+    } catch (e) {
+      return false;
+    }
+  }
+
   // Compute if current tray item is pinned
   readonly property bool isPinned: {
     if (!trayItem || widgetSection === "" || widgetIndex < 0)
@@ -35,7 +52,7 @@ PopupWindow {
     var pinnedList = widgetSettings.pinned || [];
     const itemName = trayItem.id || trayItem.title || trayItem.tooltipTitle || "";
     for (var i = 0; i < pinnedList.length; i++) {
-      if (pinnedList[i] === itemName)
+      if (wildCardMatch(itemName, pinnedList[i]))
         return true;
     }
     return false;
@@ -617,7 +634,7 @@ PopupWindow {
     var pinnedList = widgetSettings.pinned || [];
     var newPinned = [];
     for (var i = 0; i < pinnedList.length; i++) {
-      if (pinnedList[i] !== itemName) {
+      if (!wildCardMatch(itemName, pinnedList[i])) {
         newPinned.push(pinnedList[i]);
       }
     }

--- a/Modules/Bar/Extras/TrayMenu.qml
+++ b/Modules/Bar/Extras/TrayMenu.qml
@@ -33,7 +33,7 @@ PopupWindow {
     if (!widgetSettings || widgetSettings.id !== "Tray")
       return false;
     var pinnedList = widgetSettings.pinned || [];
-    const itemName = trayItem.tooltipTitle || trayItem.name || trayItem.id || "";
+    const itemName = trayItem.id || trayItem.title || trayItem.tooltipTitle || "";
     for (var i = 0; i < pinnedList.length; i++) {
       if (pinnedList[i] === itemName)
         return true;
@@ -552,7 +552,7 @@ PopupWindow {
       Logger.w("TrayMenu", "Cannot pin: missing tray item or widget info");
       return;
     }
-    const itemName = trayItem.tooltipTitle || trayItem.name || trayItem.id || "";
+    const itemName = trayItem.id || trayItem.title || trayItem.tooltipTitle || "";
     if (!itemName) {
       Logger.w("TrayMenu", "Cannot pin: tray item has no name");
       return;
@@ -598,7 +598,7 @@ PopupWindow {
       Logger.w("TrayMenu", "Cannot unpin: missing tray item or widget info");
       return;
     }
-    const itemName = trayItem.tooltipTitle || trayItem.name || trayItem.id || "";
+    const itemName = trayItem.id || trayItem.title || trayItem.tooltipTitle || "";
     if (!itemName) {
       Logger.w("TrayMenu", "Cannot unpin: tray item has no name");
       return;

--- a/Modules/Bar/Widgets/Tray.qml
+++ b/Modules/Bar/Widgets/Tray.qml
@@ -142,7 +142,7 @@ Item {
           continue;
         }
 
-        const title = item.tooltipTitle || item.name || item.id || "";
+        const title = item.id || item.title || item.tooltipTitle || "";
 
         // Skip passive items if hidePassive is enabled
         if (root.hidePassive && item.status !== undefined && (item.status === SystemTray.Passive || item.status === 0)) {
@@ -179,7 +179,7 @@ Item {
         let pinnedItems = [];
         for (var k = 0; k < newItems.length; k++) {
           const item2 = newItems[k];
-          const title2 = item2.tooltipTitle || item2.name || item2.id || "";
+          const title2 = item2.id || item2.title || item2.tooltipTitle || "";
           for (var m = 0; m < pinned.length; m++) {
             const rule2 = pinned[m];
             if (wildCardMatch(title2, rule2)) {
@@ -470,7 +470,7 @@ Item {
                 popupMenuWindow.close();
               }
               root.hoveredItemIndex = trayDelegate.index;
-              TooltipService.show(tooltipAnchor, modelData.tooltipTitle || modelData.name || modelData.id || "Tray Item", BarService.getTooltipDirection(root.screen?.name));
+              TooltipService.show(tooltipAnchor, modelData.tooltipTitle || modelData.title || modelData.id || "Tray Item", BarService.getTooltipDirection(root.screen?.name));
             } else if (root.hoveredItemIndex === trayDelegate.index) {
               root.hoveredItemIndex = -1;
               TooltipService.hide(tooltipAnchor);

--- a/Modules/Panels/Tray/TrayDrawerPanel.qml
+++ b/Modules/Panels/Tray/TrayDrawerPanel.qml
@@ -128,7 +128,7 @@ SmartPanel {
     function isPinned(item) {
       if (!pinnedList || pinnedList.length === 0)
         return false;
-      const title = item?.tooltipTitle || item?.name || item?.id || "";
+      const title = item?.id || item?.title || item?.tooltipTitle || "";
       for (var i = 0; i < pinnedList.length; i++) {
         if (wildCardMatch(title, pinnedList[i]))
           return true;
@@ -277,7 +277,7 @@ SmartPanel {
                 if (panelContent.popupMenuWindow) {
                   panelContent.popupMenuWindow.close();
                 }
-                TooltipService.show(trayIcon, modelData.tooltipTitle || modelData.name || modelData.id || "Tray Item", BarService.getTooltipDirection(root.screen?.name));
+                TooltipService.show(trayIcon, modelData.tooltipTitle || modelData.title || modelData.id || "Tray Item", BarService.getTooltipDirection(root.screen?.name));
               }
               onExited: TooltipService.hide()
             }


### PR DESCRIPTION
# Pull Request

## Motivation
Currently the identifier for the `blacklist` and `pinned` items in the tray widget is being taken from the properties `tooltipTitle`/`name`/`id`, in that order of precedence. Taking `tooltipTitle` as the first option is not ideal since that property seems to be dynamic and changes depending on certain conditions.

For example:
- Blueman - changes depending on the status of the bluetooth (`Bluetooth Disabled` / `Bluetooth Enabled`)
- KeepassXC - changes based on the database focused (`[DATABASE_NAME] - KeePassXC`)

Because of this:
- It is difficult to know the correct name to use in the `blacklist` rules
- It is possible that you set a rule for an app but when the app changes status the rule doesn't match anymore


So, the order was changed to `id`/`title`/`tooltipTitle`.
`name` property was replaced with `title` since it [doesn't seem to be a valid property](https://quickshell.org/docs/master/types/Quickshell.Services.SystemTray/SystemTrayItem/).
`wildCardMatch` function was added in `TrayMenu.qml` to keep consistency on how pinned items are verified (since in both `Tray.qml` and `TrayDrawerPanel.qml` a `wildCardMatch` function is used to check for matches with regex patterns).

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- Add rules in the `blacklist` field and verify the apps are omitted
- Verify the `Pin/Unpin Application` is working correctly
- Manually add a rule (that does not exactly match the `id` value of the app, i.e, `keepassxc`/`*KeePass*` for `KeePassXC`) in the `pinned` items in the settings
    - Verify it is pinned
    - Verify the menu show the `Unpin Application` button instead of `Pin Application`
    - Verify the `Unpin Application` button removes the entry from the settings

---
- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
https://github.com/user-attachments/assets/24488cec-9fde-40fe-a976-5d9314b5869e

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
The only app that I've seen so far that could have a problem trying to blacklist with this approach is Discord, whose ID is `chrome_status_icon_1` in my case. (Pinning it using the `Pin Application` button works fine) .
