### PR TITLE
Adjusted launcher panel output selection s

### DIFF
--- a/src/wayland/wayland_connection.cpp
+++ b/src/wayland/wayland_connection.cpp
@@ -318,6 +318,17 @@ wl_output* WaylandConnection::preferredPanelOutput(std::chrono::milliseconds poi
     }
   }
 
+  if (wl_output* output = activeToplevelOutput(); output != nullptr) {
+    return output;
+  }
+
+  if (wl_surface* keyboardSurface = lastKeyboardSurface(); keyboardSurface != nullptr) {
+    const auto it = m_surfaceOutputMap.find(keyboardSurface);
+    if (it != m_surfaceOutputMap.end() && it->second != nullptr) {
+      return it->second;
+    }
+  }
+
   if (hasFreshPointerOutput(pointerMaxAge)) {
     return m_lastPointerOutput;
   }


### PR DESCRIPTION
# Pull Request

## Motivation
launcher now follows the currently focused screen instead of defaulting to screen 1.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [X] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
