### PR TITLE
bar: when bar touches screen edge, treat clicking on the start/end padding as on the first/last widget

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -656,8 +656,13 @@ namespace {
     finalizeCapsules(instance.centerCapsuleRuns);
     finalizeCapsules(instance.endCapsuleRuns);
 
-    const float contentMainStart = padding;
-    const float contentMainEnd = std::max(contentMainStart, (isVertical ? barAreaH : barAreaW) - padding);
+    // When bar touches screen edge, put the padding inside the sections, and extend the hit targets of
+    // the first/last widgets to cover the area. So clicking on the screen edge still triggers the widget.
+    const bool screenEdgeClick = instance.barConfig.marginEnds == 0 && padding > 0;
+    const float paddingInsideSection = screenEdgeClick ? padding : 0.0f;
+    const float contentMainStart = screenEdgeClick ? 0.0f : padding;
+    const float contentMainEnd =
+        std::max(contentMainStart, (isVertical ? barAreaH : barAreaW) - (screenEdgeClick ? 0.0f : padding));
     const float contentMainSpan = std::max(0.0f, contentMainEnd - contentMainStart);
 
     auto configureSlot = [&](Node* slot, float mainOffset, float mainSize) {
@@ -675,6 +680,16 @@ namespace {
       section->setJustify(justify);
       section->layout(renderer);
     };
+
+    if (screenEdgeClick) {
+      if (isVertical) {
+        instance.startSection->setPadding(paddingInsideSection, 0.0f, 0.0f, 0.0f);
+        instance.endSection->setPadding(0.0f, 0.0f, paddingInsideSection, 0.0f);
+      } else {
+        instance.startSection->setPadding(0.0f, 0.0f, 0.0f, paddingInsideSection);
+        instance.endSection->setPadding(0.0f, paddingInsideSection, 0.0f, 0.0f);
+      }
+    }
 
     configureSection(instance.startSection, FlexJustify::Start);
     configureSection(instance.centerSection, FlexJustify::Center);
@@ -736,6 +751,28 @@ namespace {
     applyBarWidgetHitTargets(instance.startSection, instance.startSlot, isVertical);
     applyBarWidgetHitTargets(instance.centerSection, instance.centerSlot, isVertical);
     applyBarWidgetHitTargets(instance.endSection, instance.endSlot, isVertical);
+    if (screenEdgeClick) {
+      if (!instance.startSection->children().empty()) {
+        auto node = instance.startSection->children().front().get();
+        auto hitTestOutset = node->hitTestOutset();
+        if (isVertical) {
+          hitTestOutset.top += paddingInsideSection;
+        } else {
+          hitTestOutset.left += paddingInsideSection;
+        }
+        node->setHitTestOutset(hitTestOutset);
+      }
+      if (!instance.endSection->children().empty()) {
+        auto node = instance.endSection->children().back().get();
+        auto hitTestOutset = node->hitTestOutset();
+        if (isVertical) {
+          hitTestOutset.bottom += paddingInsideSection;
+        } else {
+          hitTestOutset.right += paddingInsideSection;
+        }
+        node->setHitTestOutset(hitTestOutset);
+      }
+    }
   }
 
   void tickWidgets(std::vector<std::unique_ptr<Widget>>& widgets, float deltaMs) {


### PR DESCRIPTION
# Pull Request

## Motivation
Implemented by moving the padding inside sections, and extend the hitTargets of the first/last widget to cover the padding area.

This is only active when endsMargin==0 && padding>0

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
