### PR TITLE
Alacritty template fix

### DIFF
--- a/Assets/Templates/terminal/alacritty.toml
+++ b/Assets/Templates/terminal/alacritty.toml
@@ -1,68 +1,68 @@
 [colors.primary]
-background = '{{colors.background.default.hex}}'
+background = '{{colors.surface.default.hex}}'
 foreground = '{{colors.on_surface.default.hex}}'
- 
+
 [colors.cursor]
-text = '{{colors.on_surface.default.hex}}'
-cursor = '{{colors.on_surface_variant.default.hex}}' 
- 
+text = '{{colors.surface.default.hex}}'
+cursor = '{{colors.on_surface.default.hex}}'
+
 [colors.vi_mode_cursor]
-text = '{{colors.background.default.hex}}'
-cursor = '{{colors.primary.default.hex}}' 
- 
+text = '{{colors.surface.default.hex}}'
+cursor = '{{colors.primary.default.hex}}'
+
 [colors.search.matches]
-foreground = '{{colors.surface_variant.default.hex}}' 
-background = '{{colors.tertiary.default.hex}}' 
- 
+foreground = '{{colors.on_surface_variant.default.hex}}'
+background = '{{colors.surface_variant.default.hex}}'
+
 [colors.search.focused_match]
-foreground = '{{colors.surface_variant.default.hex}}' 
-background = '{{colors.primary.default.hex}}' 
- 
-[colors.footer_bar]
-foreground = '{{colors.surface_variant.default.hex}}' 
-background = '{{colors.inverse_surface.default.hex}}' 
- 
-[colors.hints.start]
-foreground = '{{colors.surface_variant.default.hex}}' 
-background = '{{colors.secondary.default.hex}}' 
- 
-[colors.hints.end]
-foreground = '{{colors.surface_variant.default.hex}}' 
-background = '{{colors.secondary.default.hex}}' 
- 
-[colors.selection]
-text = '{{colors.background.default.hex}}'
+foreground = '{{colors.on_primary.default.hex}}'
 background = '{{colors.primary.default.hex}}'
- 
- 
+
+[colors.footer_bar]
+foreground = '{{colors.on_surface_variant.default.hex}}'
+background = '{{colors.surface_variant.default.hex}}'
+
+[colors.hints.start]
+foreground = '{{colors.on_surface_variant.default.hex}}'
+background = '{{colors.secondary.default.hex}}'
+
+[colors.hints.end]
+foreground = '{{colors.on_surface_variant.default.hex}}'
+background = '{{colors.secondary.default.hex}}'
+
+[colors.selection]
+text = '{{colors.on_surface_variant.default.hex}}'
+background = '{{colors.surface_variant.default.hex}}'
+
+
 [colors.normal]
-black = '#181818' 
-red = '{{colors.error.default.hex}}' 
-green = '{{colors.primary.default.hex}}' 
-yellow = '{{colors.inverse_primary.default.hex}}' 
-blue = '{{colors.primary.default.hex}}' 
-magenta = '{{colors.tertiary.default.hex}}' 
-cyan = '{{colors.secondary.default.hex}}' 
-white = '#BAC2DE' 
- 
- 
+black   = '{{colors.surface.default.hex}}'
+red     = '{{colors.error.default.hex}}'
+green   = '{{colors.primary.default.hex}}'
+yellow  = '{{colors.secondary.default.hex}}'
+blue    = '{{colors.tertiary.default.hex}}'
+magenta = '{{colors.primary_fixed_dim.default.hex}}'
+cyan    = '{{colors.secondary_fixed_dim.default.hex}}'
+white   = '{{colors.on_surface.default.hex}}'
+
+
 [colors.bright]
-black = '#585B70' 
-red = '#F38BA8' 
-green = '#A6E3A1' 
-yellow = '#F9E2AF' 
-blue = '#89B4FA' 
-magenta = '#F5C2E7' 
-cyan = '#94E2D5' 
-white = '#A6ADC8' 
- 
- 
+black   = '{{colors.outline.default.hex}}'
+red     = '{{colors.error.default.hex}}'
+green   = '{{colors.primary.default.hex}}'
+yellow  = '{{colors.secondary.default.hex}}'
+blue    = '{{colors.tertiary.default.hex}}'
+magenta = '{{colors.primary_fixed_dim.default.hex}}'
+cyan    = '{{colors.secondary_fixed_dim.default.hex}}'
+white   = '{{colors.on_surface.default.hex}}'
+
+
 [colors.dim]
-black = '#45475A' 
-red = '#F38BA8' 
-green = '#A6E3A1' 
-yellow = '#F9E2AF' 
-blue = '#89B4FA' 
-magenta = '#F5C2E7' 
-cyan = '#94E2D5' 
-white = '#BAC2DE' 
+black   = '{{colors.outline.default.hex}}'
+red     = '{{colors.error.default.hex}}'
+green   = '{{colors.primary.default.hex}}'
+yellow  = '{{colors.secondary.default.hex}}'
+blue    = '{{colors.tertiary.default.hex}}'
+magenta = '{{colors.primary_fixed_dim.default.hex}}'
+cyan    = '{{colors.secondary_fixed_dim.default.hex}}'
+white   = '{{colors.on_surface.default.hex}}'

--- a/Assets/Templates/terminal/alacritty.toml
+++ b/Assets/Templates/terminal/alacritty.toml
@@ -1,38 +1,38 @@
 [colors.primary]
-background = '{{colors.surface.default.hex}}'
+background = '{{colors.background.default.hex}}'
 foreground = '{{colors.on_surface.default.hex}}'
 
 [colors.cursor]
-text = '{{colors.surface.default.hex}}'
-cursor = '{{colors.on_surface.default.hex}}'
+text = '{{colors.on_surface.default.hex}}'
+cursor = '{{colors.on_surface_variant.default.hex}}'
 
 [colors.vi_mode_cursor]
-text = '{{colors.surface.default.hex}}'
+text = '{{colors.background.default.hex}}'
 cursor = '{{colors.primary.default.hex}}'
 
 [colors.search.matches]
-foreground = '{{colors.on_surface_variant.default.hex}}'
-background = '{{colors.surface_variant.default.hex}}'
+foreground = '{{colors.surface_variant.default.hex}}'
+background = '{{colors.tertiary.default.hex}}'
 
 [colors.search.focused_match]
-foreground = '{{colors.on_primary.default.hex}}'
+foreground = '{{colors.surface_variant.default.hex}}'
 background = '{{colors.primary.default.hex}}'
 
 [colors.footer_bar]
-foreground = '{{colors.on_surface_variant.default.hex}}'
-background = '{{colors.surface_variant.default.hex}}'
+foreground = '{{colors.surface_variant.default.hex}}'
+background = '{{colors.inverse_surface.default.hex}}'
 
 [colors.hints.start]
-foreground = '{{colors.on_surface_variant.default.hex}}'
+foreground = '{{colors.surface_variant.default.hex}}'
 background = '{{colors.secondary.default.hex}}'
 
 [colors.hints.end]
-foreground = '{{colors.on_surface_variant.default.hex}}'
+foreground = '{{colors.surface_variant.default.hex}}'
 background = '{{colors.secondary.default.hex}}'
 
 [colors.selection]
-text = '{{colors.on_surface_variant.default.hex}}'
-background = '{{colors.surface_variant.default.hex}}'
+text = '{{colors.background.default.hex}}'
+background = '{{colors.primary.default.hex}}'
 
 
 [colors.normal]


### PR DESCRIPTION
# Pull Request

## Motivation
Alacritty was generating colors that were not in line with the other terminals available. i.e foot, kitty. it had hardcoded hex values that were obviously not getting changed when colorschemes got generated.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(N/A)

## Testing
tried to match the generation as close as possible to kitty and foot, looked at their templates and then did some testing on multiple wallpapers. dark and light generation examples in pictures below to show the issue is resolved

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Dark and light generation test with a color block to show consistency. top terminal is kitty, bottom is alacritty.
<img width="1191" height="289" alt="ColorsDark" src="https://github.com/user-attachments/assets/ac79cf04-9701-40c9-960b-867fcd5ef0b6" />
<img width="1089" height="316" alt="ColorsLight" src="https://github.com/user-attachments/assets/9fa40271-2ec1-4721-b906-ce78474aa664" />

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
please let me know if I've used the incorrect values for some of these, I'm fairly new to stuff like this and this is even my first PR on github as a whole. willing to go back and fix something if need-be


