### PR TITLE
add sidebar stylization in the Telegram template

### DIFF
--- a/Assets/Templates/telegram.tdesktop-theme
+++ b/Assets/Templates/telegram.tdesktop-theme
@@ -137,3 +137,19 @@ photoCropPointFg: {{colors.primary.default.hex}}; // Photo crop points
 
 chat_inBubbleSelected: #313244; // inbox selected chat background
 chat_outBubbleSelected: #313244; // outbox selected chat background
+
+// --- Folders Sidebar ---
+sideBarBg: {{colors.surface.default.hex}}; // Main background of the sidebar
+sideBarBgActive: {{colors.primary_container.default.hex}}; // Active (selected) folder background
+sideBarBgRipple: {{colors.on_surface.default.hex}}20; // Ripple effect on click (with transparency)
+
+sideBarTextFg: {{colors.on_surface_variant.default.hex}}; // Inactive folders text color
+sideBarTextFgActive: {{colors.on_primary_container.default.hex}}; // Active folder text color
+
+sideBarIconFg: {{colors.on_surface_variant.default.hex}}; // Inactive folders (and burger menu) icon color
+sideBarIconFgActive: {{colors.on_primary_container.default.hex}}; // Active folder icon color
+
+sideBarBadgeBg: {{colors.primary.default.hex}}; // Unread badge background color (unmuted)
+sideBarBadgeBgMuted: {{colors.surface_variant.default.hex}}; // Unread badge background color (muted)
+sideBarBadgeFg: {{colors.on_primary.default.hex}}; // Unread badge text color (unmuted)
+sideBarBadgeFgMuted: {{colors.on_surface_variant.default.hex}}; // Unread badge text color (muted)


### PR DESCRIPTION
# Pull Request

## Motivation
Previously, the sidebar (which contains the chat folders and the hamburger menu) was not properly themed and did not inherit the Material You colors generated by Noctalia's template processor, so I added missing styling variables for the Folders Sidebar in the `telegram.tdesktop-theme` template. 

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
After I edited the `telegram.tdesktop-theme` template, I made Noctalia template processor regenerate the colors by switching the wallpaper. I verified that the sidebar background, active/inactive folder icons, text colors, and unread badges (both muted and unmuted) correctly apply the generated Material You palette.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Before:
<img width="208" height="777" alt="image" src="https://github.com/user-attachments/assets/64f4279b-1abf-48b9-a85c-9d7dc2785ac1" />
After:
<img width="216" height="787" alt="image" src="https://github.com/user-attachments/assets/8d69404f-2750-4d17-99a6-ba0db34986f0" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I also added inline comments next to the new theme properties (like sideBarBg, etc.) for clarity and to maintain consistency with the existing coding style of the template.