### PR TITLE
Fix stale template catalog entries

### DIFF
--- a/assets/templates/builtin.toml
+++ b/assets/templates/builtin.toml
@@ -80,10 +80,6 @@ category = "terminal"
 name = "Wezterm"
 category = "terminal"
 
-[catalog.yazi]
-name = "Yazi"
-category = "misc"
-
 [templates.alacritty]
 input_path = "./alacritty/alacritty.toml"
 output_path = "~/.config/alacritty/themes/noctalia.toml"
@@ -181,8 +177,3 @@ post_hook = "bash '{{ config_dir }}/starship/apply.sh'"
 input_path = "./wezterm/wezterm.toml"
 output_path = "~/.config/wezterm/colors/Noctalia.toml"
 post_hook = "bash '{{ config_dir }}/wezterm/apply.sh'"
-
-[templates.yazi]
-input_path = "./yazi/yazi.toml"
-output_path = "~/.config/yazi/flavors/noctalia.yazi/flavor.toml"
-post_hook = "bash '{{ config_dir }}/yazi/apply.sh'"

--- a/assets/templates/niri/apply.sh
+++ b/assets/templates/niri/apply.sh
@@ -11,6 +11,6 @@ if [ ! -f "$config_file" ]; then
     exit 0
 fi
 
-if ! grep -q 'include ".*noctalia\.kdl"' "$config_file"; then
+if ! grep -Fxq "$include_line" "$config_file"; then
     printf '\n%s\n' "$include_line" >>"$config_file"
 fi


### PR DESCRIPTION
## Summary
- Remove stale Yazi entries from the built-in template catalog after the template moved to community templates.
- Make the Niri apply hook check for the exact generated root include instead of any noctalia.kdl include.

## Test Plan
- build-debug/noctalia theme --list-builtins
- temporary XDG_CONFIG_HOME checks for Niri root include insertion and idempotency
- meson compile -C build-debug
- git diff --check