### PR TITLE
fix: prevent notification history crash on invalid UTF-8

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -715,3 +715,18 @@ executable('noctalia',
 install_subdir('assets',
   install_dir: get_option('datadir') / 'noctalia',
 )
+
+notification_history_utf8_test = executable('notification_history_utf8_test',
+  sources: files(
+    'tests/notification_history_utf8_test.cpp',
+    'src/core/log.cpp',
+    'src/notification/notification_history_store.cpp',
+    'src/render/core/image_decoder.cpp',
+  ),
+  dependencies: [
+    libwebp_dep,
+  ],
+  include_directories: _noctalia_inc,
+)
+
+test('notification_history_utf8', notification_history_utf8_test)

--- a/src/dbus/notification/notification_service.cpp
+++ b/src/dbus/notification/notification_service.cpp
@@ -127,10 +127,7 @@ static constexpr int32_t k_min_timeout = -1;
 
 namespace {
 
-  std::string clamp_str(std::string_view s) {
-    const auto len = std::min(s.size(), k_max_string_len);
-    return std::string{s.substr(0, len)};
-  }
+  std::string clamp_str(std::string_view s) { return StringUtils::truncateUtf8(s, k_max_string_len); }
 
   std::vector<std::string> sanitize_actions(const std::vector<std::string>& actions) {
     std::vector<std::string> sanitized;

--- a/src/notification/notification_history_store.cpp
+++ b/src/notification/notification_history_store.cpp
@@ -697,7 +697,7 @@ bool saveNotificationHistoryToFile(const std::filesystem::path& path,
     kLog.warn("could not write notification history tmp {}", tmpPath);
     return false;
   }
-  out << root.dump(2);
+  out << root.dump(2, ' ', false, nlohmann::json::error_handler_t::replace);
   out.close();
 
   std::error_code ec;

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -149,6 +149,18 @@ namespace StringUtils {
     return std::string(text);
   }
 
+  [[nodiscard]] inline std::string truncateUtf8(std::string_view text, std::size_t maxBytes) {
+    if (text.size() <= maxBytes) {
+      return std::string(text);
+    }
+
+    std::size_t end = maxBytes;
+    while (end > 0 && end < text.size() && (static_cast<unsigned char>(text[end]) & 0xC0U) == 0x80U) {
+      --end;
+    }
+    return std::string(text.substr(0, end));
+  }
+
   // Strip HTML/Pango tags and unescape XML entities.
   [[nodiscard]] inline std::string sanitizeMarkup(std::string_view s) {
     std::string out;

--- a/tests/notification_history_utf8_test.cpp
+++ b/tests/notification_history_utf8_test.cpp
@@ -1,0 +1,103 @@
+#include "notification/notification_history_store.h"
+#include "notification/notification_manager.h"
+#include "util/string_utils.h"
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <unistd.h>
+#include <utility>
+
+namespace {
+
+  Notification makeNotification(std::string body) {
+    const auto now = Clock::now();
+    const auto wallNow = WallClock::now();
+    return Notification{
+        .id = 314,
+        .origin = NotificationOrigin::External,
+        .appName = "test",
+        .summary = "summary",
+        .body = std::move(body),
+        .timeout = 6000,
+        .urgency = Urgency::Normal,
+        .actions = {},
+        .icon = std::nullopt,
+        .imageData = std::nullopt,
+        .category = std::nullopt,
+        .desktopEntry = std::nullopt,
+        .receivedTime = now,
+        .expiryTime = std::nullopt,
+        .receivedWallClock = wallNow,
+        .expiryWallClock = std::nullopt,
+    };
+  }
+
+  std::filesystem::path testPath() {
+    return std::filesystem::temp_directory_path() /
+           ("noctalia-notification-history-utf8-" + std::to_string(static_cast<long long>(getpid())) + ".json");
+  }
+
+} // namespace
+
+int main() {
+  std::string splitBoundary(1023, 'a');
+  splitBoundary.push_back(static_cast<char>(0xD1));
+  splitBoundary.push_back(static_cast<char>(0x80));
+
+  const std::string truncated = StringUtils::truncateUtf8(splitBoundary, 1024);
+  if (truncated.size() != 1023) {
+    std::cerr << "truncateUtf8 kept a partial code point at the byte limit\n";
+    return 1;
+  }
+
+  std::string exactBoundary(1022, 'a');
+  exactBoundary.push_back(static_cast<char>(0xD1));
+  exactBoundary.push_back(static_cast<char>(0x80));
+
+  const std::string exact = StringUtils::truncateUtf8(exactBoundary, 1024);
+  if (exact.size() != 1024) {
+    std::cerr << "truncateUtf8 removed a complete code point at the byte limit\n";
+    return 1;
+  }
+
+  const auto path = testPath();
+  std::filesystem::remove(path);
+  std::filesystem::remove(path.string() + ".tmp");
+
+  std::string body = "prefix ";
+  body.push_back(static_cast<char>(0xD1));
+
+  std::deque<NotificationHistoryEntry> entries;
+  entries.push_back(NotificationHistoryEntry{
+      .notification = makeNotification(std::move(body)),
+      .active = true,
+      .closeReason = std::nullopt,
+      .eventSerial = 1,
+  });
+
+  try {
+    if (!saveNotificationHistoryToFile(path, entries, 315, 2)) {
+      std::cerr << "saveNotificationHistoryToFile returned false\n";
+      return 1;
+    }
+  } catch (const std::exception& e) {
+    std::cerr << "saveNotificationHistoryToFile threw: " << e.what() << '\n';
+    return 1;
+  }
+
+  std::ifstream in(path, std::ios::binary);
+  if (!in.good()) {
+    std::cerr << "history file was not written\n";
+    return 1;
+  }
+
+  std::filesystem::remove(path);
+  return 0;
+}


### PR DESCRIPTION
## Problem

Long notification strings were truncated with a raw byte `substr(0, 1024)`. When the cut landed in the middle of a multi-byte UTF-8 code point, the stored notification body contained invalid UTF-8.

Notification history persistence later serialized that body with the default strict `nlohmann::json::dump(2)` path. That throws `json.exception.type_error.316` for incomplete UTF-8. In the observed crash, the uncaught exception triggered `std::terminate` and aborted the process.

## Summary

- truncate notification strings at UTF-8 code point boundaries
- serialize notification history with replacement handling for malformed persisted strings
- add a regression test for split UTF-8 notification bodies

## Tests

- `find src \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 clang-format --dry-run -Werror`
- `meson test -C build-pr notification_history_utf8 --print-errorlogs`
- `meson compile -C build-pr`
- `meson test -C build-pr --print-errorlogs`
