### PR TITLE
fix(MangoService): keyboard layout indicator delay for MangoWC

### DIFF
--- a/Services/Compositor/MangoService.qml
+++ b/Services/Compositor/MangoService.qml
@@ -345,14 +345,47 @@ Item {
       }
 
       function onKbLayoutChanged() {
-        if (KeyboardLayoutService) {
-          KeyboardLayoutService.setCurrentLayout(modelData.kbLayout);
-        }
+        // Not reliable for XKB-driven switches on MangoWC; handled by kbLayoutPoll
       }
     }
   }
 
   // ===== PROCESSES =====
+
+  // Keyboard layout polling - MangoWC doesn't send DWL IPC events for XKB-driven
+  // layout switches (grp:win_space_toggle), so we poll mmsg periodically.
+  property QtObject _kbLayoutPoll: Timer {
+    id: kbLayoutPoll
+    interval: 300
+    running: false
+    repeat: true
+
+    property bool busy: false
+
+    onTriggered: {
+      if (busy) return;
+      busy = true;
+      kbLayoutQuery.running = true;
+    }
+  }
+
+  property QtObject _kbLayoutQuery: Process {
+    id: kbLayoutQuery
+    command: ["mmsg", "-g", "-k"]
+
+    stdout: SplitParser {
+      onRead: line => {
+        var parts = line.trim().split(/\s+/);
+        if (parts.length >= 3 && parts[1] === "kb_layout") {
+          KeyboardLayoutService.setCurrentLayout(parts.slice(2).join(" "));
+        }
+      }
+    }
+
+    onExited: code => {
+      kbLayoutPoll.busy = false;
+    }
+  }
 
   // Scale query (mmsg -g -A) - DWL doesn't provide scale info
   property QtObject _scaleQuery: Process {
@@ -402,6 +435,9 @@ Item {
       internal.rebuildWorkspaces();
       internal.updateWindows();
     }
+
+    // Start keyboard layout polling
+    kbLayoutPoll.running = true;
 
     initialized = true;
   }
@@ -474,7 +510,7 @@ Item {
   }
 
   function cycleKeyboardLayout() {
-    Logger.w("MangoService", "Keyboard layout cycling not supported");
+    Quickshell.execDetached(["mmsg", "-s", "-d", "switch_keyboard_layout"]);
   }
 
   function getFocusedScreen() {


### PR DESCRIPTION
I'm unsure if i have setup MangoWC keyboard layout switching the right way  

The keyboard layout indicator in the bar is delayed or never updates when switching layouts via XKB combo (e.g. `grp:win_space_toggle`) on MangoWC. The compositor doesn't emit DWL IPC `kbLayoutChanged` signals for XKB-driven switches — only when `switch_keyboard_layout` dispatch is explicitly called. This makes `DwlIpcOutput.kbLayout` go stale, so the bar can't detect layout changes in real-time.

Also enables cycleKeyboardLayout() using the switch_keyboard_layout dispatch command built into MangoWC.

The changes here come from help of OpenCode Big Pickle

- [x] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Refactoring

## Related Issue
-  N/A

- [x] Tested on MangoWC

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors