### PR TITLE
Better names in battery tooltip

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -16,7 +16,7 @@
     "title": "Clipboard",
     "filter-placeholder": "Filter clipboard...",
     "entry": {
-      "title": "Clipboard entry",
+      "title": "Clipboard Entry",
       "image": "Image"
     },
     "preview": {
@@ -1798,7 +1798,7 @@
       },
       "idle": {
         "pre-action-fade": {
-          "label": "Idle dim",
+          "label": "Idle Dim",
           "description": "Seconds of fullscreen dim before the idle command; use 0 to disable"
         },
         "behaviors": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1607,7 +1607,7 @@
           "description": "Enable clipboard history, the clipboard panel, and copy/paste integration"
         },
         "screen-time-enabled": {
-          "label": "Screen time",
+          "label": "Screen Time",
           "description": "Track per-app usage and show it in Control Center"
         },
         "clipboard-history-max-entries": {
@@ -1751,27 +1751,27 @@
         },
         "compact-control-center": {
           "label": "Compact Sidebar",
-          "description": "Show only icons in the sidebar to make the control center narrower"
+          "description": "Show only icons in the sidebar to make Control Center narrower"
         },
         "placement-launcher": {
           "label": "Placement",
-          "description": "Choose whether Launcher attaches to the bar, floats near it, or opens centered"
+          "description": "Choose whether the launcher attaches to the bar, floats near it, or opens centered"
         },
         "placement-clipboard": {
           "label": "Placement",
-          "description": "Choose whether Clipboard attaches to the bar, floats near it, or opens centered"
+          "description": "Choose whether the clipboard attaches to the bar, floats near it, or opens centered"
         },
         "placement-wallpaper": {
           "label": "Placement",
-          "description": "Choose whether Wallpaper attaches to the bar, floats near it, or opens centered"
+          "description": "Choose whether the wallpaper picker attaches to the bar, floats near it, or opens centered"
         },
         "placement-session": {
           "label": "Placement",
-          "description": "Choose whether Session attaches to the bar, floats near it, or opens centered"
+          "description": "Choose whether the session menu attaches to the bar, floats near it, or opens centered"
         },
         "open-near-click-control-center": {
           "label": "Open Near Click",
-          "description": "Position the control center panel near the bar click instead of centering it along the bar"
+          "description": "Position the Control Center panel near the bar click instead of centering it along the bar"
         },
         "open-near-click-launcher": {
           "label": "Open Near Click",
@@ -1787,7 +1787,7 @@
         },
         "open-near-click-session": {
           "label": "Open Near Click",
-          "description": "Position the session panel near the bar click instead of centering it along the bar"
+          "description": "Position the session menu panel near the bar click instead of centering it along the bar"
         },
         "session-actions": {
           "label": "Entries",
@@ -2015,7 +2015,7 @@
           "placeholder": "/path/to/sound.wav"
         },
         "mpris-blacklist": {
-          "label": "MPRIS player blacklist",
+          "label": "MPRIS Player Blacklist",
           "description": "Players to ignore for media controls and Now Playing"
         },
         "ddcutil": {

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -48,6 +48,8 @@ struct UPowerDeviceInfo {
   UPowerState state;
 
   bool operator==(const UPowerDeviceInfo&) const = default;
+
+  [[nodiscard]] bool isLaptopBattery() const { return type == 2 && powerSupply; }
 };
 
 class UPowerService {

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -1,5 +1,6 @@
 #include "shell/bar/widgets/battery_widget.h"
 
+#include "dbus/upower/upower_service.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "ui/controls/box.h"
@@ -407,10 +408,30 @@ void BatteryWidget::syncState(Renderer& renderer) {
   }
 
   // Tooltip (both modes)
-  if (rootNode != nullptr) {
+  if (rootNode != nullptr) {    
+    const auto& devices = m_upower->batteryDevices();
+    auto sorted = decltype(devices){};
+    int laptopBatteryCount = 0;
+    for (const auto& dev : devices) {
+      if (dev.isLaptopBattery()) {
+        sorted.push_back(dev); ++laptopBatteryCount;
+      }
+    }
+    for (const auto& dev : devices) {
+      if (!dev.isLaptopBattery()) {
+        sorted.push_back(dev);
+      }
+    }
+
     std::vector<TooltipRow> rows;
-    for (const auto& dev : m_upower->batteryDevices()) {
-      std::string name = !dev.model.empty() ? dev.model : (!dev.nativePath.empty() ? dev.nativePath : "Battery");
+    int laptopBatteryIndex = 0;
+    for (const auto& dev : sorted) {
+      std::string name;
+      if (dev.isLaptopBattery()) {
+        name = (laptopBatteryCount > 1) ? ("Battery " + std::to_string(++laptopBatteryIndex)) : "Battery";
+      } else {
+        name = !dev.model.empty() ? dev.model : (!dev.nativePath.empty() ? dev.nativePath : "Unknown Device");
+      }
       int dp = static_cast<int>(std::round(dev.state.percentage));
       rows.push_back({std::move(name), std::to_string(dp) + "%"});
     }

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -408,13 +408,14 @@ void BatteryWidget::syncState(Renderer& renderer) {
   }
 
   // Tooltip (both modes)
-  if (rootNode != nullptr) {    
+  if (rootNode != nullptr) {
     const auto& devices = m_upower->batteryDevices();
     auto sorted = decltype(devices){};
     int laptopBatteryCount = 0;
     for (const auto& dev : devices) {
       if (dev.isLaptopBattery()) {
-        sorted.push_back(dev); ++laptopBatteryCount;
+        sorted.push_back(dev);
+        ++laptopBatteryCount;
       }
     }
     for (const auto& dev : devices) {

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -34,7 +34,7 @@ namespace {
     if (state == BatteryState::FullyCharged || state == BatteryState::PendingCharge) {
       return "battery-plugged";
     }
-    if (state == BatteryState::Unknown) {
+    if (state == BatteryState::Unknown && percentage <= 0.0) {
       return "battery-exclamation";
     }
     if (percentage >= 85.0) {

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -928,8 +928,7 @@ void ClipboardPanel::rebuildPreview(Renderer& renderer, float width, float heigh
   const std::size_t historyIndex = selectedHistoryIndex();
   if (history.empty() || historyIndex == static_cast<std::size_t>(-1)) {
     m_previewTitle->setText(i18n::tr("clipboard.entry.title"));
-    m_previewMeta->setText(history.empty() ? i18n::tr("clipboard.empty.history-message")
-                                           : i18n::tr("clipboard.empty.no-matches-title"));
+    m_previewMeta->setText("");
 
     auto empty = std::make_unique<Label>();
     empty->setText(history.empty() ? i18n::tr("clipboard.empty.history-message")


### PR DESCRIPTION
1. My laptop battery is currently displayed as "0x4C 0x32 0x32 0x4D 0x34 0x50 0x41 0x35", it's better to just use "Battery" in this case. This PR also adds naming support for multiple batteries.
2. Hiding some text in the clipboard panel for no results/history since this message is currently shown 3 times.