### PR TITLE
widget: no gap around spacer

### DIFF
--- a/src/render/scene/node.cpp
+++ b/src/render/scene/node.cpp
@@ -223,6 +223,14 @@ void Node::setFlexGrow(float grow) {
   markLayoutDirty();
 }
 
+void Node::setNoGapAroundMe(bool noGap) {
+  if (m_noGapAroundMe == noGap) {
+    return;
+  }
+  m_noGapAroundMe = noGap;
+  markLayoutDirty();
+}
+
 void Node::setVisible(bool visible) {
   if (m_visible == visible) {
     return;

--- a/src/render/scene/node.h
+++ b/src/render/scene/node.h
@@ -91,6 +91,9 @@ public:
   [[nodiscard]] float scale() const noexcept { return m_scale; }
   [[nodiscard]] float opacity() const noexcept { return m_opacity; }
   [[nodiscard]] float flexGrow() const noexcept { return m_flexGrow; }
+  [[nodiscard]] bool noGapAroundMe() const noexcept {
+    return m_noGapAroundMe;
+  } // Prevent parent from adding gaps around me
   [[nodiscard]] bool visible() const noexcept { return m_visible; }
   [[nodiscard]] bool participatesInLayout() const noexcept { return m_participatesInLayout; }
   [[nodiscard]] bool paintDirty() const noexcept { return m_paintDirty; }
@@ -111,6 +114,7 @@ public:
   void setScale(float scale);
   void setOpacity(float opacity);
   void setFlexGrow(float grow);
+  void setNoGapAroundMe(bool noGap);
   void setVisible(bool visible);
   void setParticipatesInLayout(bool participatesInLayout);
   void setClipChildren(bool clipChildren);
@@ -163,6 +167,7 @@ private:
   float m_scale = 1.0f;
   float m_opacity = 1.0f;
   float m_flexGrow = 0.0f;
+  bool m_noGapAroundMe = false;
   bool m_visible = true;
   bool m_participatesInLayout = true;
   bool m_paintDirty = true;

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1301,7 +1301,9 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
 
     auto addPlainWidget = [&](Widget& widget) {
       widget.setBarCapsuleScene(nullptr, nullptr);
-      section->addChild(widget.releaseRoot());
+      auto node = widget.releaseRoot();
+      node->setNoGapAroundMe(widget.noGapAroundMe());
+      section->addChild(std::move(node));
     };
 
     auto addSingleCapsule = [&](Widget& widget) {
@@ -1332,6 +1334,7 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
           .allowCircularSizing = true,
           .widgets = {&widget},
       });
+      shell->setNoGapAroundMe(widget.noGapAroundMe());
       section->addChild(std::move(shell));
     };
 
@@ -1415,7 +1418,9 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
         run.spec.padding = std::max(run.spec.padding, member->barCapsuleSpec().padding);
         member->setBarCapsuleScene(shellPtr, bgPtr);
         run.widgets.push_back(member.get());
-        innerPtr->addChild(member->releaseRoot());
+        auto node = member->releaseRoot();
+        node->setNoGapAroundMe(member->noGapAroundMe());
+        innerPtr->addChild(std::move(node));
       }
 
       capsuleRuns.push_back(std::move(run));

--- a/src/shell/bar/widget.h
+++ b/src/shell/bar/widget.h
@@ -44,6 +44,10 @@ public:
   }
   [[nodiscard]] virtual bool reservesMiddleClick() const noexcept { return false; }
 
+  // Widgets like Spacer can override this to indicate that no gaps should be added on either side of them
+  // in the bar, so that they can serve as separators between other widgets without adding extra spacing.
+  [[nodiscard]] virtual bool noGapAroundMe() const noexcept { return false; }
+
   [[nodiscard]] Node* root() const noexcept { return m_root ? m_root.get() : m_rootPtr; }
   [[nodiscard]] float width() const noexcept;
   [[nodiscard]] float height() const noexcept;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -333,7 +333,7 @@ std::unique_ptr<Widget> WidgetFactory::create(const std::string& name, wl_output
   }
 
   if (type == "spacer") {
-    const auto length = static_cast<float>(wc != nullptr ? wc->getDouble("length", 14.0) : 14.0);
+    const auto length = static_cast<float>(wc != nullptr ? wc->getDouble("length", 20.0) : 20.0);
     auto widget = std::make_unique<SpacerWidget>(length);
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -333,7 +333,7 @@ std::unique_ptr<Widget> WidgetFactory::create(const std::string& name, wl_output
   }
 
   if (type == "spacer") {
-    const auto length = static_cast<float>(wc != nullptr ? wc->getDouble("length", 8.0) : 8.0);
+    const auto length = static_cast<float>(wc != nullptr ? wc->getDouble("length", 14.0) : 14.0);
     auto widget = std::make_unique<SpacerWidget>(length);
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/spacer_widget.h
+++ b/src/shell/bar/widgets/spacer_widget.h
@@ -8,6 +8,8 @@ public:
 
   void create() override;
 
+  bool noGapAroundMe() const noexcept override { return true; }
+
 private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   float m_fixedLength;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -573,7 +573,7 @@ namespace settings {
     } else if (type == "settings") {
       add(stringSpec("glyph", "settings"));
     } else if (type == "spacer") {
-      add(doubleSpec("length", 14.0, 0.0, 400.0, 1.0));
+      add(doubleSpec("length", 20.0, 0.0, 400.0, 1.0));
     } else if (type == "sysmon") {
       add(selectSpec("stat", "cpu_usage", sysmonStats));
       {

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -573,7 +573,7 @@ namespace settings {
     } else if (type == "settings") {
       add(stringSpec("glyph", "settings"));
     } else if (type == "spacer") {
-      add(doubleSpec("length", 8.0, 0.0, 400.0, 1.0));
+      add(doubleSpec("length", 14.0, 0.0, 400.0, 1.0));
     } else if (type == "sysmon") {
       add(selectSpec("stat", "cpu_usage", sysmonStats));
       {

--- a/src/ui/controls/flex.cpp
+++ b/src/ui/controls/flex.cpp
@@ -521,7 +521,7 @@ LayoutSize Flex::runLayout(Renderer& renderer, const LayoutConstraints& constrai
     }
 
     float effectiveGap = m_gap;
-    if (m_justify == FlexJustify::SpaceBetween && items.size() > 1) {
+    if (m_justify == FlexJustify::SpaceBetween && items.size() > 1 && numGaps > 0) {
       effectiveGap = std::max(m_gap, (innerMain - arrangedChildrenMain) / static_cast<float>(numGaps));
     }
     const float arrangedContentMain = arrangedChildrenMain + effectiveGap * static_cast<float>(numGaps);

--- a/src/ui/controls/flex.cpp
+++ b/src/ui/controls/flex.cpp
@@ -458,7 +458,17 @@ LayoutSize Flex::runLayout(Renderer& renderer, const LayoutConstraints& constrai
     measureItem(item, false, 0.0f);
   }
 
-  const float totalGap = items.size() > 1 ? m_gap * static_cast<float>(items.size() - 1) : 0.0f;
+  int numGaps = 0;
+  {
+    bool skipNextGap = items.empty() || items[0].node->noGapAroundMe();
+    for (size_t i = 1; i < items.size(); ++i) {
+      if (!skipNextGap && !items[i].node->noGapAroundMe()) {
+        numGaps++;
+      }
+      skipNextGap = items[i].node->noGapAroundMe();
+    }
+  }
+  const float totalGap = m_gap * static_cast<float>(numGaps);
 
   if (mainKnown && totalGrow > 0.0f) {
     float fixedMain = mainPaddingStart(*this, horizontal) + mainPaddingEnd(*this, horizontal) + totalGap;
@@ -512,10 +522,9 @@ LayoutSize Flex::runLayout(Renderer& renderer, const LayoutConstraints& constrai
 
     float effectiveGap = m_gap;
     if (m_justify == FlexJustify::SpaceBetween && items.size() > 1) {
-      effectiveGap = std::max(m_gap, (innerMain - arrangedChildrenMain) / static_cast<float>(items.size() - 1));
+      effectiveGap = std::max(m_gap, (innerMain - arrangedChildrenMain) / static_cast<float>(numGaps));
     }
-    const float arrangedContentMain =
-        arrangedChildrenMain + (items.size() > 1 ? effectiveGap * static_cast<float>(items.size() - 1) : 0.0f);
+    const float arrangedContentMain = arrangedChildrenMain + effectiveGap * static_cast<float>(numGaps);
 
     float cursor = mainPaddingStart(*this, horizontal);
     if (m_justify == FlexJustify::Center) {
@@ -525,9 +534,13 @@ LayoutSize Flex::runLayout(Renderer& renderer, const LayoutConstraints& constrai
     }
 
     bool first = true;
+    bool skipNextGap = items.empty() || items.front().node->noGapAroundMe();
     for (auto& item : items) {
       if (!first) {
-        cursor += effectiveGap;
+        if (!skipNextGap && !item.node->noGapAroundMe()) {
+          cursor += effectiveGap;
+        }
+        skipNextGap = item.node->noGapAroundMe();
       }
       first = false;
 


### PR DESCRIPTION
# Pull Request

## Motivation
This PR add a Widget::noGapAroundMe() method that widgets can override to signal that the bar shouldn't add gaps (widget spacing) around it.

SpacerWidget::noGapAroundMe() == true, so that with length==0, it actually removes the space between its neighbors, i.e., reducing the space. Prior to this PR, a Spacer added 6px (the default bar widget spacing) at minimum, and there's no way to add less. With this PR, a Spacer with length in [0, 6) reduces space, while with length > 6 increases space, allowing for more precise control.

The default length of Spacer is increased from 8 to 14, to keep Spacers adding the same amount of space by default as before.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
