### PR TITLE
helix: change `ui.selection` color for legibility

### DIFF
--- a/assets/templates/helix/helix.toml
+++ b/assets/templates/helix/helix.toml
@@ -96,7 +96,7 @@
 "ui.menu" = { fg = "onSurface", bg = "surfaceContainer" }
 "ui.menu.selected" = { fg = "onPrimary", bg = "primary", modifiers = ["bold"] }
 
-"ui.selection" = { bg = "surfaceContainerHigh" }
+"ui.selection" = { bg = "surfaceContainer" }
 
 "ui.highlight" = { bg = "primaryContainer", modifiers = ["bold"] }
 


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This PR changes the color of `ui.selection` in the included Helix template, because earlier it was the same as `string` due to which it was hard to differentiate selected text from strings.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
- None

## Testing

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/925a453f-5ea5-434d-8916-275570c9f940" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
None
