### PR TITLE
fix(code): make markdown preview readable in light mode

### DIFF
--- a/Assets/Templates/code.json
+++ b/Assets/Templates/code.json
@@ -1,6 +1,6 @@
 {
     "name": "NoctaliaTheme",
-    "type": "dark",
+    "type": "{{mode}}",
     "semanticHighlighting": true,
     "semanticTokenColors": {
       "enumMember": {
@@ -1971,8 +1971,12 @@
       "terminal.foreground": "{{colors.on_background.default.hex}}",
       "terminalCursor.background": "{{colors.background.default.hex}}",
       "terminalCursor.foreground": "{{colors.primary.default.hex}}",
+      "textBlockQuote.background": "{{colors.surface_container_low.default.hex}}",
+      "textBlockQuote.border": "{{colors.outline.default.hex}}",
+      "textCodeBlock.background": "{{colors.surface_container.default.hex}}",
       "textLink.activeForeground": "{{colors.primary_container.default.hex}}",
       "textLink.foreground": "{{colors.primary.default.hex}}",
+      "textPreformat.foreground": "{{colors.on_surface.default.hex}}",
       "titleBar.activeBackground": "{{colors.surface.default.hex}}",
       "titleBar.activeForeground": "{{colors.on_surface.default.hex}}",
       "titleBar.border": "{{colors.outline.default.hex}}00",


### PR DESCRIPTION
## Motivation

Markdown preview in VSCode/VSCodium is hard to read when the Noctalia palette is in **light mode**: the theme template hardcodes `"type": "dark"`, so VSCode uses dark-theme fallbacks for UI elements the theme doesn't explicitly color (including blockquotes and inline code backgrounds). The result is dark-on-dark or low-contrast text inside blockquote / code-block regions even when the rest of the editor is on a light surface.

This PR makes the VSCode template honor the current Noctalia mode and explicitly colors the markdown-preview surfaces from the palette.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes # (none)

## Changes

`Assets/Templates/code.json`:

- `"type": "dark"` → `"type": "{{mode}}"` — the template renderer already supports `{{mode}}` (resolved to `"dark"` / `"light"` via `default_mode`, see `Scripts/python/src/theming/lib/renderer.py`), so VSCode now picks the correct light/dark defaults.
- Added four palette-aware keys so blockquote / inline-code / preformatted blocks match the rest of the theme instead of falling back to VSCode defaults:
  - `textBlockQuote.background` → `surface_container_low`
  - `textBlockQuote.border` → `outline`
  - `textCodeBlock.background` → `surface_container`
  - `textPreformat.foreground` → `on_surface`

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Verified locally by applying the equivalent patch via a user template post-hook against both a wallpaper-derived light palette and the default Noctalia light scheme, then reloading the VSCode window and opening a markdown preview.

## Screenshots / Videos

Annotated `Markdown Kitchen Sink` preview — green highlights inline blockquote, red highlights a long blockquote. All screenshots are **light mode**; dark mode is unchanged.

**Before — wallpaper-derived light palette:**
![before-wallpaper-light](https://raw.githubusercontent.com/kohanyirobert/noctalia-shell/pr-assets/before-wallpaper-light.png)

**Before — default Noctalia light scheme:**
![before-default-light](https://raw.githubusercontent.com/kohanyirobert/noctalia-shell/pr-assets/before-default-light.png)

**After — wallpaper-derived light palette:**
![after-wallpaper-light](https://raw.githubusercontent.com/kohanyirobert/noctalia-shell/pr-assets/after-wallpaper-light.png)

**After — default Noctalia light scheme:**
![after-default-light](https://raw.githubusercontent.com/kohanyirobert/noctalia-shell/pr-assets/after-default-light.png)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant) — N/A

## Additional Notes
Dark mode is unchanged (since `{{mode}}` resolves to `"dark"` there). Only the four new color keys and the `type` field differ; no token colors or other UI surfaces are touched.