### PR TITLE
Small fixes for icon resolver, network tab and translation

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -29,7 +29,7 @@
     },
     "empty": {
       "history-title": "Clipboard history is empty",
-      "history-message": "Clipboard history is empty.",
+      "history-message": "No entries in the clipboard history.",
       "no-matches-title": "No matching entries",
       "no-matches-message": "No entries match the current filter."
     }
@@ -231,8 +231,8 @@
       "clipboard": "Clipboard"
     },
     "network": {
-      "current-connection": "Current connection",
-      "available-networks": "Available networks",
+      "current-connection": "Current Connection",
+      "available-networks": "Available Networks",
       "wired-connection": "Wired connection",
       "not-connected": "Not connected",
       "wifi-on": "Wi-Fi is on",
@@ -781,14 +781,14 @@
         "delete-confirm-desc": "This GUI-created monitor override will be removed from settings.toml."
       },
       "widget": {
-        "add": "Add Widget",
+        "add": "Add widget",
         "lanes": {
           "start": "Start",
           "center": "Center",
           "end": "End",
           "customize": "Customize",
           "empty": "No widgets",
-          "empty-hint": "Use Add Widget to populate this lane."
+          "empty-hint": "Add a widget to populate this lane."
         },
         "kinds": {
           "built-in": "Built-in",
@@ -865,7 +865,7 @@
         "capsules": "Capsules",
         "clipboard": "Clipboard",
         "community": "Community",
-        "control-center": "Control Center:",
+        "control-center": "Control Center",
         "directories": "Directories",
         "effects": "Effects",
         "focus-styling": "Focus Styling",
@@ -1354,6 +1354,18 @@
         "corner-radius": {
           "label": "Corner Radius"
         },
+        "corner-top-left": {
+          "label": "Top Left Radius"
+        },
+        "corner-top-right": {
+          "label": "Top Right Radius"
+        },
+        "corner-bottom-left": {
+          "label": "Bottom Left Radius"
+        },
+        "corner-bottom-right": {
+          "label": "Bottom Right Radius"
+        },
         "background-opacity": {
           "label": "Background Opacity"
         },
@@ -1453,7 +1465,7 @@
         },
         "builtin-ids": {
           "label": "Active Built-in Templates",
-          "description": "Template IDs to render on each theme change."
+          "description": "Template IDs to render on each theme change"
         },
         "enable-community-templates": {
           "label": "Enable Community Templates",
@@ -1461,7 +1473,7 @@
         },
         "community-ids": {
           "label": "Active Community Templates",
-          "description": "Community template IDs to render on each theme change."
+          "description": "Community template IDs to render on each theme change"
         }
       },
       "shell": {
@@ -1516,7 +1528,7 @@
         },
         "clipboard-image-action": {
           "label": "Image Action Command",
-          "description": "Command to run from image clipboard entries. Use {path} for an exported image file; use {stdin} or omit {path} to pipe the image to stdin.",
+          "description": "Command to run from image clipboard entries; use {path} for the file path, {stdin} to mark the stdin position, or omit {path} to pipe automatically",
           "placeholder": "gimp {path} or satty -f -"
         },
         "osd-position": {
@@ -1603,6 +1615,18 @@
         "corner-radius": {
           "description": "Corner radius of the dock"
         },
+        "corner-top-left": {
+          "description": "Top left corner radius for the dock"
+        },
+        "corner-top-right": {
+          "description": "Top right corner radius for the dock"
+        },
+        "corner-bottom-left": {
+          "description": "Bottom left corner radius for the dock"
+        },
+        "corner-bottom-right": {
+          "description": "Bottom right corner radius for the dock"
+        },
         "background-opacity": {
           "description": "Background opacity of the dock"
         },
@@ -1631,7 +1655,7 @@
         },
         "compact-control-center": {
           "label": "Compact Sidebar",
-          "description": "Show only icons in the sidebar to make the Control Center narrower"
+          "description": "Show only icons in the sidebar to make the control center narrower"
         },
         "placement-launcher": {
           "label": "Placement",
@@ -1651,27 +1675,27 @@
         },
         "open-near-click-control-center": {
           "label": "Open Near Click",
-          "description": "Position the Control Center near the bar click instead of centering it along the bar"
+          "description": "Position the control center panel near the bar click instead of centering it along the bar"
         },
         "open-near-click-launcher": {
           "label": "Open Near Click",
-          "description": "Position the Launcher near the bar click instead of centering it along the bar"
+          "description": "Position the launcher panel near the bar click instead of centering it along the bar"
         },
         "open-near-click-clipboard": {
           "label": "Open Near Click",
-          "description": "Position the Clipboard near the bar click instead of centering it along the bar"
+          "description": "Position the clipboard panel near the bar click instead of centering it along the bar"
         },
         "open-near-click-wallpaper": {
           "label": "Open Near Click",
-          "description": "Position the Wallpaper picker near the bar click instead of centering it along the bar"
+          "description": "Position the wallpaper picker panel near the bar click instead of centering it along the bar"
         },
         "open-near-click-session": {
           "label": "Open Near Click",
-          "description": "Position the Session panel near the bar click instead of centering it along the bar"
+          "description": "Position the session panel near the bar click instead of centering it along the bar"
         },
         "session-actions": {
           "label": "Entries",
-          "description": "Power menu entries, order, custom commands, and icons.",
+          "description": "Power menu entries, order, custom commands, and icons",
           "configure": "Configure…",
           "entry-settings": "Details…"
         }
@@ -1679,37 +1703,37 @@
       "idle": {
         "pre-action-fade": {
           "label": "Idle dim",
-          "description": "Seconds of fullscreen dim before the idle command. Use 0 to disable."
+          "description": "Seconds of fullscreen dim before the idle command; use 0 to disable"
         },
         "behaviors": {
           "label": "Behaviors",
-          "description": "Named idle actions with presets (lock, displays off, suspend) or custom commands, timeouts, resume pairing, and order."
+          "description": "Named idle actions with presets (lock, displays off, suspend) or custom commands, timeouts, resume pairing, and order"
         }
       },
       "keybinds": {
         "validate": {
           "label": "Confirm",
-          "description": "Confirm selections, submit inputs, or activate the focused item."
+          "description": "Confirm selections, submit inputs, or activate the focused item"
         },
         "cancel": {
           "label": "Cancel",
-          "description": "Close popups, dismiss panels, or abort the current operation."
+          "description": "Close popups, dismiss panels, or abort the current operation"
         },
         "left": {
           "label": "Navigate left",
-          "description": "Move focus or selection to the left."
+          "description": "Move focus or selection to the left"
         },
         "right": {
           "label": "Navigate right",
-          "description": "Move focus or selection to the right."
+          "description": "Move focus or selection to the right"
         },
         "up": {
           "label": "Navigate up",
-          "description": "Move focus or selection up one row."
+          "description": "Move focus or selection up one row"
         },
         "down": {
           "label": "Navigate down",
-          "description": "Move focus or selection down one row."
+          "description": "Move focus or selection down one row"
         }
       },
       "backdrop": {
@@ -1764,12 +1788,12 @@
         },
         "directory-light": {
           "label": "Light Mode Directory",
-          "description": "Wallpaper folder used in Light theme mode",
+          "description": "Wallpaper folder used in light theme mode",
           "placeholder": "~/Pictures/Wallpapers"
         },
         "directory-dark": {
           "label": "Dark Mode Directory",
-          "description": "Wallpaper folder used in Dark theme mode",
+          "description": "Wallpaper folder used in dark theme mode",
           "placeholder": "~/Pictures/Wallpapers"
         },
         "transitions": {
@@ -1896,7 +1920,7 @@
         },
         "mpris-blacklist": {
           "label": "MPRIS player blacklist",
-          "description": "Players to ignore for media controls and Now Playing."
+          "description": "Players to ignore for media controls and Now Playing"
         },
         "ddcutil": {
           "label": "DDC/CI (ddcutil)",
@@ -2058,22 +2082,6 @@
           "label": "Content Padding",
           "description": "Padding inside the bar content area"
         },
-        "corner-top-left": {
-          "label": "Top Left Radius",
-          "description": "Top-left corner radius for the bar"
-        },
-        "corner-top-right": {
-          "label": "Top Right Radius",
-          "description": "Top-right corner radius for the bar"
-        },
-        "corner-bottom-left": {
-          "label": "Bottom Left Radius",
-          "description": "Bottom-left corner radius for the bar"
-        },
-        "corner-bottom-right": {
-          "label": "Bottom Right Radius",
-          "description": "Bottom-right corner radius for the bar"
-        },
         "widget-capsules": {
           "label": "Widget Capsules",
           "description": "Wrap widgets in capsule backgrounds"
@@ -2142,10 +2150,22 @@
           "description": "Inset from each end of the bar along its main axis"
         },
         "edge-margin": {
-          "description": "Distance from the nearest screen edge,  positive values float the bar away from it"
+          "description": "Distance from the nearest screen edge; positive values float the bar away from it"
         },
         "corner-radius": {
           "description": "Corner radius of the bar"
+        },
+        "corner-top-left": {
+          "description": "Top left corner radius for the bar"
+        },
+        "corner-top-right": {
+          "description": "Top right corner radius for the bar"
+        },
+        "corner-bottom-left": {
+          "description": "Bottom left corner radius for the bar"
+        },
+        "corner-bottom-right": {
+          "description": "Bottom right corner radius for the bar"
         },
         "background-opacity": {
           "description": "Background opacity of the bar"

--- a/src/shell/control_center/network_tab.cpp
+++ b/src/shell/control_center/network_tab.cpp
@@ -347,7 +347,7 @@ std::unique_ptr<Flex> NetworkTab::create() {
   connRow->setDirection(FlexDirection::Horizontal);
   connRow->setAlign(FlexAlign::Center);
   connRow->setGap(Style::spaceSm * scale);
-  m_disconnectRow = connRow.get();
+  m_currentRow = connRow.get();
 
   auto title = std::make_unique<Label>();
   title->setBold(true);
@@ -514,7 +514,7 @@ void NetworkTab::onClose() {
   m_rescanButton = nullptr;
   m_wifiToggle = nullptr;
   m_scanSpinner = nullptr;
-  m_disconnectRow = nullptr;
+  m_currentRow = nullptr;
   m_disconnectButton = nullptr;
   m_vpnSection = nullptr;
   m_apRows = nullptr;
@@ -609,16 +609,16 @@ void NetworkTab::syncCurrentCard() {
   if (m_network == nullptr) {
     m_currentTitle->setText(i18n::tr("control-center.network.unavailable-title"));
     m_currentDetail->setText(i18n::tr("control-center.network.unavailable-detail"));
-    if (m_disconnectRow != nullptr) {
-      m_disconnectRow->setVisible(false);
+    if (m_currentRow != nullptr) {
+      m_currentRow->setVisible(false);
     }
     return;
   }
   const NetworkState& s = m_network->state();
   m_currentTitle->setText(currentTitle(s));
   m_currentDetail->setText(currentDetail(s));
-  if (m_disconnectRow != nullptr) {
-    m_disconnectRow->setVisible(s.connected);
+  if (m_disconnectButton != nullptr) {
+      m_disconnectButton->setVisible(s.connected);
   }
   if (m_wifiToggle != nullptr) {
     m_wifiToggle->setChecked(s.wirelessEnabled);

--- a/src/shell/control_center/network_tab.cpp
+++ b/src/shell/control_center/network_tab.cpp
@@ -618,7 +618,7 @@ void NetworkTab::syncCurrentCard() {
   m_currentTitle->setText(currentTitle(s));
   m_currentDetail->setText(currentDetail(s));
   if (m_disconnectButton != nullptr) {
-      m_disconnectButton->setVisible(s.connected);
+    m_disconnectButton->setVisible(s.connected);
   }
   if (m_wifiToggle != nullptr) {
     m_wifiToggle->setChecked(s.wirelessEnabled);

--- a/src/shell/control_center/network_tab.h
+++ b/src/shell/control_center/network_tab.h
@@ -60,7 +60,7 @@ private:
 
   Button* m_rescanButton = nullptr;
   Toggle* m_wifiToggle = nullptr;
-  Flex* m_disconnectRow = nullptr;
+  Flex* m_currentRow = nullptr;
   Button* m_disconnectButton = nullptr;
   Spinner* m_scanSpinner = nullptr;
   bool m_vpnVisible = true;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -1329,6 +1329,8 @@ std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
   constexpr float kCellPad = 6.0f;
   const float cellMain = iSize + 2.0f * kCellPad;
   const float cellCross = iSize + 2.0f * kCellPad;
+  const float glyphSize = iSize * 0.8f;
+  const float glyphOffsetY = kCellPad + (iSize - glyphSize) * 0.5f;
 
   auto areaNode = std::make_unique<InputArea>();
   if (!vert) {
@@ -1349,10 +1351,10 @@ std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
   if (!glyph->setGlyph(dockLauncherIconGlyph(cfg))) {
     glyph->setGlyph("grid-dots");
   }
-  glyph->setGlyphSize(iSize * 0.8f);
+  glyph->setGlyphSize(glyphSize);
   glyph->setColor(colorSpecFromRole(ColorRole::OnSurface));
   glyph->setSize(iSize, iSize);
-  glyph->setPosition(kCellPad, kCellPad);
+  glyph->setPosition(kCellPad, glyphOffsetY);
   areaNode->addChild(std::move(glyph));
 
   auto* instPtr = &instance;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -603,19 +603,19 @@ namespace settings {
                                 SliderSetting{static_cast<float>(cfg.dock.radius), 0.0f, 80.0f, 1.0f, true},
                                 "rounded"));
     entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-top-left.label"),
-                                tr("settings.schema.bar.corner-top-left.description"), {"dock", "radius_top_left"},
+                                tr("settings.schema.dock.corner-top-left.description"), {"dock", "radius_top_left"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusTopLeft), 0.0f, 80.0f, 1.0f, true},
                                 "rounded corner", true));
     entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-top-right.label"),
-                                tr("settings.schema.bar.corner-top-right.description"), {"dock", "radius_top_right"},
+                                tr("settings.schema.dock.corner-top-right.description"), {"dock", "radius_top_right"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusTopRight), 0.0f, 80.0f, 1.0f, true},
                                 "rounded corner", true));
     entries.push_back(makeEntry(
         "dock", "shape", tr("settings.schema.shared.corner-bottom-left.label"),
-        tr("settings.schema.bar.corner-bottom-left.description"), {"dock", "radius_bottom_left"},
+        tr("settings.schema.dock.corner-bottom-left.description"), {"dock", "radius_bottom_left"},
         SliderSetting{static_cast<float>(cfg.dock.radiusBottomLeft), 0.0f, 80.0f, 1.0f, true}, "rounded corner", true));
     entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-bottom-right.label"),
-                                tr("settings.schema.bar.corner-bottom-right.description"),
+                                tr("settings.schema.dock.corner-bottom-right.description"),
                                 {"dock", "radius_bottom_right"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusBottomRight), 0.0f, 80.0f, 1.0f, true},
                                 "rounded corner", true));

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -602,19 +602,19 @@ namespace settings {
                                 tr("settings.schema.dock.corner-radius.description"), {"dock", "radius"},
                                 SliderSetting{static_cast<float>(cfg.dock.radius), 0.0f, 80.0f, 1.0f, true},
                                 "rounded"));
-    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.bar.corner-top-left.label"),
+    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-top-left.label"),
                                 tr("settings.schema.bar.corner-top-left.description"), {"dock", "radius_top_left"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusTopLeft), 0.0f, 80.0f, 1.0f, true},
                                 "rounded corner", true));
-    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.bar.corner-top-right.label"),
+    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-top-right.label"),
                                 tr("settings.schema.bar.corner-top-right.description"), {"dock", "radius_top_right"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusTopRight), 0.0f, 80.0f, 1.0f, true},
                                 "rounded corner", true));
     entries.push_back(makeEntry(
-        "dock", "shape", tr("settings.schema.bar.corner-bottom-left.label"),
+        "dock", "shape", tr("settings.schema.shared.corner-bottom-left.label"),
         tr("settings.schema.bar.corner-bottom-left.description"), {"dock", "radius_bottom_left"},
         SliderSetting{static_cast<float>(cfg.dock.radiusBottomLeft), 0.0f, 80.0f, 1.0f, true}, "rounded corner", true));
-    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.bar.corner-bottom-right.label"),
+    entries.push_back(makeEntry("dock", "shape", tr("settings.schema.shared.corner-bottom-right.label"),
                                 tr("settings.schema.bar.corner-bottom-right.description"),
                                 {"dock", "radius_bottom_right"},
                                 SliderSetting{static_cast<float>(cfg.dock.radiusBottomRight), 0.0f, 80.0f, 1.0f, true},
@@ -1308,22 +1308,22 @@ namespace settings {
                                   SliderSetting{static_cast<float>(selectedBar->radius), 0.0f, 80.0f, 1.0f, true},
                                   "rounded"));
       entries.push_back(
-          makeEntry(section, "shape", tr("settings.schema.bar.corner-top-left.label"),
+          makeEntry(section, "shape", tr("settings.schema.shared.corner-top-left.label"),
                     tr("settings.schema.bar.corner-top-left.description"), path("radius_top_left"),
                     SliderSetting{static_cast<float>(selectedBar->radiusTopLeft), 0.0f, 80.0f, 1.0f, true},
                     "rounded corner", true));
       entries.push_back(
-          makeEntry(section, "shape", tr("settings.schema.bar.corner-top-right.label"),
+          makeEntry(section, "shape", tr("settings.schema.shared.corner-top-right.label"),
                     tr("settings.schema.bar.corner-top-right.description"), path("radius_top_right"),
                     SliderSetting{static_cast<float>(selectedBar->radiusTopRight), 0.0f, 80.0f, 1.0f, true},
                     "rounded corner", true));
       entries.push_back(
-          makeEntry(section, "shape", tr("settings.schema.bar.corner-bottom-left.label"),
+          makeEntry(section, "shape", tr("settings.schema.shared.corner-bottom-left.label"),
                     tr("settings.schema.bar.corner-bottom-left.description"), path("radius_bottom_left"),
                     SliderSetting{static_cast<float>(selectedBar->radiusBottomLeft), 0.0f, 80.0f, 1.0f, true},
                     "rounded corner", true));
       entries.push_back(
-          makeEntry(section, "shape", tr("settings.schema.bar.corner-bottom-right.label"),
+          makeEntry(section, "shape", tr("settings.schema.shared.corner-bottom-right.label"),
                     tr("settings.schema.bar.corner-bottom-right.description"), path("radius_bottom_right"),
                     SliderSetting{static_cast<float>(selectedBar->radiusBottomRight), 0.0f, 80.0f, 1.0f, true},
                     "rounded corner", true));
@@ -1474,22 +1474,22 @@ namespace settings {
           tr("settings.schema.bar.corner-radius.description"), mpath("radius"),
           SliderSetting{static_cast<float>(ovr.radius.value_or(bar.radius)), 0.0f, 80.0f, 1.0f, true}, "rounded"));
       entries.push_back(makeEntry(
-          section, "shape", tr("settings.schema.bar.corner-top-left.label"),
+          section, "shape", tr("settings.schema.shared.corner-top-left.label"),
           tr("settings.schema.bar.corner-top-left.description"), mpath("radius_top_left"),
           SliderSetting{static_cast<float>(ovr.radiusTopLeft.value_or(bar.radiusTopLeft)), 0.0f, 80.0f, 1.0f, true},
           "rounded corner", true));
       entries.push_back(makeEntry(
-          section, "shape", tr("settings.schema.bar.corner-top-right.label"),
+          section, "shape", tr("settings.schema.shared.corner-top-right.label"),
           tr("settings.schema.bar.corner-top-right.description"), mpath("radius_top_right"),
           SliderSetting{static_cast<float>(ovr.radiusTopRight.value_or(bar.radiusTopRight)), 0.0f, 80.0f, 1.0f, true},
           "rounded corner", true));
-      entries.push_back(makeEntry(section, "shape", tr("settings.schema.bar.corner-bottom-left.label"),
+      entries.push_back(makeEntry(section, "shape", tr("settings.schema.shared.corner-bottom-left.label"),
                                   tr("settings.schema.bar.corner-bottom-left.description"), mpath("radius_bottom_left"),
                                   SliderSetting{static_cast<float>(ovr.radiusBottomLeft.value_or(bar.radiusBottomLeft)),
                                                 0.0f, 80.0f, 1.0f, true},
                                   "rounded corner", true));
       entries.push_back(
-          makeEntry(section, "shape", tr("settings.schema.bar.corner-bottom-right.label"),
+          makeEntry(section, "shape", tr("settings.schema.shared.corner-bottom-right.label"),
                     tr("settings.schema.bar.corner-bottom-right.description"), mpath("radius_bottom_right"),
                     SliderSetting{static_cast<float>(ovr.radiusBottomRight.value_or(bar.radiusBottomRight)), 0.0f,
                                   80.0f, 1.0f, true},

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -322,7 +322,7 @@ namespace {
       if (da.scalable != db.scalable)
         return da.scalable > db.scalable;
       if (da.maxSize != db.maxSize)
-        return da.maxSize  > db.maxSize;
+        return da.maxSize > db.maxSize;
       return da.size > db.size;
     });
 

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -257,6 +257,7 @@ namespace {
     struct DirEntry {
       std::string path;
       int size = 0;
+      int maxSize = 0;
       bool scalable = false;
     };
 
@@ -306,23 +307,22 @@ namespace {
           entry.scalable = (value == "Scalable" || value == "Threshold");
         } else if (key == "MaxSize") {
           // For threshold/scalable dirs, MaxSize gives a better sense of actual size
-          int maxSize = 0;
           try {
-            maxSize = std::stoi(std::string(value));
+            entry.maxSize = std::stoi(std::string(value));
           } catch (...) {
           }
-          if (maxSize > entry.size)
-            entry.size = maxSize;
         }
       }
     }
 
-    // Sort dirs: scalable first, then by size descending
+    // Sort dirs: scalable first, then by size descending (MaxSize first, then use Size as a tiebraker)
     std::stable_sort(dirNames.begin(), dirNames.end(), [&](const std::string& a, const std::string& b) {
       const auto& da = dirMap[a];
       const auto& db = dirMap[b];
       if (da.scalable != db.scalable)
         return da.scalable > db.scalable;
+      if (da.maxSize != db.maxSize)
+        return da.maxSize  > db.maxSize;
       return da.size > db.size;
     });
 


### PR DESCRIPTION
1. Fixing an issue with the icon resolver I experience with my icon pack: an app that has the icon "printer" will show the symbolic icon in actions/32 instead of the normal icon in apps/scalable. To solve this, I have added a comparision for the `Size` entry if `MaxSize` is equal.
2. If there is no active connection in the network tab, the "Current Connection" box is empty instead of showing the intended "Not connected" row.
3. The launcher icon in the dock is now centered instead of aligned to the top (necessary because it's scaled down to 0.8)
4. I have changed some translation keys for more consistency.