### PR TITLE
fix(tray): resolve icons in themed IconThemePath directories

### DIFF
--- a/Helpers/TrayIconResolver.js
+++ b/Helpers/TrayIconResolver.js
@@ -1,0 +1,29 @@
+function resolveCandidates(icon) {
+    if (!icon)
+        return [""];
+    if (!icon.includes("?path="))
+        return [icon];
+
+    const chunks = icon.split("?path=");
+    const name = chunks[0];
+    const path = chunks[1];
+    const fileName = name.substring(name.lastIndexOf("/") + 1);
+
+    return [
+        `file://${path}/${fileName}`,
+        `file://${path}/${fileName}.svg`,
+        `file://${path}/${fileName}.png`,
+        `file://${path}/hicolor/scalable/status/${fileName}.svg`,
+        `file://${path}/hicolor/scalable/apps/${fileName}.svg`,
+        `file://${path}/hicolor/scalable/categories/${fileName}.svg`,
+        `file://${path}/hicolor/scalable/devices/${fileName}.svg`,
+        `file://${path}/hicolor/scalable/actions/${fileName}.svg`,
+        `file://${path}/hicolor/scalable/${fileName}.svg`,
+        `file://${path}/hicolor/32x32/status/${fileName}.png`,
+        `file://${path}/hicolor/32x32/apps/${fileName}.png`,
+        `file://${path}/hicolor/48x48/status/${fileName}.png`,
+        `file://${path}/hicolor/48x48/apps/${fileName}.png`,
+        `file://${path}/hicolor/64x64/status/${fileName}.png`,
+        `file://${path}/hicolor/64x64/apps/${fileName}.png`,
+    ];
+}

--- a/Modules/Bar/Widgets/Tray.qml
+++ b/Modules/Bar/Widgets/Tray.qml
@@ -9,6 +9,7 @@ import qs.Commons
 import qs.Modules.Bar.Extras
 import qs.Services.UI
 import qs.Widgets
+import "../../../Helpers/TrayIconResolver.js" as TrayIconResolver
 
 Item {
   id: root
@@ -413,22 +414,23 @@ Item {
           asynchronous: true
           backer.fillMode: Image.PreserveAspectFit
 
-          source: {
-            let icon = modelData?.icon || "";
-            if (!icon) {
-              return "";
-            }
+          property string rawIcon: modelData?.icon || ""
+          property var _candidates: []
+          property int _tryIndex: 0
 
-            // Process icon path
-            if (icon.includes("?path=")) {
-              const chunks = icon.split("?path=");
-              const name = chunks[0];
-              const path = chunks[1];
-              const fileName = name.substring(name.lastIndexOf("/") + 1);
-              return `file://${path}/${fileName}`;
-            }
-            return icon;
+          onRawIconChanged: {
+            _candidates = TrayIconResolver.resolveCandidates(rawIcon);
+            _tryIndex = 0;
+            source = _candidates.length > 0 ? _candidates[0] : "";
           }
+
+          onStatusChanged: {
+            if (status === Image.Error && _tryIndex < _candidates.length - 1) {
+              _tryIndex++;
+              source = _candidates[_tryIndex];
+            }
+          }
+
           opacity: status === Image.Ready ? 1 : 0
 
           layer.enabled: widgetSettings.colorizeIcons !== false

--- a/Modules/Panels/Tray/TrayDrawerPanel.qml
+++ b/Modules/Panels/Tray/TrayDrawerPanel.qml
@@ -7,6 +7,7 @@ import qs.Commons
 import qs.Modules.MainScreen
 import qs.Services.UI
 import qs.Widgets
+import "../../../Helpers/TrayIconResolver.js" as TrayIconResolver
 
 // A compact grid panel listing all tray items, opened from the Tray widget
 SmartPanel {
@@ -189,18 +190,22 @@ SmartPanel {
             anchors.fill: parent
             asynchronous: true
             backer.fillMode: Image.PreserveAspectFit
-            source: {
-              let icon = modelData?.icon || "";
-              if (!icon)
-                return "";
-              if (icon.includes("?path=")) {
-                const chunks = icon.split("?path=");
-                const name = chunks[0];
-                const path = chunks[1];
-                const fileName = name.substring(name.lastIndexOf("/") + 1);
-                return `file://${path}/${fileName}`;
+
+            property string rawIcon: modelData?.icon || ""
+            property var _candidates: []
+            property int _tryIndex: 0
+
+            onRawIconChanged: {
+              _candidates = TrayIconResolver.resolveCandidates(rawIcon);
+              _tryIndex = 0;
+              source = _candidates.length > 0 ? _candidates[0] : "";
+            }
+
+            onStatusChanged: {
+              if (status === Image.Error && _tryIndex < _candidates.length - 1) {
+                _tryIndex++;
+                source = _candidates[_tryIndex];
               }
-              return icon;
             }
 
             layer.enabled: panelContent.widgetSettings.colorizeIcons !== false


### PR DESCRIPTION
# Pull Request

Apps like Gajim provide their tray icons via StatusNotifierItem with an IconThemePath that uses a standard hicolor directory structure (e.g. hicolor/scalable/status/). The previous ?path= handler only constructed a flat file URL, which failed for these apps while working for apps like Steam that store icons as flat files.

Add a TrayIconResolver helper that generates candidate paths covering both flat and hicolor subdirectory layouts, with an onStatusChanged fallback to try each candidate until one loads successfully.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #2599

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
