### PR TITLE
fix(ipc): added missing entry to Control settingsTabMap

### DIFF
--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -104,7 +104,8 @@ Singleton {
                                             "system": SettingsPanel.Tab.System,
                                             "systemmonitor": SettingsPanel.Tab.System,
                                             "userinterface": SettingsPanel.Tab.UserInterface,
-                                            "wallpaper": SettingsPanel.Tab.Wallpaper
+                                            "wallpaper": SettingsPanel.Tab.Wallpaper,
+                                            "idle": SettingsPanel.Tab.Idle
                                           })
 
   function _parseSettingsTabArg(tabArg) {


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

<!-- If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed. -->

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

I was using the ipc calls to open different settings tabs and I couldn't open the idle tab.

```
qs -c noctalia-shell ipc call settings openTab idle
```

It looked like a simple fix so I went down the openTab function and found that `idle` isn't in the map
used to resolve the arguments so I simply added it like the other tabs.

I checked if it worked on my system and I could open the tab without issue.
I didn't check anything other than opening the tab since the change is so small and shouldn't have any impact.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
<!-- - Closes #(issue number) (if any) -->

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

<!-- ## Screenshots / Videos -->
<!-- If applicable, include screenshots or videos to help illustrate your changes. -->

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

<!-- ## Additional Notes
Add any additional context or follow-up notes for reviewers. -->
