### PR TITLE
launcher/app_provider: add an option to launch apps as systemd services

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1585,6 +1585,10 @@
           "label": "Show Location",
           "description": "Show location name in weather widgets"
         },
+        "launch-app-as-systemd-service": {
+          "label": "Launch Apps as Systemd Services",
+          "description": "The launcher panel will start applications as transient systemd services."
+        },
         "clipboard-enabled": {
           "label": "Clipboard",
           "description": "Enable clipboard history, the clipboard panel, and copy/paste integration"

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1075,7 +1075,7 @@ void Application::initUi() {
           &m_idleInhibitor, &m_dependencyService, &m_compositorPlatform, &m_wallpaper));
   {
     auto launcherPanel = std::make_unique<LauncherPanel>(&m_configService, &m_asyncTextureCache);
-    launcherPanel->addProvider(std::make_unique<AppProvider>(&m_wayland));
+    launcherPanel->addProvider(std::make_unique<AppProvider>(&m_configService, &m_wayland));
     launcherPanel->addProvider(std::make_unique<WallpaperProvider>(&m_configService, &m_wayland));
     launcherPanel->addProvider(std::make_unique<MathProvider>(&m_clipboardService));
     launcherPanel->addProvider(std::make_unique<EmojiProvider>(&m_clipboardService));

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -302,6 +302,7 @@ namespace config_export {
       table.insert_or_assign("settings_show_advanced", shell.settingsShowAdvanced);
       table.insert_or_assign("middle_click_opens_widget_settings", shell.middleClickOpensWidgetSettings);
       table.insert_or_assign("show_location", shell.showLocation);
+      table.insert_or_assign("launch_app_as_systemd_service", shell.launchAppAsSystemdService);
       table.insert_or_assign("clipboard_enabled", shell.clipboardEnabled);
       table.insert_or_assign("clipboard_history_max_entries",
                              static_cast<std::int64_t>(shell.clipboardHistoryMaxEntries));

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -331,8 +331,9 @@ namespace {
            nearlyEqual(a.animation.speed, b.animation.speed) && a.avatarPath == b.avatarPath &&
            a.settingsShowAdvanced == b.settingsShowAdvanced &&
            a.middleClickOpensWidgetSettings == b.middleClickOpensWidgetSettings && a.showLocation == b.showLocation &&
-           a.clipboardEnabled == b.clipboardEnabled && a.clipboardHistoryMaxEntries == b.clipboardHistoryMaxEntries &&
-           a.screenTimeEnabled == b.screenTimeEnabled && a.clipboardAutoPaste == b.clipboardAutoPaste &&
+           a.launchAppAsSystemdService == b.launchAppAsSystemdService && a.clipboardEnabled == b.clipboardEnabled &&
+           a.clipboardHistoryMaxEntries == b.clipboardHistoryMaxEntries && a.screenTimeEnabled == b.screenTimeEnabled &&
+           a.clipboardAutoPaste == b.clipboardAutoPaste &&
            a.clipboardImageActionCommand == b.clipboardImageActionCommand && a.shadow.blur == b.shadow.blur &&
            a.shadow.offsetX == b.shadow.offsetX && a.shadow.offsetY == b.shadow.offsetY &&
            nearlyEqual(a.shadow.alpha, b.shadow.alpha) && a.panel.backgroundBlur == b.panel.backgroundBlur &&

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1432,6 +1432,9 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
     if (auto v = (*shellTbl)["show_location"].value<bool>()) {
       shell.showLocation = *v;
     }
+    if (auto v = (*shellTbl)["launch_app_as_systemd_service"].value<bool>()) {
+      shell.launchAppAsSystemdService = *v;
+    }
     if (auto v = (*shellTbl)["clipboard_enabled"].value<bool>()) {
       shell.clipboardEnabled = *v;
     }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -569,6 +569,7 @@ struct ShellConfig {
   bool settingsShowAdvanced = false;
   bool middleClickOpensWidgetSettings = true;
   bool showLocation = true;
+  bool launchAppAsSystemdService = false;
   /// When false, disables Wayland clipboard integration (history panel, data-control binding, Input paste/copy hooks).
   bool clipboardEnabled = true;
   /// Maximum unpinned clipboard history entries retained (pinned entries are exempt).

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -438,7 +438,7 @@ namespace {
     return {exitCode, std::move(out), std::move(err), timedOut, outTruncated, errTruncated};
   }
 
-  // Only alphanum, ':' and '_' allowed in systemd unit names
+  // Only alphanum, ':', '_' and '.' allowed in systemd unit names
   std::string escapeSystemdUnitName(const std::string& input) {
     std::string res;
     for (const unsigned char c : input) {
@@ -631,6 +631,9 @@ namespace process {
   void runAsyncAsApp(const std::vector<std::string>& args, const std::string& appName,
                      const std::string& activationToken, const std::string& workingDir) {
 #ifdef __linux__
+    if (args.empty() || args.front().empty()) {
+      return;
+    }
     // Check if we booted with systemd. The same logic as systemd sd_booted()
     int r = access("/run/systemd/system/", F_OK);
     if (r == 0) {

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 namespace {
+
   constexpr std::chrono::milliseconds kProcessPollInterval{100};
   constexpr std::chrono::milliseconds kProcessCommandLineCacheTtl{250};
 
@@ -534,7 +535,6 @@ namespace {
 #ifdef __linux__
     if (asSystemdService) {
       std::vector<std::string> systemdArgs;
-      systemdArgs.reserve(7 + args.size());
       systemdArgs.push_back("systemd-run");
       systemdArgs.push_back("--user");
       systemdArgs.push_back("--slice=app.slice");

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -438,25 +438,10 @@ namespace {
     return {exitCode, std::move(out), std::move(err), timedOut, outTruncated, errTruncated};
   }
 
-  // Only alphanum, ':', '_' and '.' allowed in systemd unit names
-  std::string escapeSystemdUnitName(const std::string& input) {
-    std::string res;
-    for (const unsigned char c : input) {
-      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == ':' || c == '_' ||
-          c == '.') {
-        res += c;
-      } else {
-        res += std::format("\\x{:02x}", c);
-      }
-    }
-    return res;
-  }
-
   // Double-fork + setsid so the exec'd process is not a direct child of the caller (matches
   // launcher app activation). Parent reaps the short-lived intermediate child.
   bool doubleForkExecDetached(const std::vector<std::string>& args, pid_t* reportPid,
-                              const std::string& activationToken, const std::string& workingDir = {},
-                              bool asSystemdService = false, const std::string& appName = {}) {
+                              const std::string& activationToken, const std::string& workingDir = {}) {
     int reportPipe[2] = {-1, -1};
     const bool needPid = reportPid != nullptr;
     if (needPid && ::pipe(reportPipe) != 0) {
@@ -532,49 +517,6 @@ namespace {
       ::close(reportPipe[1]);
     }
 
-#ifdef __linux__
-    if (asSystemdService) {
-      std::vector<std::string> systemdArgs;
-      systemdArgs.push_back("systemd-run");
-      systemdArgs.push_back("--user");
-      systemdArgs.push_back("--slice=app.slice");
-      // Only end the service when all subprocesses have exited. Otherwise, apps using a launcher
-      // script, e.g. vscode, would end prematurely when the script exits, and the actual app process
-      // is still running.
-      systemdArgs.push_back("--property=ExitType=cgroup");
-      if (!appName.empty()) {
-        const std::string uuid = StringUtils::generateUuid();
-        if (!uuid.empty()) {
-          systemdArgs.push_back(std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), uuid));
-        }
-      }
-      if (!workingDir.empty()) {
-        systemdArgs.push_back("--working-directory=" + workingDir);
-      }
-      if (!activationToken.empty()) {
-        ::setenv("XDG_ACTIVATION_TOKEN", activationToken.c_str(), 1);
-        ::setenv("DESKTOP_STARTUP_ID", activationToken.c_str(), 1);
-      }
-
-      // App should inherit our environment.
-      char** s = ::environ;
-      for (; *s; s++) {
-        systemdArgs.push_back("-E");
-        systemdArgs.push_back(*s);
-      }
-
-      systemdArgs.push_back("--");
-      systemdArgs.insert(systemdArgs.end(), args.begin(), args.end());
-      process::RunResult result = runSyncProcess(systemdArgs, std::nullopt);
-      if (result) {
-        ::_exit(0);
-      }
-      // If systemd-run failed, fall back to normal launch. E.g., if systemd-run is not available,
-      // or its version is too old for the switches we used, or the executable is not found.
-      // We'd unnecessarily fail again later in the last case, but seems OK to err on the safe side here.
-    }
-#endif
-
     if (!workingDir.empty() && ::chdir(workingDir.c_str()) != 0) {
       ::_exit(126);
     }
@@ -590,6 +532,100 @@ namespace {
 
     ::execvp(argv[0], argv.data());
     ::_exit(127);
+  }
+
+  // Only alphanum, ':', '_' and '.' allowed in systemd unit names
+  std::string escapeSystemdUnitName(const std::string& input) {
+    std::string res;
+    for (const unsigned char c : input) {
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == ':' || c == '_' ||
+          c == '.') {
+        res += c;
+      } else {
+        res += std::format("\\x{:02x}", c);
+      }
+    }
+    return res;
+  }
+
+  void startSystemdService(const std::vector<std::string>& args, const std::string& activationToken,
+                           const std::string& workingDir, const std::string& appName) {
+    const pid_t intermediate = ::fork();
+    if (intermediate < 0) {
+      return;
+    }
+
+    if (intermediate > 0) {
+      // Parent: wait for intermediate to exit (after it forks the grandchild).
+      while (::waitpid(intermediate, nullptr, 0) < 0 && errno == EINTR) {
+      }
+      return;
+    }
+
+    // Intermediate child: fork again and exit, so parent doesn't wait for systemd-run
+
+    const pid_t worker = ::fork();
+    if (worker != 0) {
+      ::_exit(0);
+    }
+
+    // Grandchild
+
+    std::vector<std::string> systemdArgs;
+    systemdArgs.push_back("systemd-run");
+    systemdArgs.push_back("--user");
+    systemdArgs.push_back("--slice=app.slice");
+    // Only end the service when all subprocesses have exited. Otherwise, apps using a launcher
+    // script, e.g. vscode, would end prematurely when the script exits, and the actual app process
+    // is still running.
+    systemdArgs.push_back("--property=ExitType=cgroup");
+
+    // We launch the app as a systemd service instead of a scope so the user can:
+    // 1. Place drop-in files in ~/.config/systemd/user/app-<desktop-id>@.service.d/ to set properties like resource
+    // limits or env vars.
+    // 2. See the app's output and exit code (if it fails) in `systemctl status`.
+    if (!appName.empty()) {
+      const std::string uuid = StringUtils::generateUuid();
+      if (!uuid.empty()) {
+        systemdArgs.push_back(std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), uuid));
+      }
+    }
+    if (!workingDir.empty()) {
+      systemdArgs.push_back("--working-directory=" + workingDir);
+    }
+
+    if (!activationToken.empty()) {
+      ::setenv("XDG_ACTIVATION_TOKEN", activationToken.c_str(), 1);
+      ::setenv("DESKTOP_STARTUP_ID", activationToken.c_str(), 1);
+    }
+
+    // App should inherit our environment.
+    char** s = ::environ;
+    for (; *s; s++) {
+      char c = **s;
+      if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_')) {
+        continue;
+      }
+      std::string name{*s, std::string_view(*s).find('=')};
+      systemdArgs.push_back("-E");
+      systemdArgs.push_back(name);
+    }
+
+    systemdArgs.push_back("--");
+    systemdArgs.insert(systemdArgs.end(), args.begin(), args.end());
+    process::RunResult result = runSyncProcess(systemdArgs, std::nullopt);
+    if (result) {
+      ::_exit(0);
+    }
+
+    // If systemd-run failed, fall back to normal launch. E.g., if systemd-run is not available,
+    // or its version is too old for the switches we used, or the executable is not found.
+    // We'd unnecessarily fail again later in the last case, but seems OK to err on the safe side here.
+
+    // This would be two more unnecessary forks if systemd-run is missing, but seems acceptable for
+    // the fallback path.
+    (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir);
+    ::_exit(0);
   }
 
 } // namespace
@@ -787,7 +823,7 @@ namespace process {
       return;
     }
     if (systemdAvailable()) {
-      (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir, true, appName);
+      (void)startSystemdService(args, activationToken, workingDir, appName);
       return;
     }
 #endif

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -24,7 +25,6 @@
 #include <unistd.h>
 
 namespace {
-
   constexpr std::chrono::milliseconds kProcessPollInterval{100};
   constexpr std::chrono::milliseconds kProcessCommandLineCacheTtl{250};
 
@@ -538,6 +538,11 @@ namespace {
       systemdArgs.reserve(7 + args.size());
       systemdArgs.push_back("systemd-run");
       systemdArgs.push_back("--user");
+      systemdArgs.push_back("--slice=app.slice");
+      // Only end the service when all subprocesses have exited. Otherwise, apps using a launcher
+      // script, e.g. vscode, would end prematurely when the script exits, and the actual app process 
+      // is still running.
+      systemdArgs.push_back("--property=ExitType=cgroup");
       if (!appName.empty()) {
         const std::string uuid = StringUtils::generateUuid();
         if (!uuid.empty()) {
@@ -545,12 +550,20 @@ namespace {
         }
       }
       if (!workingDir.empty()) {
-        systemdArgs.push_back(std::format("--working-directory={}", workingDir));
+        systemdArgs.push_back("--working-directory=" + workingDir);
       }
-      if (!activationToken.empty()) {
-        systemdArgs.push_back(std::format("--setenv=XDG_ACTIVATION_TOKEN={}", activationToken));
-        systemdArgs.push_back(std::format("--setenv=DESKTOP_STARTUP_ID={}", activationToken));
+      if (!activationToken.empty()) {       
+        ::setenv("XDG_ACTIVATION_TOKEN", activationToken.c_str(), 1);
+        ::setenv("DESKTOP_STARTUP_ID", activationToken.c_str(), 1);
       }
+
+      // App should inherit our environment.
+      char **s = ::environ;
+      for (; *s; s++) {
+        systemdArgs.push_back("-E");
+        systemdArgs.push_back(*s);
+      }
+
       systemdArgs.push_back("--");
       systemdArgs.insert(systemdArgs.end(), args.begin(), args.end());
       process::RunResult result = runSyncProcess(systemdArgs, std::nullopt);

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -637,25 +637,6 @@ namespace process {
     return doubleForkExecDetached(args, nullptr, activationToken, workingDir);
   }
 
-  // We don't have a return code, so we don't wait for the launch mechanism to complete (e.g., systemd-run),
-  // which might take more time than a double-fork-exec and block the UI thread for too long. Launcher/AppProvider
-  // doesn't check if the app launch succeeded, anyway.
-  void runAsyncAsApp(const std::vector<std::string>& args, const std::string& appName,
-                     const std::string& activationToken, const std::string& workingDir) {
-#ifdef __linux__
-    if (args.empty() || args.front().empty()) {
-      return;
-    }
-    // Check if we booted with systemd. The same logic as systemd sd_booted()
-    int r = access("/run/systemd/system/", F_OK);
-    if (r == 0) {
-      (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir, true, appName);
-      return;
-    }
-#endif
-    (void)runAsync(args, activationToken, workingDir);
-  }
-
   bool runAsync(std::initializer_list<const char*> args) {
     const auto command = makeCommand(args);
     return command.has_value() && runAsync(*command, {});
@@ -786,4 +767,30 @@ namespace process {
     return false;
   }
 
+  bool systemdAvailable() {
+#ifdef __linux__
+    // Check if we booted with systemd. The same logic as systemd sd_booted()
+    int r = access("/run/systemd/system/", F_OK);
+    return r == 0;
+#else
+    return false;
+#endif
+  }
+
+  // We don't have a return code, so we don't wait for the launch mechanism to complete (e.g., systemd-run),
+  // which might take more time than a double-fork-exec and block the UI thread for too long. Launcher/AppProvider
+  // doesn't check if the app launch succeeded, anyway.
+  void runAsyncAsSystemdService(const std::vector<std::string>& args, const std::string& appName,
+                                const std::string& activationToken, const std::string& workingDir) {
+#ifdef __linux__
+    if (args.empty() || args.front().empty()) {
+      return;
+    }
+    if (systemdAvailable()) {
+      (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir, true, appName);
+      return;
+    }
+#endif
+    (void)runAsync(args, activationToken, workingDir);
+  }
 } // namespace process

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -1,5 +1,7 @@
 #include "core/process.h"
 
+#include "util/string_utils.h"
+
 #include <algorithm>
 #include <array>
 #include <cerrno>
@@ -9,6 +11,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <iterator>
 #include <limits>
@@ -435,10 +438,25 @@ namespace {
     return {exitCode, std::move(out), std::move(err), timedOut, outTruncated, errTruncated};
   }
 
+  // Only alphanum, ':' and '_' allowed in systemd unit names
+  std::string escapeSystemdUnitName(const std::string& input) {
+    std::string res;
+    for (const unsigned char c : input) {
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == ':' || c == '_' ||
+          c == '.') {
+        res += c;
+      } else {
+        res += std::format("\\x{:02x}", c);
+      }
+    }
+    return res;
+  }
+
   // Double-fork + setsid so the exec'd process is not a direct child of the caller (matches
   // launcher app activation). Parent reaps the short-lived intermediate child.
   bool doubleForkExecDetached(const std::vector<std::string>& args, pid_t* reportPid,
-                              const std::string& activationToken, const std::string& workingDir = {}) {
+                              const std::string& activationToken, const std::string& workingDir = {},
+                              bool asSystemdService = false, const std::string& appName = {}) {
     int reportPipe[2] = {-1, -1};
     const bool needPid = reportPid != nullptr;
     if (needPid && ::pipe(reportPipe) != 0) {
@@ -514,6 +532,35 @@ namespace {
       ::close(reportPipe[1]);
     }
 
+#ifdef __linux__
+    if (asSystemdService) {
+      std::vector<std::string> systemdArgs;
+      systemdArgs.reserve(7 + args.size());
+      systemdArgs.push_back("systemd-run");
+      systemdArgs.push_back("--user");
+      if (!appName.empty()) {
+        systemdArgs.push_back(
+            std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), StringUtils::generateUuid()));
+      }
+      if (!workingDir.empty()) {
+        systemdArgs.push_back(std::format("--working-directory={}", workingDir));
+      }
+      if (!activationToken.empty()) {
+        systemdArgs.push_back(std::format("--setenv=XDG_ACTIVATION_TOKEN={}", activationToken));
+        systemdArgs.push_back(std::format("--setenv=DESKTOP_STARTUP_ID={}", activationToken));
+      }
+      systemdArgs.push_back("--");
+      systemdArgs.insert(systemdArgs.end(), args.begin(), args.end());
+      process::RunResult result = runSyncProcess(systemdArgs, std::nullopt);
+      if (result) {
+        ::_exit(0);
+      }
+      // If systemd-run failed, fall back to normal launch. E.g., if systemd-run is not available,
+      // or its version is too old for the switches we used, or the executable is not found.
+      // We'd unnecessarily fail again later in the last case, but seems OK to err on the safe side here.
+    }
+#endif
+
     if (!workingDir.empty()) {
       (void)::chdir(workingDir.c_str());
     }
@@ -574,6 +621,22 @@ namespace process {
       return false;
     }
     return doubleForkExecDetached(args, nullptr, activationToken, workingDir);
+  }
+
+  // We don't have a return code, so we don't wait for the launch mechanism to complete (e.g., systemd-run),
+  // which might take more time than a double-fork-exec and block the UI thread for too long. Launcher/AppProvider
+  // doesn't check if the app launch succeeded, anyway.
+  void runAsyncAsApp(const std::vector<std::string>& args, const std::string& appName,
+                     const std::string& activationToken, const std::string& workingDir) {
+#ifdef __linux__
+    // Check if we booted with systemd. The same logic as systemd sd_booted()
+    int r = access("/run/systemd/system/", F_OK);
+    if (r == 0) {
+      (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir, true, appName);
+      return;
+    }
+#endif
+    (void)runAsync(args, activationToken, workingDir);
   }
 
   bool runAsync(std::initializer_list<const char*> args) {

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -539,8 +539,10 @@ namespace {
       systemdArgs.push_back("systemd-run");
       systemdArgs.push_back("--user");
       if (!appName.empty()) {
-        systemdArgs.push_back(
-            std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), StringUtils::generateUuid()));
+        const std::string uuid = StringUtils::generateUuid();
+        if (!uuid.empty()) {
+          systemdArgs.push_back(std::format("--unit=app-{}@{}.service", escapeSystemdUnitName(appName), uuid));
+        }
       }
       if (!workingDir.empty()) {
         systemdArgs.push_back(std::format("--working-directory={}", workingDir));

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
-
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -540,7 +539,7 @@ namespace {
       systemdArgs.push_back("--user");
       systemdArgs.push_back("--slice=app.slice");
       // Only end the service when all subprocesses have exited. Otherwise, apps using a launcher
-      // script, e.g. vscode, would end prematurely when the script exits, and the actual app process 
+      // script, e.g. vscode, would end prematurely when the script exits, and the actual app process
       // is still running.
       systemdArgs.push_back("--property=ExitType=cgroup");
       if (!appName.empty()) {
@@ -552,13 +551,13 @@ namespace {
       if (!workingDir.empty()) {
         systemdArgs.push_back("--working-directory=" + workingDir);
       }
-      if (!activationToken.empty()) {       
+      if (!activationToken.empty()) {
         ::setenv("XDG_ACTIVATION_TOKEN", activationToken.c_str(), 1);
         ::setenv("DESKTOP_STARTUP_ID", activationToken.c_str(), 1);
       }
 
       // App should inherit our environment.
-      char **s = ::environ;
+      char** s = ::environ;
       for (; *s; s++) {
         systemdArgs.push_back("-E");
         systemdArgs.push_back(*s);

--- a/src/core/process.h
+++ b/src/core/process.h
@@ -32,6 +32,9 @@ namespace process {
   // non-empty, the grandchild sets XDG_ACTIVATION_TOKEN and DESKTOP_STARTUP_ID (launcher).
   [[nodiscard]] bool runAsync(const std::vector<std::string>& args, const std::string& activationToken = {},
                               const std::string& workingDir = {});
+  // Run an app in a separate unit from ours (e.g., as a systemd service), if the system supports.
+  void runAsyncAsApp(const std::vector<std::string>& args, const std::string& appName,
+                     const std::string& activationToken = {}, const std::string& workingDir = {});
   [[nodiscard]] bool runAsync(std::initializer_list<const char*> args);
   [[nodiscard]] RunResult runSync(const std::vector<std::string>& args);
   [[nodiscard]] RunResult runSync(std::initializer_list<const char*> args);

--- a/src/core/process.h
+++ b/src/core/process.h
@@ -32,9 +32,6 @@ namespace process {
   // non-empty, the grandchild sets XDG_ACTIVATION_TOKEN and DESKTOP_STARTUP_ID (launcher).
   [[nodiscard]] bool runAsync(const std::vector<std::string>& args, const std::string& activationToken = {},
                               const std::string& workingDir = {});
-  // Run an app in a separate unit from ours (e.g., as a systemd service), if the system supports.
-  void runAsyncAsApp(const std::vector<std::string>& args, const std::string& appName,
-                     const std::string& activationToken = {}, const std::string& workingDir = {});
   [[nodiscard]] bool runAsync(std::initializer_list<const char*> args);
   [[nodiscard]] RunResult runSync(const std::vector<std::string>& args);
   [[nodiscard]] RunResult runSync(std::initializer_list<const char*> args);
@@ -55,4 +52,8 @@ namespace process {
 
   [[nodiscard]] bool launchFirstAvailable(std::initializer_list<std::initializer_list<const char*>> commandVariants);
 
+  bool systemdAvailable();
+  // Run an app as a systemd service
+  void runAsyncAsSystemdService(const std::vector<std::string>& args, const std::string& appName,
+                                const std::string& activationToken = {}, const std::string& workingDir = {});
 } // namespace process

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -1,5 +1,6 @@
 #include "launcher/app_provider.h"
 
+#include "config/config_service.h"
 #include "core/process.h"
 #include "util/file_utils.h"
 #include "util/fuzzy_match.h"
@@ -198,8 +199,8 @@ namespace {
     return terminal;
   }
 
-  void launchCommand(const std::string& exec, bool terminal, const std::string& appName,
-                     const std::string& activationToken, const std::string& workingDir) {
+  void launchCommand(const std::string& exec, bool terminal, const std::string& activationToken,
+                     const std::string& workingDir, const std::string& appName, bool runAsSystemdService) {
     std::string cleanExec = stripFieldCodes(exec);
     std::vector<std::string> args = terminal ? terminalLaunchArgs(cleanExec) : tokenize(cleanExec);
 
@@ -211,12 +212,16 @@ namespace {
       return;
     }
 
-    process::runAsyncAsApp(args, appName, activationToken, workingDir);
+    if (runAsSystemdService) {
+      process::runAsyncAsSystemdService(args, appName, activationToken, workingDir);
+    } else {
+      (void)process::runAsync(args, activationToken, workingDir);
+    }
   }
 
 } // namespace
 
-AppProvider::AppProvider(WaylandConnection* wayland) : m_wayland(wayland) {}
+AppProvider::AppProvider(ConfigService* config, WaylandConnection* wayland) : m_config(config), m_wayland(wayland) {}
 
 void AppProvider::initialize() { refreshEntriesIfNeeded(); }
 
@@ -303,7 +308,8 @@ bool AppProvider::activate(const LauncherResult& result) {
     if (m_wayland != nullptr && m_wayland->hasXdgActivation()) {
       token = m_wayland->requestActivationToken(nullptr);
     }
-    launchCommand(execLine, entry.terminal, entry.id, token, entry.workingDir);
+    launchCommand(execLine, entry.terminal, token, entry.workingDir, entry.id,
+                  m_config->config().shell.launchAppAsSystemdService);
     return true;
   }
   return false;

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -198,8 +198,8 @@ namespace {
     return terminal;
   }
 
-  void launchCommand(const std::string& exec, bool terminal, const std::string& activationToken,
-                     const std::string& workingDir) {
+  void launchCommand(const std::string& exec, bool terminal, const std::string& appName,
+                     const std::string& activationToken, const std::string& workingDir) {
     std::string cleanExec = stripFieldCodes(exec);
     std::vector<std::string> args = terminal ? terminalLaunchArgs(cleanExec) : tokenize(cleanExec);
 
@@ -211,7 +211,7 @@ namespace {
       return;
     }
 
-    (void)process::runAsync(args, activationToken, workingDir);
+    process::runAsyncAsApp(args, appName, activationToken, workingDir);
   }
 
 } // namespace
@@ -303,7 +303,7 @@ bool AppProvider::activate(const LauncherResult& result) {
     if (m_wayland != nullptr && m_wayland->hasXdgActivation()) {
       token = m_wayland->requestActivationToken(nullptr);
     }
-    launchCommand(execLine, entry.terminal, token, entry.workingDir);
+    launchCommand(execLine, entry.terminal, entry.id, token, entry.workingDir);
     return true;
   }
   return false;

--- a/src/launcher/app_provider.h
+++ b/src/launcher/app_provider.h
@@ -6,11 +6,12 @@
 #include <cstdint>
 #include <vector>
 
+class ConfigService;
 class WaylandConnection;
 
 class AppProvider : public LauncherProvider {
 public:
-  explicit AppProvider(WaylandConnection* wayland = nullptr);
+  explicit AppProvider(ConfigService* config, WaylandConnection* wayland = nullptr);
 
   [[nodiscard]] std::string_view prefix() const override { return ""; }
   [[nodiscard]] std::string_view name() const override { return "Applications"; }
@@ -25,6 +26,7 @@ public:
 private:
   void refreshEntriesIfNeeded() const;
 
+  ConfigService* m_config = nullptr;
   WaylandConnection* m_wayland = nullptr;
   mutable std::vector<DesktopEntry> m_entries;
   mutable std::uint64_t m_entriesVersion = 0;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1,5 +1,6 @@
 #include "shell/settings/settings_registry.h"
 
+#include "core/process.h"
 #include "i18n/i18n.h"
 #include "render/core/color.h"
 #include "shell/control_center/shortcut_registry.h"
@@ -758,6 +759,12 @@ namespace settings {
                          ToggleSetting{cfg.shell.showLocation}, "weather");
       e.visibleWhen = weatherOn;
       entries.push_back(std::move(e));
+    }
+    if (process::systemdAvailable()) {
+      entries.push_back(makeEntry("shell", "launcher", tr("settings.schema.shell.launch-app-as-systemd-service.label"),
+                                  tr("settings.schema.shell.launch-app-as-systemd-service.description"),
+                                  {"shell", "launch_app_as_systemd_service"},
+                                  ToggleSetting{cfg.shell.launchAppAsSystemdService}));
     }
     const SettingVisibility clipboardOn{{"shell", "clipboard_enabled"}, {"true"}};
     entries.push_back(makeEntry("shell", "clipboard", tr("settings.schema.shell.clipboard-enabled.label"),

--- a/src/system/telemetry_service.cpp
+++ b/src/system/telemetry_service.cpp
@@ -7,6 +7,7 @@
 #include "system/distro_info.h"
 #include "system/hardware_info.h"
 #include "util/file_utils.h"
+#include "util/string_utils.h"
 #include "wayland/wayland_connection.h"
 
 #include <cstdint>
@@ -28,25 +29,6 @@ namespace {
     return dir + "/instance.id";
   }
 
-  std::string generateUuid() {
-    std::uint8_t bytes[16]{};
-    FILE* urandom = std::fopen("/dev/urandom", "rb");
-    if (urandom == nullptr) {
-      return {};
-    }
-    const std::size_t read = std::fread(bytes, 1, sizeof(bytes), urandom);
-    std::fclose(urandom);
-    if (read != sizeof(bytes)) {
-      return {};
-    }
-    bytes[6] = (bytes[6] & 0x0Fu) | 0x40u;
-    bytes[8] = (bytes[8] & 0x3Fu) | 0x80u;
-    return std::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-"
-                       "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-                       bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8],
-                       bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
-  }
-
   std::string loadOrCreateInstanceId() {
     const std::string path = instanceIdPath();
     if (path.empty()) {
@@ -64,7 +46,7 @@ namespace {
       }
     }
 
-    const std::string id = generateUuid();
+    const std::string id = StringUtils::generateUuid();
     if (id.empty()) {
       return {};
     }

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -5,6 +5,8 @@
 #include <cctype>
 #include <charconv>
 #include <cmath>
+#include <cstdint>
+#include <cstdio>
 #include <format>
 #include <optional>
 #include <string>

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <charconv>
 #include <cmath>
+#include <format>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -382,4 +383,22 @@ namespace StringUtils {
     return result;
   }
 
+  [[nodiscard]] inline std::string generateUuid() {
+    std::uint8_t bytes[16]{};
+    FILE* urandom = std::fopen("/dev/urandom", "rb");
+    if (urandom == nullptr) {
+      return {};
+    }
+    const std::size_t read = std::fread(bytes, 1, sizeof(bytes), urandom);
+    std::fclose(urandom);
+    if (read != sizeof(bytes)) {
+      return {};
+    }
+    bytes[6] = (bytes[6] & 0x0Fu) | 0x40u;
+    bytes[8] = (bytes[8] & 0x3Fu) | 0x80u;
+    return std::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-"
+                       "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                       bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8],
+                       bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
+  }
 } // namespace StringUtils


### PR DESCRIPTION
# Pull Request

## Motivation

<img width="2640" height="933" alt="Screenshot from 2026-05-22 10-26-06" src="https://github.com/user-attachments/assets/45c75257-4646-4965-9af3-95ea2d3819a0" />

This option is only available when compiled on Linux, and running under systemd. It's off by default. When turned on, app provider tries to launch apps as systemd services using `systemd-run --user`, and fall back to double-fork-exec if that fails.

Apps are launched as "app-{desktop-file-name}@{uuid}.service" units.

The main motivation is to prevent apps launched from Noctalia to share the cgroup with us, when running under systemd. That would make our cgroup the prime target for the userspace systemd-oomd killer, because this cgroup takes the majority of memory. Note that Noctalia itself doesn't need to be explicitly started as a systemd service for this to happen. E.g., Niri launches Noctalia in its separate `app-niri-noctalia-<id>.scope` cgroup when using `spawn-at-startup`. And all processes we spawn would share the same cgroup.

Additional benefits:
1. Users can make drop-in `.conf` files in `~/.config/systemd/user/app-<app-id>@.override.d` to tune various service parameters, e.g., additional environment vars, memory limits.
2. `systemctl --user --failed` shows failed apps, with the exit code and outputs.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
