### PR TITLE
Fix pixelation of colorized dock icons

### DIFF
--- a/Modules/Dock/DockContent.qml
+++ b/Modules/Dock/DockContent.qml
@@ -584,6 +584,7 @@ Item {
 
                 // Apply dock-specific colorization shader only to non-focused apps
                 layer.enabled: !appButton.isActive && Settings.data.dock.colorizeIcons
+                layer.smooth: true
                 layer.effect: ShaderEffect {
                   property color targetColor: Settings.data.colorSchemes.darkMode ? Color.mOnSurface : Color.mSurfaceVariant
                   property real colorizeMode: 0.0 // Dock mode (grayscale)


### PR DESCRIPTION
Another simple fix for a problem where the dock icons will appear pixelated when hovered and icon colorization is enabled.