### PR TITLE
fix: parse keyboard layout name correctly for devices with parenthese…

### DIFF
--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -458,17 +458,10 @@ Item {
 
   function handleActiveLayoutEvent(ev) {
     try {
-      let beforeParenthesis;
-      const parenthesisPos = ev.lastIndexOf('(');
-
-      if (parenthesisPos === -1) {
-        beforeParenthesis = ev;
-      } else {
-        beforeParenthesis = ev.substring(0, parenthesisPos);
-      }
-
-      const layoutNameStart = beforeParenthesis.lastIndexOf(',') + 1;
-      const layoutName = ev.substring(layoutNameStart);
+      const commaPos = ev.lastIndexOf(',') + 1;
+      if (commaPos === -1)
+        return;
+      const layoutName = ev.substring(commaPos).trim();
 
       // Ignore bogus "error" layout reported by virtual keyboards (e.g. wtype)
       if (layoutName.toLowerCase() === "error") {


### PR DESCRIPTION
# Pull Request

## Motivation
Layout notification showed messy layout name. Device names containing parentheses (e.g. "mchose-g75-v2-(8k)") caused lastIndexOf('(') to find the parenthesis in the device name instead of the layout name, resulting in incorrect parsing and showing the full device name (e.g. "mchose-g75-v2-(8k),Russian") in the layout notification.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)