### PR TITLE
fix(launcher): invalidate cache when refreshing desktop entries

### DIFF
--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -380,8 +380,6 @@ void LauncherPanel::onOpen(std::string_view context) {
   if (m_grid != nullptr) {
     m_grid->scrollView().setScrollOffset(0.0f);
   }
-  // Clear cached icon misses before each open so newly installed app icons appear.
-  m_iconResolver.invalidateCache();
   onInputChanged(initialValue);
 }
 

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -466,7 +466,11 @@ const std::string& IconResolver::resolve(const std::string& iconName, int target
   if (it != m_cache.end()) {
     return it->second;
   }
-  auto [ins, _] = m_cache.emplace(key, findIcon(iconName, targetSize));
+  auto icon = findIcon(iconName, targetSize);
+  if (icon.empty()) {
+    return m_empty;
+  }
+  auto [ins, _] = m_cache.emplace(key, icon);
   return ins->second;
 }
 


### PR DESCRIPTION
# Pull Request

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.
Currently whenever opening the launcher there is a very big delay before it renders and is able to accept input. This is happening because the icon cache gets invalidated whenever it opens and has to rebuild before it is able to display the launcher panel. This PR aims to fix the slow launch of the launcher panel.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/c2e5f15c-38f3-49cc-86eb-b0cfc228906e



After:

https://github.com/user-attachments/assets/d4ef4afb-a045-4788-b804-f7b8dc34c04e



## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

