### PR TITLE
feat(controls): Added scroll bar to drop down menus

### DIFF
--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -32,6 +32,8 @@ namespace {
 
   constexpr Logger kLog("select-dropdown-popup");
   constexpr float kMenuPadding = Style::spaceXs;
+  constexpr float kScrollbarWidth = 4.0f;
+  constexpr float kScrollbarMargin = 3.0f;
 
   Color resolved(ColorRole role, float alpha = 1.0f) { return colorForRole(role, alpha); }
 
@@ -316,6 +318,36 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
       return true;
     });
     viewportNode->addChild(std::move(area));
+  }
+
+  // Only draw scrollbar when total content is taller than the visible viewport
+  const float contentViewport = m_viewportHeight - kMenuPadding * 2.0f;
+  if (m_totalHeight > contentViewport) {
+    // Thumb height is proportional to how much of the list is visible
+    const float trackHeight = contentViewport;
+    const float thumbRatio = contentViewport / m_totalHeight;
+    const float thumbHeight = std::max(20.f, trackHeight * thumbRatio);
+
+    // Thumb Y position tracks scroll offset proportionally along the remaining track space
+    const float maxScroll = m_totalHeight - contentViewport;
+    const float thumbTravel = trackHeight - thumbHeight;
+    const float thumbY = menuY + kMenuPadding + (m_scrollOffset / maxScroll) * thumbTravel;
+
+    // Pin thumb to the right edge of menu, inset by the margin
+    const float thumbX = menuX + m_menuWidth - kScrollbarWidth - kScrollbarMargin;
+
+    auto scrollThumb = std::make_unique<RectNode>();
+    scrollThumb->setStyle(RoundedRectStyle{
+        .fill = resolved(ColorRole::OnSurface, 0.3f), // semi-transparent to feel like an overlay
+        .border = clearColor(),
+        .fillMode = FillMode::Solid,
+        .radius = kScrollbarWidth * 0.5f,
+        .softness = 1.0f,
+        .borderWidth = 0.0f,
+    });
+    scrollThumb->setPosition(thumbX, thumbY);
+    scrollThumb->setFrameSize(kScrollbarWidth, thumbHeight);
+    m_sceneRoot->addChild(std::move(scrollThumb));
   }
 
   applyHoverVisuals();


### PR DESCRIPTION
## Motivation
Just added a small scroll bar to the dropdown menus to make it more obvious that people can scroll

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="295" height="273" alt="screenshot-2026-05-18_16-20-13" src="https://github.com/user-attachments/assets/c826897c-f9a2-444b-8c6e-9c1b6010a855" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
