### PR TITLE
Feat: Add option to hide lock screen header

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -1446,6 +1446,8 @@
       "lock-screen-blur-strength-label": "Lock screen blur strength",
       "lock-screen-tint-strength-description": "Applies a tint overlay to the lock screen wallpaper.",
       "lock-screen-tint-strength-label": "Lock screen tint strength",
+      "hide-header-label": "Hide top header",
+      "hide-header-description": "Do not display the top header.",
       "monitors-desc": "Show lock screen on specific monitors. Defaults to all if none are chosen.",
       "password-chars-description": "Cute icons used to hide your password.",
       "password-chars-label": "Random password icons",

--- a/Assets/settings-search-index.json
+++ b/Assets/settings-search-index.json
@@ -1698,6 +1698,15 @@
     "subTabLabel": "common.appearance"
   },
   {
+    "labelKey": "panels.lock-screen.hide-header-label",
+    "descriptionKey": "panels.lock-screen.hide-header-description",
+    "widget": "NToggle",
+    "tab": 11,
+    "tabLabel": "panels.lock-screen.title",
+    "subTab": 0,
+    "subTabLabel": "common.appearance"
+  },
+  {
     "labelKey": "panels.lock-screen.enable-lockscreen-media-controls-label",
     "descriptionKey": "panels.lock-screen.enable-lockscreen-media-controls-description",
     "widget": "NToggle",

--- a/Commons/Settings.qml
+++ b/Commons/Settings.qml
@@ -313,6 +313,7 @@ Singleton {
       property real animationSpeed: 1.0
       property bool animationDisabled: false
       property bool compactLockScreen: false
+      property bool hideLockScreenHeader: false
       property bool lockScreenAnimations: false
       property bool lockOnSuspend: true
       property bool showSessionButtonsOnLockScreen: true

--- a/Modules/LockScreen/LockScreen.qml
+++ b/Modules/LockScreen/LockScreen.qml
@@ -145,6 +145,7 @@ Loader {
                 // Header with avatar, welcome, time, date
                 LockScreenHeader {
                   id: headerComponent
+                  visible: !Settings.data.general.hideLockScreenHeader
                 }
 
                 // Info notification

--- a/Modules/Panels/Settings/Tabs/LockScreen/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/LockScreen/AppearanceSubTab.qml
@@ -77,6 +77,14 @@ ColumnLayout {
   }
 
   NToggle {
+    label: I18n.tr("panels.lock-screen.hide-header-label")
+    description: I18n.tr("panels.lock-screen.hide-header-description")
+    checked: Settings.data.general.hideLockScreenHeader
+    onToggled: checked => Settings.data.general.hideLockScreenHeader = checked
+    defaultValue: Settings.getDefaultValue("general.hideLockScreenHeader")
+  }
+
+  NToggle {
     label: I18n.tr("panels.lock-screen.enable-lockscreen-media-controls-label")
     description: I18n.tr("panels.lock-screen.enable-lockscreen-media-controls-description")
     checked: Settings.data.general.enableLockScreenMediaControls


### PR DESCRIPTION
# Pull Request
Add option to hide lock screen header. Defaults to false.

## Motivation
I was surprised to see no ability to hide the lock screen header. I don't really want the current logged in username to be advertised. Coming from i3lock-esque lock screens, I found it strange for this info to be there for all to see. 

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
N/A

## Testing
Ran with nix run and was delighted to see it was just so easy to make this change. 

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Settings panel:
<img width="594" height="218" alt="noctalia-hide-lockscreen-header-settings" src="https://github.com/user-attachments/assets/ede7c134-7f03-4b46-ae0a-89ac35cf18d9" />

Resulting lock screen:
<img width="1920" height="1200" alt="noctallia-lock-no-header" src="https://github.com/user-attachments/assets/e79d0fe1-3b37-4b1f-910f-9d2163bdc9f5" />



## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Only added English strings. Also naming and verbiage is not my strong suit so please feel free to suggest better words :)
