### PR TITLE
workspace: detect hyprland lua config and change commands accordingly

### DIFF
--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -107,7 +107,20 @@ bool HyprlandWorkspaceBackend::connectSocket() {
 
   refreshSnapshot();
   kLog.info("connected to hyprland IPC at {}", m_eventSocketPath);
+  updateConfigProvider();
   return true;
+}
+
+void HyprlandWorkspaceBackend::updateConfigProvider() {
+  m_configLua = false;
+  const auto json = requestJson("j/status");
+  if (!json || !json->is_object()) {
+    return;
+  }
+  std::string configProvider = json->value("configProvider", "");
+  if (configProvider.compare("lua") == 0) {
+    m_configLua = true;
+  }
 }
 
 void HyprlandWorkspaceBackend::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
@@ -118,7 +131,11 @@ void HyprlandWorkspaceBackend::activate(const std::string& id) {
   }
 
   std::string response;
-  (void)sendRequest(std::format("dispatch workspace {}", id), response);
+  if (m_configLua) {
+    (void)sendRequest(std::format("dispatch hl.dsp.focus({{workspace = {}}})", id), response);
+  } else {
+    (void)sendRequest(std::format("dispatch workspace {}", id), response);
+  }
 }
 
 void HyprlandWorkspaceBackend::activateForOutput(wl_output* /*output*/, const std::string& id) { activate(id); }

--- a/src/compositors/hyprland/hyprland_workspace_backend.h
+++ b/src/compositors/hyprland/hyprland_workspace_backend.h
@@ -56,6 +56,7 @@ private:
   };
 
   bool ensureSocketPaths();
+  void updateConfigProvider();
   [[nodiscard]] bool sendRequest(const std::string& request, std::string& response) const;
   [[nodiscard]] std::optional<nlohmann::json> requestJson(const std::string& request) const;
   void refreshSnapshot();
@@ -85,6 +86,7 @@ private:
   int m_eventSocketFd = -1;
   std::string m_requestSocketPath;
   std::string m_eventSocketPath;
+  bool m_configLua;
   std::vector<char> m_readBuffer;
   std::vector<WorkspaceState> m_workspaces;
   std::unordered_map<std::uint64_t, ToplevelState> m_toplevels;


### PR DESCRIPTION
detect if hyprland uses lua configuration. If so, the commands to switch workspaces should be altered.

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ x] Code follows project style guidelines
- [ x] Self-reviewed my code
- [x ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
