### PR TITLE
fix(taskbar): show apps on inactive workspaces when grouped by workspace

### DIFF
--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -330,7 +330,7 @@ void TaskbarWidget::updateModels() {
   const auto active = m_connection.activeToplevel();
   const auto* activeHandle = active.has_value() ? active->handle : nullptr;
 
-  const auto running = m_connection.runningAppIds(m_output);
+  const auto running = m_connection.runningAppIds(m_groupByWorkspace ? nullptr : m_output);
   const auto resolvedRunning = app_identity::resolveRunningApps(running, desktopEntries());
   std::vector<WorkspaceModel> nextWorkspaces;
   std::unordered_map<std::string, std::vector<std::string>> runningByWorkspace;
@@ -381,7 +381,7 @@ void TaskbarWidget::updateModels() {
     const std::string nameLower = !run.entry.nameLower.empty() ? run.entry.nameLower : run.runningLower;
     const std::string appId = !run.entry.id.empty() ? run.entry.id : run.runningAppId;
 
-    const auto windows = m_connection.windowsForApp(idLower, startupLower, m_output);
+    const auto windows = m_connection.windowsForApp(idLower, startupLower, m_groupByWorkspace ? nullptr : m_output);
     for (const auto& window : windows) {
       const auto handleKey = reinterpret_cast<std::uintptr_t>(window.handle);
       if (!processedHandles.insert(handleKey).second) {


### PR DESCRIPTION
# Pull Request
## Motivation
Windows on inactive workspaces never receive wl_output association via wlr-foreign-toplevel-management (Sway/Niri only send output_enter for visible windows). Use a null output filter for runningAppIds and windowsForApp when group_by_workspace is enabled so all windows are included in the task list. Workspace assignment matching then places each window into the correct capsule using the IPC tree data.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [X] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
