### PR TITLE
fix(dock): refresh pinned apps on reload

### DIFF
--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -171,7 +171,6 @@ void Dock::reload() {
   const auto& cfg = m_config->config().dock;
   m_lastDockConfig = cfg;
   m_lastShadow = m_config->config().shell.shadow;
-  m_lastPinnedConfig = cfg.pinned;
   m_lastBarLayerStack = barLayerStackSignature(m_config->config());
 
   if (!cfg.enabled) {


### PR DESCRIPTION
## Summary
- refresh dock pinned apps when the pinned config changes during dock reload
- keep the previous pinned snapshot until refreshPinnedAppsIfNeeded() compares it with the new config

## Problem
Dock::reload() updated m_lastPinnedConfig before refreshPinnedAppsIfNeeded() ran. When only dock.pinned changed, the refresh helper saw the new config as already cached and skipped rebuilding the pinned app list.

## Verification
- clang-format --dry-run -Werror src/shell/dock/dock.cpp
- git diff --check
- meson setup build-debug --buildtype=debug
- meson compile -C build-debug