### PR TITLE
feat: Added LockService to automate screen locking

### DIFF
--- a/Services/Power/LockService.qml
+++ b/Services/Power/LockService.qml
@@ -1,0 +1,121 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services.UI
+
+Singleton {
+  id: root
+
+  property bool _lockingForSleep: false
+  property string _lastMember: ""
+
+  function init() {
+    Logger.i("LockService", "Service started");
+    sleepInhibitor.running = true;
+    lockMonitor.running = true;
+  }
+
+  //Delay inhibitor
+  Process {
+    id: sleepInhibitor
+    command: [
+      "systemd-inhibit",
+        "--what=sleep",
+        "--why=Locking screen before sleep",
+        "--mode=delay",
+      "sleep", "infinity"
+    ]
+    running: false
+
+    onExited: function(code, status) {
+      Logger.d("LockService", "Sleep inhibitor released");
+      reacquireTimer.start();
+    }
+  }
+
+  //D-Bus signal monitor (System bus)
+  Process {
+    id: lockMonitor
+    command: [
+      "dbus-monitor", "--system",
+        "type='signal',interface='org.freedesktop.login1.Session',member='Lock'",
+        "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"
+    ]
+    running: false
+
+    stdout: SplitParser {
+      onRead: function(line) {
+        if (line.includes("member=Lock")) {
+          Logger.i("LockService", "System Lock signal received - locking");
+          root._triggerLock();
+          return;
+        }
+
+        if (line.includes("member=PrepareForSleep")) {
+          root._lastMember = "PrepareForSleep";
+          return;
+        }
+
+        if (root._lastMember === "PrepareForSleep") {
+          if (line.includes("boolean true")) {
+            if (!root._lockingForSleep) {
+              Logger.i("LockService", "PrepareForSleep(true) - locking");
+              root._lockingForSleep = true;
+              root._triggerLock();
+              releaseTimer.start();
+            }
+            root._lastMember = "";
+          } else if (line.includes("boolean false")) {
+            Logger.i("LockService", "System resumed");
+            root._lockingForSleep = false;
+            root._lastMember = "";
+          }
+        }
+      }
+    }
+
+    onExited: function(code, status) {
+      Logger.w("LockService", "Monitor exited:", code, "— restarting");
+      restartMonitorTimer.start();
+    }
+  }
+
+  Timer {
+    id: releaseTimer
+    interval: 1500
+    repeat: false
+    onTriggered: {
+      Logger.i("LockService", "Releasing sleep inhibitor");
+      sleepInhibitor.running = false;
+    }
+  }
+
+  Timer {
+    id: reacquireTimer
+    interval: 1000
+    repeat: false
+    onTriggered: {
+      if (!root._lockingForSleep) {
+        sleepInhibitor.running = true;
+        Logger.d("LockService", "Sleep inhibitor reacquired");
+      }
+    }
+  }
+
+  Timer {
+    id: restartMonitorTimer
+    interval: 1500
+    repeat: false
+    onTriggered: lockMonitor.running = true
+  }
+
+  function _triggerLock() {
+    if (PanelService.lockScreen && !PanelService.lockScreen.active) {
+      PanelService.lockScreen.active = true;
+    }
+    IdleService.lockRequested();
+  }
+}

--- a/shell.qml
+++ b/shell.qml
@@ -109,6 +109,7 @@ ShellRoot {
           NightLightService.apply();
           IdleInhibitorService.init();
           IdleService.init();
+          LockService.init();
           PowerProfileService.init();
           HostService.init();
           NotificationRulesService.init();


### PR DESCRIPTION
# Pull Request

<!-- If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed. -->

Adds monitoring `org.freedesktop.login1` to call `lockScreen` in a "natural" way

## Motivation
It was infuriating that the system didn't lock when closing the laptop lid and the screen lock didn't work via `loginctl`

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2252

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

https://github.com/user-attachments/assets/d59b86de-0b7d-4cd2-af63-59d750c6a05f

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
