### PR TITLE
fix(battery): apply panel settings from the widget that opened it

### DIFF
--- a/Modules/Bar/Widgets/Battery.qml
+++ b/Modules/Bar/Widgets/Battery.qml
@@ -247,17 +247,19 @@ Item {
   // ==================== SHARED ====================
 
   function getBatteryPanel() {
-    var panel = PanelService.getPanel("batteryPanel", screen);
-    if (panel) {
-      panel.panelID = {
-        showPowerProfiles: widgetSettings.showPowerProfiles !== undefined ? widgetSettings.showPowerProfiles : widgetMetadata.showPowerProfiles,
-        showNoctaliaPerformance: widgetSettings.showNoctaliaPerformance !== undefined ? widgetSettings.showNoctaliaPerformance : widgetMetadata.showNoctaliaPerformance
-      };
-    }
-    return panel;
+    return PanelService.getPanel("batteryPanel", screen);
   }
 
   function toggleBatteryPanel() {
-    getBatteryPanel()?.toggle(root);
+    var panel = getBatteryPanel();
+    if (panel) {
+      if (!panel.isPanelOpen) {
+        panel.panelID = {
+          showPowerProfiles: widgetSettings.showPowerProfiles !== undefined ? widgetSettings.showPowerProfiles : widgetMetadata.showPowerProfiles,
+          showNoctaliaPerformance: widgetSettings.showNoctaliaPerformance !== undefined ? widgetSettings.showNoctaliaPerformance : widgetMetadata.showNoctaliaPerformance
+        };
+      }
+      panel.toggle(root);
+    }
   }
 }


### PR DESCRIPTION
## Problem

When two Battery widgets are configured simultaneously (e.g. one for the laptop battery, one for a Bluetooth headset), the **Show power profile controls** and **Show Noctalia Performance toggle** settings from the second widget were being ignored — the first widget's settings always won.

## Root cause

`getBatteryPanel()` was writing `panelID` (which controls `showPowerProfiles` and `showNoctaliaPerformance` in the panel) as a side effect on every call. This function was also called from a reactive QML `tooltipText` binding on each widget instance:

```qml
tooltipText: !getBatteryPanel()?.isPanelOpen ? root.tooltipContent : ""
```

Because this binding depends on `isPanelOpen`, it re-evaluates on every panel open/close. With two widget instances, both bindings fire and the last one to run overwrites `panelID` — consistently producing the first widget's settings.

## Fix

- `getBatteryPanel()` now only returns the panel, with no side effects
- `panelID` is written in `toggleBatteryPanel()`, guarded by `!panel.isPanelOpen` so it only fires when actually opening the panel — not when closing it

This ensures the panel always reflects the settings of the widget that opened it, for its entire open → close lifecycle.

## Testing

Reproduced with two Battery widgets (laptop + Bluetooth headset) with different `showPowerProfiles` / `showNoctaliaPerformance` values. Confirmed fix resolves the issue.