### PR TITLE
Fix tray menu not closing / not updating

### DIFF
--- a/Modules/Bar/Extras/TrayMenu.qml
+++ b/Modules/Bar/Extras/TrayMenu.qml
@@ -462,15 +462,16 @@ PopupWindow {
                              } else {
                                // Click on regular items triggers them
                                modelData.triggered();
-                               root.hideMenu();
-
-                               // Close the drawer if it's open
-                               if (root.screen) {
-                                 const panel = PanelService.getPanel("trayDrawerPanel", root.screen);
-                                 if (panel && panel.visible) {
-                                   panel.close();
-                                 }
-                               }
+                               const screen = root.screen;
+                               Qt.callLater(() => {
+                                              PanelService.closeTrayMenu(screen);
+                                              if (screen) {
+                                                const panel = PanelService.getPanel("trayDrawerPanel", screen);
+                                                if (panel && panel.visible) {
+                                                  panel.close();
+                                                }
+                                              }
+                                            });
                              }
                            }
                          }
@@ -541,6 +542,7 @@ PopupWindow {
             } else {
               root.addToPinned();
             }
+            PanelService.closeTrayMenu(root.screen);
           }
         }
       }

--- a/Services/UI/PanelService.qml
+++ b/Services/UI/PanelService.qml
@@ -114,6 +114,8 @@ Singleton {
     // Close any previously opened menu first
     closeContextMenu(screen);
 
+    // Force refresh when reopening the same tray item.
+    trayMenu.trayItem = null;
     trayMenu.trayItem = trayItem;
     trayMenu.widgetSection = widgetSection;
     trayMenu.widgetIndex = widgetIndex;


### PR DESCRIPTION
# Pull Request

## Motivation

This PR aims to fix two bugs with tray menus:
- They are not closing properly after making a click on item in the menu. The focus remains on the closed layer instead of going to windows, forcing to make an extra click to return back to normal.
- They are not updating changed text properly. For example, after enabling some option in the tray menu and then reopening that menu, it says it's still disabled, even though in the program itself it's actually enabled as expected.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Should probably solve #1957, though I did not test this with Amnezia.

## Testing

Did test with my own project with a tray icon, these changes make it work as expected.

Also tested with Telegram Desktop's "Enable/Disable Notifications", now works as expected.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
None

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
None
