### PR TITLE
NBusyIndicator: follow color change

### DIFF
--- a/Widgets/NBusyIndicator.qml
+++ b/Widgets/NBusyIndicator.qml
@@ -13,6 +13,8 @@ Item {
   implicitWidth: size
   implicitHeight: size
 
+  onColorChanged: canvas.requestPaint()
+
   // GPU-optimized spinner - draw once, rotate with GPU transform
   Item {
     id: spinner


### PR DESCRIPTION
I noticed that the spinning circle in the network and Bluetooth panel (when connecting/disconnecting) doesn't use the proper color since it doesn't update its color when the connection status changes. Luckily, this can be fixed by just adding a single line.