### PR TITLE
fix(mpris): Stops hammering unresponsive players after a few attempts

### DIFF
--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -315,7 +315,8 @@ namespace {
   constexpr auto k_position_retry_interval = std::chrono::milliseconds{1000};
   constexpr auto k_position_candidate_retry_interval = std::chrono::milliseconds{250};
   constexpr auto k_position_retry_max_backoff = std::chrono::milliseconds{30'000};
-  constexpr int k_position_refresh_failure_threshold = 5;
+  // Threshold for consecutive failures while fetching full player properties in addOrRefreshPlayer.
+  constexpr int k_player_properties_failure_threshold = 5;
   constexpr auto k_recent_track_change_guard_window = std::chrono::milliseconds{8000};
   constexpr auto k_recent_track_change_slack = std::chrono::milliseconds{750};
   constexpr auto k_position_candidate_match_window = std::chrono::milliseconds{2500};
@@ -409,6 +410,33 @@ void MprisService::refreshPlayerPosition(const std::string& busName, bool notify
   }
 }
 
+bool MprisService::shouldRetryPositionRefresh(const std::string& busName) const {
+  const auto failureIt = m_positionRefreshFailures.find(busName);
+  // This guard uses full-properties fetch failures tracked in addOrRefreshPlayer.
+  // Position-only Get(Position) failures in refreshPlayerPosition are logged but do not increment this counter.
+  return failureIt == m_positionRefreshFailures.end() || failureIt->second < k_player_properties_failure_threshold;
+}
+
+std::chrono::milliseconds MprisService::positionRetryInterval(const std::string& busName,
+                                                              std::chrono::milliseconds fallback) const {
+  if (const auto backoffIt = m_positionRefreshBackoffMs.find(busName); backoffIt != m_positionRefreshBackoffMs.end()) {
+    return backoffIt->second;
+  }
+  return fallback;
+}
+
+void MprisService::schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback) {
+  auto& timerId = m_positionResyncTimers[busName];
+  const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
+  const auto retryInterval = positionRetryInterval(busName, fallback);
+  timerId = TimerManager::instance().start(timerId, retryInterval, [this, timerAliveGuard, busName]() {
+    if (timerAliveGuard.expired()) {
+      return;
+    }
+    refreshPlayerPosition(busName, true);
+  });
+}
+
 void MprisService::applyPositionSample(const std::string& busName, int64_t rawPositionUs, bool notifyChange) {
   const auto playerIt = m_players.find(busName);
   if (playerIt == m_players.end()) {
@@ -466,14 +494,7 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
     if (playerIt->second.playbackStatus != "Stopped") {
       m_positionRefreshFailures[busName] = 0;
       m_positionRefreshBackoffMs.erase(busName);
-      auto& timerId = m_positionResyncTimers[busName];
-      const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-      timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-        if (timerAliveGuard.expired()) {
-          return;
-        }
-        refreshPlayerPosition(busName, true);
-      });
+      schedulePositionRefreshRetry(busName, k_position_retry_interval);
     }
     return;
   }
@@ -541,19 +562,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       m_pendingPositionCandidateUs[busName] = normalizedUs;
       m_pendingPositionCandidateMatches[busName] = 0;
       m_pendingPositionCandidateAt[busName] = now;
-      if (playerIt->second.playbackStatus == "Playing") {
-        const auto failureIt = m_positionRefreshFailures.find(busName);
-        if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
-          auto& timerId = m_positionResyncTimers[busName];
-          const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-          timerId = TimerManager::instance().start(timerId, k_position_candidate_retry_interval,
-                                                   [this, timerAliveGuard, busName]() {
-                                                     if (timerAliveGuard.expired()) {
-                                                       return;
-                                                     }
-                                                     refreshPlayerPosition(busName, true);
-                                                   });
-        }
+      if (playerIt->second.playbackStatus == "Playing" && shouldRetryPositionRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval);
       }
       return;
     }
@@ -564,15 +574,7 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       if (matchCount < 2) {
         m_pendingPositionCandidateUs[busName] = normalizedUs;
         m_pendingPositionCandidateAt[busName] = now;
-        auto& timerId = m_positionResyncTimers[busName];
-        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId = TimerManager::instance().start(timerId, k_position_candidate_retry_interval,
-                                                 [this, timerAliveGuard, busName]() {
-                                                   if (timerAliveGuard.expired()) {
-                                                     return;
-                                                   }
-                                                   refreshPlayerPosition(busName, true);
-                                                 });
+        schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval);
         return;
       }
     }
@@ -583,21 +585,9 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
   if (!authoritativeSample) {
     const bool hasAuthoritativeSample =
         m_hasAuthoritativePositionSample.contains(busName) && m_hasAuthoritativePositionSample.at(busName);
-    if (playerIt->second.playbackStatus == "Playing" && !hasAuthoritativeSample) {
-      const auto failureIt = m_positionRefreshFailures.find(busName);
-      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
-        auto& timerId = m_positionResyncTimers[busName];
-        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        const auto backoffIt = m_positionRefreshBackoffMs.find(busName);
-        const auto retryInterval =
-            (backoffIt != m_positionRefreshBackoffMs.end()) ? backoffIt->second : k_position_retry_interval;
-        timerId = TimerManager::instance().start(timerId, retryInterval, [this, timerAliveGuard, busName]() {
-          if (timerAliveGuard.expired()) {
-            return;
-          }
-          refreshPlayerPosition(busName, true);
-        });
-      }
+    if (playerIt->second.playbackStatus == "Playing" && !hasAuthoritativeSample &&
+        shouldRetryPositionRefresh(busName)) {
+      schedulePositionRefreshRetry(busName, k_position_retry_interval);
     }
     return;
   }
@@ -1597,14 +1587,15 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 
                   const bool rootFailed = rootErr.has_value();
                   const bool playerFailed = playerErr.has_value();
+                  const bool hadRefreshFailure = rootFailed || playerFailed;
 
-                  // Track position refresh failures and give up after threshold
-                  if (rootFailed || playerFailed) {
+                  // Track full-properties fetch failures and give up after threshold.
+                  if (hadRefreshFailure) {
                     int& failureCount = m_positionRefreshFailures[busName];
                     ++failureCount;
 
-                    if (failureCount >= k_position_refresh_failure_threshold) {
-                      kLog.warn("player position query disabled after {} failures name={}", failureCount, busName);
+                    if (failureCount >= k_player_properties_failure_threshold) {
+                      kLog.warn("player properties refresh disabled after {} failures name={}", failureCount, busName);
                       // Cancel the timer to stop polling this player
                       if (auto it = m_positionResyncTimers.find(busName); it != m_positionResyncTimers.end()) {
                         TimerManager::instance().cancel(it->second);
@@ -1619,7 +1610,7 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
                       } else {
                         backoff = std::min(backoff * 2, k_position_retry_max_backoff);
                       }
-                      kLog.debug("player position query backoff failures={} interval={}ms name={}", failureCount,
+                      kLog.debug("player properties refresh backoff failures={} interval={}ms name={}", failureCount,
                                  backoff.count(), busName);
                     }
                   }
@@ -1644,7 +1635,7 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 
                   const MprisPlayerInfo info =
                       readPlayerInfoFromProperties(busName, effectiveRootProps, effectivePlayerProps);
-                  applyPlayerSnapshot(busName, info, hadPositionSignal);
+                  applyPlayerSnapshot(busName, info, hadPositionSignal, hadRefreshFailure);
                 });
           } catch (const sdbus::Error& e) {
             kLog.warn("player query failed name={} err={}", busName, e.what());
@@ -1657,12 +1648,14 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
   }
 }
 
-void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info,
-                                       bool hadPositionSignal) {
+void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info, bool hadPositionSignal,
+                                       bool hadRefreshFailure) {
   m_recoveryBackoffMs = std::chrono::milliseconds{500};
-  // Reset position refresh failures when we get a successful snapshot
-  m_positionRefreshFailures[busName] = 0;
-  m_positionRefreshBackoffMs.erase(busName);
+  // Reset position refresh state only when both interfaces were fetched successfully.
+  if (!hadRefreshFailure) {
+    m_positionRefreshFailures[busName] = 0;
+    m_positionRefreshBackoffMs.erase(busName);
+  }
   const auto previousActive = activePlayer();
   const auto now = std::chrono::steady_clock::now();
   if (info.playbackStatus == "Playing") {
@@ -1703,17 +1696,8 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      const auto failureIt = m_positionRefreshFailures.find(busName);
-      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
-        auto& timerId = m_positionResyncTimers[busName];
-        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId =
-            TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-              if (timerAliveGuard.expired()) {
-                return;
-              }
-              refreshPlayerPosition(busName, true);
-            });
+      if (shouldRetryPositionRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_retry_interval);
       }
     }
     return;
@@ -1870,17 +1854,8 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      const auto failureIt = m_positionRefreshFailures.find(busName);
-      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
-        auto& timerId = m_positionResyncTimers[busName];
-        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId =
-            TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-              if (timerAliveGuard.expired()) {
-                return;
-              }
-              refreshPlayerPosition(busName, true);
-            });
+      if (shouldRetryPositionRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_retry_interval);
       }
     }
 

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -314,6 +314,7 @@ namespace {
   constexpr Logger kLog("mpris");
   constexpr auto k_position_retry_interval = std::chrono::milliseconds{1000};
   constexpr auto k_position_candidate_retry_interval = std::chrono::milliseconds{250};
+  constexpr auto k_position_retry_initial_backoff = std::chrono::milliseconds{2000};
   constexpr auto k_position_retry_max_backoff = std::chrono::milliseconds{30'000};
   // Threshold for consecutive failures while fetching full player properties in addOrRefreshPlayer.
   constexpr int k_player_properties_failure_threshold = 5;
@@ -410,25 +411,29 @@ void MprisService::refreshPlayerPosition(const std::string& busName, bool notify
   }
 }
 
-bool MprisService::shouldRetryPositionRefresh(const std::string& busName) const {
-  const auto failureIt = m_positionRefreshFailures.find(busName);
-  // This guard uses full-properties fetch failures tracked in addOrRefreshPlayer.
-  // Position-only Get(Position) failures in refreshPlayerPosition are logged but do not increment this counter.
-  return failureIt == m_positionRefreshFailures.end() || failureIt->second < k_player_properties_failure_threshold;
+bool MprisService::shouldRetryPropertiesRefresh(const std::string& busName) const {
+  const auto failureIt = m_playerPropertiesFailures.find(busName);
+  return failureIt == m_playerPropertiesFailures.end() || failureIt->second < k_player_properties_failure_threshold;
 }
 
-std::chrono::milliseconds MprisService::positionRetryInterval(const std::string& busName,
-                                                              std::chrono::milliseconds fallback) const {
-  if (const auto backoffIt = m_positionRefreshBackoffMs.find(busName); backoffIt != m_positionRefreshBackoffMs.end()) {
+std::chrono::milliseconds MprisService::propertiesRefreshRetryInterval(const std::string& busName,
+                                                                       std::chrono::milliseconds fallback,
+                                                                       bool usePropertiesBackoff) const {
+  if (!usePropertiesBackoff) {
+    return fallback;
+  }
+  if (const auto backoffIt = m_playerPropertiesRefreshBackoffMs.find(busName);
+      backoffIt != m_playerPropertiesRefreshBackoffMs.end()) {
     return backoffIt->second;
   }
   return fallback;
 }
 
-void MprisService::schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback) {
+void MprisService::schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback,
+                                                bool usePropertiesBackoff) {
   auto& timerId = m_positionResyncTimers[busName];
   const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-  const auto retryInterval = positionRetryInterval(busName, fallback);
+  const auto retryInterval = propertiesRefreshRetryInterval(busName, fallback, usePropertiesBackoff);
   timerId = TimerManager::instance().start(timerId, retryInterval, [this, timerAliveGuard, busName]() {
     if (timerAliveGuard.expired()) {
       return;
@@ -491,10 +496,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
         m_changeCallback();
       }
     }
-    if (playerIt->second.playbackStatus != "Stopped") {
-      m_positionRefreshFailures[busName] = 0;
-      m_positionRefreshBackoffMs.erase(busName);
-      schedulePositionRefreshRetry(busName, k_position_retry_interval);
+    if (playerIt->second.playbackStatus != "Stopped" && shouldRetryPropertiesRefresh(busName)) {
+      schedulePositionRefreshRetry(busName, k_position_retry_interval, true);
     }
     return;
   }
@@ -562,8 +565,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       m_pendingPositionCandidateUs[busName] = normalizedUs;
       m_pendingPositionCandidateMatches[busName] = 0;
       m_pendingPositionCandidateAt[busName] = now;
-      if (playerIt->second.playbackStatus == "Playing" && shouldRetryPositionRefresh(busName)) {
-        schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval);
+      if (playerIt->second.playbackStatus == "Playing" && shouldRetryPropertiesRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval, false);
       }
       return;
     }
@@ -574,7 +577,9 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       if (matchCount < 2) {
         m_pendingPositionCandidateUs[busName] = normalizedUs;
         m_pendingPositionCandidateAt[busName] = now;
-        schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval);
+        if (shouldRetryPropertiesRefresh(busName)) {
+          schedulePositionRefreshRetry(busName, k_position_candidate_retry_interval, false);
+        }
         return;
       }
     }
@@ -586,8 +591,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
     const bool hasAuthoritativeSample =
         m_hasAuthoritativePositionSample.contains(busName) && m_hasAuthoritativePositionSample.at(busName);
     if (playerIt->second.playbackStatus == "Playing" && !hasAuthoritativeSample &&
-        shouldRetryPositionRefresh(busName)) {
-      schedulePositionRefreshRetry(busName, k_position_retry_interval);
+        shouldRetryPropertiesRefresh(busName)) {
+      schedulePositionRefreshRetry(busName, k_position_retry_interval, true);
     }
     return;
   }
@@ -1587,14 +1592,14 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 
                   const bool rootFailed = rootErr.has_value();
                   const bool playerFailed = playerErr.has_value();
-                  const bool hadRefreshFailure = rootFailed || playerFailed;
+                  const bool hadFullRefreshFailure = rootFailed && playerFailed;
 
                   // Track full-properties fetch failures and give up after threshold.
-                  if (hadRefreshFailure) {
-                    int& failureCount = m_positionRefreshFailures[busName];
+                  if (hadFullRefreshFailure) {
+                    int& failureCount = m_playerPropertiesFailures[busName];
                     ++failureCount;
 
-                    if (failureCount >= k_player_properties_failure_threshold) {
+                    if (failureCount == k_player_properties_failure_threshold) {
                       kLog.warn("player properties refresh disabled after {} failures name={}", failureCount, busName);
                       // Cancel the timer to stop polling this player
                       if (auto it = m_positionResyncTimers.find(busName); it != m_positionResyncTimers.end()) {
@@ -1602,11 +1607,14 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
                         m_positionResyncTimers.erase(it);
                       }
                       return;
+                    } else if (failureCount > k_player_properties_failure_threshold) {
+                      return;
                     } else if (failureCount > 1) {
+                      // Keep the first failure on the normal retry cadence before backing off.
                       // Apply exponential backoff
-                      auto& backoff = m_positionRefreshBackoffMs[busName];
+                      auto& backoff = m_playerPropertiesRefreshBackoffMs[busName];
                       if (backoff.count() == 0) {
-                        backoff = std::chrono::milliseconds{2000};
+                        backoff = k_position_retry_initial_backoff;
                       } else {
                         backoff = std::min(backoff * 2, k_position_retry_max_backoff);
                       }
@@ -1635,7 +1643,7 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 
                   const MprisPlayerInfo info =
                       readPlayerInfoFromProperties(busName, effectiveRootProps, effectivePlayerProps);
-                  applyPlayerSnapshot(busName, info, hadPositionSignal, hadRefreshFailure);
+                  applyPlayerSnapshot(busName, info, hadPositionSignal, hadFullRefreshFailure);
                 });
           } catch (const sdbus::Error& e) {
             kLog.warn("player query failed name={} err={}", busName, e.what());
@@ -1649,12 +1657,11 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 }
 
 void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info, bool hadPositionSignal,
-                                       bool hadRefreshFailure) {
+                                       bool hadFullRefreshFailure) {
   m_recoveryBackoffMs = std::chrono::milliseconds{500};
-  // Reset position refresh state only when both interfaces were fetched successfully.
-  if (!hadRefreshFailure) {
-    m_positionRefreshFailures[busName] = 0;
-    m_positionRefreshBackoffMs.erase(busName);
+  if (!hadFullRefreshFailure) {
+    m_playerPropertiesFailures[busName] = 0;
+    m_playerPropertiesRefreshBackoffMs.erase(busName);
   }
   const auto previousActive = activePlayer();
   const auto now = std::chrono::steady_clock::now();
@@ -1696,8 +1703,8 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      if (shouldRetryPositionRefresh(busName)) {
-        schedulePositionRefreshRetry(busName, k_position_retry_interval);
+      if (shouldRetryPropertiesRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_retry_interval, true);
       }
     }
     return;
@@ -1854,8 +1861,8 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      if (shouldRetryPositionRefresh(busName)) {
-        schedulePositionRefreshRetry(busName, k_position_retry_interval);
+      if (shouldRetryPropertiesRefresh(busName)) {
+        schedulePositionRefreshRetry(busName, k_position_retry_interval, true);
       }
     }
 
@@ -1898,8 +1905,8 @@ void MprisService::removePlayer(const std::string& busName) {
   m_lastPropertiesUpdate.erase(busName);
   m_lastPlayingUpdate.erase(busName);
   m_lastStrongMetadataUpdate.erase(busName);
-  m_positionRefreshFailures.erase(busName);
-  m_positionRefreshBackoffMs.erase(busName);
+  m_playerPropertiesFailures.erase(busName);
+  m_playerPropertiesRefreshBackoffMs.erase(busName);
   if (m_lastActivePlayer == busName) {
     m_lastActivePlayer.clear();
   }

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -589,7 +589,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
         auto& timerId = m_positionResyncTimers[busName];
         const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
         const auto backoffIt = m_positionRefreshBackoffMs.find(busName);
-        const auto retryInterval = (backoffIt != m_positionRefreshBackoffMs.end()) ? backoffIt->second : k_position_retry_interval;
+        const auto retryInterval =
+            (backoffIt != m_positionRefreshBackoffMs.end()) ? backoffIt->second : k_position_retry_interval;
         timerId = TimerManager::instance().start(timerId, retryInterval, [this, timerAliveGuard, busName]() {
           if (timerAliveGuard.expired()) {
             return;
@@ -1601,7 +1602,7 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
                   if (rootFailed || playerFailed) {
                     int& failureCount = m_positionRefreshFailures[busName];
                     ++failureCount;
-                    
+
                     if (failureCount >= k_position_refresh_failure_threshold) {
                       kLog.warn("player position query disabled after {} failures name={}", failureCount, busName);
                       // Cancel the timer to stop polling this player
@@ -1618,7 +1619,8 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
                       } else {
                         backoff = std::min(backoff * 2, k_position_retry_max_backoff);
                       }
-                      kLog.debug("player position query backoff failures={} interval={}ms name={}", failureCount, backoff.count(), busName);
+                      kLog.debug("player position query backoff failures={} interval={}ms name={}", failureCount,
+                                 backoff.count(), busName);
                     }
                   }
 
@@ -1705,12 +1707,13 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
       if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
         auto& timerId = m_positionResyncTimers[busName];
         const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-          if (timerAliveGuard.expired()) {
-            return;
-          }
-          refreshPlayerPosition(busName, true);
-        });
+        timerId =
+            TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
+              if (timerAliveGuard.expired()) {
+                return;
+              }
+              refreshPlayerPosition(busName, true);
+            });
       }
     }
     return;
@@ -1871,12 +1874,13 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
       if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
         auto& timerId = m_positionResyncTimers[busName];
         const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-          if (timerAliveGuard.expired()) {
-            return;
-          }
-          refreshPlayerPosition(busName, true);
-        });
+        timerId =
+            TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
+              if (timerAliveGuard.expired()) {
+                return;
+              }
+              refreshPlayerPosition(busName, true);
+            });
       }
     }
 

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -314,6 +314,8 @@ namespace {
   constexpr Logger kLog("mpris");
   constexpr auto k_position_retry_interval = std::chrono::milliseconds{1000};
   constexpr auto k_position_candidate_retry_interval = std::chrono::milliseconds{250};
+  constexpr auto k_position_retry_max_backoff = std::chrono::milliseconds{30'000};
+  constexpr int k_position_refresh_failure_threshold = 5;
   constexpr auto k_recent_track_change_guard_window = std::chrono::milliseconds{8000};
   constexpr auto k_recent_track_change_slack = std::chrono::milliseconds{750};
   constexpr auto k_position_candidate_match_window = std::chrono::milliseconds{2500};
@@ -462,6 +464,8 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       }
     }
     if (playerIt->second.playbackStatus != "Stopped") {
+      m_positionRefreshFailures[busName] = 0;
+      m_positionRefreshBackoffMs.erase(busName);
       auto& timerId = m_positionResyncTimers[busName];
       const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
       timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
@@ -538,15 +542,18 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       m_pendingPositionCandidateMatches[busName] = 0;
       m_pendingPositionCandidateAt[busName] = now;
       if (playerIt->second.playbackStatus == "Playing") {
-        auto& timerId = m_positionResyncTimers[busName];
-        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-        timerId = TimerManager::instance().start(timerId, k_position_candidate_retry_interval,
-                                                 [this, timerAliveGuard, busName]() {
-                                                   if (timerAliveGuard.expired()) {
-                                                     return;
-                                                   }
-                                                   refreshPlayerPosition(busName, true);
-                                                 });
+        const auto failureIt = m_positionRefreshFailures.find(busName);
+        if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
+          auto& timerId = m_positionResyncTimers[busName];
+          const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
+          timerId = TimerManager::instance().start(timerId, k_position_candidate_retry_interval,
+                                                   [this, timerAliveGuard, busName]() {
+                                                     if (timerAliveGuard.expired()) {
+                                                       return;
+                                                     }
+                                                     refreshPlayerPosition(busName, true);
+                                                   });
+        }
       }
       return;
     }
@@ -577,14 +584,19 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
     const bool hasAuthoritativeSample =
         m_hasAuthoritativePositionSample.contains(busName) && m_hasAuthoritativePositionSample.at(busName);
     if (playerIt->second.playbackStatus == "Playing" && !hasAuthoritativeSample) {
-      auto& timerId = m_positionResyncTimers[busName];
-      const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-      timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-        if (timerAliveGuard.expired()) {
-          return;
-        }
-        refreshPlayerPosition(busName, true);
-      });
+      const auto failureIt = m_positionRefreshFailures.find(busName);
+      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
+        auto& timerId = m_positionResyncTimers[busName];
+        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
+        const auto backoffIt = m_positionRefreshBackoffMs.find(busName);
+        const auto retryInterval = (backoffIt != m_positionRefreshBackoffMs.end()) ? backoffIt->second : k_position_retry_interval;
+        timerId = TimerManager::instance().start(timerId, retryInterval, [this, timerAliveGuard, busName]() {
+          if (timerAliveGuard.expired()) {
+            return;
+          }
+          refreshPlayerPosition(busName, true);
+        });
+      }
     }
     return;
   }
@@ -1585,6 +1597,31 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
                   const bool rootFailed = rootErr.has_value();
                   const bool playerFailed = playerErr.has_value();
 
+                  // Track position refresh failures and give up after threshold
+                  if (rootFailed || playerFailed) {
+                    int& failureCount = m_positionRefreshFailures[busName];
+                    ++failureCount;
+                    
+                    if (failureCount >= k_position_refresh_failure_threshold) {
+                      kLog.warn("player position query disabled after {} failures name={}", failureCount, busName);
+                      // Cancel the timer to stop polling this player
+                      if (auto it = m_positionResyncTimers.find(busName); it != m_positionResyncTimers.end()) {
+                        TimerManager::instance().cancel(it->second);
+                        m_positionResyncTimers.erase(it);
+                      }
+                      return;
+                    } else if (failureCount > 1) {
+                      // Apply exponential backoff
+                      auto& backoff = m_positionRefreshBackoffMs[busName];
+                      if (backoff.count() == 0) {
+                        backoff = std::chrono::milliseconds{2000};
+                      } else {
+                        backoff = std::min(backoff * 2, k_position_retry_max_backoff);
+                      }
+                      kLog.debug("player position query backoff failures={} interval={}ms name={}", failureCount, backoff.count(), busName);
+                    }
+                  }
+
                   // If both interfaces failed for a player we've never seen before, we'd produce a phantom
                   // entry with all-empty fields. Bail out and let recovery rediscover it instead.
                   if (rootFailed && playerFailed && !m_players.contains(busName)) {
@@ -1621,6 +1658,9 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
 void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info,
                                        bool hadPositionSignal) {
   m_recoveryBackoffMs = std::chrono::milliseconds{500};
+  // Reset position refresh failures when we get a successful snapshot
+  m_positionRefreshFailures[busName] = 0;
+  m_positionRefreshBackoffMs.erase(busName);
   const auto previousActive = activePlayer();
   const auto now = std::chrono::steady_clock::now();
   if (info.playbackStatus == "Playing") {
@@ -1661,14 +1701,17 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      auto& timerId = m_positionResyncTimers[busName];
-      const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-      timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-        if (timerAliveGuard.expired()) {
-          return;
-        }
-        refreshPlayerPosition(busName, true);
-      });
+      const auto failureIt = m_positionRefreshFailures.find(busName);
+      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
+        auto& timerId = m_positionResyncTimers[busName];
+        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
+        timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
+          if (timerAliveGuard.expired()) {
+            return;
+          }
+          refreshPlayerPosition(busName, true);
+        });
+      }
     }
     return;
   }
@@ -1824,14 +1867,17 @@ void MprisService::applyPlayerSnapshot(const std::string& busName, const MprisPl
         }
         refreshPlayerPosition(busName, true);
       });
-      auto& timerId = m_positionResyncTimers[busName];
-      const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
-      timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
-        if (timerAliveGuard.expired()) {
-          return;
-        }
-        refreshPlayerPosition(busName, true);
-      });
+      const auto failureIt = m_positionRefreshFailures.find(busName);
+      if (failureIt == m_positionRefreshFailures.end() || failureIt->second < k_position_refresh_failure_threshold) {
+        auto& timerId = m_positionResyncTimers[busName];
+        const std::weak_ptr<void> timerAliveGuard = m_aliveGuard;
+        timerId = TimerManager::instance().start(timerId, k_position_retry_interval, [this, timerAliveGuard, busName]() {
+          if (timerAliveGuard.expired()) {
+            return;
+          }
+          refreshPlayerPosition(busName, true);
+        });
+      }
     }
 
     if (trackChanged) {
@@ -1873,6 +1919,8 @@ void MprisService::removePlayer(const std::string& busName) {
   m_lastPropertiesUpdate.erase(busName);
   m_lastPlayingUpdate.erase(busName);
   m_lastStrongMetadataUpdate.erase(busName);
+  m_positionRefreshFailures.erase(busName);
+  m_positionRefreshBackoffMs.erase(busName);
   if (m_lastActivePlayer == busName) {
     m_lastActivePlayer.clear();
   }

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -176,6 +176,8 @@ private:
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastPropertiesUpdate;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastPlayingUpdate;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastStrongMetadataUpdate;
+  std::unordered_map<std::string, int> m_positionRefreshFailures;
+  std::unordered_map<std::string, std::chrono::milliseconds> m_positionRefreshBackoffMs;
   std::deque<std::string> m_pendingDiscoveryBusNames;
   std::string m_lastActivePlayer;
   std::string m_lastEmittedActivePlayer;

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -109,11 +109,13 @@ private:
   void scheduleRecoveryDiscovery();
   void addOrRefreshPlayer(const std::string& busName);
   void applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info, bool hadPositionSignal,
-                           bool hadRefreshFailure);
-  [[nodiscard]] bool shouldRetryPositionRefresh(const std::string& busName) const;
-  [[nodiscard]] std::chrono::milliseconds positionRetryInterval(const std::string& busName,
-                                                                std::chrono::milliseconds fallback) const;
-  void schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback);
+                           bool hadFullRefreshFailure);
+  [[nodiscard]] bool shouldRetryPropertiesRefresh(const std::string& busName) const;
+  [[nodiscard]] std::chrono::milliseconds propertiesRefreshRetryInterval(const std::string& busName,
+                                                                         std::chrono::milliseconds fallback,
+                                                                         bool usePropertiesBackoff) const;
+  void schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback,
+                                    bool usePropertiesBackoff);
   void refreshPlayerPosition(const std::string& busName, bool notifyChange);
   void applyPositionSample(const std::string& busName, int64_t rawPositionUs, bool notifyChange);
   void removePlayer(const std::string& busName);
@@ -181,8 +183,8 @@ private:
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastPropertiesUpdate;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastPlayingUpdate;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_lastStrongMetadataUpdate;
-  std::unordered_map<std::string, int> m_positionRefreshFailures;
-  std::unordered_map<std::string, std::chrono::milliseconds> m_positionRefreshBackoffMs;
+  std::unordered_map<std::string, int> m_playerPropertiesFailures;
+  std::unordered_map<std::string, std::chrono::milliseconds> m_playerPropertiesRefreshBackoffMs;
   std::deque<std::string> m_pendingDiscoveryBusNames;
   std::string m_lastActivePlayer;
   std::string m_lastEmittedActivePlayer;

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -108,7 +108,12 @@ private:
   void scheduleStartupRediscovery();
   void scheduleRecoveryDiscovery();
   void addOrRefreshPlayer(const std::string& busName);
-  void applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info, bool hadPositionSignal);
+  void applyPlayerSnapshot(const std::string& busName, const MprisPlayerInfo& info, bool hadPositionSignal,
+                           bool hadRefreshFailure);
+  [[nodiscard]] bool shouldRetryPositionRefresh(const std::string& busName) const;
+  [[nodiscard]] std::chrono::milliseconds positionRetryInterval(const std::string& busName,
+                                                                std::chrono::milliseconds fallback) const;
+  void schedulePositionRefreshRetry(const std::string& busName, std::chrono::milliseconds fallback);
   void refreshPlayerPosition(const std::string& busName, bool notifyChange);
   void applyPositionSample(const std::string& busName, int64_t rawPositionUs, bool notifyChange);
   void removePlayer(const std::string& busName);


### PR DESCRIPTION
 Stops hammering unresponsive players after a few attempts
 Uses exponential backoff to reduce CPU usage while trying 
 Cleans up resources by canceling timers for unresponsive players
 Allows recovery if a player becomes responsive again 
 Maintains existing behavior for functional MPRIS players
