### PR TITLE
Fix Dock position issues

### DIFF
--- a/Modules/Dock/Dock.qml
+++ b/Modules/Dock/Dock.qml
@@ -843,7 +843,7 @@ Loader {
           color: "transparent"
 
           WlrLayershell.namespace: "noctalia-dock-" + (screen?.name || "unknown")
-          WlrLayershell.exclusionMode: exclusive ? ExclusionMode.Auto : ExclusionMode.Ignore
+          WlrLayershell.exclusionMode: exclusive ? ExclusionMode.Auto : ExclusionMode.Normal
 
           // Slide animation: content slides inside a fixed window, no margin animation.
           // Only reserve extra space for sliding when auto-hide is enabled
@@ -887,31 +887,18 @@ Loader {
           anchors.right: dockPosition === "right"
 
           // Static margins — no animation, window stays put
-          margins.top: dockPosition === "top" ? (barAtSameEdge && !exclusive ? barHeight + (barFloating ? Settings.data.bar.marginVertical : 0) + floatingMargin : floatingMargin) : 0
-          margins.bottom: dockPosition === "bottom" ? (barAtSameEdge && !exclusive ? barHeight + (barFloating ? Settings.data.bar.marginVertical : 0) + floatingMargin : floatingMargin) : 0
-          margins.left: dockPosition === "left" ? (barAtSameEdge && !exclusive ? barHeight + (barFloating ? Settings.data.bar.marginHorizontal : 0) + floatingMargin : floatingMargin) : 0
-          margins.right: dockPosition === "right" ? (barAtSameEdge && !exclusive ? barHeight + (barFloating ? Settings.data.bar.marginHorizontal : 0) + floatingMargin : floatingMargin) : 0
+          margins.top: dockPosition === "top" ? floatingMargin : 0
+          margins.bottom: dockPosition === "bottom" ? floatingMargin : 0
+          margins.left: dockPosition === "left" ? floatingMargin : 0
+          margins.right: dockPosition === "right" ? floatingMargin : 0
 
           // Container wrapper for animations
           Item {
             id: dockContainerWrapper
 
-            // Helper properties for orthogonal bar detection
-            readonly property string screenBarPosition: Settings.getBarPositionForScreen(modelData?.name)
-            readonly property bool barOnLeft: hasBar && screenBarPosition === "left" && !barFloating
-            readonly property bool barOnRight: hasBar && screenBarPosition === "right" && !barFloating
-            readonly property bool barOnTop: hasBar && screenBarPosition === "top" && !barFloating
-            readonly property bool barOnBottom: hasBar && screenBarPosition === "bottom" && !barFloating
-
-            // Calculate padding needed to shift center to match exclusive mode
-            readonly property int extraTop: (isVertical && !exclusive && barOnTop) ? barHeight : 0
-            readonly property int extraBottom: (isVertical && !exclusive && barOnBottom) ? barHeight : 0
-            readonly property int extraLeft: (!isVertical && !exclusive && barOnLeft) ? barHeight : 0
-            readonly property int extraRight: (!isVertical && !exclusive && barOnRight) ? barHeight : 0
-
             // Expose content size for window sizing (before slide padding)
-            readonly property int contentWidth: dockContent.dockContainer.width + extraLeft + extraRight + 2
-            readonly property int contentHeight: dockContent.dockContainer.height + extraTop + extraBottom + 2
+            readonly property int contentWidth: dockContent.dockContainer.width + 2
+            readonly property int contentHeight: dockContent.dockContainer.height + 2
 
             // Add +2 buffer for fractional scaling issues
             width: contentWidth
@@ -938,10 +925,10 @@ Loader {
               id: dockContent
               anchors.fill: parent
               dockRoot: root
-              extraTop: dockContainerWrapper.extraTop
-              extraBottom: dockContainerWrapper.extraBottom
-              extraLeft: dockContainerWrapper.extraLeft
-              extraRight: dockContainerWrapper.extraRight
+              extraTop: 0
+              extraBottom: 0
+              extraLeft: 0
+              extraRight: 0
             }
           }
         }

--- a/Modules/MainScreen/BarExclusionZone.qml
+++ b/Modules/MainScreen/BarExclusionZone.qml
@@ -56,16 +56,16 @@ PanelWindow {
   // Size based on orientation
   implicitWidth: {
     if (edge === "left" || edge === "right") {
-      return thickness + barMarginH - bleedInset;
+      return thickness + (2 * barMarginH) - bleedInset;
     }
     return 0; // Auto-width when left/right anchors are true
   }
 
   implicitHeight: {
     if (edge === "top" || edge === "bottom") {
-      return thickness + barMarginV - bleedInset;
+      return thickness + (2 * barMarginV) - bleedInset;
     }
-    return 0; // Auto-height when top/bottom anchors are true
+    return 10; // Auto-height when top/bottom anchors are true
   }
 
   Component.onCompleted: {

--- a/Modules/MainScreen/BarExclusionZone.qml
+++ b/Modules/MainScreen/BarExclusionZone.qml
@@ -65,7 +65,7 @@ PanelWindow {
     if (edge === "top" || edge === "bottom") {
       return thickness + (2 * barMarginV) - bleedInset;
     }
-    return 10; // Auto-height when top/bottom anchors are true
+    return 0; // Auto-height when top/bottom anchors are true
   }
 
   Component.onCompleted: {


### PR DESCRIPTION
# Pull Request

## Motivation
The Dock does not take the Bar's exclusive zone into account when centring on the left and right edges meaning it is off-centre. This can be seen with the Dock not aligning with the Dock Indicator.

I also switched the ExclusionMode to Normal because it automatically takes the exclusion zone into account and simplifies the code, and doubled `barMarginH` and `barMarginH` because the Bar's margin extends both ways.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/90ada028-9a96-4c2f-8fc7-c4637b6c0bea


## Checklist
- [ fi] Code follows project style guidelines
- [ ] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
