### PR TITLE
fix(battery): hide non-laptop batteries on lock screen indicator

### DIFF
--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -106,7 +106,7 @@ Loader {
               Item {
                 id: batteryIndicator
 
-                property bool isReady: BatteryService.batteryReady
+                property bool isReady: BatteryService.batteryReady && BatteryService.hasLaptopBattery
                 property real percent: BatteryService.batteryPercentage
                 property bool charging: BatteryService.batteryCharging
                 property bool pluggedIn: BatteryService.batteryPluggedIn

--- a/Services/Hardware/BatteryService.qml
+++ b/Services/Hardware/BatteryService.qml
@@ -18,6 +18,7 @@ Singleton {
   readonly property bool batteryPluggedIn: isPluggedIn(primaryDevice)
   readonly property bool batteryReady: isDeviceReady(primaryDevice)
   readonly property bool batteryPresent: isDevicePresent(primaryDevice)
+  readonly property bool hasLaptopBattery: _laptopBattery !== null
   readonly property real warningThreshold: Settings.data.systemMonitor.batteryWarningThreshold
   readonly property real criticalThreshold: Settings.data.systemMonitor.batteryCriticalThreshold
   readonly property string batteryIcon: getIcon(batteryPercentage, batteryCharging, batteryPluggedIn, batteryReady)
@@ -47,7 +48,8 @@ Singleton {
     return list;
   }
 
-  readonly property var _laptopBattery: UPower.displayDevice.isPresent ? UPower.displayDevice : (laptopBatteries.length > 0 ? laptopBatteries[0] : null)
+  readonly property var _realBatteries: UPower.devices.values.filter(d => d.isLaptopBattery && !d.nativePath.includes("DisplayDevice"))
+  readonly property var _laptopBattery: _realBatteries.length > 0 ? (UPower.displayDevice.isPresent ? UPower.displayDevice : _realBatteries[0]) : null
   readonly property var _bluetoothBattery: bluetoothBatteries.length > 0 ? bluetoothBatteries[0] : null
 
   property var deviceModel: {


### PR DESCRIPTION
## Motivation

On desktops without a laptop battery, the primary device falls back to anything with a battery (such as Bluetooth headphones). This causes the lock screen to show the peripheral's charge level.

This PR hides that indicator on the lock-screen (which confused me when I saw a 100% on my desktop).

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)