### PR TITLE
widget: Added a new Debug widget for debug builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -526,6 +526,7 @@ _noctalia_sources = files(
   'src/shell/bar/widgets/custom_button_widget.cpp',
   'src/shell/bar/widgets/clipboard_widget.cpp',
   'src/shell/bar/widgets/clock_widget.cpp',
+  'src/shell/bar/widgets/debug_indicator_widget.cpp',
   'src/shell/bar/widgets/idle_inhibitor_widget.cpp',
   'src/shell/bar/widgets/keyboard_layout_widget.cpp',
   'src/shell/bar/widgets/lock_keys_widget.cpp',

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1200,6 +1200,19 @@ void Bar::populateWidgets(BarInstance& instance) {
   createWidgets(instance.barConfig.startWidgets, instance.startWidgets);
   createWidgets(instance.barConfig.centerWidgets, instance.centerWidgets);
   createWidgets(instance.barConfig.endWidgets, instance.endWidgets);
+
+#ifndef NDEBUG
+  // Preprend a red "debug" pill to the end section if running a debug
+  if (instance.barConfig.name == "default" || instance.barConfig.name.empty()) {
+    auto debugWidget = m_widgetFactory->create("debug_indicator", instance.output, instance.barConfig.scale,
+                                               instance.barConfig.position, instance.barConfig.name);
+    if (debugWidget != nullptr) {
+      debugWidget->setConfigName("debug_indicator");
+      debugWidget->create();
+      instance.endWidgets.insert(instance.endWidgets.begin(), std::move(debugWidget));
+    }
+  }
+#endif
 }
 
 void Bar::attachWidgetsToSections(BarInstance& instance) {

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1202,15 +1202,13 @@ void Bar::populateWidgets(BarInstance& instance) {
   createWidgets(instance.barConfig.endWidgets, instance.endWidgets);
 
 #ifndef NDEBUG
-  // Preprend a red "debug" pill to the end section if running a debug
-  if (instance.barConfig.name == "default" || instance.barConfig.name.empty()) {
-    auto debugWidget = m_widgetFactory->create("debug_indicator", instance.output, instance.barConfig.scale,
-                                               instance.barConfig.position, instance.barConfig.name);
-    if (debugWidget != nullptr) {
-      debugWidget->setConfigName("debug_indicator");
-      debugWidget->create();
-      instance.endWidgets.insert(instance.endWidgets.begin(), std::move(debugWidget));
-    }
+  // Prepend a red "debug" pill to the end section if running a debug
+  auto debugWidget = m_widgetFactory->create("debug_indicator", instance.output, instance.barConfig.scale,
+                                             instance.barConfig.position, instance.barConfig.name);
+  if (debugWidget != nullptr) {
+    debugWidget->setConfigName("debug_indicator");
+    debugWidget->create();
+    instance.endWidgets.insert(instance.endWidgets.begin(), std::move(debugWidget));
   }
 #endif
 }

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -11,11 +11,6 @@
 #include "notification/notification_manager.h"
 #include "pipewire/pipewire_spectrum.h"
 #include "shell/bar/widgets/active_window_widget.h"
-
-#ifndef NDEBUG
-#include "shell/bar/widgets/debug_indicator_widget.h"
-#endif
-
 #include "shell/bar/widgets/audio_visualizer_widget.h"
 #include "shell/bar/widgets/battery_widget.h"
 #include "shell/bar/widgets/bluetooth_widget.h"
@@ -24,6 +19,9 @@
 #include "shell/bar/widgets/clock_widget.h"
 #include "shell/bar/widgets/control_center_widget.h"
 #include "shell/bar/widgets/custom_button_widget.h"
+#ifndef NDEBUG
+#include "shell/bar/widgets/debug_indicator_widget.h"
+#endif
 #include "shell/bar/widgets/idle_inhibitor_widget.h"
 #include "shell/bar/widgets/keyboard_layout_widget.h"
 #include "shell/bar/widgets/launcher_widget.h"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -11,6 +11,14 @@
 #include "notification/notification_manager.h"
 #include "pipewire/pipewire_spectrum.h"
 #include "shell/bar/widgets/active_window_widget.h"
+
+#include <memory>
+
+// Only compile debug_indicator_widget when building debug
+#ifndef NDBUG
+#include "shell/bar/widgets/debug_indicator_widget.h"
+#endif
+
 #include "shell/bar/widgets/audio_visualizer_widget.h"
 #include "shell/bar/widgets/battery_widget.h"
 #include "shell/bar/widgets/bluetooth_widget.h"
@@ -466,6 +474,14 @@ std::unique_ptr<Widget> WidgetFactory::create(const std::string& name, wl_output
     widget->setContentScale(contentScale);
     return widget;
   }
+
+#ifndef NDEBUG
+  if (type == "debug_indicator") {
+    auto widget = std::make_unique<DebugIndicatorWidget>();
+    widget->setContentScale(contentScale);
+    return widget;
+  }
+#endif
 
   kLog.warn("widget factory: unknown widget \"{}\"", name);
   return nullptr;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -12,10 +12,7 @@
 #include "pipewire/pipewire_spectrum.h"
 #include "shell/bar/widgets/active_window_widget.h"
 
-#include <memory>
-
-// Only compile debug_indicator_widget when building debug
-#ifndef NDBUG
+#ifndef NDEBUG
 #include "shell/bar/widgets/debug_indicator_widget.h"
 #endif
 
@@ -60,6 +57,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace {

--- a/src/shell/bar/widgets/debug_indicator_widget.cpp
+++ b/src/shell/bar/widgets/debug_indicator_widget.cpp
@@ -1,0 +1,42 @@
+#include "debug_indicator_widget.h"
+#ifndef NDEBUG
+
+#include "shell/bar/widgets/debug_indicator_widget.h"
+#include "ui/controls/chip.h"
+#include "ui/controls/label.h"
+#include "ui/palette.h"
+#include "ui/style.h"
+
+#include <memory>
+
+DebugIndicatorWidget::DebugIndicatorWidget() = default;
+
+void DebugIndicatorWidget::create() {
+  auto chip = std::make_unique<Chip>();
+
+  // Override Chip's default active/inactive styling with a red pill
+  chip->setFill(colorSpecFromRole(ColorRole::Error));
+  chip->label()->setColor(colorSpecFromRole(ColorRole::OnError));
+  chip->label()->setBold(true);
+  chip->setText("DEBUG");
+  chip->clearBorder();
+  chip->setRadius(999.0f);
+  chip->setPadding(2.0f, Style::spaceSm);
+
+  m_chip = chip.get();
+  setRoot(std::move(chip));
+}
+
+void DebugIndicatorWidget::doLayout(Renderer& renderer, float /*containerWidth*/, float /*containerHeight*/) {
+  if (m_chip == nullptr) {
+    return;
+  }
+  const LayoutConstraints unconstrained{};
+  auto* node = root();
+  if (node != nullptr) {
+    const auto size = m_chip->measure(renderer, unconstrained);
+    node->setSize(size.width, size.height);
+  }
+}
+
+#endif

--- a/src/shell/bar/widgets/debug_indicator_widget.cpp
+++ b/src/shell/bar/widgets/debug_indicator_widget.cpp
@@ -1,7 +1,7 @@
-#include "debug_indicator_widget.h"
 #ifndef NDEBUG
 
 #include "shell/bar/widgets/debug_indicator_widget.h"
+
 #include "ui/controls/chip.h"
 #include "ui/controls/label.h"
 #include "ui/palette.h"
@@ -20,7 +20,6 @@ void DebugIndicatorWidget::create() {
   chip->label()->setBold(true);
   chip->setText("DEBUG");
   chip->clearBorder();
-  chip->setRadius(999.0f);
   chip->setPadding(2.0f, Style::spaceSm);
 
   m_chip = chip.get();
@@ -28,15 +27,10 @@ void DebugIndicatorWidget::create() {
 }
 
 void DebugIndicatorWidget::doLayout(Renderer& renderer, float /*containerWidth*/, float /*containerHeight*/) {
-  if (m_chip == nullptr) {
-    return;
-  }
   const LayoutConstraints unconstrained{};
-  auto* node = root();
-  if (node != nullptr) {
-    const auto size = m_chip->measure(renderer, unconstrained);
-    node->setSize(size.width, size.height);
-  }
+  const auto size = m_chip->measure(renderer, unconstrained);
+  m_chip->setRadius(std::min(size.width, size.height) * 0.5f);
+  root()->setSize(size.width, size.height);
 }
 
 #endif

--- a/src/shell/bar/widgets/debug_indicator_widget.cpp
+++ b/src/shell/bar/widgets/debug_indicator_widget.cpp
@@ -14,7 +14,6 @@ DebugIndicatorWidget::DebugIndicatorWidget() = default;
 void DebugIndicatorWidget::create() {
   auto chip = std::make_unique<Chip>();
 
-  // Override Chip's default active/inactive styling with a red pill
   chip->setFill(colorSpecFromRole(ColorRole::Error));
   chip->label()->setColor(colorSpecFromRole(ColorRole::OnError));
   chip->label()->setBold(true);

--- a/src/shell/bar/widgets/debug_indicator_widget.h
+++ b/src/shell/bar/widgets/debug_indicator_widget.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifndef NDEBUG
+
+#include "shell/bar/widget.h"
+
+class Chip;
+class Renderer;
+
+class DebugIndicatorWidget : public Widget {
+public:
+  DebugIndicatorWidget();
+
+  void create() override;
+
+private:
+  void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
+
+  Chip* m_chip = nullptr;
+};
+
+#endif


### PR DESCRIPTION
## Description
This specifically adds a forced Debug widget on the default bar, indicating that the user is running a Debug build of Noctalia. This is a small QoL change for those that forget that they're running a debug build (myself).

You can merge it or not, I was just toying around.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="311" height="39" alt="image" src="https://github.com/user-attachments/assets/630b2a34-95d2-4dc0-b8c0-61a5f9945010" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)