### PR TITLE
fix(mango): correct config filename and sourcing syntax in apply.sh

### DIFF
--- a/assets/templates/mango/apply.sh
+++ b/assets/templates/mango/apply.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-config_file="${XDG_CONFIG_HOME:-$HOME/.config}/mango/mango.conf"
-include_line='include "~/.config/mango/noctalia.conf"'
+config_file="$HOME/.config/mango/config.conf"
+include_line="source=$HOME/.config/mango/noctalia.conf"
 
 mkdir -p "$(dirname "$config_file")"
 
@@ -11,6 +11,6 @@ if [ ! -f "$config_file" ]; then
     exit 0
 fi
 
-if ! grep -q 'include ".*noctalia\.conf"' "$config_file"; then
+if ! grep -q 'source=.*noctalia\.conf' "$config_file"; then
     printf '\n%s\n' "$include_line" >>"$config_file"
 fi


### PR DESCRIPTION
# Pull Request

## Motivation
noctalia v5 theme template adding for mangowm config file name and source syntax is fixed

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested on mangowm
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
**Removed** `XDG_CONFIG_HOME` fallback since mango hardcodes `$HOME/.config/mango/config.conf` and does not respect `XDG_CONFIG_HOME`.