### PR TITLE
Add dock launcher button options

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -841,10 +841,6 @@
         "start": "Start",
         "end": "End"
       },
-      "dock-launcher-icon": {
-        "dots": "Dots",
-        "search": "Search"
-      },
       "layer": {
         "top": "Top",
         "overlay": "Overlay"
@@ -1373,7 +1369,7 @@
         },
         "launcher-icon": {
           "label": "Launcher Icon",
-          "description": "Icon shown on the dock launcher button"
+          "description": "Tabler icon shown on the dock launcher button"
         },
         "active-icon-scale": {
           "label": "Active Icon Scale",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -836,6 +836,15 @@
         "left": "Left",
         "right": "Right"
       },
+      "dock-launcher-position": {
+        "none": "None",
+        "start": "Start",
+        "end": "End"
+      },
+      "dock-launcher-icon": {
+        "dots": "Dots",
+        "search": "Search"
+      },
       "layer": {
         "top": "Top",
         "overlay": "Overlay"
@@ -1357,6 +1366,14 @@
         "show-instance-count": {
           "label": "Show Instance Count",
           "description": "Show a badge with the number of open instances"
+        },
+        "launcher-position": {
+          "label": "Launcher Button",
+          "description": "Show a launcher button at the start or end of the dock"
+        },
+        "launcher-icon": {
+          "label": "Launcher Icon",
+          "description": "Icon shown on the dock launcher button"
         },
         "active-icon-scale": {
           "label": "Active Icon Scale",

--- a/example.toml
+++ b/example.toml
@@ -226,7 +226,7 @@ inactive_opacity    = 0.85
 show_dots           = false
 show_instance_count = true
 launcher_position   = "none"       # none | start | end
-launcher_icon       = "dots"       # dots | search
+launcher_icon       = "grid-dots"  # Tabler glyph name
 active_monitor_only = false
 pinned              = []            # e.g. ["firefox", "code", "kitty"]
 

--- a/example.toml
+++ b/example.toml
@@ -225,6 +225,8 @@ active_opacity      = 1.0
 inactive_opacity    = 0.85
 show_dots           = false
 show_instance_count = true
+launcher_position   = "none"       # none | start | end
+launcher_icon       = "dots"       # dots | search
 active_monitor_only = false
 pinned              = []            # e.g. ["firefox", "code", "kitty"]
 

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -284,7 +284,8 @@ namespace {
            a.showRunning == b.showRunning && a.autoHide == b.autoHide && a.reserveSpace == b.reserveSpace &&
            nearlyEqual(a.activeScale, b.activeScale) && nearlyEqual(a.inactiveScale, b.inactiveScale) &&
            nearlyEqual(a.activeOpacity, b.activeOpacity) && nearlyEqual(a.inactiveOpacity, b.inactiveOpacity) &&
-           a.showDots == b.showDots && a.showInstanceCount == b.showInstanceCount && a.pinned == b.pinned;
+           a.showDots == b.showDots && a.showInstanceCount == b.showInstanceCount &&
+           a.launcherPosition == b.launcherPosition && a.launcherIcon == b.launcherIcon && a.pinned == b.pinned;
   }
 
   bool shellConfigEqual(const ShellConfig& a, const ShellConfig& b) {

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1572,13 +1572,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
         kLog.warn("invalid dock.launcher_position '{}'; expected none, start, or end", *v);
       }
     }
-    if (auto v = (*dockTbl)["launcher_icon"].value<std::string>()) {
-      if (*v == "dots" || *v == "search") {
-        dock.launcherIcon = *v;
-      } else {
-        kLog.warn("invalid dock.launcher_icon '{}'; expected dots or search", *v);
-      }
-    }
+    if (auto v = (*dockTbl)["launcher_icon"].value<std::string>())
+      dock.launcherIcon = *v;
     if (auto* arr = (*dockTbl)["pinned"].as_array())
       dock.pinned = readStringArray(*arr);
   }

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1565,6 +1565,20 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
       dock.showDots = *v;
     if (auto v = (*dockTbl)["show_instance_count"].value<bool>())
       dock.showInstanceCount = *v;
+    if (auto v = (*dockTbl)["launcher_position"].value<std::string>()) {
+      if (*v == "none" || *v == "start" || *v == "end") {
+        dock.launcherPosition = *v;
+      } else {
+        kLog.warn("invalid dock.launcher_position '{}'; expected none, start, or end", *v);
+      }
+    }
+    if (auto v = (*dockTbl)["launcher_icon"].value<std::string>()) {
+      if (*v == "dots" || *v == "search") {
+        dock.launcherIcon = *v;
+      } else {
+        kLog.warn("invalid dock.launcher_icon '{}'; expected dots or search", *v);
+      }
+    }
     if (auto* arr = (*dockTbl)["pinned"].as_array())
       dock.pinned = readStringArray(*arr);
   }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -247,22 +247,22 @@ struct DockConfig {
   std::int32_t padding = 8;        // inner padding around the icon row
   std::int32_t itemSpacing = 6;    // gap between items
   float backgroundOpacity = 0.88f;
-  std::int32_t radius = 16;              // dock background corner radius
-  std::int32_t marginEnds = 0;           // inset from each end of the dock along its main axis
-  std::int32_t marginEdge = 8;           // distance from the nearest screen edge (floats the dock when > 0)
-  bool shadow = true;                    // use the global shell shadow
-  bool showRunning = true;               // also show running apps not in pinned list
-  bool autoHide = false;                 // fade out when not hovered (overlay mode)
-  bool reserveSpace = false;             // keep compositor exclusive zone even while auto-hidden
-  float activeScale = 1.0f;              // focused app icon scale
-  float inactiveScale = 0.85f;           // non-focused app icon scale
-  float activeOpacity = 1.0f;            // focused app icon opacity
-  float inactiveOpacity = 0.85f;         // non-focused app icon opacity
-  bool showDots = false;                 // show optional running window dots beside app icons
-  bool showInstanceCount = true;         // show a badge with count when app has >1 window
-  std::string launcherPosition = "none"; // none | start | end
-  std::string launcherIcon = "dots";     // dots | search
-  std::vector<std::string> pinned;       // desktop entry IDs to always show
+  std::int32_t radius = 16;               // dock background corner radius
+  std::int32_t marginEnds = 0;            // inset from each end of the dock along its main axis
+  std::int32_t marginEdge = 8;            // distance from the nearest screen edge (floats the dock when > 0)
+  bool shadow = true;                     // use the global shell shadow
+  bool showRunning = true;                // also show running apps not in pinned list
+  bool autoHide = false;                  // fade out when not hovered (overlay mode)
+  bool reserveSpace = false;              // keep compositor exclusive zone even while auto-hidden
+  float activeScale = 1.0f;               // focused app icon scale
+  float inactiveScale = 0.85f;            // non-focused app icon scale
+  float activeOpacity = 1.0f;             // focused app icon opacity
+  float inactiveOpacity = 0.85f;          // non-focused app icon opacity
+  bool showDots = false;                  // show optional running window dots beside app icons
+  bool showInstanceCount = true;          // show a badge with count when app has >1 window
+  std::string launcherPosition = "none";  // none | start | end
+  std::string launcherIcon = "grid-dots"; // Tabler glyph name
+  std::vector<std::string> pinned;        // desktop entry IDs to always show
 
   bool operator==(const DockConfig&) const = default;
 };

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -247,20 +247,22 @@ struct DockConfig {
   std::int32_t padding = 8;        // inner padding around the icon row
   std::int32_t itemSpacing = 6;    // gap between items
   float backgroundOpacity = 0.88f;
-  std::int32_t radius = 16;        // dock background corner radius
-  std::int32_t marginEnds = 0;     // inset from each end of the dock along its main axis
-  std::int32_t marginEdge = 8;     // distance from the nearest screen edge (floats the dock when > 0)
-  bool shadow = true;              // use the global shell shadow
-  bool showRunning = true;         // also show running apps not in pinned list
-  bool autoHide = false;           // fade out when not hovered (overlay mode)
-  bool reserveSpace = false;       // keep compositor exclusive zone even while auto-hidden
-  float activeScale = 1.0f;        // focused app icon scale
-  float inactiveScale = 0.85f;     // non-focused app icon scale
-  float activeOpacity = 1.0f;      // focused app icon opacity
-  float inactiveOpacity = 0.85f;   // non-focused app icon opacity
-  bool showDots = false;           // show optional running window dots beside app icons
-  bool showInstanceCount = true;   // show a badge with count when app has >1 window
-  std::vector<std::string> pinned; // desktop entry IDs to always show
+  std::int32_t radius = 16;              // dock background corner radius
+  std::int32_t marginEnds = 0;           // inset from each end of the dock along its main axis
+  std::int32_t marginEdge = 8;           // distance from the nearest screen edge (floats the dock when > 0)
+  bool shadow = true;                    // use the global shell shadow
+  bool showRunning = true;               // also show running apps not in pinned list
+  bool autoHide = false;                 // fade out when not hovered (overlay mode)
+  bool reserveSpace = false;             // keep compositor exclusive zone even while auto-hidden
+  float activeScale = 1.0f;              // focused app icon scale
+  float inactiveScale = 0.85f;           // non-focused app icon scale
+  float activeOpacity = 1.0f;            // focused app icon opacity
+  float inactiveOpacity = 0.85f;         // non-focused app icon opacity
+  bool showDots = false;                 // show optional running window dots beside app icons
+  bool showInstanceCount = true;         // show a badge with count when app has >1 window
+  std::string launcherPosition = "none"; // none | start | end
+  std::string launcherIcon = "dots";     // dots | search
+  std::vector<std::string> pinned;       // desktop entry IDs to always show
 
   bool operator==(const DockConfig&) const = default;
 };

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -11,6 +11,7 @@
 #include "render/render_context.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"
 #include "system/app_identity.h"
 #include "system/desktop_entry.h"
@@ -127,6 +128,14 @@ namespace {
     if (pos == "right")
       return LayerShellAnchor::Right;
     return LayerShellAnchor::Bottom; // default
+  }
+
+  std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
+    return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
+  }
+
+  std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
+    return cfg.launcherIcon == "search" ? "search" : "grid-dots";
   }
 
 } // namespace
@@ -505,7 +514,7 @@ void Dock::createInstance(const WaylandOutput& output) {
   const auto& shadowConfig = m_config->config().shell.shadow;
   const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadowConfig);
   const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
-  const auto panelW = dockContentSize(cfg.pinned.size());
+  const auto panelW = dockContentSize(cfg.pinned.size() + dockLauncherButtonCount(cfg));
   const auto panelH = dockThickness();
   const auto anchor = positionToAnchor(cfg.position);
   const bool isBottom = (cfg.position == "bottom");
@@ -973,6 +982,10 @@ void Dock::rebuildItems(DockInstance& instance) {
     runningLower.push_back(StringUtils::toLower(run.entry.id));
   }
 
+  if (cfg.launcherPosition == "start") {
+    instance.row->addChild(createLauncherButton(instance));
+  }
+
   // Reserve up-front so emplace_back never reallocates while lambdas hold raw pointers.
   instance.items.reserve(itemEntries.size());
 
@@ -1105,6 +1118,10 @@ void Dock::rebuildItems(DockInstance& instance) {
     item.area = static_cast<InputArea*>(instance.row->addChild(std::move(areaNode)));
   }
 
+  if (cfg.launcherPosition == "end") {
+    instance.row->addChild(createLauncherButton(instance));
+  }
+
   instance.modelSerial = m_modelSerial;
 
   // Force surface resize when item count changes.
@@ -1119,7 +1136,7 @@ void Dock::resizeSurface(DockInstance& instance) {
   const auto& cfg = m_config->config().dock;
   const bool vert = isVertical();
   const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-  const auto panelW = dockContentSize(instance.items.size());
+  const auto panelW = dockContentSize(instance.items.size() + dockLauncherButtonCount(cfg));
   const auto panelH = dockThickness();
   const bool isBottom = (cfg.position == "bottom");
 
@@ -1260,6 +1277,60 @@ bool Dock::matchesRunningApp(const DockItemView& item, const std::vector<std::st
     }
   }
   return false;
+}
+
+std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
+  const auto& cfg = m_config->config().dock;
+  const bool vert = isVertical();
+  const float iSize = static_cast<float>(cfg.iconSize);
+  constexpr float kCellPad = 6.0f;
+  const float cellMain = iSize + 2.0f * kCellPad;
+  const float cellCross = iSize + 2.0f * kCellPad;
+
+  auto areaNode = std::make_unique<InputArea>();
+  if (!vert) {
+    areaNode->setSize(cellMain, cellCross);
+  } else {
+    areaNode->setSize(cellCross, cellMain);
+  }
+
+  auto bg = std::make_unique<Box>();
+  bg->setSize(cellMain, cellMain);
+  bg->setPosition(0.0f, 0.0f);
+  bg->setRadius(static_cast<float>(cfg.radius));
+  bg->setFill(clearColorSpec());
+  auto* bgPtr = bg.get();
+  areaNode->addChild(std::move(bg));
+
+  auto glyph = std::make_unique<Glyph>();
+  glyph->setGlyph(dockLauncherIconGlyph(cfg));
+  glyph->setGlyphSize(iSize * 0.8f);
+  glyph->setColor(colorSpecFromRole(ColorRole::OnSurface));
+  glyph->setSize(iSize, iSize);
+  glyph->setPosition(kCellPad, kCellPad);
+  areaNode->addChild(std::move(glyph));
+
+  auto* instPtr = &instance;
+  areaNode->setOnEnter([bgPtr, instPtr](const InputArea::PointerData&) {
+    bgPtr->setFill(colorSpecFromRole(ColorRole::Hover, 0.8f));
+    if (instPtr->sceneRoot != nullptr) {
+      instPtr->sceneRoot->markPaintDirty();
+    }
+  });
+  areaNode->setOnLeave([bgPtr, instPtr]() {
+    bgPtr->setFill(clearColorSpec());
+    if (instPtr->sceneRoot != nullptr) {
+      instPtr->sceneRoot->markPaintDirty();
+    }
+  });
+  areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT}));
+  areaNode->setOnClick([instPtr](const InputArea::PointerData& d) {
+    if (d.button == BTN_LEFT) {
+      PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = instPtr->output});
+    }
+  });
+
+  return areaNode;
 }
 
 void Dock::launchEntry(const DesktopEntry& entry) {

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -135,7 +135,7 @@ namespace {
   }
 
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
-    return cfg.launcherIcon == "search" ? "search" : "grid-dots";
+    return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
   }
 
 } // namespace
@@ -1303,7 +1303,9 @@ std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
   areaNode->addChild(std::move(bg));
 
   auto glyph = std::make_unique<Glyph>();
-  glyph->setGlyph(dockLauncherIconGlyph(cfg));
+  if (!glyph->setGlyph(dockLauncherIconGlyph(cfg))) {
+    glyph->setGlyph("grid-dots");
+  }
   glyph->setGlyphSize(iSize * 0.8f);
   glyph->setColor(colorSpecFromRole(ColorRole::OnSurface));
   glyph->setSize(iSize, iSize);

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -114,6 +114,7 @@ private:
   void resizeSurface(DockInstance& instance);
   void updateVisuals(DockInstance& instance);
   void applyPanelPalette(DockInstance& instance);
+  std::unique_ptr<InputArea> createLauncherButton(DockInstance& instance);
   void launchEntry(const DesktopEntry& entry);
   void launchAction(const DesktopAction& action);
   void handleItemClick(DockInstance& instance, DockItemView& item);

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -167,6 +167,10 @@ namespace settings {
       return path.size() >= 5 && path[0] == "bar" && path[2] == "monitor";
     }
 
+    bool isDockLauncherIconPath(const std::vector<std::string>& path) {
+      return path.size() == 2 && path[0] == "dock" && path[1] == "launcher_icon";
+    }
+
     bool monitorOverrideHasExplicitValue(const Config& cfg, const std::vector<std::string>& path) {
       if (!isMonitorOverrideSettingPath(path)) {
         return false;
@@ -891,6 +895,37 @@ namespace settings {
       return input;
     };
 
+    const auto makeGlyphText = [&](const TextSetting& setting, std::vector<std::string> path) -> std::unique_ptr<Node> {
+      auto wrap = std::make_unique<Flex>();
+      wrap->setDirection(FlexDirection::Horizontal);
+      wrap->setAlign(FlexAlign::Center);
+      wrap->setGap(Style::spaceSm * scale);
+      wrap->addChild(makeText(setting.value, setting.placeholder, path, setting.width));
+
+      auto pickerButton = std::make_unique<Button>();
+      pickerButton->setVariant(ButtonVariant::Secondary);
+      pickerButton->setGlyph("apps");
+      pickerButton->setGlyphSize(Style::fontSizeBody * scale);
+      pickerButton->setMinHeight(Style::controlHeight * scale);
+      pickerButton->setMinWidth(Style::controlHeight * scale);
+      pickerButton->setPadding(Style::spaceXs * scale, Style::spaceSm * scale);
+      pickerButton->setRadius(Style::radiusMd * scale);
+      pickerButton->setOnClick([setOverride = ctx.setOverride, path, currentValue = setting.value]() {
+        GlyphPickerDialogOptions options;
+        if (!currentValue.empty()) {
+          options.initialGlyph = currentValue;
+        }
+        (void)GlyphPickerDialog::open(std::move(options), [setOverride, path](std::optional<GlyphPickerResult> result) {
+          if (!result.has_value()) {
+            return;
+          }
+          setOverride(path, result->name);
+        });
+      });
+      wrap->addChild(std::move(pickerButton));
+      return wrap;
+    };
+
     const auto makeOptionalNumber = [&](const OptionalNumberSetting& setting, std::vector<std::string> path) {
       auto input = std::make_unique<Input>();
       input->setValue(setting.value.has_value() ? std::format("{}", *setting.value) : "");
@@ -1497,6 +1532,9 @@ namespace settings {
               return makeSlider(control.value, control.minValue, control.maxValue, control.step, entry.path,
                                 control.integerValue, control.linkedCommit);
             } else if constexpr (std::is_same_v<T, TextSetting>) {
+              if (isDockLauncherIconPath(entry.path)) {
+                return makeGlyphText(control, entry.path);
+              }
               return makeText(control.value, control.placeholder, entry.path, control.width);
             } else if constexpr (std::is_same_v<T, OptionalNumberSetting>) {
               return makeOptionalNumber(control, entry.path);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -246,6 +246,17 @@ namespace settings {
                                       {"right", "settings.options.edge.right"}},
                                      selected));
     };
+    const auto launcherPositionSelect = [](std::string_view selected) {
+      return asSegmented(plainSelect({{"none", "settings.options.dock-launcher-position.none"},
+                                      {"start", "settings.options.dock-launcher-position.start"},
+                                      {"end", "settings.options.dock-launcher-position.end"}},
+                                     selected));
+    };
+    const auto launcherIconSelect = [](std::string_view selected) {
+      return asSegmented(plainSelect({{"dots", "settings.options.dock-launcher-icon.dots"},
+                                      {"search", "settings.options.dock-launcher-icon.search"}},
+                                     selected));
+    };
     std::vector<SettingEntry> entries;
 
     // Appearance
@@ -479,6 +490,12 @@ namespace settings {
                                 tr("settings.schema.dock.show-instance-count.description"),
                                 {"dock", "show_instance_count"}, ToggleSetting{cfg.dock.showInstanceCount},
                                 "badge windows"));
+    entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.launcher-position.label"),
+                                tr("settings.schema.dock.launcher-position.description"), {"dock", "launcher_position"},
+                                launcherPositionSelect(cfg.dock.launcherPosition), "launcher apps grid"));
+    entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.launcher-icon.label"),
+                                tr("settings.schema.dock.launcher-icon.description"), {"dock", "launcher_icon"},
+                                launcherIconSelect(cfg.dock.launcherIcon), "launcher apps search grid"));
     entries.push_back(makeEntry("dock", "layout", tr("settings.schema.shared.position.label"),
                                 tr("settings.schema.dock.position.description"), {"dock", "position"},
                                 positionSelect(cfg.dock.position), "edge"));

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -252,11 +252,6 @@ namespace settings {
                                       {"end", "settings.options.dock-launcher-position.end"}},
                                      selected));
     };
-    const auto launcherIconSelect = [](std::string_view selected) {
-      return asSegmented(plainSelect({{"dots", "settings.options.dock-launcher-icon.dots"},
-                                      {"search", "settings.options.dock-launcher-icon.search"}},
-                                     selected));
-    };
     std::vector<SettingEntry> entries;
 
     // Appearance
@@ -495,7 +490,7 @@ namespace settings {
                                 launcherPositionSelect(cfg.dock.launcherPosition), "launcher apps grid"));
     entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.dock.launcher-icon.label"),
                                 tr("settings.schema.dock.launcher-icon.description"), {"dock", "launcher_icon"},
-                                launcherIconSelect(cfg.dock.launcherIcon), "launcher apps search grid"));
+                                TextSetting{cfg.dock.launcherIcon, "grid-dots"}, "launcher apps icon glyph"));
     entries.push_back(makeEntry("dock", "layout", tr("settings.schema.shared.position.label"),
                                 tr("settings.schema.dock.position.description"), {"dock", "position"},
                                 positionSelect(cfg.dock.position), "edge"));


### PR DESCRIPTION
## Summary
- Add optional dock launcher button placement via dock.launcher_position: none, start, or end.
- Add dock.launcher_icon with dots and search variants.
- Expose both options in settings and example config.

## Test Plan
- meson compile -C build-debug
- jq empty assets/translations/en.json
- python3 -c 'import tomllib; tomllib.load(open("example.toml", "rb")); print("ok")'
- git diff --check
- meson test -C build-debug (No tests defined.)