### PR TITLE
feat: add autoNetworkEnabled setting to gate automatic network requests

### DIFF
--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -142,7 +142,8 @@
       ]
     },
     "reverseScroll": false,
-    "smoothScrollEnabled": true
+    "smoothScrollEnabled": true,
+    "autoNetworkEnabled": true
   },
   "ui": {
     "fontDefault": "",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -348,6 +348,11 @@ Singleton {
       }
       property bool reverseScroll: false
       property bool smoothScrollEnabled: true
+      // Controls whether automatic (non-user-initiated) network fetches are enabled.
+      // Distro packagers: set default to false to comply with policies requiring
+      // explicit user consent for network access. Users can re-enable in settings.
+      // Build-time: sed -i 's/"autoNetworkEnabled": true/"autoNetworkEnabled": false/' Assets/settings-default.json
+      property bool autoNetworkEnabled: true
     }
 
     // ui

--- a/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
+++ b/Modules/Panels/Settings/Tabs/ColorScheme/SchemeDownloader.qml
@@ -173,6 +173,10 @@ Popup {
   }
 
   function fetchAvailableSchemesFromAPI() {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     if (fetching) {
       return;
     }

--- a/Services/Location/LocationService.qml
+++ b/Services/Location/LocationService.qml
@@ -194,7 +194,7 @@ Singleton {
     }
   }
 
-  // Query geocoding API to convert location name to coordinates
+  // (runs only when user has explicitly configured a location in Settings)
   function geocodeLocation(locationName, callback, errorCallback) {
     if (locationName === "") {
       isFetchingWeather = false;
@@ -226,7 +226,7 @@ Singleton {
     xhr.send();
   }
 
-  // Fetch weather data from Open-Meteo API
+  // (runs only when user has explicitly enabled weather in Settings)
   function fetchWeatherData(latitude, longitude, errorCallback) {
     Logger.d("Location", "Fetching weather from api.open-meteo.com");
     var url = "https://api.open-meteo.com/v1/forecast?latitude=" + latitude + "&longitude=" + longitude + "&current_weather=true&current=relativehumidity_2m,surface_pressure,is_day&daily=temperature_2m_max,temperature_2m_min,weathercode,sunset,sunrise&timezone=auto";
@@ -263,6 +263,11 @@ Singleton {
 
   // Geolocate via IP address using the Noctalia API
   function geolocate(callback, errorCallback) {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      if (errorCallback) errorCallback("Location", "IP geolocation disabled (autoNetworkEnabled=false)");
+      return;
+    }
+
     Logger.d("Location", "Geolocating via IP");
     var url = "https://api.noctalia.dev/geolocate";
     var xhr = new XMLHttpRequest();

--- a/Services/Noctalia/GitHubService.qml
+++ b/Services/Noctalia/GitHubService.qml
@@ -96,6 +96,10 @@ Singleton {
 
   // --------------------------------
   function fetchFromGitHub() {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     if (isFetchingData) {
       Logger.d("GitHub", "GitHub data is still fetching");
       return;

--- a/Services/Noctalia/PluginService.qml
+++ b/Services/Noctalia/PluginService.qml
@@ -180,7 +180,10 @@ Singleton {
       if (manifest) {
         pluginsToLoad.push(enabledIds[i]);
       } else {
-        Logger.w("PluginService", "Plugin", enabledIds[i], "is enabled but not found on disk - install");
+        if (!Settings.data.general.autoNetworkEnabled) {
+          Logger.w("PluginService", "Plugin", enabledIds[i], "is enabled but not found on disk (auto-install disabled, autoNetworkEnabled=false)");
+          continue;
+        }
         var sourceUrl = PluginRegistry.getPluginSourceUrl(enabledIds[i]);
         root.installPlugin({
                              id: enabledIds[i],
@@ -269,6 +272,10 @@ Singleton {
 
   // Fetch plugin registry from a source using git sparse-checkout
   function fetchPluginRegistry(source) {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     var repoUrl = source.url;
 
     Logger.d("PluginService", "Fetching registry from:", repoUrl);

--- a/Services/Noctalia/SupporterService.qml
+++ b/Services/Noctalia/SupporterService.qml
@@ -72,6 +72,10 @@ Singleton {
   }
 
   function fetchFromApi() {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     if (isFetching) {
       Logger.d("Supporter", "Already fetching");
       return;

--- a/Services/Noctalia/TelemetryService.qml
+++ b/Services/Noctalia/TelemetryService.qml
@@ -19,6 +19,10 @@ Singleton {
   readonly property string telemetryEndpoint: Quickshell.env("NOCTALIA_TELEMETRY_ENDPOINT") || "https://api.noctalia.dev/ping"
 
   function init() {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     if (initialized)
       return;
 

--- a/Services/Noctalia/UpdateService.qml
+++ b/Services/Noctalia/UpdateService.qml
@@ -303,6 +303,10 @@ Singleton {
   }
 
   function showLatestChangelog() {
+    if (!Settings.data.general.autoNetworkEnabled) {
+      return;
+    }
+
     if (!currentVersion)
       return;
 


### PR DESCRIPTION
# Pull Request
## Motivation
Introducing a setting to avoid network requests that are not initiated by a user.

I just wired it to a configuration value that defaults to `true` not to break existing/upstream implementations, but we will switch it to `false` by default in openSUSE.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2511

## Testing
Just packaged this and spinned up on my machine.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [X] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
