### PR TITLE
[V4] fix(mangowc): poll keyboard layout via mmsg instead of unreliable DWL events

### DIFF
--- a/Services/Compositor/MangoService.qml
+++ b/Services/Compositor/MangoService.qml
@@ -345,9 +345,7 @@ Item {
       }
 
       function onKbLayoutChanged() {
-        if (KeyboardLayoutService) {
-          KeyboardLayoutService.setCurrentLayout(modelData.kbLayout);
-        }
+        // Not reliable for XKB-driven switches on MangoWC; handled by kbLayoutPoll
       }
     }
   }
@@ -373,6 +371,41 @@ Item {
                   scaleQuery.buffer = "";
                 }
               }
+  }
+
+  // Keyboard layout polling - MangoWC doesn't send DWL IPC events for XKB-driven
+  // layout switches (grp:win_space_toggle), so we poll mmsg periodically.
+  property QtObject _kbLayoutPoll: Timer {
+    id: kbLayoutPoll
+    interval: 300
+    running: false
+    repeat: true
+
+    property bool busy: false
+
+    onTriggered: {
+      if (busy) return;
+      busy = true;
+      kbLayoutQuery.running = true;
+    }
+  }
+
+  property QtObject _kbLayoutQuery: Process {
+    id: kbLayoutQuery
+    command: ["mmsg", "-g", "-k"]
+
+    stdout: SplitParser {
+      onRead: line => {
+        var parts = line.trim().split(/\s+/);
+        if (parts.length >= 3 && parts[1] === "kb_layout") {
+          KeyboardLayoutService.setCurrentLayout(parts.slice(2).join(" "));
+        }
+      }
+    }
+
+    onExited: code => {
+      kbLayoutPoll.busy = false;
+    }
   }
 
   // ===== TOPLEVEL MANAGER CONNECTION =====
@@ -402,6 +435,9 @@ Item {
       internal.rebuildWorkspaces();
       internal.updateWindows();
     }
+
+    // Start keyboard layout polling
+    kbLayoutPoll.running = true;
 
     initialized = true;
   }
@@ -474,7 +510,7 @@ Item {
   }
 
   function cycleKeyboardLayout() {
-    Logger.w("MangoService", "Keyboard layout cycling not supported");
+    Quickshell.execDetached(["mmsg", "-s", "-d", "switch_keyboard_layout"]);
   }
 
   function getFocusedScreen() {


### PR DESCRIPTION
Most of changes is done by OpenCode Big Pickle, i have self-reviewed most of the code , its single files and fews blocks of function changes so

These changes was mades because i notice a lag / delay of the Language layout indicator

MangoWC doesn't send DWL IPC events for XKB-driven layout switches (e.g. grp:win_space_toggle), so onKbLayoutChanged was unreliable.

- Removed optimistic setCurrentLayout from onKbLayoutChanged
- Added a Timer + Process to poll mmsg -g -k every 300ms
- Implemented cycleKeyboardLayout() with mmsg switch_keyboard_layout

- [x] Bug fix

## Testing

Layout indicator changes near-instant
- [x] Tested on MangoWC

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)