### PR TITLE
fix(bluetooth): unblock rfkill when enabling a blocked adapter

### DIFF
--- a/Services/Networking/BluetoothService.qml
+++ b/Services/Networking/BluetoothService.qml
@@ -152,6 +152,16 @@ Singleton {
       Logger.d("Bluetooth", "Enable/Disable skipped: no adapter");
       return;
     }
+    // quickshell's BluetoothAdapter.setEnabled() refuses to write Powered
+    // while the adapter is rfkill-blocked, so a partial airplane-mode exit
+    // (wifi unblocked, bluetooth still blocked) leaves the toggle dead.
+    // Lift the soft block ourselves; logind grants the seat user rw on
+    // /dev/rfkill so no privilege escalation is needed.
+    if (state && adapter.state === BluetoothAdapter.Blocked) {
+      Logger.i("Bluetooth", "Adapter rfkill-blocked, unblocking");
+      Quickshell.execDetached(["sh", "-c", "rfkill unblock bluetooth && bluetoothctl power on"]);
+      return;
+    }
     try {
       adapter.enabled = state;
       Logger.i("Bluetooth", "SetBluetoothEnabled", state);


### PR DESCRIPTION
## Motivation
quickshell's `BluetoothAdapter.setEnabled()` early-returns with `Cannot enable adapter because it is blocked by rfkill` and never writes the `Powered` property when the adapter is in the `Blocked` state. That leaves the bluetooth toggle dead after a partial airplane-mode exit — e.g. the laptop's airplane Fn key (kernel `rfkill block all`), then wifi is re-enabled via NetworkManager while bluetooth stays soft-blocked. `systemd-rfkill` persists that block across reboots, so the toggle stays broken until the user runs `rfkill unblock bluetooth` by hand.

`logind` grants the active seat user `rw` on `/dev/rfkill` (uaccess), so the shell can lift the soft block itself — same mechanism `setAirplaneMode()` already relies on. When the adapter is blocked and the user asks to enable it, run `rfkill unblock bluetooth && bluetoothctl power on` and let the resulting state change propagate back through quickshell.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- n/a

## Testing
- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Steps:
1. `rfkill block bluetooth` → `bluetoothctl show` reports `PowerState: off-blocked`
2. Click the bluetooth toggle in the bar / control center
3. Before: log spams `Cannot enable adapter because it is blocked by rfkill`, toggle does nothing
4. After: log shows `Bluetooth Adapter rfkill-blocked, unblocking`, adapter ends up `Powered: yes`

## Screenshots / Videos
n/a (no visual change)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
`bluetoothctl power on` is chained after the unblock because quickshell's `setEnabled` would still see the stale `Blocked` state if called synchronously; going through `bluetoothctl` avoids the race without adding a timer.
