### PR TITLE
Add optional dock running dots

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1289,7 +1289,11 @@
         },
         "show-running": {
           "label": "Show Running",
-          "description": "Show indicators for running applications"
+          "description": "Show running applications that are not pinned"
+        },
+        "show-dots": {
+          "label": "Show Dots",
+          "description": "Show running window dots beside dock icons"
         },
         "show-instance-count": {
           "label": "Show Instance Count",

--- a/example.toml
+++ b/example.toml
@@ -221,6 +221,7 @@ active_scale        = 1.0
 inactive_scale      = 0.85
 active_opacity      = 1.0
 inactive_opacity    = 0.85
+show_dots           = false
 show_instance_count = true
 active_monitor_only = false
 pinned              = []            # e.g. ["firefox", "code", "kitty"]

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -280,7 +280,7 @@ namespace {
            a.showRunning == b.showRunning && a.autoHide == b.autoHide && a.reserveSpace == b.reserveSpace &&
            nearlyEqual(a.activeScale, b.activeScale) && nearlyEqual(a.inactiveScale, b.inactiveScale) &&
            nearlyEqual(a.activeOpacity, b.activeOpacity) && nearlyEqual(a.inactiveOpacity, b.inactiveOpacity) &&
-           a.showInstanceCount == b.showInstanceCount && a.pinned == b.pinned;
+           a.showDots == b.showDots && a.showInstanceCount == b.showInstanceCount && a.pinned == b.pinned;
   }
 
   bool shellConfigEqual(const ShellConfig& a, const ShellConfig& b) {

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1492,6 +1492,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
       dock.activeOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
     if (auto v = (*dockTbl)["inactive_opacity"].value<double>())
       dock.inactiveOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
+    if (auto v = (*dockTbl)["show_dots"].value<bool>())
+      dock.showDots = *v;
     if (auto v = (*dockTbl)["show_instance_count"].value<bool>())
       dock.showInstanceCount = *v;
     if (auto* arr = (*dockTbl)["pinned"].as_array())

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -232,6 +232,7 @@ struct DockConfig {
   float inactiveScale = 0.85f;     // non-focused app icon scale
   float activeOpacity = 1.0f;      // focused app icon opacity
   float inactiveOpacity = 0.85f;   // non-focused app icon opacity
+  bool showDots = false;           // show optional running window dots beside app icons
   bool showInstanceCount = true;   // show a badge with count when app has >1 window
   std::vector<std::string> pinned; // desktop entry IDs to always show
 

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -1195,7 +1195,7 @@ void Dock::updateVisuals(DockInstance& instance) {
     }
 
     if (cfg.showDots) {
-      const std::size_t dotCount = item.running ? std::min<std::size_t>(std::max<std::size_t>(count, 1), 3) : 0;
+      const std::size_t dotCount = std::min<std::size_t>(count, 3);
       const float iSize = static_cast<float>(cfg.iconSize);
       constexpr float kCellPad = 6.0f;
       const float cellMain = iSize + 2.0f * kCellPad;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -41,6 +41,9 @@ namespace {
   constexpr float kBadgeSizeRatio = 0.30f; // fraction of icon size
   constexpr float kBadgeMinSize = 16.0f;   // minimum diameter in px
   constexpr float kBadgeFontRatio = 0.72f; // font size relative to badge diameter
+  constexpr float kDotSizeRatio = 0.09f;
+  constexpr float kDotMinSize = 4.0f;
+  constexpr float kDotGap = 3.0f;
 
   // Thin strip (px) kept in the input region when auto-hide is in the hidden
   // state, so the pointer can re-trigger show on approach to the screen edge.
@@ -1022,6 +1025,29 @@ void Dock::rebuildItems(DockInstance& instance) {
       item.iconGlyph = static_cast<Glyph*>(areaNode->addChild(std::move(glyph)));
     }
 
+    if (cfg.showDots) {
+      const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
+      const bool verticalDots = cfg.position == "left" || cfg.position == "right";
+
+      for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
+        auto dotNode = std::make_unique<Box>();
+        dotNode->setRadius(dot * 0.5f);
+        dotNode->setSize(dot, dot);
+        dotNode->setFill(colorSpecFromRole(ColorRole::Secondary));
+        dotNode->setVisible(false);
+
+        if (verticalDots) {
+          const float x = cfg.position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+          dotNode->setPosition(x, std::round((cellMain - dot) * 0.5f));
+        } else {
+          const float y = cfg.position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+          dotNode->setPosition(std::round((cellMain - dot) * 0.5f), y);
+        }
+
+        item.dotIndicators[dotIndex] = static_cast<Box*>(areaNode->addChild(std::move(dotNode)));
+      }
+    }
+
     // Instance-count badge — top-right corner of the icon, initially hidden.
     if (cfg.showInstanceCount) {
       const float bd = std::max(kBadgeMinSize, iSize * kBadgeSizeRatio);
@@ -1159,27 +1185,62 @@ void Dock::updateVisuals(DockInstance& instance) {
       }
     }
 
-    // Instance-count badge.
-    if (item.badge != nullptr && item.badgeLabel != nullptr) {
+    const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
+    std::size_t count = 0;
+    if (needsWindowCount) {
       const auto windows = m_platform->windowsForApp(item.idLower, item.startupWmClassLower,
                                                      currentDockFilterOutput(cfg, instance.output));
-      const std::size_t count = windows.size();
-      if (count != item.instanceCount) {
-        item.instanceCount = count;
-        const bool show = (count >= 2);
-        item.badge->setVisible(show);
-        item.badgeLabel->setVisible(show);
-        if (show) {
-          const std::string label = (count > 9) ? "9+" : std::to_string(count);
-          item.badgeLabel->setText(label);
-          item.badgeLabel->setColor(colorSpecFromRole(ColorRole::OnPrimary));
-          item.badge->setFill(colorSpecFromRole(ColorRole::Primary));
-          if (m_renderContext != nullptr) {
-            const float bd = std::max(kBadgeMinSize, static_cast<float>(cfg.iconSize) * kBadgeSizeRatio);
-            item.badgeLabel->measure(*m_renderContext);
-            item.badgeLabel->setPosition(std::round((bd - item.badgeLabel->width()) * 0.5f),
-                                         std::round((bd - item.badgeLabel->height()) * 0.5f));
+      count = windows.size();
+      item.instanceCount = count;
+    }
+
+    if (cfg.showDots) {
+      const std::size_t dotCount = item.running ? std::min<std::size_t>(std::max<std::size_t>(count, 1), 3) : 0;
+      const float iSize = static_cast<float>(cfg.iconSize);
+      constexpr float kCellPad = 6.0f;
+      const float cellMain = iSize + 2.0f * kCellPad;
+      const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
+      const float groupLength =
+          dotCount == 0 ? dot : dot * static_cast<float>(dotCount) + kDotGap * static_cast<float>(dotCount - 1);
+      const float groupStart = std::round((cellMain - groupLength) * 0.5f);
+      const bool verticalDots = cfg.position == "left" || cfg.position == "right";
+
+      for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
+        if (item.dotIndicators[dotIndex] == nullptr) {
+          continue;
+        }
+        Box* dotNode = item.dotIndicators[dotIndex];
+        const bool visible = dotIndex < dotCount;
+        dotNode->setVisible(visible);
+        dotNode->setFill(colorSpecFromRole(ColorRole::Secondary));
+        if (visible) {
+          const float main = groupStart + static_cast<float>(dotIndex) * (dot + kDotGap);
+          if (verticalDots) {
+            const float x = cfg.position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+            dotNode->setPosition(x, main);
+          } else {
+            const float y = cfg.position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+            dotNode->setPosition(main, y);
           }
+        }
+      }
+    }
+
+    // Instance-count badge.
+    if (item.badge != nullptr && item.badgeLabel != nullptr) {
+      const bool show = count >= 2;
+      item.badge->setVisible(show);
+      item.badgeLabel->setVisible(show);
+      if (show) {
+        const std::string label = (count > 9) ? "9+" : std::to_string(count);
+        item.badgeLabel->setText(label);
+        item.badgeLabel->setColor(colorSpecFromRole(ColorRole::OnPrimary));
+        item.badge->setFill(colorSpecFromRole(ColorRole::Primary));
+        if (m_renderContext != nullptr) {
+          const float bd = std::max(kBadgeMinSize, static_cast<float>(cfg.iconSize) * kBadgeSizeRatio);
+          item.badgeLabel->measure(*m_renderContext);
+          item.badgeLabel->setPosition(std::round((bd - item.badgeLabel->width()) * 0.5f),
+                                       std::round((bd - item.badgeLabel->height()) * 0.5f));
         }
       }
     }

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -9,6 +9,7 @@
 #include "ui/signal.h"
 #include "wayland/popup_surface.h"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -58,6 +59,7 @@ private:
     std::string startupWmClassLower;
     InputArea* area = nullptr;
     Box* background = nullptr;
+    std::array<Box*, 3> dotIndicators{};
     Box* badge = nullptr;
     Label* badgeLabel = nullptr;
     Image* iconImage = nullptr;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -453,6 +453,9 @@ namespace settings {
     entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.show-running.label"),
                                 tr("settings.schema.dock.show-running.description"), {"dock", "show_running"},
                                 ToggleSetting{cfg.dock.showRunning}, "windows"));
+    entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.show-dots.label"),
+                                tr("settings.schema.dock.show-dots.description"), {"dock", "show_dots"},
+                                ToggleSetting{cfg.dock.showDots}, "running dots"));
     entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.show-instance-count.label"),
                                 tr("settings.schema.dock.show-instance-count.description"),
                                 {"dock", "show_instance_count"}, ToggleSetting{cfg.dock.showInstanceCount},


### PR DESCRIPTION
## Summary
- Add an optional `show_dots` dock setting, disabled by default.
- Render up to three palette-aware running window dots beside dock icons.
- Keep instance count badges unchanged for `2+` windows.

## Screenshot
![Dock running dots](https://raw.githubusercontent.com/DFSko/noctalia-shell/pr-assets/dock-running-dots/.github/pr-assets/dock-running-dots.png)

## Test Plan
- `git diff --check upstream/v5..HEAD`
- `meson compile -C build-debug`
- Manually verified the dock with `show_dots = true` on a right-positioned dock.
