### PR TITLE
feat(mango): add missing `dropcolor` & `splitcolor` for mango template

### DIFF
--- a/assets/templates/mango/mango.conf
+++ b/assets/templates/mango/mango.conf
@@ -4,6 +4,8 @@
 shadowscolor = 0x{{colors.shadow.default.hex_stripped}}ff
 rootcolor = 0x{{colors.surface.default.hex_stripped}}ff
 bordercolor = 0x{{colors.outline.default.hex_stripped}}ff
+dropcolor = 0x{{colors.primary.default.hex_stripped}}80
+splitcolor = 0x{{colors.tertiary.default.hex_stripped}}ff
 focuscolor = 0x{{colors.primary.default.hex_stripped}}ff
 maximizescreencolor = 0x{{colors.secondary.default.hex_stripped}}ff
 urgentcolor = 0x{{colors.error.default.hex_stripped}}ff


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
add missing color variables for mango template

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested on mangowm
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/2677b4f4-56ea-4208-9985-63dc509f9625


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
