### PR TITLE
dock: add per-monitor output selector & hide when empty

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1613,6 +1613,10 @@
           "label": "Active Monitor Only",
           "description": "Only show the dock on the active monitor"
         },
+        "monitors": {
+          "label": "Displays",
+          "description": "Choose which displays show the dock; leave empty to show on all displays"
+        },
         "icon-size": {
           "label": "Icon Size",
           "description": "Size of dock icons in pixels"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1611,7 +1611,7 @@
       "dock": {
         "active-monitor-only": {
           "label": "Active Monitor Only",
-          "description": "Only show the dock on the active monitor"
+          "description": "Only show applications running on the active monitor"
         },
         "monitors": {
           "label": "Displays",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1615,7 +1615,7 @@
         },
         "monitors": {
           "label": "Displays",
-          "description": "Choose which displays show the dock; leave empty to show on all displays"
+          "description": "Choose which displays show the dock; leave empty for all. Active-monitor filtering applies within these displays."
         },
         "icon-size": {
           "label": "Icon Size",

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -507,6 +507,7 @@ namespace config_export {
       table.insert_or_assign("launcher_position", dock.launcherPosition);
       table.insert_or_assign("launcher_icon", dock.launcherIcon);
       table.insert_or_assign("pinned", stringArray(dock.pinned));
+      table.insert_or_assign("monitors", stringArray(dock.monitors));
       return table;
     }
 

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -319,7 +319,8 @@ namespace {
            nearlyEqual(a.activeScale, b.activeScale) && nearlyEqual(a.inactiveScale, b.inactiveScale) &&
            nearlyEqual(a.activeOpacity, b.activeOpacity) && nearlyEqual(a.inactiveOpacity, b.inactiveOpacity) &&
            a.showDots == b.showDots && a.showInstanceCount == b.showInstanceCount &&
-           a.launcherPosition == b.launcherPosition && a.launcherIcon == b.launcherIcon && a.pinned == b.pinned;
+           a.launcherPosition == b.launcherPosition && a.launcherIcon == b.launcherIcon && a.pinned == b.pinned &&
+           a.monitors == b.monitors;
   }
 
   bool shellConfigEqual(const ShellConfig& a, const ShellConfig& b) {

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1837,6 +1837,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
       dock.launcherIcon = *v;
     if (auto* arr = (*dockTbl)["pinned"].as_array())
       dock.pinned = readStringArray(*arr);
+    if (const auto* v = (*dockTbl).get("monitors"))
+      dock.monitors = readStringArray(*v);
   }
 
   // Parse [desktop_widgets]

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1837,8 +1837,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
       dock.launcherIcon = *v;
     if (auto* arr = (*dockTbl)["pinned"].as_array())
       dock.pinned = readStringArray(*arr);
-    if (const auto* v = (*dockTbl).get("monitors"))
-      dock.monitors = readStringArray(*v);
+    if (auto* arr = (*dockTbl)["monitors"].as_array())
+      dock.monitors = readStringArray(*arr);
   }
 
   // Parse [desktop_widgets]

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -347,6 +347,7 @@ struct DockConfig {
   std::string launcherPosition = "none";  // none | start | end
   std::string launcherIcon = "grid-dots"; // Tabler glyph name
   std::vector<std::string> pinned;        // desktop entry IDs to always show
+  std::vector<std::string> monitors;      // connector names to show on; empty = all outputs
 
   bool operator==(const DockConfig&) const = default;
 };

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -154,6 +154,22 @@ namespace {
     return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
   }
 
+  bool outputHasAnyDockItems(const DockConfig& cfg, const CompositorPlatform& platform, const WaylandOutput& output) {
+    if (!cfg.pinned.empty()) {
+      return true;
+    }
+    if (dockLauncherButtonCount(cfg) > 0) {
+      return true;
+    }
+    if (cfg.showRunning) {
+      wl_output* const filter = cfg.activeMonitorOnly ? output.output : nullptr;
+      if (!platform.runningAppIds(filter).empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
     return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
   }
@@ -263,11 +279,17 @@ void Dock::onOutputChange() {
 }
 
 void Dock::refresh() {
-  if (m_instances.empty()) {
+  if (m_config == nullptr || m_platform == nullptr || !m_config->config().dock.enabled) {
     return;
   }
 
   refreshPinnedAppsIfNeeded();
+
+  syncInstances();
+
+  if (m_instances.empty()) {
+    return;
+  }
 
   for (auto& inst : m_instances) {
     if (inst->surface == nullptr) {
@@ -516,12 +538,16 @@ void Dock::syncInstances() {
   const auto& outputs = m_platform->outputs();
   const auto& cfg = m_config->config().dock;
   const auto& selectedMonitors = cfg.monitors;
-  const auto outputAllowed = [&selectedMonitors](const WaylandOutput& output) {
-    if (selectedMonitors.empty()) {
-      return true;
+  const auto outputAllowed = [&](const WaylandOutput& output) {
+    if (!selectedMonitors.empty() &&
+        std::none_of(selectedMonitors.begin(), selectedMonitors.end(),
+                     [&output](const std::string& m) { return m == output.connectorName; })) {
+      return false;
     }
-    return std::any_of(selectedMonitors.begin(), selectedMonitors.end(),
-                       [&output](const std::string& m) { return m == output.connectorName; });
+    if (!outputHasAnyDockItems(cfg, *m_platform, output)) {
+      return false;
+    }
+    return true;
   };
 
   // Remove instances for dead outputs or outputs no longer selected.

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -237,9 +237,7 @@ void Dock::reload() {
 
   refreshPinnedAppsIfNeeded();
 
-  m_instances.clear();
-  m_surfaceMap.clear();
-  m_hoveredInstance = nullptr;
+  closeAllInstances();
 
   if (wl_display_roundtrip(m_platform->display()) < 0) {
     const int roundtripErrno = errno;
@@ -268,7 +266,24 @@ void Dock::closeAllInstances() {
   m_itemMenu.reset();
   m_surfaceMap.clear();
   m_hoveredInstance = nullptr;
+  m_popupOwnerInstance = nullptr;
   m_instances.clear();
+}
+
+void Dock::detachInstanceState(DockInstance& inst) {
+  if (inst.surface != nullptr) {
+    if (wl_surface* const wls = inst.surface->wlSurface()) {
+      m_surfaceMap.erase(wls);
+    }
+  }
+  if (m_hoveredInstance == &inst) {
+    m_hoveredInstance = nullptr;
+  }
+  if (m_popupOwnerInstance == &inst) {
+    m_windowMenu.reset();
+    m_itemMenu.reset();
+    m_popupOwnerInstance = nullptr;
+  }
 }
 
 void Dock::onOutputChange() {
@@ -541,7 +556,7 @@ void Dock::syncInstances() {
   const auto outputAllowed = [&](const WaylandOutput& output) {
     if (!selectedMonitors.empty() &&
         std::none_of(selectedMonitors.begin(), selectedMonitors.end(),
-                     [&output](const std::string& m) { return m == output.connectorName; })) {
+                     [&output](const std::string& m) { return outputMatchesSelector(m, output); })) {
       return false;
     }
     if (!outputHasAnyDockItems(cfg, *m_platform, output)) {
@@ -551,12 +566,14 @@ void Dock::syncInstances() {
   };
 
   // Remove instances for dead outputs or outputs no longer selected.
-  std::erase_if(m_instances, [&outputs, &outputAllowed](const auto& inst) {
+  std::erase_if(m_instances, [this, &outputs, &outputAllowed](const auto& inst) {
     const auto it =
         std::find_if(outputs.begin(), outputs.end(), [&inst](const auto& o) { return o.name == inst->outputName; });
-    if (it == outputs.end())
-      return true;
-    return !outputAllowed(*it);
+    const bool drop = (it == outputs.end()) || !outputAllowed(*it);
+    if (drop) {
+      detachInstanceState(*inst);
+    }
+    return drop;
   });
 
   for (const auto& output : outputs) {

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -154,22 +154,6 @@ namespace {
     return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
   }
 
-  bool outputHasAnyDockItems(const DockConfig& cfg, const CompositorPlatform& platform, const WaylandOutput& output) {
-    if (!cfg.pinned.empty()) {
-      return true;
-    }
-    if (dockLauncherButtonCount(cfg) > 0) {
-      return true;
-    }
-    if (cfg.showRunning) {
-      wl_output* const filter = cfg.activeMonitorOnly ? output.output : nullptr;
-      if (!platform.runningAppIds(filter).empty()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
     return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
   }
@@ -553,16 +537,27 @@ void Dock::syncInstances() {
   const auto& outputs = m_platform->outputs();
   const auto& cfg = m_config->config().dock;
   const auto& selectedMonitors = cfg.monitors;
+  const bool hasStaticContent = !cfg.pinned.empty() || dockLauncherButtonCount(cfg) > 0;
+  // When activeMonitorOnly is off, the running-apps check is identical for every output, so hoist it.
+  const bool anyRunningGlobal = (!hasStaticContent && cfg.showRunning && !cfg.activeMonitorOnly)
+                                    ? !m_platform->runningAppIds(nullptr).empty()
+                                    : false;
   const auto outputAllowed = [&](const WaylandOutput& output) {
     if (!selectedMonitors.empty() &&
         std::none_of(selectedMonitors.begin(), selectedMonitors.end(),
                      [&output](const std::string& m) { return outputMatchesSelector(m, output); })) {
       return false;
     }
-    if (!outputHasAnyDockItems(cfg, *m_platform, output)) {
+    if (hasStaticContent) {
+      return true;
+    }
+    if (!cfg.showRunning) {
       return false;
     }
-    return true;
+    if (cfg.activeMonitorOnly) {
+      return !m_platform->runningAppIds(output.output).empty();
+    }
+    return anyRunningGlobal;
   };
 
   // Remove instances for dead outputs or outputs no longer selected.

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -514,14 +514,29 @@ bool Dock::refreshPinnedAppsIfNeeded() {
 
 void Dock::syncInstances() {
   const auto& outputs = m_platform->outputs();
+  const auto& cfg = m_config->config().dock;
+  const auto& selectedMonitors = cfg.monitors;
+  const auto outputAllowed = [&selectedMonitors](const WaylandOutput& output) {
+    if (selectedMonitors.empty()) {
+      return true;
+    }
+    return std::any_of(selectedMonitors.begin(), selectedMonitors.end(),
+                       [&output](const std::string& m) { return m == output.connectorName; });
+  };
 
-  // Remove instances for dead outputs.
-  std::erase_if(m_instances, [&outputs](const auto& inst) {
-    return !std::any_of(outputs.begin(), outputs.end(), [&inst](const auto& o) { return o.name == inst->outputName; });
+  // Remove instances for dead outputs or outputs no longer selected.
+  std::erase_if(m_instances, [&outputs, &outputAllowed](const auto& inst) {
+    const auto it =
+        std::find_if(outputs.begin(), outputs.end(), [&inst](const auto& o) { return o.name == inst->outputName; });
+    if (it == outputs.end())
+      return true;
+    return !outputAllowed(*it);
   });
 
   for (const auto& output : outputs) {
     if (!output.done)
+      continue;
+    if (!outputAllowed(output))
       continue;
     const bool exists = std::any_of(m_instances.begin(), m_instances.end(),
                                     [&output](const auto& inst) { return inst->outputName == output.name; });

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -106,6 +106,9 @@ private:
   void syncInstances();
   void createInstance(const WaylandOutput& output);
   void destroyInstance(std::uint32_t outputName);
+  // Drop any references the dock keeps to an instance (surface map, hovered, popup owner)
+  // before the instance is destroyed. Safe to call multiple times.
+  void detachInstanceState(DockInstance& inst);
   void prepareFrame(DockInstance& instance, bool needsUpdate, bool needsLayout);
   bool syncInstanceModel(DockInstance& instance);
   void applyDockCompositorBlur(DockInstance& instance);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -520,6 +520,10 @@ namespace settings {
     entries.push_back(makeEntry("dock", "general", tr("settings.schema.dock.active-monitor-only.label"),
                                 tr("settings.schema.dock.active-monitor-only.description"),
                                 {"dock", "active_monitor_only"}, ToggleSetting{cfg.dock.activeMonitorOnly}, "monitor"));
+    entries.push_back(makeEntry("dock", "general", tr("settings.schema.dock.monitors.label"),
+                                tr("settings.schema.dock.monitors.description"), {"dock", "monitors"},
+                                ListSetting{.items = cfg.dock.monitors, .suggestedOptions = env.availableOutputs},
+                                "monitor output display screen"));
     entries.push_back(makeEntry("dock", "behavior", tr("settings.schema.shared.auto-hide.label"),
                                 tr("settings.schema.dock.auto-hide.description"), {"dock", "auto_hide"},
                                 ToggleSetting{cfg.dock.autoHide}, "autohide"));


### PR DESCRIPTION
# Pull Request

## Motivation
Dock: Settings should have an output/monitor selector

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue


## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="1037" height="300" alt="image" src="https://github.com/user-attachments/assets/39fa222e-f9d1-4f15-96da-e8da4df8058b" />


## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
