### PR TITLE
Replace bold bools with numeric font weight

### DIFF
--- a/src/render/core/renderer.h
+++ b/src/render/core/renderer.h
@@ -9,6 +9,21 @@ class TextureManager;
 
 enum class TextAlign : std::uint8_t { Start, Center, End };
 
+enum class FontWeight : int {
+  Thin = 100,
+  UltraLight = 200,
+  Light = 300,
+  SemiLight = 350,
+  Book = 380,
+  Normal = 400,
+  Medium = 500,
+  SemiBold = 600,
+  Bold = 700,
+  UltraBold = 800,
+  Heavy = 900,
+  UltraHeavy = 1000,
+};
+
 struct TextMetrics {
   float width = 0.0f;
   float left = 0.0f;
@@ -25,14 +40,14 @@ class Renderer {
 public:
   virtual ~Renderer() = default;
 
-  [[nodiscard]] virtual TextMetrics measureText(std::string_view text, float fontSize, bool bold = false,
-                                                float maxWidth = 0.0f, int maxLines = 0,
-                                                TextAlign align = TextAlign::Start,
+  [[nodiscard]] virtual TextMetrics measureText(std::string_view text, float fontSize,
+                                                FontWeight fontWeight = FontWeight::Normal, float maxWidth = 0.0f,
+                                                int maxLines = 0, TextAlign align = TextAlign::Start,
                                                 std::string_view fontFamily = {}) = 0;
-  [[nodiscard]] virtual TextMetrics measureFont(float fontSize, bool bold = false) = 0;
+  [[nodiscard]] virtual TextMetrics measureFont(float fontSize, FontWeight fontWeight = FontWeight::Normal) = 0;
   virtual void measureTextCursorStops(std::string_view text, float fontSize,
                                       const std::vector<std::size_t>& byteOffsets, std::vector<float>& outStops,
-                                      bool bold = false) = 0;
+                                      FontWeight fontWeight = FontWeight::Normal) = 0;
   [[nodiscard]] virtual TextMetrics measureGlyph(char32_t codepoint, float fontSize) = 0;
   [[nodiscard]] virtual TextureManager& textureManager() = 0;
   [[nodiscard]] virtual float renderScale() const noexcept = 0;

--- a/src/render/render_context.cpp
+++ b/src/render/render_context.cpp
@@ -176,9 +176,9 @@ void RenderContext::renderScene(RenderTarget& target, Node* sceneRoot) {
   logSlowRenderOperation(ms, "renderScene took {:.1f}ms total", ms);
 }
 
-TextMetrics RenderContext::measureText(std::string_view text, float fontSize, bool bold, float maxWidth, int maxLines,
-                                       TextAlign align, std::string_view fontFamily) {
-  auto m = m_textRenderer.measure(text, fontSize, bold, maxWidth, maxLines, align, fontFamily);
+TextMetrics RenderContext::measureText(std::string_view text, float fontSize, FontWeight fontWeight, float maxWidth,
+                                       int maxLines, TextAlign align, std::string_view fontFamily) {
+  auto m = m_textRenderer.measure(text, fontSize, fontWeight, maxWidth, maxLines, align, fontFamily);
   return TextMetrics{.width = m.width,
                      .left = m.left,
                      .right = m.right,
@@ -190,8 +190,8 @@ TextMetrics RenderContext::measureText(std::string_view text, float fontSize, bo
                      .inkRight = m.inkRight};
 }
 
-TextMetrics RenderContext::measureFont(float fontSize, bool bold) {
-  auto m = m_textRenderer.measureFont(fontSize, bold);
+TextMetrics RenderContext::measureFont(float fontSize, FontWeight fontWeight) {
+  auto m = m_textRenderer.measureFont(fontSize, fontWeight);
   return TextMetrics{.width = m.width,
                      .left = m.left,
                      .right = m.right,
@@ -205,8 +205,8 @@ TextMetrics RenderContext::measureFont(float fontSize, bool bold) {
 
 void RenderContext::measureTextCursorStops(std::string_view text, float fontSize,
                                            const std::vector<std::size_t>& byteOffsets, std::vector<float>& outStops,
-                                           bool bold) {
-  m_textRenderer.measureCursorStops(text, fontSize, byteOffsets, outStops, bold);
+                                           FontWeight fontWeight) {
+  m_textRenderer.measureCursorStops(text, fontSize, byteOffsets, outStops, fontWeight);
 }
 
 TextMetrics RenderContext::measureGlyph(char32_t codepoint, float fontSize) {
@@ -269,11 +269,11 @@ void RenderContext::renderNode(const Node* node, const Mat3& parentTransform, fl
         shadowColor.a *= effectiveOpacity;
         const Mat3 shadowTransform = worldTransform * Mat3::translation(text->shadowOffsetX(), text->shadowOffsetY());
         m_textRenderer.draw(sw, sh, 0.0f, 0.0f, text->text(), text->fontSize(), shadowColor, shadowTransform,
-                            text->bold(), text->maxWidth(), text->maxLines(), text->textAlign(), font);
+                            text->fontWeight(), text->maxWidth(), text->maxLines(), text->textAlign(), font);
       }
       auto color = text->color();
       color.a *= effectiveOpacity;
-      m_textRenderer.draw(sw, sh, 0.0f, 0.0f, text->text(), text->fontSize(), color, worldTransform, text->bold(),
+      m_textRenderer.draw(sw, sh, 0.0f, 0.0f, text->text(), text->fontSize(), color, worldTransform, text->fontWeight(),
                           text->maxWidth(), text->maxLines(), text->textAlign(), font);
     }
     break;

--- a/src/render/render_context.h
+++ b/src/render/render_context.h
@@ -40,12 +40,13 @@ public:
   [[nodiscard]] const RenderBackend& backend() const noexcept { return *m_backend; }
 
   // Renderer interface — used by widgets for measurement and textures
-  [[nodiscard]] TextMetrics measureText(std::string_view text, float fontSize, bool bold = false, float maxWidth = 0.0f,
+  [[nodiscard]] TextMetrics measureText(std::string_view text, float fontSize,
+                                        FontWeight fontWeight = FontWeight::Normal, float maxWidth = 0.0f,
                                         int maxLines = 0, TextAlign align = TextAlign::Start,
                                         std::string_view fontFamily = {}) override;
-  [[nodiscard]] TextMetrics measureFont(float fontSize, bool bold = false) override;
+  [[nodiscard]] TextMetrics measureFont(float fontSize, FontWeight fontWeight) override;
   void measureTextCursorStops(std::string_view text, float fontSize, const std::vector<std::size_t>& byteOffsets,
-                              std::vector<float>& outStops, bool bold = false) override;
+                              std::vector<float>& outStops, FontWeight fontWeight = FontWeight::Normal) override;
   [[nodiscard]] TextMetrics measureGlyph(char32_t codepoint, float fontSize) override;
   [[nodiscard]] TextureManager& textureManager() override;
   [[nodiscard]] float renderScale() const noexcept override { return m_renderScale; }

--- a/src/render/scene/text_node.h
+++ b/src/render/scene/text_node.h
@@ -15,7 +15,7 @@ public:
   [[nodiscard]] const Color& color() const noexcept { return m_color; }
   [[nodiscard]] float maxWidth() const noexcept { return m_maxWidth; }
   [[nodiscard]] int maxLines() const noexcept { return m_maxLines; }
-  [[nodiscard]] bool bold() const noexcept { return m_bold; }
+  [[nodiscard]] FontWeight fontWeight() const noexcept { return static_cast<FontWeight>(m_fontWeight); }
   [[nodiscard]] const std::string& fontFamily() const noexcept { return m_fontFamily; }
 
   void setText(std::string text) {
@@ -59,10 +59,20 @@ public:
   }
 
   void setBold(bool bold) {
-    if (m_bold == bold) {
+    const int fontWeight = bold ? static_cast<int>(FontWeight::Bold) : static_cast<int>(FontWeight::Normal);
+    if (m_fontWeight == fontWeight) {
       return;
     }
-    m_bold = bold;
+    m_fontWeight = fontWeight;
+    markLayoutDirty();
+  }
+
+  void setFontWeight(FontWeight fontWeight) {
+    const int value = static_cast<int>(fontWeight);
+    if (m_fontWeight == value) {
+      return;
+    }
+    m_fontWeight = value;
     markLayoutDirty();
   }
 
@@ -113,7 +123,7 @@ private:
   int m_maxLines = 0;
   Color m_color;
   TextAlign m_textAlign = TextAlign::Start;
-  bool m_bold = false;
+  int m_fontWeight = static_cast<int>(FontWeight::Normal);
   bool m_hasShadow = false;
   Color m_shadowColor;
   float m_shadowOffsetX = 0.0f;

--- a/src/render/text/cairo_text_renderer.cpp
+++ b/src/render/text/cairo_text_renderer.cpp
@@ -172,9 +172,9 @@ namespace {
 // ── CacheKey equality/hash ──────────────────────────────────────────────────
 
 bool CairoTextRenderer::CacheKey::operator==(const CacheKey& other) const noexcept {
-  return bold == other.bold && sizeQ == other.sizeQ && scaleQ == other.scaleQ && maxWidthQ == other.maxWidthQ &&
-         maxLines == other.maxLines && align == other.align && colorRgba == other.colorRgba && text == other.text &&
-         fontFamily == other.fontFamily;
+  return fontWeight == other.fontWeight && sizeQ == other.sizeQ && scaleQ == other.scaleQ &&
+         maxWidthQ == other.maxWidthQ && maxLines == other.maxLines && align == other.align &&
+         colorRgba == other.colorRgba && text == other.text && fontFamily == other.fontFamily;
 }
 
 std::size_t CairoTextRenderer::CacheKeyHash::operator()(const CacheKey& k) const noexcept {
@@ -186,13 +186,14 @@ std::size_t CairoTextRenderer::CacheKeyHash::operator()(const CacheKey& k) const
   hashCombine(seed, std::hash<std::uint16_t>{}(k.maxLines));
   hashCombine(seed, std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(k.align)));
   hashCombine(seed, std::hash<std::uint32_t>{}(k.colorRgba));
-  hashCombine(seed, std::hash<bool>{}(k.bold));
+  hashCombine(seed, std::hash<int>{}(static_cast<int>(k.fontWeight)));
   return seed;
 }
 
 bool CairoTextRenderer::MetricsKey::operator==(const MetricsKey& other) const noexcept {
-  return bold == other.bold && sizeQ == other.sizeQ && scaleQ == other.scaleQ && maxWidthQ == other.maxWidthQ &&
-         maxLines == other.maxLines && align == other.align && text == other.text && fontFamily == other.fontFamily;
+  return fontWeight == other.fontWeight && sizeQ == other.sizeQ && scaleQ == other.scaleQ &&
+         maxWidthQ == other.maxWidthQ && maxLines == other.maxLines && align == other.align && text == other.text &&
+         fontFamily == other.fontFamily;
 }
 
 std::size_t CairoTextRenderer::MetricsKeyHash::operator()(const MetricsKey& k) const noexcept {
@@ -203,7 +204,7 @@ std::size_t CairoTextRenderer::MetricsKeyHash::operator()(const MetricsKey& k) c
   hashCombine(seed, std::hash<std::uint16_t>{}(k.scaleQ));
   hashCombine(seed, std::hash<std::uint16_t>{}(k.maxLines));
   hashCombine(seed, std::hash<std::uint8_t>{}(static_cast<std::uint8_t>(k.align)));
-  hashCombine(seed, std::hash<bool>{}(k.bold));
+  hashCombine(seed, std::hash<int>{}(static_cast<int>(k.fontWeight)));
   return seed;
 }
 
@@ -315,8 +316,9 @@ void CairoTextRenderer::notifyFontConfigChanged() {
 
 // ── Layout construction ─────────────────────────────────────────────────────
 
-PangoLayout* CairoTextRenderer::buildLayout(std::string_view text, float fontSize, bool bold, float maxWidthPxScaled,
-                                            int maxLines, TextAlign align, std::string_view fontFamily) const {
+PangoLayout* CairoTextRenderer::buildLayout(std::string_view text, float fontSize, FontWeight fontWeight,
+                                            float maxWidthPxScaled, int maxLines, TextAlign align,
+                                            std::string_view fontFamily) const {
   PangoLayout* layout = pango_layout_new(m_pangoContext);
 
   const float rasterSize = std::max(1.0f, fontSize * m_contentScale);
@@ -326,7 +328,7 @@ PangoLayout* CairoTextRenderer::buildLayout(std::string_view text, float fontSiz
     fontFamilyStr.assign(fontFamily);
   }
   pango_font_description_set_family(desc, fontFamilyStr.empty() ? m_fontFamily.c_str() : fontFamilyStr.c_str());
-  pango_font_description_set_weight(desc, bold ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
+  pango_font_description_set_weight(desc, static_cast<PangoWeight>(fontWeight));
   pango_font_description_set_absolute_size(desc, static_cast<double>(rasterSize) * PANGO_SCALE);
   pango_layout_set_font_description(layout, desc);
   pango_font_description_free(desc);
@@ -411,7 +413,7 @@ CairoTextRenderer::TextMetrics CairoTextRenderer::metricsFromLayout(PangoLayout*
 
 // ── measure / truncate ──────────────────────────────────────────────────────
 
-CairoTextRenderer::TextMetrics CairoTextRenderer::measure(std::string_view text, float fontSize, bool bold,
+CairoTextRenderer::TextMetrics CairoTextRenderer::measure(std::string_view text, float fontSize, FontWeight fontWeight,
                                                           float maxWidth, int maxLines, TextAlign align,
                                                           std::string_view fontFamily) {
   if (m_pangoContext == nullptr || text.empty()) {
@@ -426,14 +428,14 @@ CairoTextRenderer::TextMetrics CairoTextRenderer::measure(std::string_view text,
   key.scaleQ = quantizeScale(m_contentScale);
   key.maxLines = static_cast<std::uint16_t>(std::max(0, maxLines));
   key.align = align;
-  key.bold = bold;
+  key.fontWeight = fontWeight;
 
   auto it = m_metricsCache.find(key);
   if (it != m_metricsCache.end()) {
     return it->second;
   }
 
-  PangoLayout* layout = buildLayout(text, fontSize, bold, maxWidth * m_contentScale, maxLines, align, fontFamily);
+  PangoLayout* layout = buildLayout(text, fontSize, fontWeight, maxWidth * m_contentScale, maxLines, align, fontFamily);
   const auto metrics = metricsFromLayout(layout);
   g_object_unref(layout);
 
@@ -444,7 +446,7 @@ CairoTextRenderer::TextMetrics CairoTextRenderer::measure(std::string_view text,
   return metrics;
 }
 
-CairoTextRenderer::TextMetrics CairoTextRenderer::measureFont(float fontSize, bool bold) const {
+CairoTextRenderer::TextMetrics CairoTextRenderer::measureFont(float fontSize, FontWeight fontWeight) const {
   if (m_pangoContext == nullptr) {
     return {};
   }
@@ -452,7 +454,7 @@ CairoTextRenderer::TextMetrics CairoTextRenderer::measureFont(float fontSize, bo
   const float rasterSize = std::max(1.0f, fontSize * m_contentScale);
   PangoFontDescription* desc = pango_font_description_new();
   pango_font_description_set_family(desc, m_fontFamily.c_str());
-  pango_font_description_set_weight(desc, bold ? PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL);
+  pango_font_description_set_weight(desc, static_cast<PangoWeight>(fontWeight));
   pango_font_description_set_absolute_size(desc, static_cast<double>(rasterSize) * PANGO_SCALE);
 
   PangoFontMetrics* metrics = pango_context_get_metrics(m_pangoContext, desc, pango_language_get_default());
@@ -487,7 +489,7 @@ CairoTextRenderer::TextMetrics CairoTextRenderer::measureFont(float fontSize, bo
 
 void CairoTextRenderer::measureCursorStops(std::string_view text, float fontSize,
                                            const std::vector<std::size_t>& byteOffsets, std::vector<float>& outStops,
-                                           bool bold) {
+                                           FontWeight fontWeight) {
   outStops.clear();
   outStops.reserve(byteOffsets.size());
 
@@ -499,7 +501,7 @@ void CairoTextRenderer::measureCursorStops(std::string_view text, float fontSize
     return;
   }
 
-  PangoLayout* layout = buildLayout(text, fontSize, bold, 0.0f, 0, TextAlign::Start);
+  PangoLayout* layout = buildLayout(text, fontSize, fontWeight, 0.0f, 0, TextAlign::Start);
   const float invScale = 1.0f / m_contentScale;
   const float pscale = 1.0f / static_cast<float>(PANGO_SCALE);
   for (const std::size_t offset : byteOffsets) {
@@ -763,9 +765,10 @@ void CairoTextRenderer::evictIfNeeded() {
   }
 }
 
-CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_view text, float fontSize, bool bold,
-                                                                    float maxWidth, int maxLines, TextAlign align,
-                                                                    const Color& color, std::string_view fontFamily) {
+CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_view text, float fontSize,
+                                                                    FontWeight fontWeight, float maxWidth, int maxLines,
+                                                                    TextAlign align, const Color& color,
+                                                                    std::string_view fontFamily) {
   // Tinted (A8 coverage) entries are color-independent — the shader applies
   // u_tint at draw time, so one cache entry serves every color. RGBA entries
   // (mixed content with COLR emoji) bake non-emoji ink color into the Cairo
@@ -782,7 +785,7 @@ CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_
   key.scaleQ = quantizeScale(m_contentScale);
   key.maxLines = static_cast<std::uint16_t>(std::max(0, maxLines));
   key.align = align;
-  key.bold = bold;
+  key.fontWeight = fontWeight;
   key.colorRgba = tinted ? 0u : packColorRgb(color);
 
   auto it = m_cache.find(key);
@@ -791,7 +794,7 @@ CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_
     return &it->second;
   }
 
-  PangoLayout* layout = buildLayout(text, fontSize, bold, maxWidth * m_contentScale, maxLines, align, fontFamily);
+  PangoLayout* layout = buildLayout(text, fontSize, fontWeight, maxWidth * m_contentScale, maxLines, align, fontFamily);
   Color rasterColor = color;
   if (!tinted) {
     rasterColor.a = 1.0f;
@@ -808,7 +811,7 @@ CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_
   mkey.scaleQ = key.scaleQ;
   mkey.maxLines = key.maxLines;
   mkey.align = key.align;
-  mkey.bold = key.bold;
+  mkey.fontWeight = key.fontWeight;
   if (m_metricsCache.size() >= kMaxMetricsEntries) {
     m_metricsCache.clear();
   }
@@ -826,13 +829,13 @@ CairoTextRenderer::CacheEntry* CairoTextRenderer::lookupOrRasterize(std::string_
 // ── draw ────────────────────────────────────────────────────────────────────
 
 void CairoTextRenderer::draw(float surfaceWidth, float surfaceHeight, float x, float baselineY, std::string_view text,
-                             float fontSize, const Color& color, const Mat3& transform, bool bold, float maxWidth,
-                             int maxLines, TextAlign align, std::string_view fontFamily) {
+                             float fontSize, const Color& color, const Mat3& transform, FontWeight fontWeight,
+                             float maxWidth, int maxLines, TextAlign align, std::string_view fontFamily) {
   if (m_pangoContext == nullptr || m_backend == nullptr || text.empty()) {
     return;
   }
 
-  CacheEntry* entry = lookupOrRasterize(text, fontSize, bold, maxWidth, maxLines, align, color, fontFamily);
+  CacheEntry* entry = lookupOrRasterize(text, fontSize, fontWeight, maxWidth, maxLines, align, color, fontFamily);
   if (entry == nullptr || entry->tiles.empty()) {
     return;
   }

--- a/src/render/text/cairo_text_renderer.h
+++ b/src/render/text/cairo_text_renderer.h
@@ -57,16 +57,17 @@ public:
   void setFontFamily(std::string family);
   void notifyFontConfigChanged();
 
-  [[nodiscard]] TextMetrics measure(std::string_view text, float fontSize, bool bold = false, float maxWidth = 0.0f,
-                                    int maxLines = 0, TextAlign align = TextAlign::Start,
+  [[nodiscard]] TextMetrics measure(std::string_view text, float fontSize, FontWeight fontWeight = FontWeight::Normal,
+                                    float maxWidth = 0.0f, int maxLines = 0, TextAlign align = TextAlign::Start,
                                     std::string_view fontFamily = {});
-  [[nodiscard]] TextMetrics measureFont(float fontSize, bool bold = false) const;
+  [[nodiscard]] TextMetrics measureFont(float fontSize, FontWeight fontWeight) const;
   void measureCursorStops(std::string_view text, float fontSize, const std::vector<std::size_t>& byteOffsets,
-                          std::vector<float>& outStops, bool bold = false);
+                          std::vector<float>& outStops, FontWeight fontWeight = FontWeight::Normal);
 
   void draw(float surfaceWidth, float surfaceHeight, float x, float baselineY, std::string_view text, float fontSize,
-            const Color& color, const Mat3& transform, bool bold = false, float maxWidth = 0.0f, int maxLines = 0,
-            TextAlign align = TextAlign::Start, std::string_view fontFamily = {});
+            const Color& color, const Mat3& transform, FontWeight fontWeight = FontWeight::Normal,
+            float maxWidth = 0.0f, int maxLines = 0, TextAlign align = TextAlign::Start,
+            std::string_view fontFamily = {});
 
 private:
   struct CacheKey {
@@ -78,7 +79,7 @@ private:
     std::uint16_t scaleQ = 0;    // contentScale * 64 + 0.5
     std::uint16_t maxLines = 0;  // 0 = no explicit limit (use '\n'-count fallback)
     TextAlign align = TextAlign::Start;
-    bool bold = false;
+    FontWeight fontWeight = FontWeight::Normal;
 
     bool operator==(const CacheKey& other) const noexcept;
   };
@@ -97,7 +98,7 @@ private:
     std::uint16_t scaleQ = 0;
     std::uint16_t maxLines = 0;
     TextAlign align = TextAlign::Start;
-    bool bold = false;
+    FontWeight fontWeight = FontWeight::Normal;
 
     bool operator==(const MetricsKey& other) const noexcept;
   };
@@ -137,8 +138,8 @@ private:
   using MetricsMap = std::unordered_map<MetricsKey, TextMetrics, MetricsKeyHash>;
 
   // Build a PangoLayout at the given scaled size. Caller owns the layout (g_object_unref).
-  PangoLayout* buildLayout(std::string_view text, float fontSize, bool bold, float maxWidthPxScaled, int maxLines,
-                           TextAlign align, std::string_view fontFamily = {}) const;
+  PangoLayout* buildLayout(std::string_view text, float fontSize, FontWeight fontWeight, float maxWidthPxScaled,
+                           int maxLines, TextAlign align, std::string_view fontFamily = {}) const;
   // Render a layout into a new GL texture; fills out fields of `entry`.
   // When `tinted` is true, rasterizes as CAIRO_FORMAT_A8 and uploads alpha
   // coverage so the color is applied via u_tint at draw time. When false,
@@ -148,8 +149,8 @@ private:
   // Extract logical metrics from a laid-out PangoLayout, dividing by PANGO_SCALE and by scale.
   TextMetrics metricsFromLayout(PangoLayout* layout) const;
 
-  CacheEntry* lookupOrRasterize(std::string_view text, float fontSize, bool bold, float maxWidth, int maxLines,
-                                TextAlign align, const Color& color, std::string_view fontFamily = {});
+  CacheEntry* lookupOrRasterize(std::string_view text, float fontSize, FontWeight fontWeight, float maxWidth,
+                                int maxLines, TextAlign align, const Color& color, std::string_view fontFamily = {});
   void touch(CacheMap::iterator it);
   void evict(CacheMap::iterator it);
   void evictIfNeeded();

--- a/src/shell/bar/widgets/clock_widget.cpp
+++ b/src/shell/bar/widgets/clock_widget.cpp
@@ -140,9 +140,9 @@ void ClockWidget::doLayout(Renderer& renderer, float containerWidth, float conta
 
   if (showSecondary) {
     const auto primaryMetrics =
-        renderer.measureText(m_lastPrimaryText, primaryFontSize, true, 0.0f, 1, TextAlign::Start);
+        renderer.measureText(m_lastPrimaryText, primaryFontSize, FontWeight::Bold, 0.0f, 1, TextAlign::Start);
     const auto secondaryMetrics =
-        renderer.measureText(m_lastSecondaryText, secondaryFontSize, false, 0.0f, 1, TextAlign::Start);
+        renderer.measureText(m_lastSecondaryText, secondaryFontSize, FontWeight::Normal, 0.0f, 1, TextAlign::Start);
     const float primaryInkWidth = std::max(0.0f, primaryMetrics.inkRight - primaryMetrics.inkLeft);
     const float secondaryInkWidth = std::max(0.0f, secondaryMetrics.inkRight - secondaryMetrics.inkLeft);
     width = std::max({width, primaryInkWidth, secondaryInkWidth});

--- a/src/shell/bar/widgets/keyboard_layout_widget.cpp
+++ b/src/shell/bar/widgets/keyboard_layout_widget.cpp
@@ -354,7 +354,7 @@ void KeyboardLayoutWidget::doLayout(Renderer& renderer, float containerWidth, fl
   m_label->setTextAlign(m_isVertical ? TextAlign::Center : TextAlign::Start);
   if (!m_hideLabel) {
     const float stableLabelWidth =
-        std::round(renderer.measureText(kVerticalStableLabel, m_label->fontSize(), true).width);
+        std::round(renderer.measureText(kVerticalStableLabel, m_label->fontSize(), FontWeight::Bold).width);
     m_label->setMinWidth(m_isVertical ? std::min(containerWidth, stableLabelWidth) : 0.0f);
     m_label->measure(renderer);
   }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -94,7 +94,7 @@ namespace {
     const float maxTextWidth = maxWidth * 0.82f;
     const float maxTextHeight = maxHeight * 0.82f;
     while (fontSize >= minFontSize) {
-      const auto metrics = renderer.measureText(label, fontSize, true);
+      const auto metrics = renderer.measureText(label, fontSize, FontWeight::Bold);
       const float textWidth = std::max(0.0f, metrics.right - metrics.left);
       const float textHeight = std::max(0.0f, metrics.bottom - metrics.top);
       if (textWidth <= maxTextWidth && textHeight <= maxTextHeight) {
@@ -112,7 +112,7 @@ namespace {
 
   [[nodiscard]] WorkspaceDiscSize measureWorkspaceDiscSize(Renderer& renderer, std::string_view label, float fontSize,
                                                            float minHeight, float scale) {
-    const auto metrics = renderer.measureText(label, fontSize, true);
+    const auto metrics = renderer.measureText(label, fontSize, FontWeight::Bold);
     const float textW = std::max(0.0f, metrics.right - metrics.left);
     const float pad = Style::spaceXs * scale;
     WorkspaceDiscSize size{};

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -206,7 +206,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
     });
 
     if (slot.showLabel) {
-      const TextMetrics tm = renderer.measureText(labels[i], labelFontSize, true);
+      const TextMetrics tm = renderer.measureText(labels[i], labelFontSize, FontWeight::Bold);
       slot.textWidth = std::max(tm.right - tm.left, tm.inkRight - tm.inkLeft);
       const float logicalCenter = (tm.left + tm.right) * 0.5f;
       const float inkCenter = (tm.inkLeft + tm.inkRight) * 0.5f;
@@ -236,7 +236,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
         slot.activeWidth = slot.inactiveWidth;
       }
       if (slot.showLabel) {
-        const TextMetrics tm = renderer.measureText(slot.label, labelFontSize, true);
+        const TextMetrics tm = renderer.measureText(slot.label, labelFontSize, FontWeight::Bold);
         maxLabelHeight = std::max(maxLabelHeight, tm.bottom - tm.top);
       }
       continue;
@@ -380,7 +380,8 @@ void WorkspacesWidget::retarget(Renderer& renderer) {
         it.text->measure(renderer);
         const float fontSize = it.text->fontSize();
         const bool labelIsBold = labelBold() && (!m_minimal || ws.active);
-        const TextMetrics tm = renderer.measureText(label, fontSize, labelIsBold);
+        const TextMetrics tm =
+            renderer.measureText(label, fontSize, labelIsBold ? FontWeight::Bold : FontWeight::Normal);
         const float logCenter = (tm.left + tm.right) * 0.5f;
         const float inkCenter = (tm.inkLeft + tm.inkRight) * 0.5f;
         it.inkCenterOffset = inkCenter - logCenter;

--- a/src/shell/control_center/audio_tab.cpp
+++ b/src/shell/control_center/audio_tab.cpp
@@ -1991,7 +1991,8 @@ void AudioTab::syncValueLabelWidths(Renderer& renderer) {
   const float sliderMax = sliderMaxPercent();
   if (m_syncedPercentLabelMinWidth < 0.0f || std::abs(sliderMax - m_lastSyncedPercentLabelSliderMax) >= 0.0001f) {
     const std::string sampleLabel = widestPercentLabel(sliderMax);
-    const TextMetrics metrics = renderer.measureText(sampleLabel, Style::fontSizeBody * contentScale(), true);
+    const TextMetrics metrics =
+        renderer.measureText(sampleLabel, Style::fontSizeBody * contentScale(), FontWeight::Bold);
     m_syncedPercentLabelMinWidth = std::round(metrics.width);
     m_lastSyncedPercentLabelSliderMax = sliderMax;
   }

--- a/src/shell/control_center/notifications_tab.cpp
+++ b/src/shell/control_center/notifications_tab.cpp
@@ -182,23 +182,23 @@ namespace {
     return !isToday && !isYesterday;
   }
 
-  float measuredTextHeight(Renderer& renderer, std::string_view text, float fontSize, bool bold, float maxWidth,
-                           int maxLines) {
+  float measuredTextHeight(Renderer& renderer, std::string_view text, float fontSize, FontWeight fontWeight,
+                           float maxWidth, int maxLines) {
     if (text.empty()) {
       return 0.0f;
     }
-    const auto bounds = renderer.measureText(text, fontSize, bold, maxWidth, maxLines);
+    const auto bounds = renderer.measureText(text, fontSize, fontWeight, maxWidth, maxLines);
     return std::max(0.0f, bounds.bottom - bounds.top);
   }
 
-  bool canExpandText(Renderer& renderer, std::string_view text, float fontSize, bool bold, float maxWidth,
+  bool canExpandText(Renderer& renderer, std::string_view text, float fontSize, FontWeight fontWeight, float maxWidth,
                      int collapsedMaxLines) {
     if (text.empty()) {
       return false;
     }
 
-    const float collapsedHeight = measuredTextHeight(renderer, text, fontSize, bold, maxWidth, collapsedMaxLines);
-    const float expandedHeight = measuredTextHeight(renderer, text, fontSize, bold, maxWidth, kExpandedMaxLines);
+    const float collapsedHeight = measuredTextHeight(renderer, text, fontSize, fontWeight, maxWidth, collapsedMaxLines);
+    const float expandedHeight = measuredTextHeight(renderer, text, fontSize, fontWeight, maxWidth, kExpandedMaxLines);
     return expandedHeight > collapsedHeight + 0.5f;
   }
 
@@ -226,12 +226,13 @@ namespace {
     const std::string bodyText = StringUtils::trimLeadingBlankLines(entry.notification.body);
     metrics.summaryText = summaryText;
 
-    const bool summaryExpandable = canExpandText(renderer, summaryText, Style::fontSizeBody * scale, true,
+    const bool summaryExpandable = canExpandText(renderer, summaryText, Style::fontSizeBody * scale, FontWeight::Bold,
                                                  metrics.cardTextWidth, kSummaryMaxLines);
     bool bodyLineTruncated = false;
     const std::string collapsedBodyText = StringUtils::truncateByLines(bodyText, kBodyMaxLines, &bodyLineTruncated);
-    const bool bodyExpandable = bodyLineTruncated || canExpandText(renderer, bodyText, Style::fontSizeCaption * scale,
-                                                                   false, metrics.cardTextWidth, kBodyMaxLines);
+    const bool bodyExpandable =
+        bodyLineTruncated || canExpandText(renderer, bodyText, Style::fontSizeCaption * scale, FontWeight::Normal,
+                                           metrics.cardTextWidth, kBodyMaxLines);
     metrics.canExpand = summaryExpandable || bodyExpandable;
     metrics.expanded = metrics.canExpand && expandedRequested;
     metrics.bodyText = metrics.expanded ? bodyText : collapsedBodyText;
@@ -247,16 +248,16 @@ namespace {
 
     metrics.metaLine = entry.notification.appName + " • " + relativeMetaLine(entry.notification);
 
-    const float metaHeight =
-        measuredTextHeight(renderer, metrics.metaLine, Style::fontSizeCaption * scale, false, metrics.metaTextWidth, 0);
+    const float metaHeight = measuredTextHeight(renderer, metrics.metaLine, Style::fontSizeCaption * scale,
+                                                FontWeight::Normal, metrics.metaTextWidth, 0);
     const float headerHeight = std::max({iconPx, actionButtonSize, metaHeight});
     const float summaryHeight =
-        measuredTextHeight(renderer, metrics.summaryText, Style::fontSizeBody * scale, true, metrics.cardTextWidth,
-                           metrics.expanded ? kExpandedMaxLines : kSummaryMaxLines);
+        measuredTextHeight(renderer, metrics.summaryText, Style::fontSizeBody * scale, FontWeight::Bold,
+                           metrics.cardTextWidth, metrics.expanded ? kExpandedMaxLines : kSummaryMaxLines);
     const float bodyHeight =
         metrics.bodyText.empty()
             ? 0.0f
-            : measuredTextHeight(renderer, metrics.bodyText, Style::fontSizeCaption * scale, false,
+            : measuredTextHeight(renderer, metrics.bodyText, Style::fontSizeCaption * scale, FontWeight::Normal,
                                  metrics.cardTextWidth, metrics.expanded ? kExpandedMaxLines : kBodyMaxLines);
 
     const float actionsRowHeight =

--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -59,12 +59,13 @@ namespace settings {
       std::shared_ptr<std::vector<Flex*>> itemNodes;
     };
 
-    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                     FontWeight fontWeight = FontWeight::Normal) {
       auto label = std::make_unique<Label>();
       label->setText(text);
       label->setFontSize(fontSize);
       label->setColor(color);
-      label->setBold(bold);
+      label->setFontWeight(fontWeight);
       return label;
     }
 
@@ -83,7 +84,8 @@ namespace settings {
       wrap->setGap(Style::spaceXs * scale);
       wrap->setPadding(Style::spaceSm * scale, 0.0f, 0.0f, 0.0f);
       wrap->addChild(std::make_unique<Separator>());
-      wrap->addChild(makeLabel(title, Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::Secondary), true));
+      wrap->addChild(
+          makeLabel(title, Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::Secondary), FontWeight::Bold));
       return wrap;
     }
 
@@ -756,7 +758,7 @@ namespace settings {
       header->setGap(1.0f * ctx.scale);
       header->setPadding(Style::spaceXs * ctx.scale, 0.0f);
       header->addChild(makeLabel(i18n::tr("settings.entities.widget.raw.title"), Style::fontSizeCaption * ctx.scale,
-                                 colorSpecFromRole(ColorRole::OnSurface), true));
+                                 colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
       header->addChild(makeSettingSubtitleLabel(i18n::tr("settings.entities.widget.raw.description"), ctx.scale));
       panel.addChild(std::move(header));
 
@@ -777,15 +779,15 @@ namespace settings {
         row->setPadding(Style::spaceXs * ctx.scale, 0.0f);
         row->setMinHeight(Style::controlHeightSm * ctx.scale);
 
-        row->addChild(
-            makeLabel(key, Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface), true));
+        row->addChild(makeLabel(key, Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface),
+                                FontWeight::Bold));
 
         auto spacer = std::make_unique<Flex>();
         spacer->setFlexGrow(1.0f);
         row->addChild(std::move(spacer));
 
         row->addChild(makeLabel(settingValueAsDisplayString(valueIt->second), Style::fontSizeCaption * ctx.scale,
-                                colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
         if (overridden) {
           auto deleteBtn = std::make_unique<Button>();
@@ -849,9 +851,9 @@ namespace settings {
       panelHeader->setGap(Style::spaceXs * ctx.scale);
       panelHeader->addChild(makeLabel(i18n::tr("settings.entities.widget.settings.title"),
                                       Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface),
-                                      true));
+                                      FontWeight::Bold));
       panelHeader->addChild(makeLabel(widgetType, Style::fontSizeCaption * ctx.scale,
-                                      colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                      colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
       panel->addChild(std::move(panelHeader));
 
       std::size_t visibleSpecs = 0;
@@ -1082,7 +1084,7 @@ namespace settings {
       if (visibleSpecs == 0) {
         panel->addChild(makeLabel(i18n::tr("settings.entities.widget.settings.empty"),
                                   Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                  false));
+                                  FontWeight::Normal));
       }
 
       item.addChild(std::move(panel));
@@ -1136,10 +1138,10 @@ namespace settings {
         headerRow->setGap(Style::spaceSm * ctx.scale);
         headerRow->addChild(makeLabel(i18n::tr("settings.entities.widget.inspector.edit-title"),
                                       Style::fontSizeCaption * ctx.scale,
-                                      colorSpecFromRole(ColorRole::OnSurfaceVariant), true));
+                                      colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Bold));
         {
-          auto titleLabel =
-              makeLabel(info.title, Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::OnSurface), true);
+          auto titleLabel = makeLabel(info.title, Style::fontSizeBody * ctx.scale,
+                                      colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold);
           titleLabel->setMaxLines(1);
           titleLabel->setFlexGrow(1.0f);
           headerRow->addChild(std::move(titleLabel));
@@ -1150,8 +1152,8 @@ namespace settings {
         kindBadge->setPadding(0, Style::spaceXs * ctx.scale);
         kindBadge->setRadius(Style::scaledRadiusSm(ctx.scale));
         kindBadge->setFill(widgetBadgeColor(info.kind));
-        kindBadge->addChild(
-            makeLabel(info.badge, Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface), true));
+        kindBadge->addChild(makeLabel(info.badge, Style::fontSizeCaption * ctx.scale,
+                                      colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
         headerRow->addChild(std::move(kindBadge));
 
         auto headerSpacer = std::make_unique<Flex>();
@@ -1184,7 +1186,7 @@ namespace settings {
           groupRow->addChild(makeGlyph("stack-back", Style::fontSizeCaption * ctx.scale,
                                        colorSpecFromRole(ColorRole::OnSurfaceVariant)));
           groupRow->addChild(makeLabel(capsuleGroup, Style::fontSizeCaption * ctx.scale,
-                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
           inspector->addChild(std::move(groupRow));
         }
 
@@ -1344,10 +1346,10 @@ namespace settings {
 
           confirmPanel->addChild(
               makeLabel(i18n::tr("settings.entities.widget.instance.delete-confirm-title", "name", widgetName),
-                        Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error), true));
+                        Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error), FontWeight::Bold));
           confirmPanel->addChild(makeLabel(i18n::tr("settings.entities.widget.instance.delete-confirm-desc"),
                                            Style::fontSizeCaption * ctx.scale,
-                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
           auto confirmRow = std::make_unique<Flex>();
           confirmRow->setDirection(FlexDirection::Horizontal);
@@ -1434,7 +1436,7 @@ namespace settings {
     titleRow->setAlign(FlexAlign::Center);
     titleRow->setGap(Style::spaceSm * ctx.scale);
     titleRow->addChild(makeLabel(i18n::tr("settings.entities.widget.editor.title"), Style::fontSizeBody * ctx.scale,
-                                 colorSpecFromRole(ColorRole::OnSurface), false));
+                                 colorSpecFromRole(ColorRole::OnSurface), FontWeight::Normal));
     block->addChild(std::move(titleRow));
 
     block->addChild(makeSettingSubtitleLabel(i18n::tr("settings.entities.widget.editor.description"), ctx.scale));
@@ -1499,7 +1501,7 @@ namespace settings {
       laneHeader->setAlign(FlexAlign::Center);
       laneHeader->setGap(Style::spaceXs * ctx.scale);
       laneHeader->addChild(makeLabel(laneLabel(laneKey), Style::fontSizeBody * ctx.scale,
-                                     colorSpecFromRole(ColorRole::OnSurface), true));
+                                     colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
       if (overridden) {
         auto badge = std::make_unique<Flex>();
         badge->setAlign(FlexAlign::Center);
@@ -1507,7 +1509,7 @@ namespace settings {
         badge->setRadius(Style::scaledRadiusSm(ctx.scale));
         badge->setFill(colorSpecFromRole(ColorRole::Primary, 0.15f));
         badge->addChild(makeLabel(i18n::tr("settings.badges.override"), Style::fontSizeCaption * ctx.scale,
-                                  colorSpecFromRole(ColorRole::Primary), true));
+                                  colorSpecFromRole(ColorRole::Primary), FontWeight::Bold));
         laneHeader->addChild(std::move(badge));
       }
       if (inherited) {
@@ -1517,7 +1519,7 @@ namespace settings {
         badge->setRadius(Style::scaledRadiusSm(ctx.scale));
         badge->setFill(colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.14f));
         badge->addChild(makeLabel(i18n::tr("settings.badges.inherited"), Style::fontSizeCaption * ctx.scale,
-                                  colorSpecFromRole(ColorRole::OnSurfaceVariant), true));
+                                  colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Bold));
         laneHeader->addChild(std::move(badge));
       }
       auto laneSpacer = std::make_unique<Flex>();
@@ -1560,8 +1562,8 @@ namespace settings {
         itemTop->setAlign(FlexAlign::Center);
         itemTop->setGap(Style::spaceXs * ctx.scale);
         {
-          auto titleLabel =
-              makeLabel(info.title, Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface), true);
+          auto titleLabel = makeLabel(info.title, Style::fontSizeCaption * ctx.scale,
+                                      colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold);
           titleLabel->setMaxLines(1);
           titleLabel->setFlexGrow(1.0f);
           itemTop->addChild(std::move(titleLabel));
@@ -1571,8 +1573,8 @@ namespace settings {
         kindBadge->setPadding(0, Style::spaceXs * ctx.scale);
         kindBadge->setRadius(Style::scaledRadiusSm(ctx.scale));
         kindBadge->setFill(widgetBadgeColor(info.kind));
-        kindBadge->addChild(
-            makeLabel(info.badge, Style::fontSizeCaption * ctx.scale, colorSpecFromRole(ColorRole::OnSurface), true));
+        kindBadge->addChild(makeLabel(info.badge, Style::fontSizeCaption * ctx.scale,
+                                      colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
         itemTop->addChild(std::move(kindBadge));
         if (!capsuleGroup.empty()) {
           itemTop->addChild(makeGlyph("stack-back", Style::fontSizeCaption * ctx.scale,
@@ -1591,7 +1593,7 @@ namespace settings {
           groupRow->addChild(makeGlyph("stack-back", Style::fontSizeCaption * ctx.scale,
                                        colorSpecFromRole(ColorRole::OnSurfaceVariant)));
           groupRow->addChild(makeLabel(capsuleGroup, Style::fontSizeCaption * ctx.scale,
-                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
           item->addChild(std::move(groupRow));
         }
 
@@ -1781,10 +1783,10 @@ namespace settings {
         emptyState->setBorder(colorSpecFromRole(ColorRole::Outline, 0.18f), Style::borderWidth);
         emptyState->addChild(makeLabel(i18n::tr("settings.entities.widget.lanes.empty"),
                                        Style::fontSizeCaption * ctx.scale,
-                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), true));
+                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Bold));
         emptyState->addChild(makeLabel(i18n::tr("settings.entities.widget.lanes.empty-hint"),
                                        Style::fontSizeCaption * ctx.scale,
-                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
         lane->addChild(std::move(emptyState));
       }
 

--- a/src/shell/settings/config_export_dialog_popup.cpp
+++ b/src/shell/settings/config_export_dialog_popup.cpp
@@ -48,12 +48,13 @@ namespace settings {
       };
     }
 
-    std::unique_ptr<Label> makeLabel(std::string text, float fontSize, ColorSpec color, bool bold = false) {
+    std::unique_ptr<Label> makeLabel(std::string text, float fontSize, ColorSpec color,
+                                     FontWeight fontWeight = FontWeight::Normal) {
       auto label = std::make_unique<Label>();
       label->setText(text);
       label->setFontSize(fontSize);
       label->setColor(color);
-      label->setBold(bold);
+      label->setFontWeight(fontWeight);
       return label;
     }
 
@@ -151,7 +152,8 @@ namespace settings {
     copy->setGap(Style::spaceXs * m_scale);
     copy->setFlexGrow(1.0f);
 
-    auto titleLabel = makeLabel(title, Style::fontSizeBody * m_scale, colorSpecFromRole(ColorRole::OnSurface), true);
+    auto titleLabel =
+        makeLabel(title, Style::fontSizeBody * m_scale, colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold);
     titleLabel->setMaxLines(1);
     copy->addChild(std::move(titleLabel));
 
@@ -188,7 +190,7 @@ namespace settings {
     header->setGap(Style::spaceSm * m_scale);
 
     auto title = makeLabel(i18n::tr("settings.export-config.title"), Style::fontSizeTitle * m_scale,
-                           colorSpecFromRole(ColorRole::OnSurface), true);
+                           colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold);
     title->setFlexGrow(1.0f);
     header->addChild(std::move(title));
 

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -47,12 +47,13 @@
 namespace settings {
   namespace {
 
-    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                     FontWeight fontWeight = FontWeight::Normal) {
       auto label = std::make_unique<Label>();
       label->setText(text);
       label->setFontSize(fontSize);
       label->setColor(color);
-      label->setBold(bold);
+      label->setFontWeight(fontWeight);
       return label;
     }
 
@@ -450,7 +451,7 @@ namespace settings {
       iconCol->setAlign(FlexAlign::Stretch);
       iconCol->setGap(Style::spaceSm * scale);
       iconCol->addChild(makeLabel(i18n::tr("settings.session-actions.icon-label"), Style::fontSizeCaption * scale,
-                                  colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                  colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
       auto glyphBtnRow = std::make_unique<Flex>();
       glyphBtnRow->setDirection(FlexDirection::Horizontal);
@@ -517,7 +518,7 @@ namespace settings {
 
       fields->addChild(makeLabel(i18n::tr("settings.session-actions.kind-section-label"),
                                  Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                 false));
+                                 FontWeight::Normal));
       auto kindSelect = std::make_unique<Select>();
       kindSelect->setOptions(optionLabels(kindOptions));
       if (const auto ki = optionIndex(kindOptions, row.action)) {
@@ -543,7 +544,7 @@ namespace settings {
       labelBlock->setGap(Style::spaceXs * scale);
       labelBlock->setFlexGrow(1.0f);
       labelBlock->addChild(makeLabel(i18n::tr("settings.session-actions.label-field"), Style::fontSizeCaption * scale,
-                                     colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                     colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
       auto labelIn = std::make_unique<Input>();
       labelIn->setValue(row.label.value_or(""));
       labelIn->setPlaceholder(i18n::tr("settings.session-actions.label-placeholder"));
@@ -574,7 +575,7 @@ namespace settings {
       cmdBlock->setGap(Style::spaceXs * scale);
       cmdBlock->setFlexGrow(1.0f);
       cmdBlock->addChild(makeLabel(i18n::tr("settings.session-actions.command-label"), Style::fontSizeCaption * scale,
-                                   colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                   colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
       auto cmdIn = std::make_unique<Input>();
       cmdIn->setValue(row.command.value_or(""));
       cmdIn->setPlaceholder(i18n::tr("settings.session-actions.command-placeholder"));
@@ -606,7 +607,7 @@ namespace settings {
       variantBlock->setFlexGrow(1.0f);
       variantBlock->addChild(makeLabel(i18n::tr("settings.session-actions.variant-label"),
                                        Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                       false));
+                                       FontWeight::Normal));
       auto variantSelect = std::make_unique<Select>();
       const std::vector<SelectOption> variantOptions = sessionActionVariantOptions();
       variantSelect->setOptions(optionLabels(variantOptions));
@@ -639,7 +640,7 @@ namespace settings {
       shortcutBlock->setFlexGrow(1.0f);
       shortcutBlock->addChild(makeLabel(i18n::tr("settings.session-actions.shortcut-label"),
                                         Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                        false));
+                                        FontWeight::Normal));
 
       auto shortcutRecorder = std::make_unique<KeybindRecorder>();
       shortcutRecorder->setScale(scale);
@@ -712,8 +713,9 @@ namespace settings {
       suspendLockGrp->setGap(Style::spaceSm * scale);
       suspendLockGrp->setFillWidth(true);
       suspendLockGrp->setVisible(showSuspendLock);
-      auto suspendLockLabel = makeLabel(i18n::tr("settings.idle.behavior.lock-before-suspend-label"),
-                                        Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), false);
+      auto suspendLockLabel =
+          makeLabel(i18n::tr("settings.idle.behavior.lock-before-suspend-label"), Style::fontSizeBody * scale,
+                    colorSpecFromRole(ColorRole::OnSurface), FontWeight::Normal);
       suspendLockLabel->setFlexGrow(1.0f);
       suspendLockGrp->addChild(std::move(suspendLockLabel));
       auto suspendLockToggle = std::make_unique<Toggle>();
@@ -731,8 +733,8 @@ namespace settings {
         block->setDirection(FlexDirection::Vertical);
         block->setAlign(FlexAlign::Stretch);
         block->setGap(Style::spaceXs * scale);
-        block->addChild(
-            makeLabel(label, Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+        block->addChild(makeLabel(label, Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                                  FontWeight::Normal));
         auto input = std::make_unique<Input>();
         input->setValue(target);
         input->setPlaceholder(placeholder);
@@ -770,7 +772,7 @@ namespace settings {
       kindBlock->setGap(Style::spaceXs * scale);
       kindBlock->addChild(makeLabel(i18n::tr("settings.idle.behavior.kind-section-label"),
                                     Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                    false));
+                                    FontWeight::Normal));
       auto kindSelect = std::make_unique<Select>();
       kindSelect->setOptions(optionLabels(idleActionOptions));
       if (const auto ki = optionIndex(idleActionOptions, norm.action)) {
@@ -805,7 +807,7 @@ namespace settings {
       nameBlock->setAlign(FlexAlign::Stretch);
       nameBlock->setGap(Style::spaceXs * scale);
       nameBlock->addChild(makeLabel(i18n::tr("settings.idle.behavior.name-label"), Style::fontSizeCaption * scale,
-                                    colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                    colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
       auto nameIn = std::make_unique<Input>();
       nameIn->setValue(row.name);
       nameIn->setPlaceholder(i18n::tr("settings.idle.behavior.name-placeholder"));
@@ -835,7 +837,7 @@ namespace settings {
       timeoutBlock->setAlign(FlexAlign::Stretch);
       timeoutBlock->setGap(Style::spaceXs * scale);
       timeoutBlock->addChild(makeLabel(i18n::tr("settings.idle.behavior.timeout-label"), Style::fontSizeCaption * scale,
-                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                       colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
       auto timeoutIn = std::make_unique<Input>();
       timeoutIn->setValue(std::format("{}", row.timeoutSeconds));
       timeoutIn->setPlaceholder("660");
@@ -951,7 +953,8 @@ namespace settings {
       titleGlyph->setColor(colorSpecFromRole(ColorRole::Primary));
       titleRow->addChild(std::move(titleGlyph));
 
-      titleRow->addChild(makeLabel(title, Style::fontSizeHeader * scale, colorSpecFromRole(ColorRole::Primary), true));
+      titleRow->addChild(
+          makeLabel(title, Style::fontSizeHeader * scale, colorSpecFromRole(ColorRole::Primary), FontWeight::Bold));
 
       section->addChild(std::move(titleRow));
       auto* raw = section.get();
@@ -971,10 +974,11 @@ namespace settings {
         groupHeader->setPadding(Style::spaceSm * scale, 0.0f, 0.0f, 0.0f);
         groupHeader->addChild(std::make_unique<Separator>());
         groupHeader->addChild(
-            makeLabel(title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::Secondary), true));
+            makeLabel(title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::Secondary), FontWeight::Bold));
         section.addChild(std::move(groupHeader));
       } else {
-        section.addChild(makeLabel(title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::Secondary), true));
+        section.addChild(
+            makeLabel(title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::Secondary), FontWeight::Bold));
       }
     };
 
@@ -1002,7 +1006,7 @@ namespace settings {
       }
       badge->setRadius(Style::scaledRadiusSm(scale));
       badge->setFill(fill);
-      badge->addChild(makeLabel(label, Style::fontSizeCaption * scale, color, true));
+      badge->addChild(makeLabel(label, Style::fontSizeCaption * scale, color, FontWeight::Bold));
       return badge;
     };
 
@@ -1054,8 +1058,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       if (entry.advanced) {
         titleRow->addChild(makeAdvancedBadge());
       }
@@ -1524,8 +1528,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       auto titleSpacer = std::make_unique<Flex>();
       titleSpacer->setFlexGrow(1.0f);
       titleRow->addChild(std::move(titleSpacer));
@@ -1587,8 +1591,8 @@ namespace settings {
           setOverride(path, ordered);
         });
         item->addChild(std::move(checkbox));
-        item->addChild(
-            makeLabel(option.label, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), false));
+        item->addChild(makeLabel(option.label, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                 FontWeight::Normal));
 
         checkRow->addChild(std::move(item));
       }
@@ -1611,8 +1615,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       auto titleSpacer = std::make_unique<Flex>();
       titleSpacer->setFlexGrow(1.0f);
       titleRow->addChild(std::move(titleSpacer));
@@ -1690,8 +1694,8 @@ namespace settings {
       titleRow->setFillWidth(true);
       // Reserve the Reset button's height so columns line up even when only some are overridden.
       titleRow->setMinHeight(Style::controlHeightSm * scale);
-      auto titleLabel =
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true);
+      auto titleLabel = makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                  FontWeight::Bold);
       titleLabel->setMaxLines(2);
       titleRow->addChild(std::move(titleLabel));
       auto titleSpacer = std::make_unique<Flex>();
@@ -1809,8 +1813,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       auto titleSpacer = std::make_unique<Flex>();
       titleSpacer->setFlexGrow(1.0f);
       titleRow->addChild(std::move(titleSpacer));
@@ -1886,8 +1890,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       auto titleSpacer = std::make_unique<Flex>();
       titleSpacer->setFlexGrow(1.0f);
       titleRow->addChild(std::move(titleSpacer));
@@ -2036,8 +2040,8 @@ namespace settings {
       titleRow->setAlign(FlexAlign::Center);
       titleRow->setGap(Style::spaceSm * scale);
       titleRow->setFillWidth(true);
-      titleRow->addChild(
-          makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      titleRow->addChild(makeLabel(entry.title, Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurface),
+                                   FontWeight::Bold));
       auto titleSpacer = std::make_unique<Flex>();
       titleSpacer->setFlexGrow(1.0f);
       titleRow->addChild(std::move(titleSpacer));
@@ -2416,9 +2420,9 @@ namespace settings {
       emptyState->setBorder(colorSpecFromRole(ColorRole::Outline, 0.28f), Style::borderWidth);
       emptyState->setRadius(Style::scaledRadiusMd(scale));
       emptyState->addChild(makeLabel(i18n::tr("settings.window.no-results"), Style::fontSizeBody * scale,
-                                     colorSpecFromRole(ColorRole::OnSurface), true));
+                                     colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
       emptyState->addChild(makeLabel(i18n::tr("settings.window.no-results-hint"), Style::fontSizeCaption * scale,
-                                     colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                     colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
       auto emptyRow = std::make_unique<Flex>();
       emptyRow->setDirection(FlexDirection::Horizontal);

--- a/src/shell/settings/settings_entity_editor.cpp
+++ b/src/shell/settings/settings_entity_editor.cpp
@@ -20,12 +20,13 @@
 namespace settings {
   namespace {
 
-    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                     FontWeight fontWeight = FontWeight::Normal) {
       auto label = std::make_unique<Label>();
       label->setText(text);
       label->setFontSize(fontSize);
       label->setColor(color);
-      label->setBold(bold);
+      label->setFontWeight(fontWeight);
       return label;
     }
 
@@ -52,7 +53,8 @@ namespace settings {
       section->setPadding(Style::spaceSm * scale, Style::spaceMd * scale);
       section->setCardStyle(scale, 1.0f, showBorder);
       section->setFill(colorSpecFromRole(ColorRole::Surface));
-      section->addChild(makeLabel(title, Style::fontSizeTitle * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+      section->addChild(
+          makeLabel(title, Style::fontSizeTitle * scale, colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
 
       auto* raw = section.get();
       content.addChild(std::move(section));
@@ -161,10 +163,10 @@ namespace settings {
 
           confirmPanel->addChild(
               makeLabel(i18n::tr("settings.entities.monitor-override.delete-confirm-title", "name", match),
-                        Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error), true));
+                        Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error), FontWeight::Bold));
           confirmPanel->addChild(makeLabel(i18n::tr("settings.entities.monitor-override.delete-confirm-desc"),
                                            Style::fontSizeCaption * ctx.scale,
-                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
           auto confirmRow = std::make_unique<Flex>();
           confirmRow->setDirection(FlexDirection::Horizontal);
@@ -353,10 +355,11 @@ namespace settings {
           confirmPanel->setBorder(colorSpecFromRole(ColorRole::Error, 0.5f), Style::borderWidth);
 
           confirmPanel->addChild(makeLabel(i18n::tr("settings.entities.bar.delete-confirm-title", "name", barName),
-                                           Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error), true));
+                                           Style::fontSizeBody * ctx.scale, colorSpecFromRole(ColorRole::Error),
+                                           FontWeight::Bold));
           confirmPanel->addChild(makeLabel(i18n::tr("settings.entities.bar.delete-confirm-desc"),
                                            Style::fontSizeCaption * ctx.scale,
-                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), false));
+                                           colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal));
 
           auto confirmRow = std::make_unique<Flex>();
           confirmRow->setDirection(FlexDirection::Horizontal);

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -72,12 +72,13 @@ namespace {
     return palettePreviewFromMetadata(palette.preview.dark);
   }
 
-  std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+  std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                   FontWeight fontWeight = FontWeight::Normal) {
     auto label = std::make_unique<Label>();
     label->setText(text);
     label->setFontSize(fontSize);
     label->setColor(color);
-    label->setBold(bold);
+    label->setFontWeight(fontWeight);
     return label;
   }
 
@@ -558,7 +559,7 @@ std::unique_ptr<Flex> SettingsWindow::buildFilterRow(float scale, const std::str
   filters->addChild(std::make_unique<Spacer>());
 
   auto advancedLabel = makeLabel(i18n::tr("settings.badges.advanced"), Style::fontSizeBody * scale,
-                                 colorSpecFromRole(ColorRole::OnSurfaceVariant), false);
+                                 colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal);
   filters->addChild(std::move(advancedLabel));
 
   auto advancedToggle = std::make_unique<Toggle>();
@@ -581,7 +582,7 @@ std::unique_ptr<Flex> SettingsWindow::buildFilterRow(float scale, const std::str
   filters->addChild(std::move(advancedToggle));
 
   auto overriddenLabel = makeLabel(i18n::tr("settings.window.filter-modified"), Style::fontSizeBody * scale,
-                                   colorSpecFromRole(ColorRole::OnSurfaceVariant), false);
+                                   colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal);
   filters->addChild(std::move(overriddenLabel));
 
   auto overriddenToggle = std::make_unique<Toggle>();
@@ -647,8 +648,9 @@ std::unique_ptr<Flex> SettingsWindow::buildStatusRow(float scale) {
   status->setBorder(colorSpecFromRole(m_statusIsError ? ColorRole::Error : ColorRole::Secondary, 0.45f),
                     Style::borderWidth);
 
-  auto message = makeLabel(m_statusMessage, Style::fontSizeCaption * scale,
-                           colorSpecFromRole(m_statusIsError ? ColorRole::Error : ColorRole::Secondary), true);
+  auto message =
+      makeLabel(m_statusMessage, Style::fontSizeCaption * scale,
+                colorSpecFromRole(m_statusIsError ? ColorRole::Error : ColorRole::Secondary), FontWeight::Bold);
   message->setFlexGrow(1.0f);
   status->addChild(std::move(message));
 

--- a/src/shell/settings/widget_add_popup.cpp
+++ b/src/shell/settings/widget_add_popup.cpp
@@ -42,12 +42,13 @@ namespace settings {
       return std::string(lane);
     }
 
-    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+    std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                     FontWeight fontWeight = FontWeight::Normal) {
       auto label = std::make_unique<Label>();
       label->setText(text);
       label->setFontSize(fontSize);
       label->setColor(color);
-      label->setBold(bold);
+      label->setFontWeight(fontWeight);
       return label;
     }
 
@@ -367,7 +368,8 @@ namespace settings {
     const std::string title = m_createFormVisible
                                   ? instanceFormTitle()
                                   : i18n::tr("settings.entities.widget.inspector.add-title", "lane", lane);
-    auto titleLabel = makeLabel(title, Style::fontSizeBody * m_scale, colorSpecFromRole(ColorRole::OnSurface), true);
+    auto titleLabel =
+        makeLabel(title, Style::fontSizeBody * m_scale, colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold);
     if (m_createFormVisible) {
       titleLabel->setMaxLines(2);
     }
@@ -380,7 +382,7 @@ namespace settings {
     if (!m_createFormVisible) {
       header->addChild(makeLabel(i18n::tr("settings.entities.widget.picker.instance-toggle"),
                                  Style::fontSizeCaption * m_scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                                 false));
+                                 FontWeight::Normal));
 
       auto instanceToggle = std::make_unique<Toggle>();
       instanceToggle->setScale(m_scale);

--- a/src/shell/settings/widget_add_popup.cpp
+++ b/src/shell/settings/widget_add_popup.cpp
@@ -544,7 +544,7 @@ namespace settings {
     float contentWidth = kCreateMinWidth * m_scale;
     if (m_renderContext != nullptr && !m_createLabel.empty()) {
       const float fontSize = Style::fontSizeBody * m_scale;
-      const TextMetrics titleMetrics = m_renderContext->measureText(instanceFormTitle(), fontSize, true);
+      const TextMetrics titleMetrics = m_renderContext->measureText(instanceFormTitle(), fontSize, FontWeight::Bold);
       const float closeBtn = Style::controlHeightSm * m_scale;
       const float headerGap = Style::spaceSm * m_scale;
       const float rootPadding = Style::spaceSm * m_scale * 2.0f;

--- a/src/shell/setup_wizard/setup_wizard_panel.cpp
+++ b/src/shell/setup_wizard/setup_wizard_panel.cpp
@@ -54,12 +54,13 @@ namespace {
       {"theme.scheme.muted", "muted"},
   };
 
-  std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color, bool bold = false) {
+  std::unique_ptr<Label> makeLabel(std::string_view text, float fontSize, const ColorSpec& color,
+                                   FontWeight fontWeight = FontWeight::Normal) {
     auto label = std::make_unique<Label>();
     label->setText(text);
     label->setFontSize(fontSize);
     label->setColor(color);
-    label->setBold(bold);
+    label->setFontWeight(fontWeight);
     return label;
   }
 
@@ -172,8 +173,8 @@ void SetupWizardPanel::create() {
 
     auto copy = makeTextColumn();
     copy->setGap(Style::spaceXs * scale);
-    copy->addChild(
-        makeLabel(i18n::tr("setup-wizard.title"), 18.0f * scale, colorSpecFromRole(ColorRole::OnSurface), true));
+    copy->addChild(makeLabel(i18n::tr("setup-wizard.title"), 18.0f * scale, colorSpecFromRole(ColorRole::OnSurface),
+                             FontWeight::Bold));
     copy->addChild(makeLabel(i18n::tr("setup-wizard.subtitle"), Style::fontSizeBody * scale,
                              colorSpecFromRole(ColorRole::OnSurfaceVariant)));
     header->addChild(std::move(copy));
@@ -190,7 +191,7 @@ void SetupWizardPanel::create() {
     {
       auto col = makeTextColumn();
       col->addChild(makeLabel(i18n::tr("settings.schema.shell.telemetry.label"), Style::fontSizeBody * scale,
-                              colorSpecFromRole(ColorRole::OnSurface), true));
+                              colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
       auto description = makeLabel(i18n::tr("settings.schema.shell.telemetry.description"),
                                    Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant));
       description->setMaxLines(8);
@@ -216,7 +217,7 @@ void SetupWizardPanel::create() {
     {
       auto col = makeTextColumn();
       col->addChild(makeLabel(i18n::tr("setup-wizard.wallpaper"), Style::fontSizeBody * scale,
-                              colorSpecFromRole(ColorRole::OnSurface), true));
+                              colorSpecFromRole(ColorRole::OnSurface), FontWeight::Bold));
       const std::string currentPath = m_config->getDefaultWallpaperPath();
       auto pathLabel = makeLabel(currentPath.empty() ? i18n::tr("setup-wizard.no-wallpaper-selected") : currentPath,
                                  Style::fontSizeCaption * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant));

--- a/src/shell/tooltip/tooltip_manager.cpp
+++ b/src/shell/tooltip/tooltip_manager.cpp
@@ -199,7 +199,8 @@ TooltipManager::Size TooltipManager::measureContent(const TooltipContent& conten
   }
 
   if (const auto* text = std::get_if<std::string>(&content)) {
-    auto metrics = m_renderContext->measureText(*text, Style::fontSizeCaption, false, kMaxContentWidth, kMaxTextLines);
+    auto metrics = m_renderContext->measureText(*text, Style::fontSizeCaption, FontWeight::Normal, kMaxContentWidth,
+                                                kMaxTextLines);
     auto w = static_cast<std::uint32_t>(std::ceil(metrics.width + kPadH * 2.0f + kBorder * 2.0f));
     auto h = static_cast<std::uint32_t>(std::ceil((metrics.bottom - metrics.top) + kPadV * 2.0f + kBorder * 2.0f));
     return {std::max(w, 1u), std::max(h, 1u)};

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -502,7 +502,7 @@ void Input::doLayout(Renderer& renderer) {
     if (!m_value.empty() && m_stopX.size() > 1U) {
       textExtent = m_stopX.back();
     } else if (m_value.empty() && !m_placeholder.empty()) {
-      textExtent = renderer.measureText(m_placeholder, m_fontSize, m_label->bold()).width;
+      textExtent = renderer.measureText(m_placeholder, m_fontSize, m_label->fontWeight()).width;
     }
     if (vw > 0.0f && textExtent > 0.0f && textExtent + 0.5f < vw) {
       m_contentLeadSlack = std::round((vw - textExtent) * 0.5f);

--- a/src/ui/controls/label.cpp
+++ b/src/ui/controls/label.cpp
@@ -94,11 +94,13 @@ void Label::setMaxLines(int maxLines) {
   m_measureCached = false;
 }
 
-void Label::setBold(bool bold) {
-  if (m_textNode->bold() == bold) {
+void Label::setBold(bool bold) { setFontWeight(bold ? FontWeight::Bold : FontWeight::Normal); }
+
+void Label::setFontWeight(FontWeight fontWeight) {
+  if (m_textNode->fontWeight() == fontWeight) {
     return;
   }
-  m_textNode->setBold(bold);
+  m_textNode->setFontWeight(fontWeight);
   m_measureCached = false;
 }
 
@@ -110,7 +112,7 @@ const Color& Label::color() const noexcept { return m_textNode->color(); }
 
 float Label::maxWidth() const noexcept { return m_userMaxWidth; }
 
-bool Label::bold() const noexcept { return m_textNode->bold(); }
+FontWeight Label::fontWeight() const noexcept { return m_textNode->fontWeight(); }
 
 TextAlign Label::textAlign() const noexcept { return m_textNode->textAlign(); }
 
@@ -394,10 +396,11 @@ LayoutSize Label::measureWithConstraints(Renderer& renderer, const LayoutConstra
       m_autoScroll || (effectiveMaxLines == 1) ||
       (effectiveMaxLines == 0 && configuredMaxWidth <= 0.0f && m_plainText.find('\n') == std::string::npos);
   const TextAlign align = m_textNode->textAlign();
+  const FontWeight fontWeight = m_textNode->fontWeight();
   const float renderScale = renderer.renderScale();
   const std::uint64_t textMetricsGeneration = renderer.textMetricsGeneration();
   if (m_measureCached && m_cachedText == m_plainText && m_cachedFontSize == m_textNode->fontSize() &&
-      m_cachedBold == m_textNode->bold() && m_cachedMaxWidth == m_userMaxWidth && m_cachedMaxLines == m_userMaxLines &&
+      m_cachedFontWeight == fontWeight && m_cachedMaxWidth == m_userMaxWidth && m_cachedMaxLines == m_userMaxLines &&
       m_cachedMinWidth == m_minWidth && m_cachedConstraintMinWidth == constraints.minWidth &&
       m_cachedConstraintMaxWidth == constraints.maxWidth && m_cachedHasConstraintMaxWidth == constraints.hasMaxWidth &&
       m_cachedRenderScale == renderScale && m_cachedTextMetricsGeneration == textMetricsGeneration &&
@@ -422,7 +425,7 @@ LayoutSize Label::measureWithConstraints(Renderer& renderer, const LayoutConstra
     }
   }
 
-  auto metrics = renderer.measureText(m_plainText, m_textNode->fontSize(), m_textNode->bold(), measureMaxWidth,
+  auto metrics = renderer.measureText(m_plainText, m_textNode->fontSize(), fontWeight, measureMaxWidth,
                                       effectiveMaxLines, align, m_textNode->fontFamily());
   const float measuredWidth = measureMaxWidth > 0.0f ? std::min(metrics.width, measureMaxWidth) : metrics.width;
   m_fullTextWidth = m_autoScroll ? measuredWidth : 0.0f;
@@ -500,8 +503,8 @@ LayoutSize Label::measureWithConstraints(Renderer& renderer, const LayoutConstra
   }
 
   if (overflow && m_autoScroll) {
-    auto gapMetrics = renderer.measureText(kMarqueeGap, m_textNode->fontSize(), m_textNode->bold(), 0.0f, 1, align,
-                                           m_textNode->fontFamily());
+    auto gapMetrics =
+        renderer.measureText(kMarqueeGap, m_textNode->fontSize(), fontWeight, 0.0f, 1, align, m_textNode->fontFamily());
     m_marqueeLoopPeriod = m_fullTextWidth + gapMetrics.width;
     m_textNode->setText(m_plainText + kMarqueeGap + m_plainText);
   } else {
@@ -513,7 +516,7 @@ LayoutSize Label::measureWithConstraints(Renderer& renderer, const LayoutConstra
 
   m_cachedText = m_plainText;
   m_cachedFontSize = m_textNode->fontSize();
-  m_cachedBold = m_textNode->bold();
+  m_cachedFontWeight = fontWeight;
   m_cachedMaxWidth = m_userMaxWidth;
   m_cachedMaxLines = m_userMaxLines;
   m_cachedMinWidth = m_minWidth;

--- a/src/ui/controls/label.h
+++ b/src/ui/controls/label.h
@@ -31,6 +31,7 @@ public:
   void setMaxWidth(float maxWidth);
   void setMaxLines(int maxLines);
   void setBold(bool bold);
+  void setFontWeight(FontWeight fontWeight);
   void setTextAlign(TextAlign align);
   // StableLogical uses the resolved font line box; InkCentered centers the current glyph ink.
   void setBaselineMode(LabelBaselineMode mode);
@@ -51,7 +52,7 @@ public:
   [[nodiscard]] float fontSize() const noexcept;
   [[nodiscard]] const Color& color() const noexcept;
   [[nodiscard]] float maxWidth() const noexcept;
-  [[nodiscard]] bool bold() const noexcept;
+  [[nodiscard]] FontWeight fontWeight() const noexcept;
   [[nodiscard]] TextAlign textAlign() const noexcept;
   [[nodiscard]] LabelBaselineMode baselineMode() const noexcept { return m_baselineMode; }
   [[nodiscard]] float baselineOffset() const noexcept { return m_baselineOffset; }
@@ -98,7 +99,7 @@ private:
   int m_cachedMaxLines = 0;
   TextAlign m_cachedTextAlign = TextAlign::Start;
   LabelBaselineMode m_cachedBaselineMode = LabelBaselineMode::StableLogical;
-  bool m_cachedBold = false;
+  FontWeight m_cachedFontWeight = FontWeight::Normal;
   bool m_cachedAutoScroll = false;
   bool m_cachedHasConstraintMaxWidth = false;
   bool m_measureCached = false;

--- a/src/ui/controls/stepper.cpp
+++ b/src/ui/controls/stepper.cpp
@@ -246,8 +246,8 @@ void Stepper::syncValueFieldMinWidth(Renderer& renderer) {
   const float fs = Style::fontSizeBody * m_scale;
   const std::string minText = std::to_string(m_min) + m_valueSuffix;
   const std::string maxText = std::to_string(m_max) + m_valueSuffix;
-  const float wMin = renderer.measureText(minText, fs, false).width;
-  const float wMax = renderer.measureText(maxText, fs, false).width;
+  const float wMin = renderer.measureText(minText, fs, FontWeight::Normal).width;
+  const float wMax = renderer.measureText(maxText, fs, FontWeight::Normal).width;
   const float textInset = valueInputHorizontalPadding(m_scale) + kInputTextInnerInset;
   m_valueInput->setMinLayoutWidth(std::max(wMin, wMax) + textInset * 2.0f);
 }


### PR DESCRIPTION
## Motivation
This is the first step for supporting more font weights like medium and semibold. This commit is only for the internals. After this we can actually expose font weights to the user.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors

## Additional notes
Please don't squash these commits when merging since I already squashed them into logical items.