### PR TITLE
Add Triad compositor backend

### DIFF
--- a/Modules/Background/Overview.qml
+++ b/Modules/Background/Overview.qml
@@ -8,7 +8,7 @@ import qs.Services.Power
 import qs.Services.UI
 
 Loader {
-  active: CompositorService.isNiri && Settings.data.wallpaper.enabled && Settings.data.wallpaper.overviewEnabled && (!PowerProfileService.noctaliaPerformanceMode || !Settings.data.noctaliaPerformance.disableWallpaper)
+  active: CompositorService.supportsOverview && Settings.data.wallpaper.enabled && Settings.data.wallpaper.overviewEnabled && (!PowerProfileService.noctaliaPerformanceMode || !Settings.data.noctaliaPerformance.disableWallpaper)
 
   sourceComponent: Variants {
     model: Quickshell.screens
@@ -27,7 +27,7 @@ Loader {
 
       Component.onCompleted: {
         if (modelData) {
-          Logger.d("Overview", "Loading overview for Niri on", modelData.name);
+          Logger.d("Overview", "Loading overview on", modelData.name);
         }
       }
 

--- a/Modules/Bar/Widgets/KeyboardLayout.qml
+++ b/Modules/Bar/Widgets/KeyboardLayout.qml
@@ -48,6 +48,8 @@ Item {
 
   implicitWidth: pill.width
   implicitHeight: pill.height
+  visible: CompositorService.supportsKeyboardLayout
+  enabled: CompositorService.supportsKeyboardLayout
 
   NPopupContextMenu {
     id: contextMenu

--- a/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/AppearanceSubTab.qml
@@ -236,7 +236,7 @@ ColumnLayout {
 
   NToggle {
     Layout.fillWidth: true
-    visible: CompositorService.isNiri
+    visible: CompositorService.supportsOverview
     label: I18n.tr("panels.bar.appearance-hide-on-overview-label")
     description: I18n.tr("panels.bar.appearance-hide-on-overview-description")
     checked: Settings.data.bar.hideOnOverview

--- a/Modules/Panels/Settings/Tabs/Bar/BehaviorSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Bar/BehaviorSubTab.qml
@@ -33,7 +33,7 @@ ColumnLayout {
               "name": I18n.tr("panels.bar.behavior-workspace-scroll-option-workspace")
             }
           ];
-      if (CompositorService.isNiri) {
+      if (CompositorService.supportsWorkspaceContentScroll) {
         items.push({
                      "key": "content",
                      "name": I18n.tr("panels.bar.behavior-workspace-scroll-option-content")

--- a/Modules/Panels/Settings/Tabs/Wallpaper/GeneralSubTab.qml
+++ b/Modules/Panels/Settings/Tabs/Wallpaper/GeneralSubTab.qml
@@ -211,11 +211,11 @@ ColumnLayout {
 
   NDivider {
     Layout.fillWidth: true
-    visible: CompositorService.isNiri
+    visible: CompositorService.supportsOverview
   }
 
   ColumnLayout {
-    visible: CompositorService.isNiri
+    visible: CompositorService.supportsOverview
     enabled: Settings.data.wallpaper.enabled
     spacing: Style.marginL
     Layout.fillWidth: true

--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -15,6 +15,7 @@ Singleton {
   property bool isNiri: false
   property bool isSway: false
   property bool isMango: false
+  property bool isTriad: false
   property bool isLabwc: false
   property bool isExtWorkspace: false
   property bool isScroll: false
@@ -30,6 +31,14 @@ Singleton {
 
   // Overview state (Niri-specific, defaults to false for other compositors)
   property bool overviewActive: false
+  property bool supportsOverview: isNiri || (backend !== null && backend.supportsOverview === true)
+  property bool supportsWorkspaceSwitching: backend !== null && backend.switchToWorkspace !== undefined && (backend.supportsWorkspaceSwitching === undefined || backend.supportsWorkspaceSwitching === true)
+  property bool supportsWorkspaceContentScroll: isNiri || (backend !== null && backend.supportsWorkspaceContentScroll === true)
+  property bool supportsWindowFocus: backend !== null && backend.focusWindow !== undefined && (backend.supportsWindowFocus === undefined || backend.supportsWindowFocus === true)
+  property bool supportsWindowClose: backend !== null && backend.closeWindow !== undefined && (backend.supportsWindowClose === undefined || backend.supportsWindowClose === true)
+  property bool supportsSpawn: backend !== null && backend.spawn !== undefined && (backend.supportsSpawn === undefined || backend.supportsSpawn === true)
+  property bool supportsMonitorPower: backend !== null && backend.turnOffMonitors !== undefined && (backend.supportsMonitorPower === undefined || backend.supportsMonitorPower === true)
+  property bool supportsKeyboardLayout: backend !== null && backend.cycleKeyboardLayout !== undefined && (backend.supportsKeyboardLayout === undefined || backend.supportsKeyboardLayout === true)
 
   // Global workspaces flag (workspaces shared across all outputs)
   // True for LabWC (stacking compositor), false for tiling WMs with per-output workspaces
@@ -66,17 +75,32 @@ Singleton {
   function detectCompositor() {
     const hyprlandSignature = Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE");
     const niriSocket = Quickshell.env("NIRI_SOCKET");
+    const triadSocket = Quickshell.env("TRIAD_SOCKET");
     const swaySock = Quickshell.env("SWAYSOCK");
     const currentDesktop = Quickshell.env("XDG_CURRENT_DESKTOP");
+    const sessionDesktop = Quickshell.env("XDG_SESSION_DESKTOP");
+    const desktopSession = Quickshell.env("DESKTOP_SESSION");
+    const riverWm = Quickshell.env("RIVER_WM");
     const labwcPid = Quickshell.env("LABWC_PID");
+    const triadDetected = (triadSocket && triadSocket.length > 0) || (riverWm && riverWm.toLowerCase() === "triad") || (currentDesktop && currentDesktop.toLowerCase().includes("triad")) || (sessionDesktop && sessionDesktop.toLowerCase().includes("triad")) || (desktopSession && desktopSession.toLowerCase().includes("triad"));
 
     // Check for MangoWC using XDG_CURRENT_DESKTOP environment variable
     // MangoWC sets XDG_CURRENT_DESKTOP=mango
-    if (currentDesktop && currentDesktop.toLowerCase().includes("mango")) {
+    if (triadDetected) {
+      isHyprland = false;
+      isNiri = false;
+      isSway = false;
+      isMango = false;
+      isTriad = true;
+      isLabwc = false;
+      isExtWorkspace = false;
+      backendLoader.sourceComponent = triadComponent;
+    } else if (currentDesktop && currentDesktop.toLowerCase().includes("mango")) {
       isHyprland = false;
       isNiri = false;
       isSway = false;
       isMango = true;
+      isTriad = false;
       isLabwc = false;
       isExtWorkspace = false;
       backendLoader.sourceComponent = mangoComponent;
@@ -85,6 +109,7 @@ Singleton {
       isNiri = false;
       isSway = false;
       isMango = false;
+      isTriad = false;
       isLabwc = true;
       isExtWorkspace = false;
       backendLoader.sourceComponent = labwcComponent;
@@ -94,6 +119,7 @@ Singleton {
       isNiri = true;
       isSway = false;
       isMango = false;
+      isTriad = false;
       isLabwc = false;
       isExtWorkspace = false;
       backendLoader.sourceComponent = niriComponent;
@@ -102,6 +128,7 @@ Singleton {
       isNiri = false;
       isSway = false;
       isMango = false;
+      isTriad = false;
       isLabwc = false;
       isExtWorkspace = false;
       backendLoader.sourceComponent = hyprlandComponent;
@@ -110,6 +137,7 @@ Singleton {
       isNiri = false;
       isSway = true;
       isMango = false;
+      isTriad = false;
       isLabwc = false;
       isExtWorkspace = false;
       isScroll = currentDesktop && currentDesktop.toLowerCase().includes("scroll");
@@ -120,6 +148,7 @@ Singleton {
       isNiri = false;
       isSway = false;
       isMango = false;
+      isTriad = false;
       isLabwc = false;
       isExtWorkspace = true;
       backendLoader.sourceComponent = extWorkspaceComponent;
@@ -188,6 +217,14 @@ Singleton {
     id: mangoComponent
     MangoService {
       id: mangoBackend
+    }
+  }
+
+  // Triad backend component
+  Component {
+    id: triadComponent
+    TriadService {
+      id: triadBackend
     }
   }
 
@@ -390,6 +427,10 @@ Singleton {
 
   // Generic workspace switching
   function switchToWorkspace(workspace) {
+    if (!supportsWorkspaceSwitching) {
+      Logger.w("Compositor", "Workspace switching is not supported by the active backend");
+      return;
+    }
     if (backend && backend.switchToWorkspace) {
       backend.switchToWorkspace(workspace);
     } else {
@@ -399,6 +440,10 @@ Singleton {
 
   // Scrollable workspace content (Niri)
   function scrollWorkspaceContent(direction) {
+    if (!supportsWorkspaceContentScroll) {
+      Logger.w("Compositor", "Workspace content scrolling is not supported by the active backend");
+      return;
+    }
     if (backend && backend.scrollWorkspaceContent) {
       backend.scrollWorkspaceContent(direction);
     }
@@ -429,6 +474,10 @@ Singleton {
 
   // Set focused window
   function focusWindow(window) {
+    if (!supportsWindowFocus) {
+      Logger.w("Compositor", "Window focus is not supported by the active backend");
+      return;
+    }
     if (backend && backend.focusWindow) {
       backend.focusWindow(window);
     } else {
@@ -438,6 +487,10 @@ Singleton {
 
   // Close window
   function closeWindow(window) {
+    if (!supportsWindowClose) {
+      Logger.w("Compositor", "Window closing is not supported by the active backend");
+      return;
+    }
     if (backend && backend.closeWindow) {
       backend.closeWindow(window);
     } else {
@@ -451,7 +504,7 @@ Singleton {
     const cmdArray = Array.isArray(command) ? command : (command && typeof command === "object" && command.length !== undefined) ? Array.from(command) : [command];
 
     Logger.d("CompositorService", `Spawning: ${cmdArray.join(" ")}`);
-    if (backend && backend.spawn) {
+    if (supportsSpawn && backend && backend.spawn) {
       backend.spawn(cmdArray);
     } else {
       try {
@@ -539,6 +592,10 @@ Singleton {
 
   function turnOffMonitors() {
     Logger.i("Compositor", "Turn off monitors requested");
+    if (!supportsMonitorPower) {
+      Logger.w("Compositor", "Monitor power control is not supported by the active backend");
+      return;
+    }
     if (backend && backend.turnOffMonitors) {
       backend.turnOffMonitors();
     } else {
@@ -548,6 +605,10 @@ Singleton {
 
   function turnOnMonitors() {
     Logger.i("Compositor", "Turn on monitors requested");
+    if (!supportsMonitorPower) {
+      Logger.w("Compositor", "Monitor power control is not supported by the active backend");
+      return;
+    }
     if (backend && backend.turnOnMonitors) {
       backend.turnOnMonitors();
     } else {
@@ -582,6 +643,8 @@ Singleton {
   }
 
   function cycleKeyboardLayout() {
+    if (!supportsKeyboardLayout)
+      return;
     if (backend && backend.cycleKeyboardLayout) {
       backend.cycleKeyboardLayout();
     }

--- a/Services/Compositor/TriadService.qml
+++ b/Services/Compositor/TriadService.qml
@@ -1,0 +1,697 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services.Keyboard
+
+Item {
+  id: root
+
+  property int floatingWindowPosition: Number.MAX_SAFE_INTEGER
+
+  property ListModel workspaces: ListModel {}
+  property var windows: []
+  property int focusedWindowIndex: -1
+
+  property bool overviewActive: false
+  property bool initialized: false
+  property bool globalWorkspaces: false
+  property bool connected: false
+  property bool stateReady: false
+
+  property var capabilities: ({
+                                "event_stream": true,
+                                "state": true,
+                                "layout_state": true,
+                                "overview": true,
+                                "workspace_switching": true,
+                                "workspace_content_scroll": true,
+                                "window_focus": true,
+                                "window_close": true,
+                                "spawn": true,
+                                "keyboard_layout": true,
+                                "output_metadata": true,
+                                "monitor_power": false,
+                                "workspace_urgency": false
+                              })
+  property bool supportsOverview: capabilities.overview === true
+  property bool supportsWorkspaceSwitching: capabilities.workspace_switching === true
+  property bool supportsWorkspaceContentScroll: capabilities.workspace_content_scroll === true
+  property bool supportsWindowFocus: capabilities.window_focus === true
+  property bool supportsWindowClose: capabilities.window_close === true
+  property bool supportsSpawn: capabilities.spawn === true
+  property bool supportsKeyboardLayout: capabilities.keyboard_layout === true
+  property bool supportsMonitorPower: capabilities.monitor_power === true
+  property bool supportsWorkspaceUrgency: capabilities.workspace_urgency === true
+
+  property var keyboardLayouts: []
+  property var outputCache: ({})
+  property var workspaceCache: ({})
+  property string capabilitiesSignature: ""
+  property string outputSignature: ""
+  property string workspaceSignature: ""
+  property string windowListSignature: ""
+  property string windowFocusSignature: ""
+  property string keyboardSignature: ""
+
+  property string socketPath: {
+    const configured = Quickshell.env("TRIAD_SOCKET");
+    if (configured && configured.length > 0)
+      return configured;
+    const runtime = Quickshell.env("XDG_RUNTIME_DIR") || "/tmp";
+    return runtime + "/triad.sock";
+  }
+
+  property var requestQueue: []
+  property var activeRequest: null
+  property bool requestSent: false
+  property bool eventReconnectEnabled: false
+  property int requestTimeoutMs: 2000
+  property int reconnectAttempt: 0
+  property int reconnectBaseMs: 500
+  property int reconnectMaxMs: 5000
+
+  signal workspaceChanged
+  signal activeWindowChanged
+  signal windowListChanged
+  signal displayScalesChanged
+
+  function initialize() {
+    connectEventStream();
+    initialized = true;
+    Logger.i("TriadService", "Service started with native IPC socket: " + socketPath);
+  }
+
+  function triadRequest(request, extra) {
+    const payload = {
+      "version": 1,
+      "request": request
+    };
+    if (extra) {
+      for (const key in extra) {
+        payload[key] = extra[key];
+      }
+    }
+    return JSON.stringify({
+                            "triad": payload
+                          });
+  }
+
+  function triadAction(action, extra) {
+    const payload = {
+      "version": 1,
+      "request": "action",
+      "action": action
+    };
+    if (extra) {
+      for (const key in extra) {
+        payload[key] = extra[key];
+      }
+    }
+    return JSON.stringify({
+                            "triad": payload
+                          });
+  }
+
+  function sendRequest(payload, callback) {
+    requestQueue.push({
+                        "payload": payload,
+                        "callback": callback || null
+                      });
+    pumpRequestQueue();
+  }
+
+  function pumpRequestQueue() {
+    if (activeRequest || requestQueue.length === 0)
+      return;
+
+    activeRequest = requestQueue.shift();
+    requestSent = false;
+    requestTimeout.stop();
+    requestSocket.path = socketPath;
+    requestSocket.connected = true;
+  }
+
+  function finishActiveRequest() {
+    requestTimeout.stop();
+    activeRequest = null;
+    requestSent = false;
+    Qt.callLater(root.pumpRequestQueue);
+  }
+
+  function refreshState() {
+    sendRequest(triadRequest("state"), reply => {
+      if (reply && reply.ok && reply.triad && reply.triad.state) {
+        applyState(reply.triad.state);
+      }
+    });
+  }
+
+  function refreshCapabilities() {
+    sendRequest(triadRequest("capabilities"), reply => {
+      if (reply && reply.ok && reply.triad && reply.triad.capabilities) {
+        applyCapabilities(reply.triad.capabilities);
+      }
+    });
+  }
+
+  Socket {
+    id: requestSocket
+    parser: SplitParser {
+      splitMarker: "\n"
+      onRead: data => {
+        if (!root.activeRequest)
+          return;
+        try {
+          const reply = JSON.parse(data);
+          if (root.activeRequest.callback)
+            root.activeRequest.callback(reply);
+          if (!reply.ok)
+            Logger.w("TriadService", "Request failed:", data);
+        } catch (e) {
+          Logger.w("TriadService", "Failed to parse request reply:", e, data);
+        }
+        requestSocket.connected = false;
+      }
+    }
+    onConnectionStateChanged: {
+      if (connected && root.activeRequest && !root.requestSent) {
+        root.requestSent = true;
+        write(root.activeRequest.payload + "\n");
+        flush();
+        requestTimeout.restart();
+      } else if (!connected && root.activeRequest) {
+        root.finishActiveRequest();
+      }
+    }
+    onError: error => {
+      Logger.w("TriadService", "Request socket error:", error);
+      connected = false;
+      root.finishActiveRequest();
+    }
+  }
+
+  Timer {
+    id: requestTimeout
+    interval: root.requestTimeoutMs
+    repeat: false
+    onTriggered: {
+      if (!root.activeRequest)
+        return;
+      Logger.w("TriadService", "Request timed out");
+      requestSocket.connected = false;
+      root.finishActiveRequest();
+    }
+  }
+
+  Socket {
+    id: eventSocket
+    parser: SplitParser {
+      splitMarker: "\n"
+      onRead: data => root.handleEventLine(data)
+    }
+    onConnectionStateChanged: {
+      if (connected) {
+        root.connected = true;
+        root.reconnectAttempt = 0;
+        write(root.triadRequest("event-stream", {
+                                  "events": ["state", "layout", "window"]
+                                }) + "\n");
+        flush();
+      } else if (root.eventReconnectEnabled) {
+        root.connected = false;
+        root.stateReady = false;
+        root.scheduleReconnect();
+      }
+    }
+    onError: error => {
+      Logger.w("TriadService", "Event socket error:", error);
+      connected = false;
+      root.connected = false;
+      root.stateReady = false;
+      root.scheduleReconnect();
+    }
+  }
+
+  Timer {
+    id: reconnectTimer
+    interval: 1000
+    repeat: false
+    onTriggered: root.connectEventStream()
+  }
+
+  function scheduleReconnect() {
+    if (reconnectTimer.running)
+      return;
+    const delay = Math.min(reconnectMaxMs, reconnectBaseMs * Math.pow(2, reconnectAttempt));
+    reconnectAttempt = Math.min(reconnectAttempt + 1, 8);
+    reconnectTimer.interval = delay;
+    reconnectTimer.restart();
+  }
+
+  function connectEventStream() {
+    root.eventReconnectEnabled = false;
+    reconnectTimer.stop();
+    if (eventSocket.connected)
+      eventSocket.connected = false;
+    root.eventReconnectEnabled = true;
+    eventSocket.path = socketPath;
+    eventSocket.connected = true;
+  }
+
+  function handleEventLine(line) {
+    if (!line || line.length === 0)
+      return;
+
+    try {
+      const rootObject = JSON.parse(line);
+      if (rootObject.ok !== undefined)
+        return;
+      if (!rootObject.triad)
+        return;
+
+      const event = rootObject.triad.event;
+      if (event === "state-changed") {
+        applyState(rootObject.triad.state);
+      } else if (event === "layout-state-changed") {
+        applyLayoutState(rootObject.triad.state);
+      } else if (event === "window-changed") {
+        applyWindowChanged(rootObject.triad.window);
+      }
+    } catch (e) {
+      Logger.w("TriadService", "Failed to parse event:", e, line);
+    }
+  }
+
+  Component.onDestruction: {
+    eventReconnectEnabled = false;
+    reconnectTimer.stop();
+    requestTimeout.stop();
+    requestQueue = [];
+    activeRequest = null;
+    requestSent = false;
+    if (eventSocket.connected)
+      eventSocket.connected = false;
+    if (requestSocket.connected)
+      requestSocket.connected = false;
+  }
+
+  function applyState(state) {
+    if (!state)
+      return;
+
+    stateReady = true;
+    if (state.capabilities)
+      applyCapabilities(state.capabilities);
+    if (state.outputs)
+      applyOutputs(state.outputs);
+    if (state.layout)
+      applyLayoutState(state.layout);
+    if (state.windows)
+      applyWindows(state.windows);
+    if (state.overview)
+      applyOverview(state.overview);
+    if (state.keyboard_layouts)
+      applyKeyboardLayouts(state.keyboard_layouts, state.current_keyboard_layout_idx || 0);
+  }
+
+  function applyCapabilities(nextCapabilities) {
+    if (!nextCapabilities)
+      return;
+
+    const merged = {};
+    for (const key in capabilities) {
+      merged[key] = capabilities[key] === true;
+    }
+    for (const nextKey in nextCapabilities) {
+      merged[nextKey] = nextCapabilities[nextKey] === true;
+    }
+    const signature = JSON.stringify(merged);
+    if (signature === capabilitiesSignature)
+      return;
+    capabilitiesSignature = signature;
+    capabilities = merged;
+  }
+
+  function applyOverview(overview) {
+    const nextActive = overview && overview.is_open === true;
+    if (overviewActive !== nextActive)
+      overviewActive = nextActive;
+  }
+
+  function projectedOutputSignature(output) {
+    const geometry = output.geometry || {};
+    return [output.name || "", output.connected !== false ? 1 : 0, output.scale || 1.0, geometry.width || 0, geometry.height || 0, geometry.x || 0, geometry.y || 0, output.physical_width || 0, output.physical_height || 0, output.refresh_rate || 60000, output.transform || "Normal"].join(":");
+  }
+
+  function applyOutputs(outputs) {
+    const nextCache = {};
+    const signatureParts = [];
+    for (var i = 0; i < outputs.length; i++) {
+      const output = outputs[i];
+      const geometry = output.geometry || {};
+      signatureParts.push(projectedOutputSignature(output));
+      nextCache[output.name] = {
+        "name": output.name,
+        "connected": output.connected !== false,
+        "scale": output.scale || 1.0,
+        "width": geometry.width || 0,
+        "height": geometry.height || 0,
+        "x": geometry.x || 0,
+        "y": geometry.y || 0,
+        "physical_width": output.physical_width || 0,
+        "physical_height": output.physical_height || 0,
+        "refresh_rate": output.refresh_rate || 60000,
+        "vrr_supported": false,
+        "vrr_enabled": false,
+        "transform": output.transform || "Normal"
+      };
+    }
+    const signature = signatureParts.join("|");
+    if (signature === outputSignature)
+      return;
+    outputSignature = signature;
+    windowListSignature = "";
+    outputCache = nextCache;
+    queryDisplayScales();
+  }
+
+  function projectedWorkspaceSignature(ws) {
+    return [ws.tag_id, ws.workspace_idx, ws.name || "", ws.output || "", ws.layout || "", ws.layout_kind || "", ws.runtime_kind || "", ws.layout_source || "", ws.fallback_layout || "", ws.is_configured === true ? 1 : 0, ws.is_active === true ? 1 : 0, ws.is_output_visible === true ? 1 : 0, ws.occupied === true ? 1 : 0, ws.is_urgent === true ? 1 : 0, ws.focused_window_id
+            || 0].join(":");
+  }
+
+  function applyLayoutState(layout) {
+    if (!layout || !layout.workspaces)
+      return;
+
+    const nextCache = {};
+    const workspaceList = [];
+    const signatureParts = [];
+    for (var i = 0; i < layout.workspaces.length; i++) {
+      const ws = layout.workspaces[i];
+      const isFocused = ws.is_active === true;
+      const isActive = ws.is_output_visible === true;
+      const isOccupied = ws.occupied === true;
+      const isConfigured = ws.is_configured === true;
+      signatureParts.push(projectedWorkspaceSignature(ws));
+      const wsData = {
+        "id": ws.tag_id,
+        "idx": ws.workspace_idx,
+        "displayIdx": ws.workspace_idx,
+        "triadWorkspaceIdx": ws.workspace_idx,
+        "handle": ws.workspace_idx,
+        "name": ws.name || "",
+        "output": ws.output || "",
+        "layout": ws.layout || "",
+        "layoutKind": ws.layout_kind || "",
+        "runtimeKind": ws.runtime_kind || "",
+        "layoutSource": ws.layout_source || "",
+        "fallbackLayout": ws.fallback_layout || "",
+        "isConfigured": isConfigured,
+        "isOutputVisible": ws.is_output_visible === true,
+        "isFocused": isFocused,
+        "isActive": isActive,
+        "isUrgent": supportsWorkspaceUrgency && ws.is_urgent === true,
+        "isOccupied": isOccupied
+      };
+      nextCache[wsData.id] = wsData;
+      if (isFocused || isActive || isOccupied || isConfigured)
+        workspaceList.push(wsData);
+    }
+
+    workspaceList.sort((a, b) => {
+      if (a.output !== b.output)
+        return a.output.localeCompare(b.output);
+      return a.idx - b.idx;
+    });
+    const displayList = workspaceList.slice().sort((a, b) => a.idx - b.idx);
+    for (var displayIndex = 0; displayIndex < displayList.length; displayIndex++) {
+      displayList[displayIndex].idx = displayIndex + 1;
+      displayList[displayIndex].displayIdx = displayIndex + 1;
+    }
+
+    const signature = signatureParts.join("|") + "=>" + workspaceList.map(ws => [ws.id, ws.idx, ws.displayIdx, ws.triadWorkspaceIdx, ws.handle, ws.name, ws.output, ws.layout, ws.layoutKind, ws.runtimeKind, ws.layoutSource, ws.fallbackLayout, ws.isConfigured ? 1 : 0, ws.isFocused ? 1 : 0, ws.isActive ? 1 : 0, ws.isUrgent ? 1 : 0, ws.isOccupied ? 1 : 0].join(
+      ":")).join("|");
+    if (signature === workspaceSignature)
+      return;
+    workspaceSignature = signature;
+    windowListSignature = "";
+
+    workspaces.clear();
+    for (var j = 0; j < workspaceList.length; j++) {
+      workspaces.append(workspaceList[j]);
+    }
+
+    workspaceCache = nextCache;
+    workspaceChanged();
+  }
+
+  function toWindowPosition(win) {
+    if (win.is_floating) {
+      return {
+        "x": floatingWindowPosition,
+        "y": floatingWindowPosition
+      };
+    }
+    const position = win.position || {};
+    return {
+      "x": position.column_idx || 0,
+      "y": position.window_idx || 0
+    };
+  }
+
+  function projectedWindowListSignature(win) {
+    const position = win.position || {};
+    return [win.id, win.title || "", win.app_id || "", win.tag_id || -1, win.output || "", win.is_floating === true ? 1 : 0, win.is_fullscreen === true ? 1 : 0, win.is_floating === true ? floatingWindowPosition : position.column_idx || 0, win.is_floating === true ? floatingWindowPosition : position.window_idx || 0].join(":");
+  }
+
+  function projectWindow(win) {
+    return {
+      "id": win.id,
+      "title": win.title || "",
+      "appId": win.app_id || "",
+      "workspaceId": win.tag_id || -1,
+      "isFocused": win.is_focused === true,
+      "output": win.output || "",
+      "position": toWindowPosition(win),
+      "fullscreen": win.is_fullscreen === true,
+      "floating": win.is_floating === true
+    };
+  }
+
+  function applyWindows(snapshotWindows) {
+    const windowsList = [];
+    const signatureParts = [];
+    const focusedIds = [];
+
+    for (var i = 0; i < snapshotWindows.length; i++) {
+      const win = snapshotWindows[i];
+      signatureParts.push(projectedWindowListSignature(win));
+      if (win.is_focused === true)
+        focusedIds.push(win.id);
+      windowsList.push(projectWindow(win));
+    }
+
+    const nextListSignature = signatureParts.join("|");
+    const previousFocusSignature = windowFocusSignature;
+    const nextFocusSignature = focusedIds.join(",");
+    if (nextListSignature === windowListSignature && nextFocusSignature === previousFocusSignature)
+      return;
+
+    const sortedWindows = toSortedWindowList(windowsList);
+    windows = sortedWindows;
+    safeUpdateFocusedWindow();
+
+    if (nextListSignature !== windowListSignature) {
+      windowListSignature = nextListSignature;
+      windowFocusSignature = nextFocusSignature;
+      windowListChanged();
+      if (nextFocusSignature !== previousFocusSignature)
+        activeWindowChanged();
+      return;
+    }
+
+    if (nextFocusSignature !== previousFocusSignature) {
+      windowFocusSignature = nextFocusSignature;
+      activeWindowChanged();
+    }
+  }
+
+  function applyWindowChanged(win) {
+    if (!win || win.id === undefined || win.id === null)
+      return;
+
+    const projected = projectWindow(win);
+    var existingIndex = -1;
+    var wasFocused = false;
+    for (var i = 0; i < windows.length; i++) {
+      if (windows[i].id === projected.id) {
+        existingIndex = i;
+        wasFocused = windows[i].isFocused === true;
+        break;
+      }
+    }
+
+    if (existingIndex < 0) {
+      refreshState();
+      return;
+    }
+
+    const nextWindows = windows.slice();
+    nextWindows[existingIndex] = projected;
+    windows = toSortedWindowList(nextWindows);
+    safeUpdateFocusedWindow();
+    windowListSignature = "";
+    windowFocusSignature = "";
+    windowListChanged();
+    if (wasFocused || projected.isFocused)
+      activeWindowChanged();
+  }
+
+  function applyKeyboardLayouts(nextLayouts, currentIndex) {
+    const signature = nextLayouts.join("|") + ":" + currentIndex;
+    if (signature === keyboardSignature)
+      return;
+    keyboardSignature = signature;
+    keyboardLayouts = nextLayouts;
+    const layoutName = keyboardLayouts[currentIndex];
+    if (layoutName)
+      KeyboardLayoutService.setCurrentLayout(layoutName);
+  }
+
+  function toSortedWindowList(windowList) {
+    return windowList.map(win => {
+      const workspace = workspaceCache[win.workspaceId];
+      const output = (workspace && workspace.output) ? outputCache[workspace.output] : outputCache[win.output];
+      return {
+        "window": win,
+        "workspaceIdx": workspace ? workspace.handle || workspace.idx : 0,
+        "outputX": output ? output.x : 0,
+        "outputY": output ? output.y : 0
+      };
+    }).sort((a, b) => {
+      if (a.outputX !== b.outputX)
+        return a.outputX - b.outputX;
+      if (a.outputY !== b.outputY)
+        return a.outputY - b.outputY;
+      if (a.workspaceIdx !== b.workspaceIdx)
+        return a.workspaceIdx - b.workspaceIdx;
+      if (a.window.position.x !== b.window.position.x)
+        return a.window.position.x - b.window.position.x;
+      if (a.window.position.y !== b.window.position.y)
+        return a.window.position.y - b.window.position.y;
+      return a.window.id - b.window.id;
+    }).map(info => info.window);
+  }
+
+  function safeUpdateFocusedWindow() {
+    focusedWindowIndex = -1;
+    for (var i = 0; i < windows.length; i++) {
+      if (windows[i].isFocused) {
+        focusedWindowIndex = i;
+        break;
+      }
+    }
+  }
+
+  function queryDisplayScales() {
+    if (CompositorService && CompositorService.onDisplayScalesUpdated) {
+      CompositorService.onDisplayScalesUpdated(outputCache);
+    }
+  }
+
+  function switchToWorkspace(workspace) {
+    if (!supportsWorkspaceSwitching) {
+      Logger.w("TriadService", "Workspace switching is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("focus-workspace", {
+                              "workspace_idx": workspace.triadWorkspaceIdx !== undefined ? workspace.triadWorkspaceIdx : (workspace.handle !== undefined ? workspace.handle : workspace.idx)
+                            }));
+  }
+
+  function scrollWorkspaceContent(direction) {
+    if (!supportsWorkspaceContentScroll) {
+      Logger.w("TriadService", "Workspace content scrolling is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction(direction < 0 ? "focus-column-left" : "focus-column-right"));
+  }
+
+  function focusWindow(window) {
+    if (!supportsWindowFocus) {
+      Logger.w("TriadService", "Window focus is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("focus-window", {
+                              "id": window.id
+                            }));
+  }
+
+  function closeWindow(window) {
+    if (!supportsWindowClose) {
+      Logger.w("TriadService", "Window close is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("close-window", {
+                              "id": window.id
+                            }));
+  }
+
+  function turnOffMonitors() {
+    if (!supportsMonitorPower) {
+      Logger.w("TriadService", "Monitor power off is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("power-off-monitors"));
+  }
+
+  function turnOnMonitors() {
+    if (!supportsMonitorPower) {
+      Logger.w("TriadService", "Monitor power on is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("power-on-monitors"));
+  }
+
+  function logout() {
+    sendRequest(triadAction("exit-session"));
+  }
+
+  function cycleKeyboardLayout() {
+    if (!supportsKeyboardLayout) {
+      Logger.w("TriadService", "Keyboard layout switching is not exposed by native Triad IPC");
+      return;
+    }
+    sendRequest(triadAction("switch-keyboard-layout", {
+                              "layout": "next"
+                            }));
+  }
+
+  function getFocusedScreen() {
+    for (var i = 0; i < workspaces.count; i++) {
+      const ws = workspaces.get(i);
+      if (!ws.isFocused)
+        continue;
+      for (var j = 0; j < Quickshell.screens.length; j++) {
+        if (Quickshell.screens[j].name === ws.output)
+          return Quickshell.screens[j];
+      }
+    }
+    return null;
+  }
+
+  function spawn(command) {
+    if (!supportsSpawn) {
+      Logger.w("TriadService", "Spawning commands is not exposed by native Triad IPC");
+      return;
+    }
+    const argv = Array.isArray(command) ? command : Array.from(command || []);
+    if (argv.length === 0)
+      return;
+    sendRequest(triadAction("spawn", {
+                              "argv": argv
+                            }));
+  }
+}


### PR DESCRIPTION
Adds a Triad backend.

Triad is a programmable window manager built on River. It has its own IPC, but also exposes a Niri-compatible facade so shells like Noctalia can already run on it without changes. This backend uses the native IPC instead, which is cleaner and avoids treating Triad as fake Niri inside Noctalia.

I think it is worth adding because the shared Noctalia changes are small, and Triad users get a better integration path than the compatibility shim. Workspace clicks, overview state, monitor power, keyboard layout, spawn, and window updates can all go through the compositor backend directly.

Triad is a little different from most compositors Noctalia supports because each workspace can use a different layout model. The backend reads workspace, window, output, overview, keyboard layout, and capability state directly from Triad, then maps that into the normal compositor service shape.

I know v5 is where most work is happening. Happy to move this there if that makes more sense.

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

Tested on Triad with three monitors. Workspace switching, window focus updates, overview bar hiding, keyboard layout, spawn, monitor power, and workspace content scrolling all work here.

- [ ] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

No screenshots. It should look the same.

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

Triad: https://github.com/greenm01/triad