### PR TITLE
WallpaperService: auto-detect new wallpapers via inotify

### DIFF
--- a/Services/UI/WallpaperService.qml
+++ b/Services/UI/WallpaperService.qml
@@ -1619,6 +1619,27 @@ Singleton {
   }
 
   // -------------------------------------------------------------------
+  // Directory watcher - auto-detects new wallpapers added to local collection
+  // -------------------------------------------------------------------
+  Timer {
+    id: directoryWatchDebounce
+    interval: 1000
+    repeat: false
+    onTriggered: {
+      Logger.d("Wallpaper", "Wallpaper directory changed on disk, refreshing list")
+      root.refreshWallpapersList()
+    }
+  }
+
+  FileView {
+    id: wallpaperDirectoryWatcher
+    path: root.defaultDirectory !== "" ? root.defaultDirectory : undefined
+    printErrors: false
+    watchChanges: true
+    onFileChanged: directoryWatchDebounce.restart()
+  }
+
+  // -------------------------------------------------------------------
   // Cache file persistence
   // -------------------------------------------------------------------
   FileView {


### PR DESCRIPTION
## Motivation

Add a FileView watcher on the user configured wallpaper directory so that new wallpapers are picked up automatically without having to press refresh.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)