### PR TITLE
Fix potential Bluetooth problem on boot

### DIFF
--- a/Modules/Bar/Widgets/ControlCenter.qml
+++ b/Modules/Bar/Widgets/ControlCenter.qml
@@ -121,7 +121,7 @@ NIconButton {
   IconImage {
     id: customOrDistroLogo
     anchors.centerIn: parent
-    width: root.buttonSize * 0.8
+    width: root.buttonSize * 0.7
     height: width
     source: {
       if (useDistroLogo)

--- a/Modules/Bar/Widgets/Launcher.qml
+++ b/Modules/Bar/Widgets/Launcher.qml
@@ -96,7 +96,7 @@ NIconButton {
   IconImage {
     id: customOrDistroLogo
     anchors.centerIn: parent
-    width: root.buttonSize * 0.8
+    width: root.buttonSize * 0.7
     height: width
     source: {
       if (useDistroLogo)

--- a/Services/Networking/BluetoothService.qml
+++ b/Services/Networking/BluetoothService.qml
@@ -71,10 +71,16 @@ Singleton {
     }
   }
 
-  // Handle potential case where Quickshell doesnt't properly update adapter after system wakeup
+  // Handle potential case where Quickshell doesnt't properly update adapter after boot or system wakeup
   Connections {
     target: Time
     function onResumed() {
+      ctlPollTimer.restart();
+    }
+  }
+
+  onAdapterChanged: {
+    if (adapter) {
       ctlPollTimer.restart();
     }
   }


### PR DESCRIPTION
1. Adding a fix for a potential problem with BluetoothService's `adapter.enabled` described here: #2541
2. Slightly reducing the distro logo for the launcher and control center widget to make the Arch icon fit better (some people complained about this: #2533 & #2461)

Before:
<img width="50" height="40" alt="Screenshot_2026-04-24 12-17-22" src="https://github.com/user-attachments/assets/b258a209-6b2c-4171-94ea-6bec6764088c" />
After:
<img width="50" height="40" alt="Screenshot_2026-04-24 12-17-42" src="https://github.com/user-attachments/assets/e6041849-baf8-4de5-bf47-1a93b2bea788" />
