### PR TITLE
weathertab: do no crash when forcastdays is empty (v5)

### DIFF
--- a/src/shell/control_center/weather_tab.cpp
+++ b/src/shell/control_center/weather_tab.cpp
@@ -659,13 +659,15 @@ void WeatherTab::sync(Renderer& renderer) {
   }
   auto unit = m_weather->displayTemperatureUnit();
   if (m_tempMaxLabel != nullptr) {
-    auto temp =
-        static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMaxC)));
+    auto temp = (snapshot.forecastDays.empty() ? 0
+                                               : static_cast<int>(std::lround(m_weather->displayTemperature(
+                                                     snapshot.forecastDays.front().temperatureMaxC))));
     m_tempMaxLabel->setText(!snapshot.forecastDays.empty() ? std::format("{}{}", temp, unit) : std::string("--"));
   }
   if (m_tempMinLabel != nullptr) {
-    auto temp =
-        static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.forecastDays.front().temperatureMinC)));
+    auto temp = (snapshot.forecastDays.empty() ? 0
+                                               : static_cast<int>(std::lround(m_weather->displayTemperature(
+                                                     snapshot.forecastDays.front().temperatureMinC))));
     m_tempMinLabel->setText(!snapshot.forecastDays.empty() ? std::format("{}{}", temp, unit) : std::string("--"));
   }
   if (m_elevationLabel != nullptr) {


### PR DESCRIPTION
# Pull Request

add guard against empty snapshot.forcastdays vector

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [ x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [ x] Code follows project style guidelines
- [ x] Self-reviewed my code
- [x ] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
