### PR TITLE
Update nix build instructions to use librsvg (v5)

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,7 +22,8 @@
   curl,
   libwebp,
   glib,
-  polkit
+  polkit,
+  librsvg
 }:
 
 stdenv.mkDerivation {
@@ -61,6 +62,7 @@ stdenv.mkDerivation {
     libwebp
     glib
     polkit
+    librsvg
   ];
 
   mesonBuildType = "release";


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
Since nanosvg doesn't properly support the full svg spec, librsvg was added recently, but fails on nix since the build instructions don't include the library.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Build & run on my x86-64 NixOS laptop using `nix run .`

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)