### PR TITLE
Implement media volume handling

### DIFF
--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -1574,6 +1574,8 @@
       "types-lockkey-label": "Lock keys",
       "types-media-description": "Show OSD when media playback state changes (play, pause, skip).",
       "types-media-label": "Media playback",
+      "types-media-volume-description": "Show OSD when media volume changes.",
+      "types-media-volume-label": "Media volume",
       "types-title": "OSD trigger events",
       "types-volume-description": "Show OSD when audio output volume changes.",
       "types-volume-label": "Output volume"

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1574,6 +1574,8 @@
       "types-lockkey-label": "Lock keys",
       "types-media-description": "Show OSD when media playback state changes (play, pause, skip).",
       "types-media-label": "Media playback",
+      "types-media-volume-description": "Show OSD when media volume changes.",
+      "types-media-volume-label": "Media volume",
       "types-title": "OSD trigger events",
       "types-volume-description": "Show OSD when audio output volume changes.",
       "types-volume-label": "Output volume"

--- a/Assets/settings-default.json
+++ b/Assets/settings-default.json
@@ -478,7 +478,8 @@
     "enabledTypes": [
       0,
       1,
-      2
+      2,
+      4
     ],
     "monitors": []
   },

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -707,7 +707,7 @@ Singleton {
       property int autoHideMs: 2000
       property bool overlayLayer: true
       property real backgroundOpacity: 1.0
-      property list<var> enabledTypes: [OSD.Type.Volume, OSD.Type.InputVolume, OSD.Type.Brightness]
+      property list<var> enabledTypes: [OSD.Type.Volume, OSD.Type.InputVolume, OSD.Type.Brightness, OSD.Type.MediaVolume]
       property list<string> monitors: [] // holds osd visibility per monitor
     }
 

--- a/Modules/Bar/Widgets/MediaMini.qml
+++ b/Modules/Bar/Widgets/MediaMini.qml
@@ -64,6 +64,9 @@ Item {
   readonly property bool shouldHideEmpty: !hasPlayer && hideMode === "hidden"
   readonly property bool isHidden: shouldHideIdle || shouldHideEmpty
 
+  // Volume scroll
+  property int wheelAccumulator: 0
+
   // Title
   readonly property string title: {
     if (!hasPlayer)
@@ -391,6 +394,27 @@ Item {
     hoverEnabled: true
     cursorShape: Qt.PointingHandCursor
     acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton | Qt.ForwardButton | Qt.BackButton
+
+    onWheel: function (ev) {
+      // Hide tooltip as soon as the user starts scrolling to adjust volume
+      TooltipService.hide();
+
+      ev.accepted = true;
+
+      var delta = ev.pixelDelta.y;
+
+      if (ev.inverted)
+            delta *= -1;
+
+      wheelAccumulator += delta;
+      if (wheelAccumulator >= 120) {
+        wheelAccumulator = 0;
+        MediaService.increaseVolume();
+      } else if (wheelAccumulator <= -120) {
+        wheelAccumulator = 0;
+        MediaService.decreaseVolume();
+      }
+    }
 
     onClicked: mouse => {
                  TooltipService.hide();

--- a/Modules/Cards/MediaCard.qml
+++ b/Modules/Cards/MediaCard.qml
@@ -420,6 +420,77 @@ NBox {
             }
           }
 
+          // Volume slider
+          Item {
+            id: volumeWrapper
+            visible: MediaService.volumeSupported
+            Layout.fillWidth: true
+            height: Style.baseWidgetSize * 0.5
+
+            property real localVolume: -1
+            property real lastSentVolume: -1
+            property real volumeEpsilon: 0.01
+            property real volume: {
+              if (!MediaService.volumeSupported)
+                return 0;
+              return MediaService.volume;
+            }
+
+            Timer {
+              id: volumeDebounce
+              interval: 75
+              repeat: false
+              onTriggered: {
+                if (volumeWrapper.localVolume >= 0) {
+                  const next = Math.max(0, Math.min(1, volumeWrapper.localVolume));
+                  if (volumeWrapper.lastSentVolume < 0 || Math.abs(next - volumeWrapper.lastSentVolume) >= volumeWrapper.volumeEpsilon) {
+                    MediaService.setVolume(next);
+                    volumeWrapper.lastSentVolume = next;
+                  }
+                }
+              }
+            }
+
+            RowLayout {
+              anchors.fill: parent
+              spacing: 2
+
+              NIcon {
+                icon: "volume"
+                color: Color.mOnSurfaceVariant
+              }
+
+              NSlider {
+                id: volumeSlider
+                Layout.fillWidth: true
+                from: 0
+                to: 1
+                stepSize: 0
+                snapAlways: false
+                heightRatio: 0.6
+
+                value: MediaService.volume
+
+                onMoved: {
+                  volumeWrapper.localVolume = value;
+                  volumeDebounce.restart();
+                }
+                onPressedChanged: {
+                  if (pressed) {
+                    volumeWrapper.localVolume = value;
+                    MediaService.setVolume(value);
+                    volumeWrapper.lastSentVolume = value;
+                  } else {
+                    volumeDebounce.stop();
+                    MediaService.setVolume(value);
+                    volumeWrapper.localVolume = -1;
+                    volumeWrapper.lastSentVolume = -1;
+                  }
+                }
+              }
+            }
+          }
+
           // Spacer to push media controls down
           Item {
             Layout.preferredHeight: Style.marginL

--- a/Modules/OSD/OSD.qml
+++ b/Modules/OSD/OSD.qml
@@ -19,7 +19,8 @@ Variants {
     Volume,
     InputVolume,
     Brightness,
-    LockKey
+    LockKey,
+    MediaVolume
   }
 
   model: Quickshell.screens.filter(screen => (Settings.data.osd.monitors.includes(screen.name) || Settings.data.osd.monitors.length === 0) && Settings.data.osd.enabled)
@@ -45,6 +46,7 @@ Variants {
     readonly property bool isMuted: AudioService.muted
     readonly property real currentInputVolume: AudioService.inputVolume
     readonly property bool isInputMuted: AudioService.inputMuted
+    readonly property real currentMediaVolume: MediaService.volume
     readonly property real epsilon: 0.005
 
     // LockKey OSD enabled state (reactive to settings)
@@ -72,6 +74,9 @@ Variants {
         return currentVolume <= 0.5 ? "volume-low" : "volume-high";
       case OSD.Type.InputVolume:
         return isInputMuted ? "microphone-off" : "microphone";
+      case OSD.Type.MediaVolume:
+        // Show music-off icon when volume is effectively 0% (within rounding threshold)
+        return currentMediaVolume < root.epsilon ? "music-off" : "music";
       case OSD.Type.Brightness:
         // Show sun-off icon when brightness is effectively 0% (within rounding threshold)
         if (currentBrightness < root.epsilon)
@@ -90,6 +95,8 @@ Variants {
         return isMuted ? 0 : currentVolume;
       case OSD.Type.InputVolume:
         return isInputMuted ? 0 : currentInputVolume;
+      case OSD.Type.MediaVolume:
+        return currentMediaVolume;
       case OSD.Type.Brightness:
         return currentBrightness;
       case OSD.Type.LockKey:
@@ -124,7 +131,7 @@ Variants {
     }
 
     function getProgressColor() {
-      const isMutedState = (currentOSDType === OSD.Type.Volume && isMuted) || (currentOSDType === OSD.Type.InputVolume && isInputMuted);
+      const isMutedState = (currentOSDType === OSD.Type.Volume && isMuted) || (currentOSDType === OSD.Type.InputVolume && isInputMuted) || (currentOSDType === OSD.Type.MediaVolume && currentMediaVolume < root.epsilon);
       if (isMutedState) {
         return Color.mError;
       }
@@ -150,7 +157,7 @@ Variants {
     }
 
     function getIconColor() {
-      const isMutedState = (currentOSDType === OSD.Type.Volume && isMuted) || (currentOSDType === OSD.Type.InputVolume && isInputMuted);
+      const isMutedState = (currentOSDType === OSD.Type.Volume && isMuted) || (currentOSDType === OSD.Type.InputVolume && isInputMuted) || (currentOSDType === OSD.Type.MediaVolume && currentMediaVolume < root.epsilon);
       if (isMutedState)
         return Color.mError;
 
@@ -310,6 +317,15 @@ Variants {
                          showOSD(OSD.Type.InputVolume);
                        });
         }
+      }
+    }
+
+    // MediaService monitoring
+    Connections {
+      target: MediaService
+
+      function onVolumeChanged() {
+        showOSD(OSD.Type.MediaVolume);
       }
     }
 

--- a/Modules/Panels/Media/MediaPlayerPanel.qml
+++ b/Modules/Panels/Media/MediaPlayerPanel.qml
@@ -479,6 +479,109 @@ SmartPanel {
             }
 
             Item {
+              id: volumeWrapper
+              visible: MediaService.volumeSupported
+              Layout.fillWidth: true
+              Layout.preferredHeight: volumeColumn.implicitHeight
+
+              property real localVolume: -1
+              property real lastSentVolume: -1
+              property real volumeEpsilon: 0.01
+              property real volume: {
+                if (!MediaService.volumeSupported)
+                  return 0;
+                return MediaService.volume;
+              }
+
+              Timer {
+                id: volumeDebounce
+                interval: 75
+                repeat: false
+                onTriggered: {
+                  if (volumeWrapper.localVolume >= 0) {
+                    const next = Math.max(0, Math.min(1, volumeWrapper.localVolume));
+                    if (volumeWrapper.lastSentVolume < 0 || Math.abs(next - volumeWrapper.lastSentVolume) >= volumeWrapper.volumeEpsilon) {
+                      MediaService.setVolume(next);
+                      volumeWrapper.lastSentVolume = next;
+                    }
+                  }
+                }
+              }
+
+
+
+              ColumnLayout {
+                id: volumeColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                spacing: 2
+
+                RowLayout {
+                  anchors.fill: parent
+                  spacing: 2
+
+                  NIcon {
+                    icon: "volume"
+                    color: Color.mOnSurfaceVariant
+                  }
+
+                  Item {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: root.compactMode ? (Style.baseWidgetSize * 0.4) : (Style.baseWidgetSize * 0.5)
+
+                    NSlider {
+                      id: volumeSlider
+                      anchors.fill: parent
+                      from: 0
+                      to: 1
+                      stepSize: 0
+                      snapAlways: false
+                      heightRatio: 0.4
+
+                      value: MediaService.volume
+
+                      onMoved: {
+                        volumeWrapper.localVolume = value;
+                        volumeDebounce.restart();
+                      }
+                      onPressedChanged: {
+                        if (pressed) {
+                          volumeWrapper.localVolume = value;
+                          MediaService.setVolume(value);
+                          volumeWrapper.lastSentVolume = value;
+                        } else {
+                          volumeDebounce.stop();
+                          MediaService.setVolume(value);
+                          volumeWrapper.localVolume = -1;
+                          volumeWrapper.lastSentVolume = -1;
+                        }
+                      }
+                    }
+                  }
+                }
+
+                RowLayout {
+                  Layout.fillWidth: true
+                  spacing: 0
+
+                  Item {
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
+                  }
+
+                  NText {
+                    text: MediaService.volumeString
+                    pointSize: Style.fontSizeXS
+                    color: Color.mOnSurfaceVariant
+                    horizontalAlignment: Text.AlignRight
+                    visible: volumeWrapper.visible
+                  }
+                }
+              }
+            }
+
+            Item {
               Layout.preferredHeight: root.isSideBySide ? Style.marginM : Style.marginS
             }
 

--- a/Modules/Panels/Settings/Tabs/Osd/EventsSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Osd/EventsSubTab.qml
@@ -30,6 +30,10 @@ ColumnLayout {
       {
         type: OSD.Type.LockKey,
         key: "types-lockkey"
+      },
+      {
+        type: OSD.Type.MediaVolume,
+        key: "types-media-volume"
       }
     ]
     delegate: NCheckbox {

--- a/Services/Control/IPCService.qml
+++ b/Services/Control/IPCService.qml
@@ -814,6 +814,14 @@ Singleton {
       }
       MediaService.seekByRatio(positionVal);
     }
+
+    function increase() {
+      MediaService.increaseVolume();
+    }
+
+    function decrease() {
+      MediaService.decreaseVolume();
+    }
   }
 
   IpcHandler {

--- a/Services/Media/MediaService.qml
+++ b/Services/Media/MediaService.qml
@@ -25,6 +25,12 @@ Singleton {
     }
   }
 
+  function formatVolume(volume) {
+    if (isNaN(volume) || volume < 0)
+      volume = 0;
+    return Math.floor(volume * 100) + " %";
+  }
+
   property var currentPlayer: null
   property string playerIdentity: currentPlayer ? (currentPlayer.identity || "") : ""
   property real currentPosition: 0
@@ -43,6 +49,8 @@ Singleton {
   property bool canSeek: currentPlayer ? currentPlayer.canSeek : false
   property bool isMuted: currentPlayer ? currentPlayer.volume < root.epsilon : false
   property real volume: currentPlayer ? currentPlayer.volume : 0.0
+  property bool volumeSupported: currentPlayer ? currentPlayer.volumeSupported : false
+  property string volumeString: formatVolume(volume)
   property string positionString: formatTime(currentPosition)
   property string lengthString: formatTime(trackLength)
   property real infiniteTrackLength: 922337203685
@@ -293,6 +301,13 @@ Singleton {
       let seekPosition = ratio * target.length;
       target.position = seekPosition;
       currentPosition = seekPosition;
+    }
+  }
+
+  function setVolume(value) {
+    let target = currentPlayer ? (currentPlayer._controlTarget || currentPlayer) : null;
+    if (target && target.canControl && target.volumeSupported) {
+      target.volume = Math.max(0.0, Math.min(1.0, value));
     }
   }
 

--- a/Services/Media/MediaService.qml
+++ b/Services/Media/MediaService.qml
@@ -41,6 +41,8 @@ Singleton {
   property bool canGoNext: currentPlayer ? currentPlayer.canGoNext : false
   property bool canGoPrevious: currentPlayer ? currentPlayer.canGoPrevious : false
   property bool canSeek: currentPlayer ? currentPlayer.canSeek : false
+  property bool isMuted: currentPlayer ? currentPlayer.volume < root.epsilon : false
+  property real volume: currentPlayer ? currentPlayer.volume : 0.0
   property string positionString: formatTime(currentPosition)
   property string lengthString: formatTime(trackLength)
   property real infiniteTrackLength: 922337203685

--- a/Services/Media/MediaService.qml
+++ b/Services/Media/MediaService.qml
@@ -45,6 +45,8 @@ Singleton {
   property string lengthString: formatTime(trackLength)
   property real infiniteTrackLength: 922337203685
 
+  readonly property real stepVolume: Settings.data.audio.volumeStep / 100.0
+
   Component.onCompleted: {
     updateCurrentPlayer();
   }
@@ -289,6 +291,20 @@ Singleton {
       let seekPosition = ratio * target.length;
       target.position = seekPosition;
       currentPosition = seekPosition;
+    }
+  }
+
+  function increaseVolume() {
+    let target = currentPlayer ? (currentPlayer._controlTarget || currentPlayer) : null;
+    if (target && target.canControl && target.volumeSupported) {
+      target.volume = Math.min(1.0, target.volume + stepVolume);
+    }
+  }
+
+  function decreaseVolume() {
+    let target = currentPlayer ? (currentPlayer._controlTarget || currentPlayer) : null;
+    if (target && target.canControl && target.volumeSupported) {
+      target.volume = Math.max(0.0, target.volume - stepVolume);
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Motivation

I used to change my media volume by scrolling over my MPD component when I was
using waybar.

This adds that behavior to MediaMini and hooks the media volume up to OSD.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
I was running my code and used mpdris2 to change the volume of my music. It
works in both directions, so changes through mpc get shown in the OSD and vice
versa.

Note that Quickshell exposes `volume` and `volumeSupported`. I have not tested how this behaves with `volumeSupported = false`

See https://github.com/noctalia-dev/noctalia-qs/blob/75d180c28a9ab4470e980f3d6f706ad6c5213add/src/services/mpris/player.hpp#L147-L149

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes

~~I think this should have other icons in the OSD, but I wasn't sure how to add
new icons to the ttf. At the same time, Tabler does not have any other volume
icons, though we could use `music` and `music-off` kinda like how the input
volume OSD works.~~ I chose to use `music` and `music-off`

One oddity I noticed is that `onWheel` of `MouseArea` gives different values
than `onWheel` of `Item` (as used in the Volume widget). The magic number 120
probably needs to be tweaked due to this. Alternatively, we could switch all
other widgets to use `MouseArea` to make this more consistent.
