### PR TITLE
Fix: Taskbar overflows a little bit on smart width

### DIFF
--- a/Modules/Bar/Widgets/Taskbar.qml
+++ b/Modules/Bar/Widgets/Taskbar.qml
@@ -68,7 +68,7 @@ Item {
     if (smartWidth && combinedModel.length > 0) {
       if (maxTaskbarWidth > 0) {
         var entriesCount = combinedModel.length;
-        var maxWidthPerEntry = (maxTaskbarWidth / entriesCount) - itemSize - Style.marginS - Style.margin2M;
+        var maxWidthPerEntry = (maxTaskbarWidth / entriesCount) - itemSize - Style.marginS - Style.margin2M - Style.marginXXS;
         calculatedWidth = Math.min(calculatedWidth, maxWidthPerEntry);
       }
 


### PR DESCRIPTION
GridLayout.columnSpacing was not accounted when calculating the auto width.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)
