### PR TITLE
chore(justfile): add job dependencies

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,13 +19,13 @@ configure m=mode:
     fi
     ln -sfn "build-{{m}}/compile_commands.json" compile_commands.json
 
-build m=mode:
+build m=mode: (configure m)
     meson compile -C build-{{m}}
 
-run m=mode:
+run m=mode: (build m)
     ./build-{{m}}/noctalia
 
-install m=mode:
+install m=mode: (configure m)
     meson install -C build-{{m}}
 
 format:
@@ -40,7 +40,4 @@ clean m=mode:
     fi
     rm -rf build-{{m}}
 
-rebuild m=mode:
-    just clean {{m}}
-    just configure {{m}}
-    just build {{m}}
+rebuild m=mode: (clean m) (build m)


### PR DESCRIPTION
## Motivation
It's just cleaner and more convenient this way. Now you can run `just run` directly to _just run_ the shell without needing to remember configure and build separately.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Testing
- [x] Tested

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors