### PR TITLE
Hyprland: use correct workspacev2 argument

### DIFF
--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -379,7 +379,7 @@ void HyprlandWorkspaceBackend::handleEvent(std::string_view event, std::string_v
 
   if (event == "workspacev2") {
     const auto args = parseEventArgs(data, 2);
-    const auto id = parseInt(args[1]);
+    const auto id = parseInt(args[0]);
     if (!id.has_value()) {
       return;
     }


### PR DESCRIPTION
during rework of df184243b the workspacev2 event processing converted the workspacename argument to a workspaceid.

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ x] Code follows project style guidelines
- [ x] Self-reviewed my code
- [ x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
