### PR TITLE
fix(tray_widget): hide the widget when empty

### DIFF
--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -611,6 +611,8 @@ void TrayWidget::rebuild(Renderer& renderer) {
       m_container->addChild(std::move(area));
     }
   }
+
+  m_container->setVisible(!m_container->children().empty());
 }
 
 std::string TrayWidget::drawerChevronGlyph(bool panelOpen) const {


### PR DESCRIPTION
## Motivation
This removes extraneous widget spacing.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots
Note the spacing between the volume and bluetooth widgets.

Before fix:
<img width="414" height="29" alt="image" src="https://github.com/user-attachments/assets/a70d7497-8772-4ea4-a337-50d7a4f91eec" />

After fix:
<img width="421" height="27" alt="image" src="https://github.com/user-attachments/assets/2f70c34e-c6ec-4a81-afe3-75917f64fd95" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
