### PR TITLE
fix(tray) Some of the icons (Easyeffects) was come back black on black

### DIFF
--- a/src/render/core/image_file_loader.cpp
+++ b/src/render/core/image_file_loader.cpp
@@ -16,10 +16,6 @@
 
 namespace {
 
-  bool isLikelySymbolicIconPath(std::string_view path) {
-    return path.find("symbolic") != std::string_view::npos || path.find("/status/") != std::string_view::npos;
-  }
-
   // Convert a cairo ARGB32 image surface (premultiplied BGRA on little-endian)
   // into the non-premultiplied RGBA buffer the rest of the pipeline expects.
   void argb32ToRgba(const unsigned char* src, int srcStride, std::uint8_t* dst, int width, int height) {
@@ -47,7 +43,7 @@ namespace {
   }
 
   std::optional<LoadedImageFile> rasterizeSvg(const std::vector<std::uint8_t>& fileData, int targetSize,
-                                              bool symbolicMonochrome, std::string* errorMessage) {
+                                              std::string* errorMessage) {
     GError* gerror = nullptr;
     RsvgHandle* handle = rsvg_handle_new_from_data(fileData.data(), fileData.size(), &gerror);
     if (handle == nullptr) {
@@ -141,18 +137,6 @@ namespace {
     argb32ToRgba(cairo_image_surface_get_data(surface), cairo_image_surface_get_stride(surface), loaded.rgba.data(),
                  width, height);
 
-    if (symbolicMonochrome) {
-      for (std::size_t i = 0; i + 3 < loaded.rgba.size(); i += 4) {
-        const std::uint8_t a = loaded.rgba[i + 3];
-        if (a == 0) {
-          continue;
-        }
-        loaded.rgba[i + 0] = 255;
-        loaded.rgba[i + 1] = 255;
-        loaded.rgba[i + 2] = 255;
-      }
-    }
-
     cairo_surface_destroy(surface);
     g_object_unref(handle);
     return loaded;
@@ -177,7 +161,7 @@ std::optional<LoadedImageFile> loadImageFile(const std::string& path, int target
   }
 
   if (path.ends_with(".svg") || path.ends_with(".SVG")) {
-    return rasterizeSvg(fileData, targetSize, isLikelySymbolicIconPath(path), errorMessage);
+    return rasterizeSvg(fileData, targetSize, errorMessage);
   }
 
   if (auto decoded = decodeRasterImage(fileData.data(), fileData.size(), errorMessage)) {

--- a/src/render/core/image_file_loader.cpp
+++ b/src/render/core/image_file_loader.cpp
@@ -16,6 +16,10 @@
 
 namespace {
 
+  bool isLikelySymbolicIconPath(std::string_view path) {
+    return path.find("symbolic") != std::string_view::npos || path.find("/status/") != std::string_view::npos;
+  }
+
   // Convert a cairo ARGB32 image surface (premultiplied BGRA on little-endian)
   // into the non-premultiplied RGBA buffer the rest of the pipeline expects.
   void argb32ToRgba(const unsigned char* src, int srcStride, std::uint8_t* dst, int width, int height) {
@@ -43,7 +47,7 @@ namespace {
   }
 
   std::optional<LoadedImageFile> rasterizeSvg(const std::vector<std::uint8_t>& fileData, int targetSize,
-                                              std::string* errorMessage) {
+                                              bool symbolicMonochrome, std::string* errorMessage) {
     GError* gerror = nullptr;
     RsvgHandle* handle = rsvg_handle_new_from_data(fileData.data(), fileData.size(), &gerror);
     if (handle == nullptr) {
@@ -137,6 +141,18 @@ namespace {
     argb32ToRgba(cairo_image_surface_get_data(surface), cairo_image_surface_get_stride(surface), loaded.rgba.data(),
                  width, height);
 
+    if (symbolicMonochrome) {
+      for (std::size_t i = 0; i + 3 < loaded.rgba.size(); i += 4) {
+        const std::uint8_t a = loaded.rgba[i + 3];
+        if (a == 0) {
+          continue;
+        }
+        loaded.rgba[i + 0] = 255;
+        loaded.rgba[i + 1] = 255;
+        loaded.rgba[i + 2] = 255;
+      }
+    }
+
     cairo_surface_destroy(surface);
     g_object_unref(handle);
     return loaded;
@@ -161,7 +177,7 @@ std::optional<LoadedImageFile> loadImageFile(const std::string& path, int target
   }
 
   if (path.ends_with(".svg") || path.ends_with(".SVG")) {
-    return rasterizeSvg(fileData, targetSize, errorMessage);
+    return rasterizeSvg(fileData, targetSize, isLikelySymbolicIconPath(path), errorMessage);
   }
 
   if (auto decoded = decodeRasterImage(fileData.data(), fileData.size(), errorMessage)) {

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -106,9 +106,12 @@ namespace {
       if (a == 0) {
         continue;
       }
+      const float lum =
+          (loaded->rgba[i] * 0.299f + loaded->rgba[i + 1] * 0.587f + loaded->rgba[i + 2] * 0.114f) / 255.0f;
       loaded->rgba[i + 0] = rr;
       loaded->rgba[i + 1] = gg;
       loaded->rgba[i + 2] = bb;
+      loaded->rgba[i + 3] = static_cast<std::uint8_t>(std::lround(a * lum));
     }
 
     return loaded;

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -3,6 +3,7 @@
 #include "core/log.h"
 #include "core/ui_phase.h"
 #include "dbus/tray/tray_service.h"
+#include "render/core/image_file_loader.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
@@ -79,6 +80,38 @@ namespace {
 
   bool isSymbolicIconPath(std::string_view path) {
     return path.find("symbolic") != std::string_view::npos || path.find("/status/") != std::string_view::npos;
+  }
+
+  bool isSvgPath(std::string_view path) { return path.ends_with(".svg") || path.ends_with(".SVG"); }
+
+  std::optional<LoadedImageFile> loadSymbolicTrayIcon(const std::string& path, int targetSize,
+                                                      const Color& symbolicColor) {
+    std::string loadError;
+    auto loaded = loadImageFile(path, targetSize, &loadError);
+    if (!loaded) {
+      kLog.debug("tray widget symbolic icon decode failed path={} error={}", path, loadError);
+      return std::nullopt;
+    }
+
+    auto toByte = [](float channel) -> std::uint8_t {
+      const float clamped = std::clamp(channel, 0.0f, 1.0f);
+      return static_cast<std::uint8_t>(std::lround(clamped * 255.0f));
+    };
+    const std::uint8_t rr = toByte(symbolicColor.r);
+    const std::uint8_t gg = toByte(symbolicColor.g);
+    const std::uint8_t bb = toByte(symbolicColor.b);
+
+    for (std::size_t i = 0; i + 3 < loaded->rgba.size(); i += 4) {
+      const std::uint8_t a = loaded->rgba[i + 3];
+      if (a == 0) {
+        continue;
+      }
+      loaded->rgba[i + 0] = rr;
+      loaded->rgba[i + 1] = gg;
+      loaded->rgba[i + 2] = bb;
+    }
+
+    return loaded;
   }
 
   bool isUniqueBusName(std::string_view value) { return !value.empty() && value.front() == ':'; }
@@ -413,9 +446,22 @@ void TrayWidget::rebuild(Renderer& renderer) {
       auto image = std::make_unique<Image>();
       image->setFit(ImageFit::Contain);
       image->setSize(iconSize, iconSize);
-      if (image->setSourceFile(renderer, iconPath, iconRequestSize, true)) {
-        if (isSymbolicIconPath(iconPath)) {
-          image->setTint(resolveColorSpec(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))));
+      bool loadedFromFile = false;
+      const bool symbolicPath = isSymbolicIconPath(iconPath);
+      const Color symbolicColor = resolveColorSpec(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
+      if (symbolicPath && isSvgPath(iconPath)) {
+        if (auto symbolic = loadSymbolicTrayIcon(iconPath, iconRequestSize, symbolicColor)) {
+          loadedFromFile = image->setSourceRaw(renderer, symbolic->rgba.data(), symbolic->rgba.size(), symbolic->width,
+                                               symbolic->height, 0, PixmapFormat::RGBA, true);
+        }
+      }
+      if (!loadedFromFile) {
+        loadedFromFile = image->setSourceFile(renderer, iconPath, iconRequestSize, true);
+      }
+
+      if (loadedFromFile) {
+        if (symbolicPath && !isSvgPath(iconPath)) {
+          image->setTint(symbolicColor);
         }
         iconW = iconSize;
         iconH = iconSize;

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -745,13 +745,14 @@ std::string TrayWidget::resolveIconPath(const TrayItemInfo& item) {
                                        : (isUniqueBusName(item.busName) ? item.objectPath : item.id);
 
   std::vector<std::pair<const char*, const std::string*>> candidates;
-  candidates.reserve(6);
+  candidates.reserve(12);
   candidates.emplace_back("preferred", &preferred);
-  // When an explicit tray IconName is provided, treat it as authoritative.
-  // Falling back to generic app-id/title mappings can hide stateful icon
-  // changes (e.g. indicator on/off variants) behind a constant app icon.
+  // Prefer explicit tray IconName first, but still try metadata-derived
+  // candidates if that only yields symbolic/no result. Some items expose a
+  // symbolic tray name while a full-color app icon is discoverable via stable
+  // app identifiers.
   const bool hasTargetPixmap = item.needsAttention ? !item.attentionArgb32.empty() : !item.iconArgb32.empty();
-  if (preferred.empty() && !hasTargetPixmap) {
+  if (!hasTargetPixmap) {
     candidates.emplace_back("itemName", &item.itemName);
     candidates.emplace_back("processName", &item.processName);
     candidates.emplace_back("title", &item.title);

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -414,6 +414,9 @@ void TrayWidget::rebuild(Renderer& renderer) {
       image->setFit(ImageFit::Contain);
       image->setSize(iconSize, iconSize);
       if (image->setSourceFile(renderer, iconPath, iconRequestSize, true)) {
+        if (isSymbolicIconPath(iconPath)) {
+          image->setTint(resolveColorSpec(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))));
+        }
         iconW = iconSize;
         iconH = iconSize;
         kLog.debug("tray widget image load ok id={} path={} size={}x{} tex={} ptr={}", item.id, iconPath,
@@ -669,9 +672,15 @@ void TrayWidget::buildDesktopIconIndex() {
 }
 
 std::string TrayWidget::resolveIconPath(const TrayItemInfo& item) {
+  const bool hasNamedIcon = item.needsAttention ? !item.attentionIconName.empty() : !item.iconName.empty();
   if (const auto it = m_preferPixmap.find(item.id); it != m_preferPixmap.end() && it->second) {
-    kLog.debug("tray widget resolve id={} source=dynamic-pixmap", item.id);
-    return {};
+    // Some indicators publish pixmaps late (after startup) that are monochrome
+    // or stale. Keep using named-icon resolution when available.
+    if (!hasNamedIcon) {
+      kLog.debug("tray widget resolve id={} source=dynamic-pixmap", item.id);
+      return {};
+    }
+    kLog.debug("tray widget resolve id={} source=named-icon-over-pixmap", item.id);
   }
 
   if (const auto it = m_preferredIconPaths.find(item.id); it != m_preferredIconPaths.end() && !it->second.empty()) {
@@ -747,12 +756,11 @@ std::string TrayWidget::resolveIconPath(const TrayItemInfo& item) {
   std::vector<std::pair<const char*, const std::string*>> candidates;
   candidates.reserve(12);
   candidates.emplace_back("preferred", &preferred);
-  // Prefer explicit tray IconName first, but still try metadata-derived
-  // candidates if that only yields symbolic/no result. Some items expose a
-  // symbolic tray name while a full-color app icon is discoverable via stable
-  // app identifiers.
+  // When an explicit tray IconName is provided, treat it as authoritative.
+  // Falling back to generic app-id/title mappings can hide stateful icon
+  // changes (e.g. indicator on/off variants) behind a constant app icon.
   const bool hasTargetPixmap = item.needsAttention ? !item.attentionArgb32.empty() : !item.iconArgb32.empty();
-  if (!hasTargetPixmap) {
+  if (preferred.empty() && !hasTargetPixmap) {
     candidates.emplace_back("itemName", &item.itemName);
     candidates.emplace_back("processName", &item.processName);
     candidates.emplace_back("title", &item.title);


### PR DESCRIPTION
# Pull Request
## Motivation
It fills the colour in based on the onSuface color when it comes back uncoloured

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
easyeffects

## Testing
- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [X] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [X] Documentation or comments updated (if relevant)