### PR TITLE
nix: factor runtime deps into runtime-deps.nix

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,33 +1,14 @@
 {
   version ? "dirty",
   extraPackages ? [ ],
-  runtimeDeps ? [
-    brightnessctl
-    cliphist
-    ddcutil
-    wlsunset
-    wl-clipboard
-    wlr-randr
-    imagemagick
-    wget
-    (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
-  ],
+  runtimeDeps ? (callPackage ./runtime-deps.nix { inherit calendarSupport; }),
 
   lib,
+  callPackage,
   stdenvNoCC,
   # build
   qt6,
   quickshell,
-  # runtime deps
-  brightnessctl,
-  cliphist,
-  ddcutil,
-  wlsunset,
-  wl-clipboard,
-  wlr-randr,
-  imagemagick,
-  wget,
-  python3,
   wayland-scanner,
   # calendar support
   calendarSupport ? false,

--- a/nix/runtime-deps.nix
+++ b/nix/runtime-deps.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  brightnessctl,
+  cliphist,
+  ddcutil,
+  wlsunset,
+  wl-clipboard,
+  wlr-randr,
+  imagemagick,
+  wget,
+  python3,
+  calendarSupport ? false,
+}:
+[
+  brightnessctl
+  cliphist
+  ddcutil
+  wlsunset
+  wl-clipboard
+  wlr-randr
+  imagemagick
+  wget
+  (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
+]

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,6 @@
 {
   quickshell,
+  callPackage,
   nixfmt,
   statix,
   deadnix,
@@ -10,6 +11,9 @@
   kdePackages,
   mkShellNoCC,
 }:
+let
+  runtimeDeps = callPackage ./runtime-deps.nix { };
+in
 mkShellNoCC {
   #it's faster than mkDerivation / mkShell
   packages = [
@@ -30,5 +34,5 @@ mkShellNoCC {
     # CoC
     lefthook # githooks
     kdePackages.qtdeclarative # qmlfmt, qmllint, qmlls and etc; Qt6
-  ];
+  ] ++ runtimeDeps;
 }


### PR DESCRIPTION
## Motivation

Extract the runtime dependency list from package.nix into a shared nix/runtime-deps.nix so shell.nix can include the same deps.

I noticed whilst testing the battery PR that my night light stopped running as `wlsunset` was no longer in the $PATH.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)