### PR TITLE
hide dock (if auto-hide enabled) after context menu focus changes

### DIFF
--- a/Modules/Dock/DockMenu.qml
+++ b/Modules/Dock/DockMenu.qml
@@ -497,6 +497,12 @@ PopupWindow {
   function handleFocus(targetToplevel) {
     if (targetToplevel?.activate) {
       targetToplevel.activate();
+
+      // hide dock after focusing window (if not the currently focused window)
+      if (dockRoot.autoHide && window !== ToplevelManager?.activeToplevel) {
+        dockRoot.hidden = true;
+        dockRoot.unloadTimer.restart();
+      }
     }
     closeAndReset();
   }


### PR DESCRIPTION
# Pull Request

I am not sure if this is the preferred way to do this (it's probably not - perhaps a callback to the dock to tell it to hide itself would be better?) but I wanted to at least put forth some kind of effort instead of just opening an issue.

## Motivation
If dock auto-hide is enabled, when you focus a (new) window, the dock does not go away until the mouse is brought into the dock area and then removed. This feels like a bug, so I am marking it as a bugfix.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
N/A

## Testing
ran with nix run and confirmed that focusing via context menu closes the dock once the new window is focused.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Screenshots / Videos
None

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I am incredibly new to this codebase, and also only ever heard of QML like 2 days ago. I just started using Noctalia full time on Niri :)

Please feel free to let me know how something like this should be implemented! Thanks!