### PR TITLE
Refactor hyprland sockets and update commands for lua config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -590,6 +590,7 @@ _noctalia_sources = files(
   'src/compositors/ext_workspace/ext_workspace_output_backend.cpp',
   'src/compositors/ext_workspace/ext_workspace_backend.cpp',
   'src/compositors/hyprland/hyprland_runtime.cpp',
+  'src/compositors/hyprland/hyprland_event_handler.cpp',
   'src/compositors/hyprland/hyprland_output_backend.cpp',
   'src/compositors/hyprland/hyprland_workspace_backend.cpp',
   'src/compositors/hyprland/hyprland_keyboard_backend.cpp',

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -172,10 +172,6 @@ namespace {
     NiriWorkspaceBackend m_backend;
   };
 
-  [[nodiscard]] bool setHyprlandOutputPower(WaylandConnection& /*wayland*/, bool on) {
-    return compositors::hyprland::setOutputPower(on);
-  }
-
   [[nodiscard]] bool setMangoOutputPower(WaylandConnection& wayland, bool on) {
     return compositors::mango::setOutputPower(wayland, on);
   }
@@ -188,7 +184,10 @@ namespace {
   createOutputPowerBackend(compositors::CompositorRuntimeRegistry& runtimeRegistry) {
     switch (compositors::detect()) {
     case compositors::CompositorKind::Hyprland:
-      return std::make_unique<LambdaOutputPowerBackend>(&setHyprlandOutputPower);
+      return std::make_unique<LambdaOutputPowerBackend>(
+          [&runtime = runtimeRegistry.hyprland()](WaylandConnection& /*wayland*/, bool on) {
+            return compositors::hyprland::setOutputPower(runtime, on);
+          });
     case compositors::CompositorKind::Niri:
       return std::make_unique<LambdaOutputPowerBackend>(
           [&runtime = runtimeRegistry.niri()](WaylandConnection& /*wayland*/, bool on) {

--- a/src/compositors/hyprland/hyprland_event_handler.cpp
+++ b/src/compositors/hyprland/hyprland_event_handler.cpp
@@ -1,0 +1,13 @@
+#include "compositors/hyprland/hyprland_event_handler.h"
+
+#include "compositors/hyprland/hyprland_runtime.h"
+
+namespace compositors::hyprland {
+
+  HyprlandEventHandler::HyprlandEventHandler(HyprlandRuntime& runtime) : m_runtime(runtime) {
+    m_runtime.registerEventHandler(this);
+  }
+
+  HyprlandEventHandler::~HyprlandEventHandler() { m_runtime.unregisterEventHandler(this); }
+
+} // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_event_handler.h
+++ b/src/compositors/hyprland/hyprland_event_handler.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string_view>
+
+namespace compositors::hyprland {
+
+  class HyprlandRuntime;
+
+  class HyprlandEventHandler {
+  public:
+    explicit HyprlandEventHandler(HyprlandRuntime& runtime);
+    virtual ~HyprlandEventHandler();
+
+    virtual void handleEvent(std::string_view event, std::string_view data) = 0;
+    virtual void notifyCleanup() {};
+    virtual void notifyChanged() {};
+
+  protected:
+    HyprlandRuntime& m_runtime;
+  };
+
+} // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_keyboard_backend.cpp
+++ b/src/compositors/hyprland/hyprland_keyboard_backend.cpp
@@ -19,7 +19,7 @@ namespace {
 } // namespace
 
 HyprlandKeyboardBackend::HyprlandKeyboardBackend(compositors::hyprland::HyprlandRuntime& runtime)
-    : m_runtime(runtime) {}
+    : compositors::hyprland::HyprlandEventHandler(runtime) {}
 
 HyprlandKeyboardBackend::~HyprlandKeyboardBackend() { cleanup(); }
 
@@ -42,89 +42,23 @@ std::optional<std::string> HyprlandKeyboardBackend::currentLayoutName() const {
   return m_currentLayoutName;
 }
 
-bool HyprlandKeyboardBackend::connectSocket() {
-  const auto& eventSocketPath = m_runtime.eventSocketPath();
-  if (eventSocketPath.empty()) {
-    return false;
-  }
-
-  cleanup();
-
-  m_eventSocketFd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (m_eventSocketFd < 0) {
-    kLog.warn("failed to create hyprland keyboard IPC socket: {}", std::strerror(errno));
-    return false;
-  }
-
-  sockaddr_un addr{};
-  addr.sun_family = AF_UNIX;
-  if (eventSocketPath.size() >= sizeof(addr.sun_path)) {
-    kLog.warn("hyprland keyboard IPC socket path too long");
-    cleanup();
-    return false;
-  }
-  std::memcpy(addr.sun_path, eventSocketPath.c_str(), eventSocketPath.size() + 1);
-
-  if (::connect(m_eventSocketFd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    kLog.warn("failed to connect to hyprland keyboard IPC {}: {}", eventSocketPath, std::strerror(errno));
-    cleanup();
-    return false;
-  }
-
-  const int flags = ::fcntl(m_eventSocketFd, F_GETFL, 0);
-  if (flags >= 0) {
-    (void)::fcntl(m_eventSocketFd, F_SETFL, flags | O_NONBLOCK);
-  }
-
-  seedLayoutFromDevices();
-  kLog.info("connected to hyprland keyboard IPC at {}", eventSocketPath);
-  return true;
-}
-
 void HyprlandKeyboardBackend::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
-void HyprlandKeyboardBackend::dispatchPoll(short revents) {
-  if (m_eventSocketFd < 0) {
-    return;
-  }
-  if ((revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
-    kLog.warn("hyprland keyboard IPC disconnected");
-    cleanup();
-    if (m_changeCallback) {
-      m_changeCallback();
-    }
-    return;
-  }
-  if ((revents & POLLIN) != 0) {
-    readSocket();
+void HyprlandKeyboardBackend::notifyChanged() {
+  if (m_changeCallback) {
+    m_changeCallback();
   }
 }
 
-void HyprlandKeyboardBackend::cleanup() {
-  if (m_eventSocketFd >= 0) {
-    ::close(m_eventSocketFd);
-    m_eventSocketFd = -1;
-  }
-  m_readBuffer.clear();
+void HyprlandKeyboardBackend::notifyCleanup() {
   m_currentLayoutName.clear();
   m_mainKeyboardName.clear();
 }
 
-std::optional<nlohmann::json> HyprlandKeyboardBackend::requestJson(const std::string& request) const {
-  const auto response = m_runtime.request(request);
-  if (!response.has_value() || response->empty()) {
-    return std::nullopt;
-  }
-  try {
-    return nlohmann::json::parse(*response);
-  } catch (const nlohmann::json::exception& e) {
-    kLog.warn("failed to parse hyprland response for {}: {}", request, e.what());
-    return std::nullopt;
-  }
-}
+void HyprlandKeyboardBackend::cleanup() { m_runtime.cleanup(); }
 
 void HyprlandKeyboardBackend::seedLayoutFromDevices() {
-  const auto json = requestJson("j/devices");
+  const auto json = m_runtime.requestJson("j/devices");
   if (!json || !json->is_object()) {
     return;
   }
@@ -147,64 +81,12 @@ void HyprlandKeyboardBackend::seedLayoutFromDevices() {
   }
 }
 
-void HyprlandKeyboardBackend::readSocket() {
-  char buffer[4096];
-  while (true) {
-    const ssize_t n = ::recv(m_eventSocketFd, buffer, sizeof(buffer), MSG_DONTWAIT);
-    if (n > 0) {
-      m_readBuffer.insert(m_readBuffer.end(), buffer, buffer + n);
-      continue;
-    }
-    if (n == 0) {
-      cleanup();
-      if (m_changeCallback) {
-        m_changeCallback();
-      }
-      return;
-    }
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      break;
-    }
-    if (errno == EINTR) {
-      continue;
-    }
-    kLog.warn("failed to read from hyprland keyboard IPC: {}", std::strerror(errno));
-    cleanup();
-    if (m_changeCallback) {
-      m_changeCallback();
-    }
-    return;
-  }
+void HyprlandKeyboardBackend::handleEvent(std::string_view event, std::string_view data) {
 
-  parseMessages();
-}
-
-void HyprlandKeyboardBackend::parseMessages() {
-  while (true) {
-    auto it = std::find(m_readBuffer.begin(), m_readBuffer.end(), '\n');
-    if (it == m_readBuffer.end()) {
-      return;
-    }
-    std::string line(m_readBuffer.begin(), it);
-    m_readBuffer.erase(m_readBuffer.begin(), it + 1);
-    if (!line.empty()) {
-      handleEvent(line);
-    }
-  }
-}
-
-void HyprlandKeyboardBackend::handleEvent(std::string_view line) {
-  const auto split = line.find(">>");
-  if (split == std::string_view::npos) {
-    return;
-  }
-
-  const std::string_view event = line.substr(0, split);
   if (event != "activelayout") {
     return;
   }
 
-  const std::string_view data = line.substr(split + 2);
   const auto comma = data.find(',');
   if (comma == std::string_view::npos || comma + 1 >= data.size()) {
     return;
@@ -218,7 +100,5 @@ void HyprlandKeyboardBackend::handleEvent(std::string_view line) {
   }
 
   m_currentLayoutName = std::string(layoutName);
-  if (m_changeCallback) {
-    m_changeCallback();
-  }
+  notifyChanged();
 }

--- a/src/compositors/hyprland/hyprland_keyboard_backend.h
+++ b/src/compositors/hyprland/hyprland_keyboard_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "compositors/keyboard_backend.h"
+#include "hyprland_event_handler.h"
 
 #include <functional>
 #include <json.hpp>
@@ -9,11 +10,7 @@
 #include <string_view>
 #include <vector>
 
-namespace compositors::hyprland {
-  class HyprlandRuntime;
-} // namespace compositors::hyprland
-
-class HyprlandKeyboardBackend {
+class HyprlandKeyboardBackend : public compositors::hyprland::HyprlandEventHandler {
 public:
   using ChangeCallback = std::function<void()>;
 
@@ -28,23 +25,16 @@ public:
   [[nodiscard]] std::optional<KeyboardLayoutState> layoutState() const;
   [[nodiscard]] std::optional<std::string> currentLayoutName() const;
 
-  bool connectSocket();
   void setChangeCallback(ChangeCallback callback);
-  [[nodiscard]] int pollFd() const noexcept { return m_eventSocketFd; }
-  void dispatchPoll(short revents);
   void cleanup();
+  void notifyCleanup();
+  void notifyChanged();
 
 private:
-  [[nodiscard]] std::optional<nlohmann::json> requestJson(const std::string& request) const;
   void seedLayoutFromDevices();
-  void readSocket();
-  void parseMessages();
-  void handleEvent(std::string_view line);
+  void handleEvent(std::string_view event, std::string_view data);
 
-  compositors::hyprland::HyprlandRuntime& m_runtime;
-  int m_eventSocketFd = -1;
   std::string m_currentLayoutName;
   std::string m_mainKeyboardName;
-  std::vector<char> m_readBuffer;
   ChangeCallback m_changeCallback;
 };

--- a/src/compositors/hyprland/hyprland_output_backend.cpp
+++ b/src/compositors/hyprland/hyprland_output_backend.cpp
@@ -60,6 +60,14 @@ std::optional<std::string> HyprlandOutputBackend::focusedOutputName() const {
 
 namespace compositors::hyprland {
 
-  bool setOutputPower(bool on) { return process::runAsync({"hyprctl", "dispatch", "dpms", on ? "on" : "off"}); }
+  bool setOutputPower(HyprlandRuntime& runtime, bool on) {
+    std::optional<std::string> response;
+    if (runtime.configIsLua()) {
+      response = runtime.request(std::format("dispatch hl.dsp.dpms({{ action = \"{}\"}})", on ? "enable" : "disable"));
+    } else {
+      response = runtime.request(std::format("dispatch dpms {}", on ? "on" : "off"));
+    }
+    return response != std::nullopt;
+  }
 
 } // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_output_backend.h
+++ b/src/compositors/hyprland/hyprland_output_backend.h
@@ -18,6 +18,6 @@ private:
 
 namespace compositors::hyprland {
 
-  [[nodiscard]] bool setOutputPower(bool on);
+  [[nodiscard]] bool setOutputPower(HyprlandRuntime& runtime, bool on);
 
 } // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_runtime.cpp
+++ b/src/compositors/hyprland/hyprland_runtime.cpp
@@ -1,11 +1,15 @@
 #include "compositors/hyprland/hyprland_runtime.h"
 
+#include "compositors/hyprland/hyprland_event_handler.h"
 #include "core/log.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <filesystem>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <system_error>
@@ -19,9 +23,15 @@ namespace compositors::hyprland {
 
   } // namespace
 
-  bool HyprlandRuntime::available() const {
+  HyprlandRuntime::HyprlandRuntime() {
     ensureResolved();
-    return !m_socketPaths.request.empty();
+    updateConfigProvider();
+  }
+  bool HyprlandRuntime::available() const { return m_eventSocketFd >= 0; }
+
+  bool HyprlandRuntime::configIsLua() const {
+    ensureResolved();
+    return m_configIsLua;
   }
 
   const std::string& HyprlandRuntime::requestSocketPath() const {
@@ -32,6 +42,71 @@ namespace compositors::hyprland {
   const std::string& HyprlandRuntime::eventSocketPath() const {
     ensureResolved();
     return m_socketPaths.event;
+  }
+
+  bool HyprlandRuntime::connectSocket() {
+    if (m_socketPaths.event.empty()) {
+      return false;
+    }
+
+    cleanup();
+
+    m_eventSocketFd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (m_eventSocketFd < 0) {
+      kLog.warn("failed to create hyprland IPC socket: {}", std::strerror(errno));
+      return false;
+    }
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    if (m_socketPaths.event.size() >= sizeof(addr.sun_path)) {
+      kLog.warn("hyprland IPC socket path too long");
+      cleanup();
+      return false;
+    }
+    std::memcpy(addr.sun_path, m_socketPaths.event.c_str(), m_socketPaths.event.size() + 1);
+
+    if (::connect(m_eventSocketFd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+      kLog.warn("failed to connect to hyprland IPC {}: {}", m_socketPaths.event, std::strerror(errno));
+      cleanup();
+      return false;
+    }
+
+    const int flags = ::fcntl(m_eventSocketFd, F_GETFL, 0);
+    if (flags >= 0) {
+      (void)::fcntl(m_eventSocketFd, F_SETFL, flags | O_NONBLOCK);
+    }
+
+    kLog.info("connected to hyprland IPC at {}", m_socketPaths.event);
+    return true;
+  }
+
+  void HyprlandRuntime::dispatchPoll(short revents) {
+    if (m_eventSocketFd < 0) {
+      return;
+    }
+    if ((revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      kLog.warn("hyprland IPC disconnected");
+      cleanup();
+      for (const auto& eventHandler : m_eventHandlers) {
+        eventHandler->notifyChanged();
+      }
+      return;
+    }
+    if ((revents & POLLIN) != 0) {
+      readSocket();
+    }
+  }
+
+  void HyprlandRuntime::cleanup() {
+    if (m_eventSocketFd >= 0) {
+      ::close(m_eventSocketFd);
+      m_eventSocketFd = -1;
+    }
+    m_readBuffer.clear();
+    for (const auto& eventHandler : m_eventHandlers) {
+      eventHandler->notifyCleanup();
+    }
   }
 
   std::optional<std::string> HyprlandRuntime::request(std::string_view command) const {
@@ -100,9 +175,23 @@ namespace compositors::hyprland {
     return response;
   }
 
+  std::optional<nlohmann::json> HyprlandRuntime::requestJson(std::string_view command) const {
+    const auto response = request(command);
+    if (!response.has_value() || response->empty()) {
+      return std::nullopt;
+    }
+    try {
+      return nlohmann::json::parse(*response);
+    } catch (const nlohmann::json::exception& e) {
+      kLog.warn("failed to parse hyprland response for {}: {}", command, e.what());
+      return std::nullopt;
+    }
+  }
+
   void HyprlandRuntime::refresh() {
     m_socketPaths = {};
     m_resolved = false;
+    m_configIsLua = false;
     resolveSocketPaths();
   }
 
@@ -139,6 +228,81 @@ namespace compositors::hyprland {
         .request = hyprDir + "/.socket.sock",
         .event = hyprDir + "/.socket2.sock",
     };
+  }
+
+  void HyprlandRuntime::updateConfigProvider() {
+    const auto json = requestJson("j/status");
+    if (!json || !json->is_object()) {
+      return;
+    }
+    std::string configProvider = json->value("configProvider", "");
+    if (configProvider == "lua") {
+      m_configIsLua = true;
+    }
+  }
+
+  void HyprlandRuntime::registerEventHandler(HyprlandEventHandler* handler) { m_eventHandlers.push_back(handler); }
+
+  void HyprlandRuntime::unregisterEventHandler(HyprlandEventHandler* handler) {
+    m_eventHandlers.erase(std::remove(m_eventHandlers.begin(), m_eventHandlers.end(), handler), m_eventHandlers.end());
+  }
+
+  void HyprlandRuntime::handleEvent(std::string_view line) {
+    const auto split = line.find(">>");
+    if (split == std::string_view::npos) {
+      return;
+    }
+
+    const std::string_view event = line.substr(0, split);
+    const std::string_view data = line.substr(split + 2);
+
+    for (const auto& eventHandler : m_eventHandlers) {
+      eventHandler->handleEvent(event, data);
+    }
+  }
+
+  void HyprlandRuntime::readSocket() {
+    if (m_eventSocketFd < 0) {
+      kLog.warn("Event socket is not opened");
+      return;
+    }
+    char buffer[4096];
+    while (true) {
+      const ssize_t n = ::recv(m_eventSocketFd, buffer, sizeof(buffer), MSG_DONTWAIT);
+      if (n > 0) {
+        m_readBuffer.insert(m_readBuffer.end(), buffer, buffer + n);
+        continue;
+      }
+      if (n == 0) {
+        cleanup();
+        return;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        break;
+      }
+      if (errno == EINTR) {
+        continue;
+      }
+      kLog.warn("failed to read from hyprland IPC: {}", std::strerror(errno));
+      cleanup();
+      return;
+    }
+
+    parseMessages();
+  }
+
+  void HyprlandRuntime::parseMessages() {
+    while (true) {
+      auto it = std::find(m_readBuffer.begin(), m_readBuffer.end(), '\n');
+      if (it == m_readBuffer.end()) {
+        return;
+      }
+      std::string line(m_readBuffer.begin(), it);
+      m_readBuffer.erase(m_readBuffer.begin(), it + 1);
+      if (!line.empty()) {
+        handleEvent(line);
+      }
+    }
   }
 
 } // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_runtime.h
+++ b/src/compositors/hyprland/hyprland_runtime.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <json.hpp>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace compositors::hyprland {
+
+  class HyprlandEventHandler;
 
   struct IpcSocketPaths {
     std::string request;
@@ -13,20 +17,37 @@ namespace compositors::hyprland {
 
   class HyprlandRuntime {
   public:
-    HyprlandRuntime() = default;
+    HyprlandRuntime();
 
     [[nodiscard]] bool available() const;
+    [[nodiscard]] bool connectSocket();
+    [[nodiscard]] bool configIsLua() const;
     [[nodiscard]] const std::string& requestSocketPath() const;
     [[nodiscard]] const std::string& eventSocketPath() const;
     [[nodiscard]] std::optional<std::string> request(std::string_view command) const;
+    [[nodiscard]] std::optional<nlohmann::json> requestJson(std::string_view command) const;
     void refresh();
+    void cleanup();
+
+    void registerEventHandler(HyprlandEventHandler* handler);
+    void unregisterEventHandler(HyprlandEventHandler* handler);
+    [[nodiscard]] int pollFd() const noexcept { return m_eventSocketFd; }
+    void dispatchPoll(short revents);
 
   private:
     void ensureResolved() const;
     void resolveSocketPaths() const;
+    void updateConfigProvider();
+    void readSocket();
+    void parseMessages();
+    void handleEvent(std::string_view line);
 
+    int m_eventSocketFd = -1;
+    std::vector<char> m_readBuffer;
     mutable bool m_resolved = false;
+    bool m_configIsLua = false;
     mutable IpcSocketPaths m_socketPaths;
+    std::vector<HyprlandEventHandler*> m_eventHandlers;
   };
 
 } // namespace compositors::hyprland

--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -8,7 +8,6 @@
 #include <cerrno>
 #include <charconv>
 #include <cstring>
-#include <fcntl.h>
 #include <format>
 #include <string_view>
 #include <sys/socket.h>
@@ -38,63 +37,20 @@ namespace {
 
 HyprlandWorkspaceBackend::HyprlandWorkspaceBackend(OutputNameResolver outputNameResolver,
                                                    compositors::hyprland::HyprlandRuntime& runtime)
-    : m_outputNameResolver(std::move(outputNameResolver)), m_runtime(runtime) {}
+    : compositors::hyprland::HyprlandEventHandler(runtime), m_outputNameResolver(std::move(outputNameResolver)) {}
 
 void HyprlandWorkspaceBackend::setOutputNameResolver(OutputNameResolver outputNameResolver) {
   m_outputNameResolver = std::move(outputNameResolver);
 }
-
 bool HyprlandWorkspaceBackend::connectSocket() {
-  const auto& eventSocketPath = m_runtime.eventSocketPath();
-  if (eventSocketPath.empty()) {
-    return false;
+  if (m_runtime.connectSocket()) {
+    refreshSnapshot();
+    return true;
   }
-
-  cleanup();
-
-  m_eventSocketFd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (m_eventSocketFd < 0) {
-    kLog.warn("failed to create hyprland IPC socket: {}", std::strerror(errno));
-    return false;
-  }
-
-  sockaddr_un addr{};
-  addr.sun_family = AF_UNIX;
-  if (eventSocketPath.size() >= sizeof(addr.sun_path)) {
-    kLog.warn("hyprland IPC socket path too long");
-    cleanup();
-    return false;
-  }
-  std::memcpy(addr.sun_path, eventSocketPath.c_str(), eventSocketPath.size() + 1);
-
-  if (::connect(m_eventSocketFd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    kLog.warn("failed to connect to hyprland IPC {}: {}", eventSocketPath, std::strerror(errno));
-    cleanup();
-    return false;
-  }
-
-  const int flags = ::fcntl(m_eventSocketFd, F_GETFL, 0);
-  if (flags >= 0) {
-    (void)::fcntl(m_eventSocketFd, F_SETFL, flags | O_NONBLOCK);
-  }
-
-  refreshSnapshot();
-  kLog.info("connected to hyprland IPC at {}", eventSocketPath);
-  updateConfigProvider();
-  return true;
+  return false;
 }
 
-void HyprlandWorkspaceBackend::updateConfigProvider() {
-  m_configLua = false;
-  const auto json = requestJson("j/status");
-  if (!json || !json->is_object()) {
-    return;
-  }
-  std::string configProvider = json->value("configProvider", "");
-  if (configProvider.compare("lua") == 0) {
-    m_configLua = true;
-  }
-}
+bool HyprlandWorkspaceBackend::isAvailable() const noexcept { return m_runtime.available(); }
 
 void HyprlandWorkspaceBackend::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
@@ -103,7 +59,7 @@ void HyprlandWorkspaceBackend::activate(const std::string& id) {
     return;
   }
 
-  if (m_configLua) {
+  if (m_runtime.configIsLua()) {
     (void)m_runtime.request(std::format("dispatch hl.dsp.focus({{workspace = {}}})", id));
   } else {
     (void)m_runtime.request(std::format("dispatch workspace {}", id));
@@ -266,47 +222,18 @@ std::vector<WorkspaceWindow> HyprlandWorkspaceBackend::workspaceWindows(wl_outpu
   return result;
 }
 
-void HyprlandWorkspaceBackend::cleanup() {
-  if (m_eventSocketFd >= 0) {
-    ::close(m_eventSocketFd);
-    m_eventSocketFd = -1;
-  }
-  m_readBuffer.clear();
+void HyprlandWorkspaceBackend::notifyCleanup() {
   m_workspaces.clear();
   m_toplevels.clear();
   m_activeWorkspaceByMonitor.clear();
   m_nextOrdinal = 0;
 }
 
-void HyprlandWorkspaceBackend::dispatchPoll(short revents) {
-  if (m_eventSocketFd < 0) {
-    return;
-  }
-  if ((revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
-    kLog.warn("hyprland IPC disconnected");
-    cleanup();
-    if (m_changeCallback) {
-      m_changeCallback();
-    }
-    return;
-  }
-  if ((revents & POLLIN) != 0) {
-    readSocket();
-  }
-}
+void HyprlandWorkspaceBackend::cleanup() { m_runtime.cleanup(); }
 
-std::optional<nlohmann::json> HyprlandWorkspaceBackend::requestJson(const std::string& request) const {
-  const auto response = m_runtime.request(request);
-  if (!response.has_value() || response->empty()) {
-    return std::nullopt;
-  }
-  try {
-    return nlohmann::json::parse(*response);
-  } catch (const nlohmann::json::exception& e) {
-    kLog.warn("failed to parse hyprland response for {}: {}", request, e.what());
-    return std::nullopt;
-  }
-}
+int HyprlandWorkspaceBackend::pollFd() const noexcept { return m_runtime.pollFd(); }
+
+void HyprlandWorkspaceBackend::dispatchPoll(short revents) { m_runtime.dispatchPoll(revents); }
 
 void HyprlandWorkspaceBackend::refreshSnapshot() {
   refreshWorkspaces();
@@ -317,7 +244,7 @@ void HyprlandWorkspaceBackend::refreshSnapshot() {
 }
 
 void HyprlandWorkspaceBackend::refreshWorkspaces() {
-  const auto json = requestJson("j/workspaces");
+  const auto json = m_runtime.requestJson("j/workspaces");
   if (!json || !json->is_array()) {
     return;
   }
@@ -363,7 +290,7 @@ void HyprlandWorkspaceBackend::refreshWorkspaces() {
 }
 
 void HyprlandWorkspaceBackend::refreshMonitors() {
-  const auto json = requestJson("j/monitors");
+  const auto json = m_runtime.requestJson("j/monitors");
   if (!json || !json->is_array()) {
     return;
   }
@@ -398,7 +325,7 @@ void HyprlandWorkspaceBackend::refreshMonitors() {
 }
 
 void HyprlandWorkspaceBackend::refreshClients() {
-  const auto json = requestJson("j/clients");
+  const auto json = m_runtime.requestJson("j/clients");
   if (!json || !json->is_array()) {
     return;
   }
@@ -488,66 +415,13 @@ void HyprlandWorkspaceBackend::recomputeWorkspaceFlags() {
   }
 }
 
-void HyprlandWorkspaceBackend::notifyChanged() const {
+void HyprlandWorkspaceBackend::notifyChanged() {
   if (m_changeCallback) {
     m_changeCallback();
   }
 }
 
-void HyprlandWorkspaceBackend::readSocket() {
-  char buffer[4096];
-  while (true) {
-    const ssize_t n = ::recv(m_eventSocketFd, buffer, sizeof(buffer), MSG_DONTWAIT);
-    if (n > 0) {
-      m_readBuffer.insert(m_readBuffer.end(), buffer, buffer + n);
-      continue;
-    }
-    if (n == 0) {
-      cleanup();
-      if (m_changeCallback) {
-        m_changeCallback();
-      }
-      return;
-    }
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      break;
-    }
-    if (errno == EINTR) {
-      continue;
-    }
-    kLog.warn("failed to read from hyprland IPC: {}", std::strerror(errno));
-    cleanup();
-    if (m_changeCallback) {
-      m_changeCallback();
-    }
-    return;
-  }
-
-  parseMessages();
-}
-
-void HyprlandWorkspaceBackend::parseMessages() {
-  while (true) {
-    auto it = std::find(m_readBuffer.begin(), m_readBuffer.end(), '\n');
-    if (it == m_readBuffer.end()) {
-      return;
-    }
-    std::string line(m_readBuffer.begin(), it);
-    m_readBuffer.erase(m_readBuffer.begin(), it + 1);
-    if (!line.empty()) {
-      handleEvent(line);
-    }
-  }
-}
-
-void HyprlandWorkspaceBackend::handleEvent(std::string_view line) {
-  const auto split = line.find(">>");
-  if (split == std::string_view::npos) {
-    return;
-  }
-
-  const std::string_view event = line.substr(0, split);
-  const std::string_view data = line.substr(split + 2);
+void HyprlandWorkspaceBackend::handleEvent(std::string_view event, std::string_view data) {
 
   if (event == "configreloaded") {
     refreshSnapshot();

--- a/src/compositors/hyprland/hyprland_workspace_backend.h
+++ b/src/compositors/hyprland/hyprland_workspace_backend.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "compositors/workspace_backend.h"
+#include "hyprland_event_handler.h"
 
 #include <cstdint>
 #include <functional>
-#include <json.hpp>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -13,11 +13,13 @@
 
 namespace compositors::hyprland {
   class HyprlandRuntime;
+  class HyprlandEventHandler;
 } // namespace compositors::hyprland
 
 class HyprlandWorkspaceBackend final : public WorkspaceBackend,
                                        public WorkspaceOutputNameResolver,
-                                       public WorkspaceSocketConnector {
+                                       public WorkspaceSocketConnector,
+                                       public compositors::hyprland::HyprlandEventHandler {
 public:
   using OutputNameResolver = WorkspaceOutputNameResolver::Resolver;
 
@@ -27,7 +29,7 @@ public:
   void setOutputNameResolver(OutputNameResolver outputNameResolver) override;
 
   [[nodiscard]] const char* backendName() const override { return "hyprland-ipc"; }
-  [[nodiscard]] bool isAvailable() const noexcept override { return m_eventSocketFd >= 0; }
+  [[nodiscard]] bool isAvailable() const noexcept override;
   void setChangeCallback(ChangeCallback callback) override;
   void activate(const std::string& id) override;
   void activateForOutput(wl_output* output, const std::string& id) override;
@@ -38,8 +40,10 @@ public:
   appIdsByWorkspace(wl_output* output) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(wl_output* output) const override;
   void cleanup() override;
+  void notifyCleanup();
+  void notifyChanged();
 
-  [[nodiscard]] int pollFd() const noexcept override { return m_eventSocketFd; }
+  [[nodiscard]] int pollFd() const noexcept override;
   void dispatchPoll(short revents) override;
 
 private:
@@ -62,18 +66,13 @@ private:
     std::int32_t y = 0;
   };
 
-  void updateConfigProvider();
-  [[nodiscard]] std::optional<nlohmann::json> requestJson(const std::string& request) const;
   void refreshSnapshot();
   void refreshWorkspaces();
   void refreshMonitors();
   void refreshClients();
   void recomputeWorkspaceFlags();
-  void notifyChanged() const;
 
-  void readSocket();
-  void parseMessages();
-  void handleEvent(std::string_view line);
+  void handleEvent(std::string_view event, std::string_view data);
   void handleFocusedMonitor(std::string_view monitorName, std::string_view workspaceName);
   void handleWorkspaceActivated(std::string_view workspaceName);
   void clearUrgentForWorkspace(std::string_view workspaceName);
@@ -87,10 +86,6 @@ private:
   [[nodiscard]] static Workspace toWorkspace(const WorkspaceState& state);
 
   OutputNameResolver m_outputNameResolver;
-  compositors::hyprland::HyprlandRuntime& m_runtime;
-  int m_eventSocketFd = -1;
-  bool m_configLua;
-  std::vector<char> m_readBuffer;
   std::vector<WorkspaceState> m_workspaces;
   std::unordered_map<std::uint64_t, ToplevelState> m_toplevels;
   std::unordered_map<std::string, std::string> m_activeWorkspaceByMonitor;

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -1,6 +1,7 @@
 #include "shell/session/session_panel.h"
 
 #include "compositors/compositor_detect.h"
+#include "compositors/hyprland/hyprland_runtime.h"
 #include "compositors/niri/niri_runtime.h"
 #include "config/config_service.h"
 #include "core/log.h"
@@ -47,8 +48,14 @@ namespace {
     const compositors::CompositorKind compositor = logActionContext("logout");
 
     switch (compositor) {
-    case compositors::CompositorKind::Hyprland:
-      return process::launchFirstAvailable({{"hyprctl", "dispatch", "exit"}});
+    case compositors::CompositorKind::Hyprland: {
+      compositors::hyprland::HyprlandRuntime runtime;
+      if (runtime.configIsLua()) {
+        return (runtime.request("dispatch hl.dsp.exit()") != std::nullopt);
+      } else {
+        return (runtime.request("dispatch exit") != std::nullopt);
+      }
+    }
     case compositors::CompositorKind::Sway:
       return process::launchFirstAvailable({{"swaymsg", "exit"}, {"i3-msg", "exit"}});
     case compositors::CompositorKind::Niri: {


### PR DESCRIPTION
- deduplicate code, all socket interaction and json handling for hyprland is moved to hyprland_runtime.
- use the corect command for hyprland, depending on whether the config is lua or conf.

Tested with hyprland lua:
- changing workspaces
- keyboard layout changing
- dpms
- logout

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ x] Code follows project style guidelines
- [ x] Self-reviewed my code
- [ ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
