### PR TITLE
widget/workspaces: make Pill Scale setting step size more precise

### DIFF
--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -691,7 +691,7 @@ namespace settings {
         add(std::move(maxLabelChars));
       }
       {
-        auto pillScale = doubleSpec("pill_scale", 1.0, 0.1, 1.0, 0.1);
+        auto pillScale = doubleSpec("pill_scale", 1.0, 0.1, 1.0, 0.05);
         pillScale.descriptionKey = "settings.widgets.settings.pill_scale.workspaces-description";
         pillScale.visibleWhen = pillStyleOnly;
         add(std::move(pillScale));


### PR DESCRIPTION
## Motivation
`0.9` was too small for me and `1.0` was too big. `0.95` is just right.

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors