### PR TITLE
feat(nix/shell): add QML_IMPORT_PATH env var

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -7,6 +7,7 @@
   shellcheck,
   jsonfmt,
   lefthook,
+  lib,
   kdePackages,
   mkShellNoCC,
 }:
@@ -31,4 +32,6 @@ mkShellNoCC {
     lefthook # githooks
     kdePackages.qtdeclarative # qmlfmt, qmllint, qmlls and etc; Qt6
   ];
+
+  env.QML_IMPORT_PATH = lib.makeSearchPathOutput "lib" kdePackages.qtbase.qtQmlPrefix [quickshell kdePackages.qtdeclarative];
 }


### PR DESCRIPTION
# Pull Request

## Motivation
This allows qmlls to resolve Qt Quick and QuickShell QML modules

Not sure how to make the qs.* imports work though :/

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Reloaded my direnv and looked at the diagnostics in my neovim configured with
qmlls (needs to be called with the parameter `-E`!)

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
