### PR TITLE
feat(power): add SleepListenerService to auto-lock on system suspend

### DIFF
--- a/Services/Power/SleepListenerService.qml
+++ b/Services/Power/SleepListenerService.qml
@@ -25,11 +25,12 @@ Singleton {
         // dbus-monitor output for the signal contains the boolean argument (true for sleep, false for wake).
         // We look for "boolean true" to trigger the lock screen.
         if (line.includes("boolean true")) {
-          Logger.i("SleepListener", "System is preparing for sleep, triggering lock");
-          
-          // Trigger the lock screen via CompositorService.
-          // CompositorService.lock() handles checking if it's already locked.
-          CompositorService.lock();
+          if (Settings.data.general.lockOnSuspend) {
+            Logger.i("SleepListener", "System is preparing for sleep, triggering lock");
+            CompositorService.lock();
+          } else {
+            Logger.d("SleepListener", "System is preparing for sleep, but lockOnSuspend is disabled");
+          }
         } else if (line.includes("boolean false")) {
           Logger.i("SleepListener", "System has resumed from sleep");
         }

--- a/Services/Power/SleepListenerService.qml
+++ b/Services/Power/SleepListenerService.qml
@@ -1,0 +1,61 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services.Compositor
+
+Singleton {
+  id: root
+
+  function init() {
+    Logger.i("SleepListener", "Service started");
+  }
+
+  // Listen for the PrepareForSleep signal from logind.
+  // This signal is emitted when the system is about to suspend or hibernate.
+  Process {
+    id: sleepMonitor
+    command: ["dbus-monitor", "--system", "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"]
+    running: true
+
+    stdout: StdioCollector {
+      onLine: line => {
+        // dbus-monitor output for the signal contains the boolean argument (true for sleep, false for wake).
+        // We look for "boolean true" to trigger the lock screen.
+        if (line.includes("boolean true")) {
+          Logger.i("SleepListener", "System is preparing for sleep, triggering lock");
+          
+          // Trigger the lock screen via CompositorService.
+          // CompositorService.lock() handles checking if it's already locked.
+          CompositorService.lock();
+        } else if (line.includes("boolean false")) {
+          Logger.i("SleepListener", "System has resumed from sleep");
+        }
+      }
+    }
+
+    stderr: StdioCollector {
+      onLine: line => Logger.w("SleepListener", "dbus-monitor error: " + line)
+    }
+
+    onExited: (code, status) => {
+      Logger.w("SleepListener", "dbus-monitor exited with code " + code + ". Restarting...");
+      if (root.running) {
+        restartTimer.start();
+      }
+    }
+  }
+
+  Timer {
+    id: restartTimer
+    interval: 1000
+    onTriggered: sleepMonitor.running = true
+  }
+
+  // Cleanup on destruction
+  Component.onDestruction: {
+    sleepMonitor.running = false;
+  }
+}

--- a/Services/Power/SleepListenerService.qml
+++ b/Services/Power/SleepListenerService.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Commons
 import qs.Services.Compositor
+import qs.Services.UI
 
 /**
 * SleepListenerService — native system sleep detection via D-Bus.
@@ -15,8 +16,26 @@ import qs.Services.Compositor
 Singleton {
   id: root
 
+  property int checkCount: 0
+
   function init() {
     Logger.i("SleepListener", "Service started");
+  }
+
+  // Use systemd-inhibit to delay sleep until we've locked the screen.
+  // This process holds a 'delay' inhibitor for sleep. When logind prepares for sleep,
+  // it will wait for this process to terminate (or timeout) before actually suspending.
+  // We stop this process once we confirm the lock screen is active, allowing sleep to proceed.
+  Process {
+    id: sleepInhibitor
+    command: ["systemd-inhibit", "--what=sleep", "--mode=delay", "--who=Noctalia", "--why=Locking screen before sleep", "sleep", "infinity"]
+    // Only inhibit if locking on suspend is enabled.
+    running: Settings.data.general.lockOnSuspend
+
+    stderr: SplitParser {
+      splitMarker: "\n"
+      onRead: line => Logger.w("SleepListener", "inhibitor error: " + line)
+    }
   }
 
   // Listen for the PrepareForSleep signal from logind.
@@ -36,11 +55,18 @@ Singleton {
           if (Settings.data.general.lockOnSuspend) {
             Logger.i("SleepListener", "System is preparing for sleep, triggering lock");
             CompositorService.lock();
+            // Start checking if lock is active. We must release the inhibitor 
+            // only AFTER the lock screen is visually active to prevent race conditions.
+            lockCheckTimer.start();
           } else {
             Logger.d("SleepListener", "System is preparing for sleep, but lockOnSuspend is disabled");
           }
         } else if (line.includes("boolean false")) {
           Logger.i("SleepListener", "System has resumed from sleep");
+          // Re-enable inhibitor if locking is enabled so we're ready for the next suspend.
+          if (Settings.data.general.lockOnSuspend) {
+            sleepInhibitor.running = true;
+          }
         }
       }
     }
@@ -52,8 +78,27 @@ Singleton {
 
     onExited: (code, status) => {
       Logger.w("SleepListener", "dbus-monitor exited with code " + code + ". Restarting...");
-      if (root.running) {
-        restartTimer.start();
+      restartTimer.start();
+    }
+  }
+
+  Timer {
+    id: lockCheckTimer
+    interval: 100
+    repeat: true
+    onTriggered: {
+      root.checkCount++;
+      // Check if lock screen is now active and its content is loaded
+      if (PanelService && PanelService.lockScreen && PanelService.lockScreen.active && PanelService.lockScreen.item) {
+        Logger.i("SleepListener", "Lock screen active, releasing sleep inhibitor");
+        sleepInhibitor.running = false;
+        stop();
+        root.checkCount = 0;
+      } else if (root.checkCount > 30) { // 3 seconds timeout
+        Logger.w("SleepListener", "Lock screen timeout, releasing inhibitor anyway");
+        sleepInhibitor.running = false;
+        stop();
+        root.checkCount = 0;
       }
     }
   }
@@ -67,5 +112,6 @@ Singleton {
   // Cleanup on destruction
   Component.onDestruction: {
     sleepMonitor.running = false;
+    sleepInhibitor.running = false;
   }
 }

--- a/Services/Power/SleepListenerService.qml
+++ b/Services/Power/SleepListenerService.qml
@@ -17,11 +17,13 @@ Singleton {
   // This signal is emitted when the system is about to suspend or hibernate.
   Process {
     id: sleepMonitor
-    command: ["dbus-monitor", "--system", "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"]
+    command: ["stdbuf", "-oL", "dbus-monitor", "--system", "type='signal',interface='org.freedesktop.login1.Manager',member='PrepareForSleep'"]
     running: true
 
-    stdout: StdioCollector {
-      onLine: line => {
+    stdout: SplitParser {
+      splitMarker: "\n"
+      onRead: line => {
+        Logger.d("SleepListener", "Received line: " + line);
         // dbus-monitor output for the signal contains the boolean argument (true for sleep, false for wake).
         // We look for "boolean true" to trigger the lock screen.
         if (line.includes("boolean true")) {
@@ -37,8 +39,9 @@ Singleton {
       }
     }
 
-    stderr: StdioCollector {
-      onLine: line => Logger.w("SleepListener", "dbus-monitor error: " + line)
+    stderr: SplitParser {
+      splitMarker: "\n"
+      onRead: line => Logger.w("SleepListener", "dbus-monitor error: " + line)
     }
 
     onExited: (code, status) => {

--- a/Services/Power/SleepListenerService.qml
+++ b/Services/Power/SleepListenerService.qml
@@ -6,6 +6,12 @@ import Quickshell.Io
 import qs.Commons
 import qs.Services.Compositor
 
+/**
+* SleepListenerService — native system sleep detection via D-Bus.
+*
+* Listens for the PrepareForSleep signal from logind to ensure the
+* session is locked before the system suspends (e.g. lid close).
+*/
 Singleton {
   id: root
 

--- a/shell.qml
+++ b/shell.qml
@@ -109,6 +109,7 @@ ShellRoot {
           NightLightService.apply();
           IdleInhibitorService.init();
           IdleService.init();
+          SleepListenerService.init();
           PowerProfileService.init();
           HostService.init();
           NotificationRulesService.init();

--- a/shell.qml
+++ b/shell.qml
@@ -109,6 +109,7 @@ ShellRoot {
           NightLightService.apply();
           IdleInhibitorService.init();
           IdleService.init();
+          // Listen for system-level sleep signals (e.g. lid close) to trigger auto-lock
           SleepListenerService.init();
           PowerProfileService.init();
           HostService.init();


### PR DESCRIPTION
## Motivation
This PR addresses an issue where Noctalia fails to auto-lock the session when the system enters sleep via external triggers (such as closing a laptop lid or running `systemctl suspend`). 

Currently, Noctalia's locking logic is primarily tied to its internal idle timer. By introducing the `SleepListenerService`, the shell now eavesdrops on the `org.freedesktop.login1.Manager.PrepareForSleep` DBus signal, allowing it to trigger the lock screen immediately before the system suspends.

## Type of Change
- [x] Bug fix
- [x] New feature

## Related Issue
- Closes #2569

## Testing
I have verified this change by running the modified shell from source and performing the following manual tests:

- [x] **Tested on niri**
- [ ] Tested on Hyprland
- [ ] Tested on sway

**Manual Test Scenarios:**
1. **Lid Close Test:** Closing the laptop lid successfully triggers the lock screen before suspension.
2. **Manual Suspend Test:** Running `systemctl suspend` successfully triggers the lock screen.
3. **Toggle Verification:** Confirmed that the `lockOnSuspend` setting is respected (disabling it prevents the auto-lock).
4. **Resilience:** Confirmed the `dbus-monitor` subprocess automatically restarts if terminated.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
The implementation follows the established project pattern of using `Quickshell.Io` to manage system utility subprocesses (consistent with `BluetoothService.qml` and `ClipboardService.qml`). It uses `SplitParser` to ensure real-time, line-buffered signal detection.