### PR TITLE
Add Jemalloc to Nix Dependencies.

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,6 +25,7 @@
   glib,
   polkit,
   librsvg,
+  jemalloc
 }:
 
 stdenv.mkDerivation {
@@ -45,6 +46,7 @@ stdenv.mkDerivation {
     ninja
     pkg-config
     wayland-scanner
+    jemalloc
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Motivation
Jemalloc is an optional dependency, but very good for dealing with memory fragmentation over time. Very needed for this alpha on NixOS at least.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [X] Documentation or comments updated (if relevant)

## Additional Notes
We could make this optional? but, that would be via adding Nix module support (`programs.noctalia` outside of home-manager basically.) I'd rather that be an entirely different pull request from either me or someone else.
