### PR TITLE
fix(color): helix color scheme template has low readability

### DIFF
--- a/Assets/Templates/helix.toml
+++ b/Assets/Templates/helix.toml
@@ -11,15 +11,15 @@
 "constant.character" = "secondaryContainer"
 "constant.character.escape" = "tertiaryContainer"
 
-"string" = { fg = "tertiary", bg = "surfaceContainerHigh" }
-"string.regexp" = { fg = "tertiaryContainer", bg = "surfaceContainerHigh" }
-"string.special" = { fg = "tertiary", bg = "surfaceContainerHigh" }
-"string.special.symbol" = { fg = "tertiary", bg = "surfaceContainerHigh" }
+"string" = { fg = "tertiary" }
+"string.regexp" = { fg = "tertiaryContainer" }
+"string.special" = { fg = "tertiary" }
+"string.special.symbol" = { fg = "tertiary" }
 "string.special.path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
 
 "path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
 
-"comment" = { fg = "outline", bg = "surfaceContainerHigh", modifiers = ["italic"] }
+"comment" = { fg = "outline", modifiers = ["italic"] }
 
 "variable" = "onSurface"
 "variable.builtin" = "secondary"
@@ -152,8 +152,8 @@ onSurface = "{{colors.on_surface.default.hex}}"
 surfaceVariant = "{{colors.surface_variant.default.hex}}"
 onSurfaceVariant = "{{colors.on_surface_variant.default.hex}}"
 
-outline = "{{colors.outline.default.hex}}"
-outlineVariant = "{{colors.outline_variant.default.hex}}"
+outline = "{{colors.tertiary.default.hex}}"
+outlineVariant = "{{colors.secondary.default.hex}}"
 
 surfaceContainerLowest = "{{colors.surface_container_lowest.default.hex}}"
 surfaceContainerLow = "{{colors.surface_container_low.default.hex}}"


### PR DESCRIPTION
# Pull Request

- change outlineVariant color to secondary
- change outline color to tertiary
- remove backgrounds from strings and comments

## Motivation
> Taken from issue #2549

> The outline and outlineVariant colors in the Helix color scheme template generate values that are too dark. This causes readability issues, as the elements blend into the background. The lack of contrast is present even when using the curated Catppuccin template provided by Noctalia (ignoring that the catppuccin template seems to differ from the official catppuccin theme).
>
> Another issue is the string and comment backgrounds. While I don't mind this preference, the ui selection color uses the same template color, causing an issue where the background of the text and the selection are the same, preventing you from telling what is selected.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- Closes #2549 

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

More images on issue #2549

### Old Version

Near invisible brackets and commas, along with strings and comments where you can't see your selection

<img width="1028" height="120" alt="image" src="https://github.com/user-attachments/assets/771f13a2-cb9b-4454-9e2a-af31c97dda11" />

<img width="296" height="62" alt="image" src="https://github.com/user-attachments/assets/50575698-5b0c-4edc-9dfa-4071c47143c9" />

### New Version

Brackets, commas, semicolons, etc are now clearly visible. Plus, you can see your selection now.

<img width="1066" height="123" alt="image" src="https://github.com/user-attachments/assets/49d59eb8-89cb-46b5-9964-9c160c29bf1d" />

<img width="266" height="49" alt="image" src="https://github.com/user-attachments/assets/0237023c-9e45-4861-8042-7ce697840856" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
The changes are essentially proof of concept of how changing the outline colors gains more contrast and readability. Wasn't sure what color to swap the background color of strings to, so I removed them (which is entirely preference so not sure what to do).
