### PR TITLE
fix(nix): set warnings as top-level config

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -182,13 +182,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.mkIf cfg.systemd.enable [
+      ''
+        Running noctalia-shell as a systemd service has been deprecated!
+        See https://docs.noctalia.dev/getting-started/nixos/#running-the-shell for details.
+      ''
+    ];
+
     systemd.user.services.noctalia-shell = lib.mkIf cfg.systemd.enable {
-      warnings = [
-        ''
-          Running noctalia-shell as a systemd service has been deprecated!
-          See https://docs.noctalia.dev/getting-started/nixos/#running-the-shell for details.
-        ''
-      ];
       Unit = {
         Description = "Noctalia Shell - Wayland desktop shell";
         Documentation = "https://docs.noctalia.dev";


### PR DESCRIPTION
# Pull Request

## Motivation

https://github.com/noctalia-dev/noctalia-shell/pull/2495 broke the systemd feature in the Home-Manager module by setting the invalid option `systemd.user.services.noctalia-shell.warnings`, which doesn't exist.

This PR fixes that by setting the top-level module option `warnings` using `mkIf`.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
