### PR TITLE
Fix stuck modifiers when auto-paste is enabled

### DIFF
--- a/Services/Keyboard/ClipboardService.qml
+++ b/Services/Keyboard/ClipboardService.qml
@@ -471,7 +471,7 @@ Singleton {
     }
     const isImage = mime && mime.startsWith("image/");
     const typeArg = isImage ? ` --type ${mime}` : "";
-    const pasteKeys = isImage ? "wtype -M ctrl -k v" : "wtype -M ctrl -M shift v";
+    const pasteKeys = isImage ? "wtype -M ctrl -k v" : "wtype -M ctrl -M shift v -m ctrl -m shift";
     const cmd = `cliphist decode ${id} | wl-copy${typeArg} && ${pasteKeys}`;
     pasteProc.command = ["sh", "-c", cmd];
     pasteProc.running = true;
@@ -481,7 +481,7 @@ Singleton {
     if (!text)
       return;
     const escaped = text.replace(/'/g, "'\\''");
-    const cmd = `printf '%s' '${escaped}' | wl-copy && wtype -M ctrl -M shift v`;
+    const cmd = `printf '%s' '${escaped}' | wl-copy && wtype -M ctrl -M shift v -m ctrl -m shift`;
     pasteProc.command = ["sh", "-c", cmd];
     pasteProc.running = true;
   }


### PR DESCRIPTION
# Pull Request

## Motivation
For some reason when auto-paste is enabled wtype can sometimes not release modifiers, which causes all sorts of problems.
Even tho in the man wtype says `the modifiers get  released  automatically once the program terminates.` that does not seem to be the case on all systems.

This patch fixes this specific problem by releasing modifiers explicitly, such fix should not be disruptive for current users as it does not change current behavior it just adds explicit release of modifiers that should work implicitly.

I also totally understand if such change will be rejected as the problem seems to be on the wtype side, but I am not sure if it will be fixed there and as I said before it does not change current behavior, neither it adds any complexity.
For reference https://github.com/atx/wtype/issues/66

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
