### PR TITLE
widget/active_window: replace icon_only setting with a tristate

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1104,6 +1104,8 @@
         "graph": "Graph",
         "graphic": "Graphic",
         "icon": "Icon",
+        "icon-and-text": "Icon and Text",
+        "icon-only": "Icon Only",
         "id": "ID",
         "input": "Input",
         "instance": "Per Placement",
@@ -1121,7 +1123,8 @@
         "workspace-label-centered": "Centered",
         "workspace-label-inside": "Inside pill",
         "swap-percent": "Swap Percent",
-        "text": "Text"
+        "text": "Text",
+        "text-only": "Text Only"
       },
       "settings": {
         "anchor": {
@@ -1193,7 +1196,8 @@
         },
         "display": {
           "label": "Display",
-          "description": "Display mode for this widget"
+          "description": "Display mode for this widget",
+          "active-window-description": "Icon, title, or both on horizontal bars. Vertical bars stay icon-only."
         },
         "display_mode": {
           "label": "Display Mode",
@@ -1303,11 +1307,6 @@
         "hide_label": {
           "label": "Hide Label",
           "description": "Hide this widget's text label"
-        },
-        "icon_only": {
-          "label": "Icon Only",
-          "description": "Show only an icon without a text label",
-          "active-window-description": "On horizontal bars, show only the active window icon (vertical bars already use the icon only)"
         },
         "high_color": {
           "label": "High Color",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -71,6 +71,16 @@ namespace {
     return ActiveWindowTitleScrollMode::None;
   }
 
+  ActiveWindowDisplayMode parseActiveWindowDisplayMode(std::string_view value) {
+    if (value == "icon_only") {
+      return ActiveWindowDisplayMode::IconOnly;
+    }
+    if (value == "text_only") {
+      return ActiveWindowDisplayMode::TextOnly;
+    }
+    return ActiveWindowDisplayMode::IconAndText;
+  }
+
   MediaTitleScrollMode parseMediaTitleScrollMode(std::string_view value) {
     if (value == "always") {
       return MediaTitleScrollMode::Always;
@@ -119,9 +129,11 @@ std::unique_ptr<Widget> WidgetFactory::create(const std::string& name, wl_output
     const float iconSize =
         static_cast<float>(wc != nullptr ? wc->getDouble("icon_size", Style::fontSizeBody) : Style::fontSizeBody);
     const std::string titleScroll = wc != nullptr ? wc->getString("title_scroll", "none") : std::string("none");
-    const bool iconOnly = wc != nullptr ? wc->getBool("icon_only", false) : false;
+    const std::string displayMode =
+        wc != nullptr ? wc->getString("display", "icon_and_text") : std::string("icon_and_text");
     auto widget = std::make_unique<ActiveWindowWidget>(m_platform, maxWidth, minWidth, iconSize,
-                                                       parseActiveWindowTitleScrollMode(titleScroll), iconOnly);
+                                                       parseActiveWindowTitleScrollMode(titleScroll),
+                                                       parseActiveWindowDisplayMode(displayMode));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/active_window_widget.cpp
+++ b/src/shell/bar/widgets/active_window_widget.cpp
@@ -16,9 +16,9 @@
 #include <string_view>
 
 ActiveWindowWidget::ActiveWindowWidget(CompositorPlatform& platform, float maxWidth, float minWidth, float iconSize,
-                                       ActiveWindowTitleScrollMode titleScrollMode, bool iconOnly)
+                                       ActiveWindowTitleScrollMode titleScrollMode, ActiveWindowDisplayMode displayMode)
     : m_platform(platform), m_maxWidth(maxWidth), m_minWidth(minWidth), m_iconSize(iconSize),
-      m_titleScrollMode(titleScrollMode), m_iconOnly(iconOnly) {
+      m_titleScrollMode(titleScrollMode), m_displayMode(displayMode) {
   buildDesktopIconIndex();
 }
 
@@ -70,32 +70,37 @@ void ActiveWindowWidget::doLayout(Renderer& renderer, float containerWidth, floa
   const float maxLength = std::max(0.0f, m_maxWidth * m_contentScale);
   const float minLength = std::clamp(m_minWidth * m_contentScale, 0.0f, maxLength);
   m_icon->setSize(iconSize, iconSize);
-  m_icon->setVisible(true);
 
   m_title->setColor(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
 
   if (isVertical) {
     m_title->setVisible(false);
     applyTitleScrollMode(false);
+    m_icon->setVisible(true);
     m_icon->setPosition(0.0f, 0.0f);
     rootNode->setSize(m_icon->width(), m_icon->height());
   } else {
-    const bool showTitle = !m_iconOnly && !m_lastTitle.empty();
+    const bool showIcon = m_displayMode != ActiveWindowDisplayMode::TextOnly;
+    const bool showTitle = m_displayMode != ActiveWindowDisplayMode::IconOnly && !m_lastTitle.empty();
+    m_icon->setVisible(showIcon);
     m_title->setVisible(showTitle);
     applyTitleScrollMode(showTitle);
-    const float spacing = showTitle ? Style::spaceXs : 0.0f;
-    const float labelMaxWidth = showTitle ? std::max(0.0f, maxLength - m_icon->width() - spacing) : 0.0f;
+    const float spacing = showIcon && showTitle ? Style::spaceXs : 0.0f;
+    const float iconWidth = showIcon ? m_icon->width() : 0.0f;
+    const float labelMaxWidth = showTitle ? std::max(0.0f, maxLength - iconWidth - spacing) : 0.0f;
     m_title->setMaxWidth(labelMaxWidth);
     m_title->measure(renderer);
 
-    const float contentHeight = std::max(m_icon->height(), m_title->height());
-    const float iconY = std::round((contentHeight - m_icon->height()) * 0.5f);
+    const float iconHeight = showIcon ? m_icon->height() : 0.0f;
+    const float titleHeight = showTitle ? m_title->height() : 0.0f;
+    const float contentHeight = std::max(iconHeight, titleHeight);
+    const float iconY = showIcon ? std::round((contentHeight - m_icon->height()) * 0.5f) : 0.0f;
     const float labelY = std::round((contentHeight - m_title->height()) * 0.5f);
 
     m_icon->setPosition(0.0f, iconY);
-    m_title->setPosition(m_icon->width() + spacing, labelY);
+    m_title->setPosition(showIcon ? m_icon->width() + spacing : 0.0f, labelY);
 
-    const float contentWidth = showTitle ? m_title->x() + m_title->width() : m_icon->width();
+    const float contentWidth = showTitle ? m_title->x() + m_title->width() : iconWidth;
     rootNode->setSize(std::clamp(contentWidth, minLength, maxLength), contentHeight);
   }
 }

--- a/src/shell/bar/widgets/active_window_widget.h
+++ b/src/shell/bar/widgets/active_window_widget.h
@@ -19,10 +19,17 @@ enum class ActiveWindowTitleScrollMode : std::uint8_t {
   OnHover,
 };
 
+enum class ActiveWindowDisplayMode : std::uint8_t {
+  IconAndText,
+  IconOnly,
+  TextOnly,
+};
+
 class ActiveWindowWidget : public Widget {
 public:
   ActiveWindowWidget(CompositorPlatform& platform, float maxWidth, float minWidth, float iconSize,
-                     ActiveWindowTitleScrollMode titleScrollMode, bool iconOnly = false);
+                     ActiveWindowTitleScrollMode titleScrollMode,
+                     ActiveWindowDisplayMode displayMode = ActiveWindowDisplayMode::IconAndText);
 
   void create() override;
 
@@ -39,7 +46,7 @@ private:
   float m_minWidth = 80.0f;
   float m_iconSize = 16.0f;
   ActiveWindowTitleScrollMode m_titleScrollMode = ActiveWindowTitleScrollMode::None;
-  bool m_iconOnly = false;
+  ActiveWindowDisplayMode m_displayMode = ActiveWindowDisplayMode::IconAndText;
   InputArea* m_area = nullptr;
   Image* m_icon = nullptr;
   Label* m_title = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -480,6 +480,11 @@ namespace settings {
         {"always", "settings.widgets.options.always"},
         {"on_hover", "settings.widgets.options.on-hover"},
     };
+    const std::vector<WidgetSettingSelectOption> activeWindowDisplay = {
+        {"icon_and_text", "settings.widgets.options.icon-and-text"},
+        {"icon_only", "settings.widgets.options.icon-only"},
+        {"text_only", "settings.widgets.options.text-only"},
+    };
     const std::vector<WidgetSettingSelectOption> scriptedScopes = {
         {"instance", "settings.widgets.options.instance"},
         {"shared", "settings.widgets.options.shared"},
@@ -494,9 +499,9 @@ namespace settings {
       add(doubleSpec("icon_size", static_cast<double>(Style::fontSizeBody), 8.0, 64.0, 1.0));
       add(selectSpec("title_scroll", "none", mediaTitleScroll));
       {
-        auto iconOnly = boolSpec("icon_only", false);
-        iconOnly.descriptionKey = "settings.widgets.settings.icon_only.active-window-description";
-        add(std::move(iconOnly));
+        auto display = selectSpec("display", "icon_and_text", activeWindowDisplay);
+        display.descriptionKey = "settings.widgets.settings.display.active-window-description";
+        add(std::move(display));
       }
     } else if (type == "audio_visualizer") {
       add(doubleSpec("width", 56.0, 8.0, 400.0, 1.0));


### PR DESCRIPTION
The options for the Active Window widget display styles are now:
- Icon and Text
- Icon Only
- Text Only

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors