### PR TITLE
bar: add panel_background_opacity to detach attached panels from bar alpha

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1429,6 +1429,9 @@
         "background-opacity": {
           "label": "Background Opacity"
         },
+        "panel-background-opacity": {
+          "label": "Panel Background Opacity"
+        },
         "shadow": {
           "label": "Shadow"
         },
@@ -2233,6 +2236,9 @@
         },
         "background-opacity": {
           "description": "Background opacity of the bar"
+        },
+        "panel-background-opacity": {
+          "description": "Opacity for panels attached to this bar"
         },
         "border": {
           "label": "Border",

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -152,6 +152,9 @@ namespace config_export {
       table.insert_or_assign("reserve_space", bar.reserveSpace);
       table.insert_or_assign("thickness", static_cast<std::int64_t>(bar.thickness));
       table.insert_or_assign("background_opacity", static_cast<double>(bar.backgroundOpacity));
+      if (bar.panelBackgroundOpacity.has_value()) {
+        table.insert_or_assign("panel_background_opacity", static_cast<double>(*bar.panelBackgroundOpacity));
+      }
       table.insert_or_assign("border", colorSpecToConfigString(bar.border));
       table.insert_or_assign("border_width", static_cast<double>(bar.borderWidth));
       table.insert_or_assign("radius", static_cast<std::int64_t>(bar.radius));
@@ -202,6 +205,8 @@ namespace config_export {
         resolved.thickness = *ovr.thickness;
       if (ovr.backgroundOpacity)
         resolved.backgroundOpacity = *ovr.backgroundOpacity;
+      if (ovr.panelBackgroundOpacity)
+        resolved.panelBackgroundOpacity = *ovr.panelBackgroundOpacity;
       if (ovr.border)
         resolved.border = *ovr.border;
       if (ovr.borderWidth)

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -48,6 +48,13 @@ namespace {
     return !a.has_value() || nearlyEqual(*a, *b);
   }
 
+  bool optionalFloatEqual(const std::optional<float>& a, const std::optional<float>& b) noexcept {
+    if (a.has_value() != b.has_value()) {
+      return false;
+    }
+    return !a.has_value() || nearlyEqual(*a, *b);
+  }
+
   bool optionalColorSpecEqual(const std::optional<ColorSpec>& a, const std::optional<ColorSpec>& b) noexcept {
     if (a.has_value() != b.has_value()) {
       return false;
@@ -125,14 +132,15 @@ namespace {
   bool barBaseConfigEqual(const BarConfig& a, const BarConfig& b) {
     return a.name == b.name && a.position == b.position && a.enabled == b.enabled && a.autoHide == b.autoHide &&
            a.reserveSpace == b.reserveSpace && a.thickness == b.thickness &&
-           nearlyEqual(a.backgroundOpacity, b.backgroundOpacity) && colorSpecEqual(a.border, b.border) &&
-           nearlyEqual(a.borderWidth, b.borderWidth) && a.radius == b.radius && a.radiusTopLeft == b.radiusTopLeft &&
-           a.radiusTopRight == b.radiusTopRight && a.radiusBottomLeft == b.radiusBottomLeft &&
-           a.radiusBottomRight == b.radiusBottomRight && a.marginEnds == b.marginEnds && a.marginEdge == b.marginEdge &&
-           a.padding == b.padding && a.widgetSpacing == b.widgetSpacing && a.shadow == b.shadow &&
-           a.contactShadow == b.contactShadow && nearlyEqual(a.scale, b.scale) && a.startWidgets == b.startWidgets &&
-           a.centerWidgets == b.centerWidgets && a.endWidgets == b.endWidgets &&
-           a.widgetCapsuleDefault == b.widgetCapsuleDefault &&
+           nearlyEqual(a.backgroundOpacity, b.backgroundOpacity) &&
+           optionalFloatEqual(a.panelBackgroundOpacity, b.panelBackgroundOpacity) &&
+           colorSpecEqual(a.border, b.border) && nearlyEqual(a.borderWidth, b.borderWidth) && a.radius == b.radius &&
+           a.radiusTopLeft == b.radiusTopLeft && a.radiusTopRight == b.radiusTopRight &&
+           a.radiusBottomLeft == b.radiusBottomLeft && a.radiusBottomRight == b.radiusBottomRight &&
+           a.marginEnds == b.marginEnds && a.marginEdge == b.marginEdge && a.padding == b.padding &&
+           a.widgetSpacing == b.widgetSpacing && a.shadow == b.shadow && a.contactShadow == b.contactShadow &&
+           nearlyEqual(a.scale, b.scale) && a.startWidgets == b.startWidgets && a.centerWidgets == b.centerWidgets &&
+           a.endWidgets == b.endWidgets && a.widgetCapsuleDefault == b.widgetCapsuleDefault &&
            colorSpecEqual(a.widgetCapsuleFill, b.widgetCapsuleFill) &&
            optionalColorSpecEqual(a.widgetCapsuleForeground, b.widgetCapsuleForeground) &&
            optionalColorSpecEqual(a.widgetColor, b.widgetColor) && a.widgetCapsuleGroups == b.widgetCapsuleGroups &&
@@ -160,6 +168,9 @@ namespace {
     }
     if (ovr.backgroundOpacity) {
       resolved.backgroundOpacity = *ovr.backgroundOpacity;
+    }
+    if (ovr.panelBackgroundOpacity) {
+      resolved.panelBackgroundOpacity = *ovr.panelBackgroundOpacity;
     }
     if (ovr.border) {
       resolved.border = *ovr.border;

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -645,6 +645,8 @@ BarConfig ConfigService::resolveForOutput(const BarConfig& base, const WaylandOu
       resolved.thickness = *ovr.thickness;
     if (ovr.backgroundOpacity)
       resolved.backgroundOpacity = *ovr.backgroundOpacity;
+    if (ovr.panelBackgroundOpacity)
+      resolved.panelBackgroundOpacity = *ovr.panelBackgroundOpacity;
     if (ovr.border)
       resolved.border = *ovr.border;
     if (ovr.borderWidth)
@@ -1050,6 +1052,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
         bar.thickness = std::clamp(static_cast<std::int32_t>(*v), 10, 300);
       if (auto v = finiteDouble((*barTbl)["background_opacity"]))
         bar.backgroundOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
+      if (auto v = finiteDouble((*barTbl)["panel_background_opacity"]))
+        bar.panelBackgroundOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
       if (auto borderStr = colorStringValue(*barTbl, "border", "bar." + bar.name + ".border"))
         bar.border = colorSpecFromConfigString(*borderStr, "bar." + bar.name + ".border");
       if (auto v = finiteDouble((*barTbl)["border_width"]))
@@ -1146,6 +1150,8 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
             ovr.thickness = std::clamp(static_cast<std::int32_t>(*v), 10, 300);
           if (auto v = finiteDouble((*monTbl)["background_opacity"]))
             ovr.backgroundOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
+          if (auto v = finiteDouble((*monTbl)["panel_background_opacity"]))
+            ovr.panelBackgroundOpacity = std::clamp(static_cast<float>(*v), 0.0f, 1.0f);
           const std::string monitorContext = "bar." + bar.name + ".monitor." + std::string(monName.str());
           if (auto borderStr = colorStringValue(*monTbl, "border", monitorContext + ".border"))
             ovr.border = colorSpecFromConfigString(*borderStr, monitorContext + ".border");

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -23,6 +23,7 @@ struct BarMonitorOverride {
   std::optional<bool> reserveSpace;
   std::optional<std::int32_t> thickness;
   std::optional<float> backgroundOpacity;
+  std::optional<float> panelBackgroundOpacity;
   std::optional<ColorSpec> border;
   std::optional<float> borderWidth;
   std::optional<std::int32_t> radius;
@@ -62,6 +63,9 @@ struct BarConfig {
   bool reserveSpace = true; // reserve compositor exclusive zone for this bar
   std::int32_t thickness = Style::barThicknessDefault;
   float backgroundOpacity = 1.0f;
+  // When set, attached panels rooted on this bar use this opacity for their background instead of inheriting
+  // `backgroundOpacity`. Lets users keep panel chrome legible while running a fully transparent bar.
+  std::optional<float> panelBackgroundOpacity;
   // Inside outline for the bar background; attached panels inherit the resolved values.
   ColorSpec border = colorSpecFromRole(ColorRole::Outline);
   float borderWidth = 0.0f;

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -540,7 +540,7 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
     m_panelVisualWidth = panelWidth;
     m_panelVisualHeight = panelHeight;
     m_attachedBackgroundOpacity = m_activePanel->inheritsBarBackgroundOpacity()
-                                      ? barConfig.backgroundOpacity
+                                      ? barConfig.panelBackgroundOpacity.value_or(barConfig.backgroundOpacity)
                                       : m_activePanel->attachedBackgroundOpacityOverride();
     m_attachedContactShadow = barConfig.contactShadow;
     m_attachedRevealProgress = 0.0f;
@@ -1526,7 +1526,7 @@ void PanelManager::onConfigReloaded() {
   const auto barConfig = resolvePanelBarConfig(m_config, m_platform, m_output, m_sourceBarName);
   bool changed = false;
   if (m_activePanel->inheritsBarBackgroundOpacity()) {
-    const float newOpacity = barConfig.backgroundOpacity;
+    const float newOpacity = barConfig.panelBackgroundOpacity.value_or(barConfig.backgroundOpacity);
     if (std::abs(newOpacity - m_attachedBackgroundOpacity) >= 0.001f) {
       m_attachedBackgroundOpacity = newOpacity;
       m_activePanel->setPanelCardOpacity(resolvePanelCardOpacity(m_config, m_attachedBackgroundOpacity));

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1303,6 +1303,12 @@ namespace settings {
       entries.push_back(makeEntry(section, "shape", tr("settings.schema.shared.background-opacity.label"),
                                   tr("settings.schema.bar.background-opacity.description"), path("background_opacity"),
                                   SliderSetting{selectedBar->backgroundOpacity, 0.0f, 1.0f, 0.01f, false}, "alpha"));
+      entries.push_back(
+          makeEntry(section, "shape", tr("settings.schema.shared.panel-background-opacity.label"),
+                    tr("settings.schema.bar.panel-background-opacity.description"), path("panel_background_opacity"),
+                    SliderSetting{selectedBar->panelBackgroundOpacity.value_or(selectedBar->backgroundOpacity), 0.0f,
+                                  1.0f, 0.01f, false},
+                    "alpha panel attached"));
       entries.push_back(makeEntry(section, "shape", tr("settings.schema.bar.border.label"),
                                   tr("settings.schema.bar.border.description"), path("border"),
                                   colorSpecPicker(selectedBar->border), "outline color", true));
@@ -1468,6 +1474,13 @@ namespace settings {
           section, "shape", tr("settings.schema.shared.background-opacity.label"),
           tr("settings.schema.bar.background-opacity.description"), mpath("background_opacity"),
           SliderSetting{ovr.backgroundOpacity.value_or(bar.backgroundOpacity), 0.0f, 1.0f, 0.01f, false}, "alpha"));
+      entries.push_back(makeEntry(section, "shape", tr("settings.schema.shared.panel-background-opacity.label"),
+                                  tr("settings.schema.bar.panel-background-opacity.description"),
+                                  mpath("panel_background_opacity"),
+                                  SliderSetting{ovr.panelBackgroundOpacity.value_or(bar.panelBackgroundOpacity.value_or(
+                                                    ovr.backgroundOpacity.value_or(bar.backgroundOpacity))),
+                                                0.0f, 1.0f, 0.01f, false},
+                                  "alpha panel attached"));
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.bar.border.label"), tr("settings.schema.bar.border.description"),
           mpath("border"), colorSpecPicker(ovr.border, true, tr("common.states.inherit")), "outline color", true));


### PR DESCRIPTION
## Motivation

Attached panels (the clock dropdown, control center, wallpaper picker, session menu, etc.) currently inherit their host bar's `background_opacity`. That means setting the bar to 0% alpha — a popular "floating capsules only" look — also collapses every attached panel's background to invisible, leaving panel content floating with no surface behind it. There was no way to keep the bar transparent while preserving legible panel chrome.

Detached/centered panels already escape this via `shell.panel.transparency_mode` returning fixed alpha per mode; only attached panels were stuck inheriting the bar.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

Adds an optional per-bar `panel_background_opacity` (with matching per-monitor override) under `[bar.*]`. When unset, behavior is unchanged — attached panels keep inheriting `background_opacity`. When set, it replaces the inherited value as the source for the panel's background fill and the seed passed into `panelCardOpacityForTransparencyMode`, so panel cards and the contact-shadow gradient stay consistent.

Touched files:
- `src/config/config_types.h` — new optional on `BarConfig` + `BarMonitorOverride`
- `src/config/config_service.cpp` — TOML parser for both scopes and resolution in `resolveForOutput`
- `src/config/config_overrides.cpp` — equality + override-apply
- `src/config/config_export.cpp` — write the field back out (only when set)
- `src/shell/panel/panel_manager.cpp` — swap the inheritance source at both `m_attachedBackgroundOpacity` assignment sites (initial open + live config reload)
- `src/shell/settings/settings_registry.cpp` — slider entry in the bar Shape section (single-bar + per-monitor)
- `assets/translations/en.json` — label + description

## Testing
- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

Verified manually: with `bar.main.background_opacity = 0.0` and `bar.main.panel_background_opacity = 0.9`, the bar is fully invisible while the clock dropdown, control center, and other attached panels render with a normal solid surface. Toggling the new slider live updates open panels via the existing `onConfigReloaded` path. With the new field unset, behavior matches `main` exactly.

`just build release` clean, `meson test` 9/9 green, `just format` applied.