### PR TITLE
feat(battery-widget): hide when plugged/fully charged options

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1274,6 +1274,14 @@
           "label": "Hide When No New",
           "description": "Hide the notifications widget when there are no unread notifications"
         },
+        "hide_when_plugged": {
+          "label": "Hide When Plugged In",
+          "description": "Hide the battery widget while connected to AC power"
+        },
+        "hide_when_full": {
+          "label": "Hide When Full",
+          "description": "Hide the battery widget when plugged in and fully charged"
+        },
         "hide_when_empty": {
           "label": "Hide When Empty",
           "description": "Hide workspace pills whne there are no open windows",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -152,10 +152,12 @@ std::unique_ptr<Widget> WidgetFactory::create(const std::string& name, wl_output
                                        : colorSpecFromRole(ColorRole::Error);
     const std::string displayModeStr = wc != nullptr ? wc->getString("display_mode", "icon") : std::string("icon");
     const bool showLabel = wc != nullptr ? wc->getBool("show_label", true) : true;
+    const bool hideWhenPlugged = wc != nullptr ? wc->getBool("hide_when_plugged", false) : false;
+    const bool hideWhenFull = wc != nullptr ? wc->getBool("hide_when_full", false) : false;
     const BatteryDisplayMode displayMode =
         displayModeStr == "graphic" ? BatteryDisplayMode::Graphic : BatteryDisplayMode::Icon;
     auto widget = std::make_unique<BatteryWidget>(m_upower, deviceSelector, warningThreshold, warningColor, displayMode,
-                                                  showLabel);
+                                                  showLabel, hideWhenPlugged, hideWhenFull);
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -65,9 +65,11 @@ namespace {
 } // namespace
 
 BatteryWidget::BatteryWidget(UPowerService* upower, std::string deviceSelector, int warningThreshold,
-                             ColorSpec warningColor, BatteryDisplayMode displayMode, bool showLabel)
+                             ColorSpec warningColor, BatteryDisplayMode displayMode, bool showLabel,
+                             bool hideWhenPlugged, bool hideWhenFull)
     : m_upower(upower), m_deviceSelector(std::move(deviceSelector)), m_warningThreshold(warningThreshold),
-      m_warningColor(std::move(warningColor)), m_displayMode(displayMode), m_showLabel(showLabel) {}
+      m_warningColor(std::move(warningColor)), m_displayMode(displayMode), m_showLabel(showLabel),
+      m_hideWhenPlugged(hideWhenPlugged), m_hideWhenFull(hideWhenFull) {}
 
 void BatteryWidget::create() {
   auto container = std::make_unique<InputArea>();
@@ -319,22 +321,24 @@ void BatteryWidget::syncState(Renderer& renderer) {
   m_lastPresent = s.isPresent;
   m_lastVertical = m_isVertical;
 
+  const bool isCharging = s.state == BatteryState::Charging || s.state == BatteryState::FullyCharged ||
+                          s.state == BatteryState::PendingCharge;
   auto* rootNode = root();
-  if (!s.isPresent) {
+  if (!s.isPresent || (m_hideWhenPlugged && isCharging) || (m_hideWhenFull && s.state == BatteryState::FullyCharged)) {
     if (rootNode != nullptr) {
       rootNode->setVisible(false);
       rootNode->setSize(0.0f, 0.0f);
+      rootNode->setParticipatesInLayout(false);
     }
     return;
   }
 
   if (rootNode != nullptr) {
     rootNode->setVisible(true);
+    rootNode->setParticipatesInLayout(true);
   }
 
   const int pct = static_cast<int>(std::round(s.percentage));
-  const bool isCharging = s.state == BatteryState::Charging || s.state == BatteryState::FullyCharged ||
-                          s.state == BatteryState::PendingCharge;
   const bool isWarning = m_warningThreshold > 0 && pct <= m_warningThreshold && !isCharging;
   const ColorSpec normalFgColor = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
   const ColorSpec fgColor = isWarning ? m_warningColor : normalFgColor;

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -17,7 +17,7 @@ class BatteryWidget : public Widget {
 public:
   BatteryWidget(UPowerService* upower, std::string deviceSelector = "auto", int warningThreshold = 0,
                 ColorSpec warningColor = {}, BatteryDisplayMode displayMode = BatteryDisplayMode::Icon,
-                bool showLabel = true);
+                bool showLabel = true, bool hideWhenPlugged = false, bool hideWhenFull = false);
 
   void create() override;
 
@@ -40,6 +40,8 @@ private:
   ColorSpec m_warningColor;
   BatteryDisplayMode m_displayMode = BatteryDisplayMode::Icon;
   bool m_showLabel = true;
+  bool m_hideWhenPlugged = false;
+  bool m_hideWhenFull = false;
 
   // Icon mode nodes
   Glyph* m_glyph = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -511,6 +511,8 @@ namespace settings {
       add(selectSpec("display_mode", "icon",
                      {{"icon", "settings.widgets.options.icon"}, {"graphic", "settings.widgets.options.graphic"}}));
       add(boolSpec("show_label", true));
+      add(boolSpec("hide_when_plugged", false));
+      add(boolSpec("hide_when_full", false));
       add(selectSpec("device", "auto", {{"auto", "common.states.auto"}}));
       add(intSpec("warning_threshold", 20, 0.0, 100.0, 1.0));
       {


### PR DESCRIPTION
# Pull Request

## Motivation
Add a hide when plugged in optio nto the battery widget

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [X] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
