### PR TITLE
feat: add global workspace option to the workspace widget setting

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -310,6 +310,8 @@
       "follow-focused-screen-label": "Fokussiertem Bildschirm folgen",
       "show-all-workspaces-description": "Alle Arbeitsflächen anzeigen, unabhängig davon, welchem Bildschirm sie zugeordnet sind.",
       "show-all-workspaces-label": "Alle Arbeitsflächen anzeigen",
+      "focus-workspace-on-current-monitor-description": "Beim Wechseln zwischen Arbeitsflächen soll der Arbeitsflächen auf den aktuellen Monitor verschoben werden, anstatt den Fokus des Monitors zu wechseln.",
+      "focus-workspace-on-current-monitor-label": "Arbeitsflächen auf den aktuellen Monitor verschieben",
       "font-weight-description": "Visuelles Gewicht für Text im Arbeitsbereich festlegen.",
       "font-weight-label": "Schriftstärke",
       "grouped-border-opacity-description": "Legen Sie die Deckkraft für Arbeitsflächen-Container-Rahmen fest.",

--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -308,6 +308,8 @@
       "focused-color-label": "Farbe der fokussierten Arbeitsfläche",
       "follow-focused-screen-description": "Zeige Arbeitsflächen vom aktuell fokussierten Bildschirm an, statt vom Bildschirm, auf dem sich die Leiste befindet.",
       "follow-focused-screen-label": "Fokussiertem Bildschirm folgen",
+      "show-all-workspaces-description": "Alle Arbeitsflächen anzeigen, unabhängig davon, welchem Bildschirm sie zugeordnet sind.",
+      "show-all-workspaces-label": "Alle Arbeitsflächen anzeigen",
       "font-weight-description": "Visuelles Gewicht für Text im Arbeitsbereich festlegen.",
       "font-weight-label": "Schriftstärke",
       "grouped-border-opacity-description": "Legen Sie die Deckkraft für Arbeitsflächen-Container-Rahmen fest.",

--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -310,6 +310,8 @@
       "follow-focused-screen-label": "Follow focused screen",
       "show-all-workspaces-description": "Show all workspaces, regardless of the screen they are bound to.",
       "show-all-workspaces-label": "Show all workspaces",
+      "focus-workspace-on-current-monitor-description": "When switching workspaces, move the workspace to the current monitor instead of switching the monitor's focus.",
+      "focus-workspace-on-current-monitor-label": "Focus workspace on current monitor",
       "font-weight-description": "Set the visual weight for text within workspace.",
       "font-weight-label": "Font weight",
       "grouped-border-opacity-description": "Set the opacity level for workspace container borders.",

--- a/Assets/Translations/en-GB.json
+++ b/Assets/Translations/en-GB.json
@@ -308,6 +308,8 @@
       "focused-color-label": "Focused workspace colour",
       "follow-focused-screen-description": "Display workspaces from the currently focused screen, rather than the screen where the bar is located.",
       "follow-focused-screen-label": "Follow focused screen",
+      "show-all-workspaces-description": "Show all workspaces, regardless of the screen they are bound to.",
+      "show-all-workspaces-label": "Show all workspaces",
       "font-weight-description": "Set the visual weight for text within workspace.",
       "font-weight-label": "Font weight",
       "grouped-border-opacity-description": "Set the opacity level for workspace container borders.",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -310,6 +310,8 @@
       "follow-focused-screen-label": "Follow focused screen",
       "show-all-workspaces-description": "Show all workspaces, regardless of the screen they are bound to.",
       "show-all-workspaces-label": "Show all workspaces",
+      "focus-workspace-on-current-monitor-description": "When switching workspaces, move the workspace to the current monitor instead of switching the monitor's focus.",
+      "focus-workspace-on-current-monitor-label": "Focus workspace on current monitor",
       "font-weight-description": "Set the visual weight for text within workspace.",
       "font-weight-label": "Font weight",
       "grouped-border-opacity-description": "Set the opacity level for workspace container borders.",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -308,6 +308,8 @@
       "focused-color-label": "Focused workspace color",
       "follow-focused-screen-description": "Display workspaces from the currently focused screen, rather than the screen where the bar is located.",
       "follow-focused-screen-label": "Follow focused screen",
+      "show-all-workspaces-description": "Show all workspaces, regardless of the screen they are bound to.",
+      "show-all-workspaces-label": "Show all workspaces",
       "font-weight-description": "Set the visual weight for text within workspace.",
       "font-weight-label": "Font weight",
       "grouped-border-opacity-description": "Set the opacity level for workspace container borders.",

--- a/Assets/settings-widgets-default.json
+++ b/Assets/settings-widgets-default.json
@@ -214,6 +214,7 @@
     "Workspace": {
       "labelMode": "index",
       "followFocusedScreen": false,
+      "focusWorkspaceOnCurrentMonitor": false,
       "showAllWorkspaces": false,
       "hideUnoccupied": false,
       "characterCount": 2,

--- a/Assets/settings-widgets-default.json
+++ b/Assets/settings-widgets-default.json
@@ -214,6 +214,7 @@
     "Workspace": {
       "labelMode": "index",
       "followFocusedScreen": false,
+      "showAllWorkspaces": false,
       "hideUnoccupied": false,
       "characterCount": 2,
       "showApplications": false,

--- a/Modules/Bar/Extras/WorkspacePill.qml
+++ b/Modules/Bar/Extras/WorkspacePill.qml
@@ -18,6 +18,7 @@ Item {
   required property int characterCount
   required property real textRatio
   required property bool showLabelsOnlyWhenOccupied
+  required property bool focusWorkspaceOnCurrentMonitor
   required property string focusedColor
   required property string occupiedColor
   required property string emptyColor
@@ -207,7 +208,9 @@ Item {
     cursorShape: Qt.PointingHandCursor
     hoverEnabled: true
     onClicked: {
-      CompositorService.switchToWorkspace(workspace);
+      CompositorService.switchToWorkspace(workspace, {
+                                            focusWorkspaceOnCurrentMonitor: focusWorkspaceOnCurrentMonitor
+                                          });
     }
   }
 

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -59,6 +59,7 @@ Item {
   }
   readonly property bool hideUnoccupied: (widgetSettings.hideUnoccupied !== undefined) ? widgetSettings.hideUnoccupied : widgetMetadata.hideUnoccupied
   readonly property bool followFocusedScreen: (widgetSettings.followFocusedScreen !== undefined) ? widgetSettings.followFocusedScreen : widgetMetadata.followFocusedScreen
+  readonly property bool focusWorkspaceOnCurrentMonitor: (widgetSettings.focusWorkspaceOnCurrentMonitor !== undefined) ? widgetSettings.focusWorkspaceOnCurrentMonitor : widgetMetadata.focusWorkspaceOnCurrentMonitor
   readonly property bool showAllWorkspaces: (widgetSettings.showAllWorkspaces !== undefined) ? widgetSettings.showAllWorkspaces : widgetMetadata.showAllWorkspaces
   readonly property int characterCount: {
     const count = (widgetSettings.characterCount !== undefined) ? widgetSettings.characterCount : widgetMetadata.characterCount;
@@ -236,7 +237,9 @@ Item {
       return;
     const ws = localWorkspaces.get(next);
     if (ws && ws.idx !== undefined)
-      CompositorService.switchToWorkspace(ws);
+      CompositorService.switchToWorkspace(ws, {
+                                            focusWorkspaceOnCurrentMonitor: root.focusWorkspaceOnCurrentMonitor
+                                          });
   }
 
   // Helper function to normalize app IDs for case-insensitive matching
@@ -629,6 +632,7 @@ Item {
         characterCount: root.characterCount
         textRatio: root.textRatio
         showLabelsOnlyWhenOccupied: root.showLabelsOnlyWhenOccupied
+        focusWorkspaceOnCurrentMonitor: root.focusWorkspaceOnCurrentMonitor
         focusedColor: root.focusedColor
         occupiedColor: root.occupiedColor
         emptyColor: root.emptyColor
@@ -672,6 +676,7 @@ Item {
         characterCount: root.characterCount
         textRatio: root.textRatio
         showLabelsOnlyWhenOccupied: root.showLabelsOnlyWhenOccupied
+        focusWorkspaceOnCurrentMonitor: root.focusWorkspaceOnCurrentMonitor
         focusedColor: root.focusedColor
         occupiedColor: root.occupiedColor
         emptyColor: root.emptyColor
@@ -752,7 +757,9 @@ Item {
         preventStealing: true
         onPressed: mouse => {
                      if (mouse.button === Qt.LeftButton) {
-                       CompositorService.switchToWorkspace(groupedContainer.workspaceModel);
+                       CompositorService.switchToWorkspace(groupedContainer.workspaceModel, {
+                                                             focusWorkspaceOnCurrentMonitor: root.focusWorkspaceOnCurrentMonitor
+                                                           });
                      }
                    }
         onReleased: mouse => {

--- a/Modules/Bar/Widgets/Workspace.qml
+++ b/Modules/Bar/Widgets/Workspace.qml
@@ -59,6 +59,7 @@ Item {
   }
   readonly property bool hideUnoccupied: (widgetSettings.hideUnoccupied !== undefined) ? widgetSettings.hideUnoccupied : widgetMetadata.hideUnoccupied
   readonly property bool followFocusedScreen: (widgetSettings.followFocusedScreen !== undefined) ? widgetSettings.followFocusedScreen : widgetMetadata.followFocusedScreen
+  readonly property bool showAllWorkspaces: (widgetSettings.showAllWorkspaces !== undefined) ? widgetSettings.showAllWorkspaces : widgetMetadata.showAllWorkspaces
   readonly property int characterCount: {
     const count = (widgetSettings.characterCount !== undefined) ? widgetSettings.characterCount : widgetMetadata.characterCount;
     return isVertical ? Math.min(count, 2) : count;
@@ -340,7 +341,7 @@ Item {
       for (var i = 0; i < CompositorService.workspaces.count; i++) {
         const ws = CompositorService.workspaces.get(i);
         // For global workspaces (e.g., LabWC), show all workspaces on all screens
-        const matchesScreen = CompositorService.globalWorkspaces || (followFocusedScreen && ws.output.toLowerCase() == focusedOutput) || (!followFocusedScreen && ws.output.toLowerCase() == screenName);
+        const matchesScreen = CompositorService.globalWorkspaces || showAllWorkspaces || (followFocusedScreen && ws.output.toLowerCase() == focusedOutput) || (!followFocusedScreen && ws.output.toLowerCase() == screenName);
 
         if (!matchesScreen)
           continue;

--- a/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
@@ -18,6 +18,7 @@ ColumnLayout {
   property string valueLabelMode: widgetData.labelMode !== undefined ? widgetData.labelMode : widgetMetadata.labelMode
   property bool valueHideUnoccupied: widgetData.hideUnoccupied !== undefined ? widgetData.hideUnoccupied : widgetMetadata.hideUnoccupied
   property bool valueFollowFocusedScreen: widgetData.followFocusedScreen !== undefined ? widgetData.followFocusedScreen : widgetMetadata.followFocusedScreen
+  property bool valueShowAllWorkspaces: widgetData.showAllWorkspaces !== undefined ? widgetData.showAllWorkspaces : widgetMetadata.showAllWorkspaces
   property int valueCharacterCount: widgetData.characterCount !== undefined ? widgetData.characterCount : widgetMetadata.characterCount
 
   // Grouped mode settings
@@ -42,6 +43,7 @@ ColumnLayout {
     settings.hideUnoccupied = valueHideUnoccupied;
     settings.characterCount = valueCharacterCount;
     settings.followFocusedScreen = valueFollowFocusedScreen;
+    settings.showAllWorkspaces = valueShowAllWorkspaces;
     settings.showApplications = valueShowApplications;
     settings.showApplicationsHover = valueShowApplicationsHover;
     settings.showLabelsOnlyWhenOccupied = valueShowLabelsOnlyWhenOccupied;
@@ -175,6 +177,16 @@ ColumnLayout {
     checked: valueFollowFocusedScreen
     onToggled: checked => {
                  valueFollowFocusedScreen = checked;
+                 saveSettings();
+               }
+  }
+
+  NToggle {
+    label: I18n.tr("bar.workspace.show-all-workspaces-label")
+    description: I18n.tr("bar.workspace.show-all-workspaces-description")
+    checked: valueShowAllWorkspaces
+    onToggled: checked => {
+                 valueShowAllWorkspaces = checked;
                  saveSettings();
                }
   }

--- a/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/WorkspaceSettings.qml
@@ -19,6 +19,7 @@ ColumnLayout {
   property bool valueHideUnoccupied: widgetData.hideUnoccupied !== undefined ? widgetData.hideUnoccupied : widgetMetadata.hideUnoccupied
   property bool valueFollowFocusedScreen: widgetData.followFocusedScreen !== undefined ? widgetData.followFocusedScreen : widgetMetadata.followFocusedScreen
   property bool valueShowAllWorkspaces: widgetData.showAllWorkspaces !== undefined ? widgetData.showAllWorkspaces : widgetMetadata.showAllWorkspaces
+  property bool valueFocusWorkspaceOnCurrentMonitor: widgetData.focusWorkspaceOnCurrentMonitor !== undefined ? widgetData.focusWorkspaceOnCurrentMonitor : widgetMetadata.focusWorkspaceOnCurrentMonitor
   property int valueCharacterCount: widgetData.characterCount !== undefined ? widgetData.characterCount : widgetMetadata.characterCount
 
   // Grouped mode settings
@@ -44,6 +45,7 @@ ColumnLayout {
     settings.characterCount = valueCharacterCount;
     settings.followFocusedScreen = valueFollowFocusedScreen;
     settings.showAllWorkspaces = valueShowAllWorkspaces;
+    settings.focusWorkspaceOnCurrentMonitor = valueFocusWorkspaceOnCurrentMonitor;
     settings.showApplications = valueShowApplications;
     settings.showApplicationsHover = valueShowApplicationsHover;
     settings.showLabelsOnlyWhenOccupied = valueShowLabelsOnlyWhenOccupied;
@@ -187,6 +189,16 @@ ColumnLayout {
     checked: valueShowAllWorkspaces
     onToggled: checked => {
                  valueShowAllWorkspaces = checked;
+                 saveSettings();
+               }
+  }
+
+  NToggle {
+    label: I18n.tr("bar.workspace.focus-workspace-on-current-monitor-label")
+    description: I18n.tr("bar.workspace.focus-workspace-on-current-monitor-description")
+    checked: valueFocusWorkspaceOnCurrentMonitor
+    onToggled: checked => {
+                 valueFocusWorkspaceOnCurrentMonitor = checked;
                  saveSettings();
                }
   }

--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -389,9 +389,9 @@ Singleton {
   }
 
   // Generic workspace switching
-  function switchToWorkspace(workspace) {
+  function switchToWorkspace(workspace, options = {}) {
     if (backend && backend.switchToWorkspace) {
-      backend.switchToWorkspace(workspace);
+      backend.switchToWorkspace(workspace, options);
     } else {
       Logger.w("Compositor", "No backend available for workspace switching");
     }

--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -525,13 +525,16 @@ Item {
   }
 
   // Public functions
-  function switchToWorkspace(workspace) {
+  function switchToWorkspace(workspace, options = {}) {
     try {
+      const focusOnCurrent = options.focusWorkspaceOnCurrentMonitor || false;
+      const dispatcher = focusOnCurrent ? "focusworkspaceoncurrentmonitor" : "workspace";
+
       if (workspace.name) {
-        Hyprland.dispatch(`workspace ${workspace.name}`);
+        Hyprland.dispatch(`${dispatcher} ${workspace.name}`);
         return;
       }
-      Hyprland.dispatch(`workspace ${workspace.idx}`);
+      Hyprland.dispatch(`${dispatcher} ${workspace.idx}`);
     } catch (e) {
       Logger.e("HyprlandService", "Failed to switch workspace:", e);
     }

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -294,6 +294,7 @@ Singleton {
                                   "Workspace": {
                                     "labelMode": "index",
                                     "followFocusedScreen": false,
+                                    "focusWorkspaceOnCurrentMonitor": false,
                                     "showAllWorkspaces": false,
                                     "hideUnoccupied": false,
                                     "characterCount": 2,

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -294,6 +294,7 @@ Singleton {
                                   "Workspace": {
                                     "labelMode": "index",
                                     "followFocusedScreen": false,
+                                    "showAllWorkspaces": false,
                                     "hideUnoccupied": false,
                                     "characterCount": 2,
                                     "showApplications": false,


### PR DESCRIPTION
# Pull Request
- add option to the workspace widget settings to show all workspaces, regardless of the screen they are bound to.
- added another option to Focus workspace on current monitor this is needed when switching the workspace using the widget (by clicking the workspace or by scrolling).

## Motivation
This PR adds optional support global workspaces in Hyprland (other compositors might also support this with minor adjustments).

The workspace widget already shows all workspaces for Compositors that use global workspaces by defalut (e.g. LabWC) this global workspace behaviour can be easily replicated in Hyprland  so i added an option to treat workspaces as global in Noctalia as well.
This PR adds the option in the worksapce widget settings to `showAllWorkspaces`. (this is the first commit)
To make workspaces feel global in Hyprland you need to use the dispatacher `focusWorkspaceOnCurrentMonitor` instead of previously used dispatcher: `workspace` so i also added an option to the widgets settings to `Focus workspace on current monitor` (second commit).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
i found a more or less related issue #2539 

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)