### PR TITLE
fix(niri): filter out duplicates in workspace list

### DIFF
--- a/Services/Compositor/NiriService.qml
+++ b/Services/Compositor/NiriService.qml
@@ -107,6 +107,9 @@ Item {
     const workspacesList = [];
     for (var i = 0; i < niriWorkspaces.length; i++) {
       const ws = niriWorkspaces[i];
+      if (workspaceCache[ws.id]) {
+        continue;
+      }
       const wsData = {
         "id": ws.id,
         "idx": ws.idx,


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->
This fixes the workspace multiplication bug when running noctalia in niri.

## Motivation
The bug was highly annoying and looking at the code seemed easy to fix.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2463 

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
For screenshots showing the error, see #2463. This does not happen anymore after the fix.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)