### PR TITLE
Feat/custom hex widget colors

### DIFF
--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -424,6 +424,7 @@
     "contributors": "Contributors",
     "copied-to-clipboard": "Copied to clipboard",
     "countdown": "Countdown",
+    "custom-color": "Custom color",
     "customize": "Customize",
     "date": "Date",
     "default": "Default",

--- a/Commons/Color.qml
+++ b/Commons/Color.qml
@@ -303,6 +303,8 @@ Singleton {
   }
 
   function resolveColorKey(key) {
+    if (key && key.length > 0 && key.charAt(0) === "#")
+      return key;
     switch (key) {
     case "primary":
       return root.mPrimary;
@@ -318,6 +320,8 @@ Singleton {
   }
 
   function resolveOnColorKey(key) {
+    if (key && key.length > 0 && key.charAt(0) === "#")
+      return key;
     switch (key) {
     case "primary":
       return root.mOnPrimary;
@@ -333,6 +337,8 @@ Singleton {
   }
 
   function resolveColorKeyOptional(key) {
+    if (key && key.length > 0 && key.charAt(0) === "#")
+      return key;
     switch (key) {
     case "primary":
       return root.mPrimary;

--- a/Widgets/NColorChoice.qml
+++ b/Widgets/NColorChoice.qml
@@ -36,7 +36,8 @@ RowLayout {
     id: colourRow
 
     opacity: enabled ? 1.0 : 0.6
-    Layout.minimumWidth: root.diameter * Color.colorKeyModel.length
+    Layout.minimumWidth: root.diameter * (Color.colorKeyModel.length + 1)
+    Layout.rightMargin: Style.marginS
 
     Repeater {
       model: Color.colorKeyModel
@@ -126,11 +127,21 @@ RowLayout {
         }
       }
 
+      // Contrast tick: white on dark hexes, black on light hexes (matches resolveOnColorKey behavior for palette circles)
+      function contrastFor(hex) {
+        if (!hex || hex.length < 7)
+          return "#ffffff";
+        var r = parseInt(hex.substr(1, 2), 16);
+        var g = parseInt(hex.substr(3, 2), 16);
+        var b = parseInt(hex.substr(5, 2), 16);
+        return (r * 299 + g * 587 + b * 114) / 1000 > 140 ? "#000000" : "#ffffff";
+      }
+
       NIcon {
         anchors.centerIn: parent
         icon: "check"
         pointSize: Math.max(Style.fontSizeXS, customSlot.width * 0.4)
-        color: Color.mOnSurface
+        color: customSlot.contrastFor(root.currentKey)
         font.weight: Style.fontWeightBold
         visible: customSlot.isHex
       }

--- a/Widgets/NColorChoice.qml
+++ b/Widgets/NColorChoice.qml
@@ -118,7 +118,7 @@ RowLayout {
         anchors.fill: parent
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
-        onEntered: TooltipService.show(parent, "Custom color")
+        onEntered: TooltipService.show(parent, I18n.tr("common.custom-color"))
         onExited: TooltipService.hide()
         onClicked: {
           customColorDialog.selectedColor = customSlot.isHex ? root.currentKey : Color.resolveColorKey(root.currentKey);

--- a/Widgets/NColorChoice.qml
+++ b/Widgets/NColorChoice.qml
@@ -85,5 +85,67 @@ RowLayout {
         }
       }
     }
+
+    // Custom hex color slot — opens NColorPickerDialog, stores "#rrggbb" in currentKey
+    Rectangle {
+      id: customSlot
+      readonly property bool isHex: root.currentKey && root.currentKey.length > 0 && root.currentKey.charAt(0) === "#"
+      property bool isHovered: customMouseArea.containsMouse
+
+      Layout.alignment: Qt.AlignHCenter
+      implicitWidth: root.diameter
+      implicitHeight: root.diameter
+      radius: root.diameter * 0.5
+      color: isHex ? root.currentKey : "transparent"
+      border.color: (isHex || isHovered) ? Color.mOnSurface : Color.mOutline
+      border.width: Style.borderM
+
+      Rectangle {
+        visible: !customSlot.isHex
+        anchors.fill: parent
+        anchors.margins: Style.borderM
+        radius: width * 0.5
+        gradient: Gradient {
+          orientation: Gradient.Horizontal
+          GradientStop { position: 0.0; color: "#ed8796" }
+          GradientStop { position: 0.5; color: "#a6da95" }
+          GradientStop { position: 1.0; color: "#8aadf4" }
+        }
+      }
+
+      MouseArea {
+        id: customMouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onEntered: TooltipService.show(parent, "Custom color")
+        onExited: TooltipService.hide()
+        onClicked: {
+          customColorDialog.selectedColor = customSlot.isHex ? root.currentKey : Color.resolveColorKey(root.currentKey);
+          customColorDialog.open();
+        }
+      }
+
+      NIcon {
+        anchors.centerIn: parent
+        icon: "check"
+        pointSize: Math.max(Style.fontSizeXS, customSlot.width * 0.4)
+        color: Color.mOnSurface
+        font.weight: Style.fontWeightBold
+        visible: customSlot.isHex
+      }
+    }
+
+    NColorPickerDialog {
+      id: customColorDialog
+      onColorSelected: function(c) {
+        var hex = "#"
+          + Math.round(c.r * 255).toString(16).padStart(2, "0")
+          + Math.round(c.g * 255).toString(16).padStart(2, "0")
+          + Math.round(c.b * 255).toString(16).padStart(2, "0");
+        root.currentKey = hex;
+        root.selected(hex);
+      }
+    }
   }
 }


### PR DESCRIPTION
# Pull Request

  ## Motivation

  Users currently can't theme an individual widget with a one-off color without redefining a palette slot in their colorscheme — which then bleeds into every widget bound to that slot. This PR adds first-class per-widget custom hex colors, selectable
  directly from the existing widget settings color picker.

  Two small, composable changes plus an i18n key:

  1. **`Commons/Color.qml`** — `resolveColorKey`, `resolveOnColorKey`, and `resolveColorKeyOptional` short-circuit and return the input unchanged when it starts with `#`. Any setting already routed through these helpers now accepts `"#rrggbb"` /
  `"#rrggbbaa"` in addition to the existing palette keys (`primary` / `secondary` / `tertiary` / `error` / `none`).

  2. **`Widgets/NColorChoice.qml`** — appends a rainbow-gradient "custom color" circle after the palette circles. Clicking it opens the existing `NColorPickerDialog`; the picked color is converted to `#rrggbb` and emitted via the standard `selected`
  signal. Every widget settings panel that already uses `NColorChoice` (Volume, Network, Clock, Workspace, Battery, NotificationHistory, SystemMonitor, …) gains this with zero per-widget changes.

  3. **`Assets/Translations/en.json`** — adds `common.custom-color` for the new tooltip; other locales fall back to en via the existing `I18n.tr` fallback chain until translations are contributed.

  Existing palette keys keep working identically. Settings files written before this PR are untouched — the new circle is purely additive. No new dependencies, no settings-schema changes, no migrations.

  ## Type of Change
  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Refactoring

  ## Related Issue
  - N/A

  ## Testing
  - [ ] Tested on niri
  - [ ] Tested on Hyprland
  - [ ] Tested on sway
  - [x] Tested with different bar positions and density settings
  - [ ] Tested at different interface scaling values
  - [x] Tested with multiple monitors (if applicable)

  Tested on **mangowc** (not listed in the template). Verified:
  - New rainbow circle appears at the end of every widget's color row in settings
  - Picking a color via `NColorPickerDialog` saves as `"#rrggbb"` in `settings.json` and renders correctly on the widget
  - Switching back to a palette circle (primary/secondary/…) restores the palette behavior
  - Manually editing `settings.json` to set e.g. `"iconColor": "#91d7e3"` renders correctly without touching the UI
  - Existing settings load with no behavior change
  - Confirmed across two monitors with different bar positions (top / bottom) and density settings (spacious / comfortable)

  Not yet tested on niri / Hyprland / sway or at non-default UI scale — happy to validate on those if a maintainer can point me at a quick way to spin them up, or if a reviewer with that setup can spot-check.

  ## Screenshots / Videos
<img width="695" height="103" alt="image" src="https://github.com/user-attachments/assets/cf642628-b436-44f7-9f99-31fa4328ba3d" />

<img width="1527" height="989" alt="image" src="https://github.com/user-attachments/assets/97df5675-e69e-4d1e-94cf-ab45ab8f27cb" />


  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my code
  - [x] No new warnings or errors
  - [ ] Documentation or comments updated (if relevant)

  (No user-facing docs found in the repo for the color picker / widget settings; happy to add a note somewhere if maintainers point me at the right place.)

  ## Additional Notes

  None.
