### PR TITLE
taskbar: add "show window title" option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1263,6 +1263,14 @@
           "label": "Workspace Group Capsule",
           "description": "Draw the background and border around each grouped workspace. Turn off to keep icon grouping and workspace disc labels only."
         },
+        "show_window_title": {
+          "label": "Show Window Title",
+          "description": "Show the window title next to its icon (only on horizontal bars)"
+        },
+        "window_title_max_width": {
+          "label": "Window Title Max Width",
+          "description": "Maximum width in pixels for window titles"
+        },
         "height": {
           "label": "Height",
           "description": "Widget height in pixels"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -441,10 +441,13 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const ColorSpec emptyColor = wc != nullptr
         ? wc->getColorSpec("empty_color", colorSpecFromRole(ColorRole::Secondary), "widget." + name + ".empty_color")
         : colorSpecFromRole(ColorRole::Secondary);
+    const bool showWindowTitle = wc != nullptr ? wc->getBool("show_window_title", false) : false;
+    const float windowTitleMaxWidth =
+        static_cast<float>(wc != nullptr ? wc->getDouble("window_title_max_width", 100.0) : 100.0);
     auto widget = std::make_unique<TaskbarWidget>(
         m_platform, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
         workspaceLabelPlacement, hideEmptyWorkspaces, workspaceGroupCapsule, focusedColor, occupiedColor, emptyColor,
-        barPosition, m_config.shell.shadow
+        showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -132,14 +132,20 @@ TaskbarWidget::TaskbarWidget(
     CompositorPlatform& platform, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
     bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
     bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
-    ColorSpec emptyColor, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
+    ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
+    ShellConfig::ShadowConfig shadowConfig
 )
     : m_platform(platform), m_output(output), m_groupByWorkspace(groupByWorkspace), m_showAllOutputs(showAllOutputs),
       m_onlyActiveWorkspace(onlyActiveWorkspace), m_showWorkspaceLabel(showWorkspaceLabel),
       m_workspaceLabelPlacement(workspaceLabelPlacement), m_hideEmptyWorkspaces(hideEmptyWorkspaces),
       m_workspaceGroupCapsule(workspaceGroupCapsule), m_focusedColor(std::move(focusedColor)),
       m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
+      m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
       m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)) {
+  // Window title not implemented for vertical bars or workspace grouping.
+  if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
+    m_showWindowTitle = false;
+  }
   buildDesktopIconIndex();
 }
 
@@ -255,6 +261,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   const float iconSize = std::round(Style::barGlyphSize * m_contentScale);
   const float tilePadding = Style::spaceXs * 0.35f * m_contentScale;
   const float tileSize = std::round(iconSize + tilePadding * 2.0f);
+  const float tileWidthWithTitle =
+      tileSize + (m_showWindowTitle ? m_windowTitleMaxWidth * m_contentScale + tilePadding : 0.0f);
   const float groupBorderInset = Style::borderWidth * m_contentScale;
   const float groupOutlineInset = m_workspaceGroupCapsule ? groupBorderInset : 0.0f;
   const FontWeight fontWeight = labelFontWeight();
@@ -282,7 +290,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   };
   auto createTaskTile = [&](const TaskModel& task) {
     auto area = std::make_unique<InputArea>();
-    area->setFrameSize(tileSize, tileSize);
+    area->setFrameSize(tileWidthWithTitle, tileSize);
     area->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
     area->setOnAxisHandler(workspaceAxisHandler);
 
@@ -351,17 +359,40 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       area->addChild(std::move(glyph));
     }
 
+    if (m_showWindowTitle) {
+      auto label = ui::label({
+          .text = task.title,
+          .fontSize = Style::fontSizeCaption * m_contentScale,
+          .maxWidth = m_windowTitleMaxWidth * m_contentScale,
+      });
+      label->measure(renderer);
+      label->setPosition(std::round(tileSize + tilePadding), 0);
+      area->addChild(std::move(label));
+    }
+
     if (task.active) {
       const float d = std::max(4.0f, std::round(Style::barGlyphSize * 0.32f * m_contentScale));
       const float bottomInset = 0.25f * m_contentScale;
-      auto indicator = ui::box({
-          .fill = colorSpecFromRole(ColorRole::Primary),
-          .radius = resolvedBarCapsuleRadius(d, d),
-          .width = d,
-          .height = d,
-      });
-      indicator->setPosition(std::round((tileSize - d) * 0.5f), std::round(tileSize - d - bottomInset));
-      area->addChild(std::move(indicator));
+      if (m_showWindowTitle) {
+        const float lineThickness = d * 0.5f;
+        auto indicator = ui::box({
+            .fill = colorSpecFromRole(ColorRole::Primary),
+            .radius = lineThickness * 0.5f,
+            .width = tileWidthWithTitle - tilePadding * 2,
+            .height = lineThickness,
+        });
+        indicator->setPosition(tilePadding, std::round(tileSize));
+        area->addChild(std::move(indicator));
+      } else {
+        auto indicator = ui::box({
+            .fill = colorSpecFromRole(ColorRole::Primary),
+            .radius = resolvedBarCapsuleRadius(d, d),
+            .width = d,
+            .height = d,
+        });
+        indicator->setPosition(std::round((tileSize - d) * 0.5f), std::round(tileSize - d - bottomInset));
+        area->addChild(std::move(indicator));
+      }
     }
     return area;
   };

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1763,7 +1763,8 @@ bool TaskbarWidget::modelsEqual(
         || tasks[i].firstHandle != m_tasks[i].firstHandle
         || tasks[i].workspaceKey != m_tasks[i].workspaceKey
         || tasks[i].order != m_tasks[i].order
-        || tasks[i].workspaceOrder != m_tasks[i].workspaceOrder) {
+        || tasks[i].workspaceOrder != m_tasks[i].workspaceOrder
+        || (m_showWindowTitle && tasks[i].title != m_tasks[i].title)) {
       return false;
     }
   }

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -31,7 +31,8 @@ public:
       CompositorPlatform& platform, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
       bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
       bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
-      ColorSpec emptyColor, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
+      ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
+      ShellConfig::ShadowConfig shadowConfig
   );
   ~TaskbarWidget() override;
 
@@ -106,6 +107,8 @@ private:
   ColorSpec m_focusedColor = colorSpecFromRole(ColorRole::Primary);
   ColorSpec m_occupiedColor = colorSpecFromRole(ColorRole::Secondary);
   ColorSpec m_emptyColor = colorSpecFromRole(ColorRole::Secondary);
+  bool m_showWindowTitle = false;
+  float m_windowTitleMaxWidth = 100.0;
   std::string m_barPosition;
   ShellConfig::ShadowConfig m_shadowConfig;
   bool m_rebuildPending = true;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -693,6 +693,18 @@ namespace settings {
           break;
         }
       }
+      {
+        auto showWindowTitle = boolSpec("show_window_title", false);
+        showWindowTitle.visibleWhen =
+            WidgetSettingVisibility{WidgetSettingVisibilityCondition{"group_by_workspace", {"false"}}};
+        add(std::move(showWindowTitle));
+      }
+      {
+        auto windowTitleMaxWidth = doubleSpec("window_title_max_width", 100.0, 10.0, 200.0, 1.0);
+        windowTitleMaxWidth.visibleWhen =
+            WidgetSettingVisibility{WidgetSettingVisibilityCondition{"group_by_workspace", {"false"}}};
+        add(std::move(windowTitleMaxWidth));
+      }
     } else if (type == "tray") {
       add(stringListSpec("hidden"));
       add(stringListSpec("pinned"));


### PR DESCRIPTION
# Pull Request

The option only works in horizontal panels and when not grouping by workspace.

Automatic resizing of window title is not implemented because I don't know the design of the layout system enough to determine the available space for the task bar.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="3199" height="343" alt="Screenshot from 2026-05-21 14-27-12" src="https://github.com/user-attachments/assets/5017d888-3dfd-463d-9508-69e67bea818e" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)