### PR TITLE
osd: add settings for margins

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1677,6 +1677,14 @@
           "label": "Size",
           "description": "Scale OSD popups relative to the shell UI scale (1.0 keeps the default size)"
         },
+        "osd-offset-x": {
+          "label": "Horizontal Margin",
+          "description": "Absolute horizontal margin from the screen edge"
+        },
+        "osd-offset-y": {
+          "label": "Vertical Margin",
+          "description": "Absolute vertical margin from the screen edge"
+        },
         "osd-lock-keys": {
           "label": "Lock Keys",
           "description": "Show OSD popups for Caps Lock, Num Lock, and Scroll Lock changes"

--- a/example.toml
+++ b/example.toml
@@ -126,6 +126,8 @@ offset_y           = 8              # absolute vertical margin from the screen e
 position = "top_right"              # top_right | top_left | top_center | bottom_right | bottom_left | bottom_center | center_right | center_left
 orientation = "horizontal"          # horizontal | vertical
 scale = 1.0                         # OSD size multiplier applied on top of shell.ui_scale
+offset_x = 20                       # absolute horizontal margin from the screen edge
+offset_y = 8                        # absolute vertical margin from the screen edge
 lock_keys = true                    # show Caps/Num/Scroll Lock OSD popups; disable to stop polling when no widget uses them
 keyboard_layout = true            # show an OSD popup when the input keyboard layout changes
 

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -677,6 +677,8 @@ namespace config_export {
     osd.insert_or_assign("position", config.osd.position);
     osd.insert_or_assign("orientation", config.osd.orientation);
     osd.insert_or_assign("scale", static_cast<double>(config.osd.scale));
+    osd.insert_or_assign("offset_x", static_cast<std::int64_t>(config.osd.offsetX));
+    osd.insert_or_assign("offset_y", static_cast<std::int64_t>(config.osd.offsetY));
     osd.insert_or_assign("lock_keys", config.osd.lockKeys);
     osd.insert_or_assign("keyboard_layout", config.osd.keyboardLayout);
     root.insert_or_assign("osd", std::move(osd));

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -407,12 +407,12 @@ namespace {
            nearlyEqual(a.backdrop.tintIntensity, b.backdrop.tintIntensity) && dockConfigEqual(a.dock, b.dock) &&
            desktopWidgetsConfigEqual(a.desktopWidgets, b.desktopWidgets) && shellConfigEqual(a.shell, b.shell) &&
            a.osd.position == b.osd.position && a.osd.orientation == b.osd.orientation &&
-           nearlyEqual(a.osd.scale, b.osd.scale) && a.osd.lockKeys == b.osd.lockKeys &&
-           a.osd.keyboardLayout == b.osd.keyboardLayout && notificationConfigEqual(a.notification, b.notification) &&
-           a.weather.enabled == b.weather.enabled && a.weather.autoLocate == b.weather.autoLocate &&
-           a.weather.effects == b.weather.effects && a.weather.address == b.weather.address &&
-           a.weather.refreshMinutes == b.weather.refreshMinutes && a.weather.unit == b.weather.unit &&
-           a.system.monitor.enabled == b.system.monitor.enabled &&
+           nearlyEqual(a.osd.scale, b.osd.scale) && a.osd.offsetX == b.osd.offsetX && a.osd.offsetY == b.osd.offsetY &&
+           a.osd.lockKeys == b.osd.lockKeys && a.osd.keyboardLayout == b.osd.keyboardLayout &&
+           notificationConfigEqual(a.notification, b.notification) && a.weather.enabled == b.weather.enabled &&
+           a.weather.autoLocate == b.weather.autoLocate && a.weather.effects == b.weather.effects &&
+           a.weather.address == b.weather.address && a.weather.refreshMinutes == b.weather.refreshMinutes &&
+           a.weather.unit == b.weather.unit && a.system.monitor.enabled == b.system.monitor.enabled &&
            a.system.monitor.cpuPollSeconds == b.system.monitor.cpuPollSeconds &&
            a.system.monitor.gpuPollSeconds == b.system.monitor.gpuPollSeconds &&
            a.system.monitor.memoryPollSeconds == b.system.monitor.memoryPollSeconds &&

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1792,6 +1792,10 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
     if (auto v = finiteDouble((*osdTbl)["scale"])) {
       osd.scale = std::clamp(static_cast<float>(*v), 0.5f, 2.5f);
     }
+    if (auto v = (*osdTbl)["offset_x"].value<int64_t>())
+      osd.offsetX = std::max(0, static_cast<int>(*v));
+    if (auto v = (*osdTbl)["offset_y"].value<int64_t>())
+      osd.offsetY = std::max(0, static_cast<int>(*v));
     if (auto v = (*osdTbl)["lock_keys"].value<bool>())
       osd.lockKeys = *v;
     if (auto v = (*osdTbl)["keyboard_layout"].value<bool>())

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -389,6 +389,8 @@ struct OsdConfig {
   std::string position = "top_right";
   std::string orientation = "horizontal";
   float scale = 1.0f;
+  int offsetX = 20;
+  int offsetY = 8;
   bool lockKeys = true;
   bool keyboardLayout = true;
 };

--- a/src/shell/osd/osd_overlay.cpp
+++ b/src/shell/osd/osd_overlay.cpp
@@ -63,8 +63,12 @@ namespace {
   }
 
   [[nodiscard]] std::uint32_t osdSurfaceWidth(float s, const std::string& orientation) {
-    const float w = cardWidth(s, orientation) + Style::spaceMd * s;
+    const float w = cardWidth(s, orientation) + Style::spaceMd * s * 2.0f;
     return static_cast<std::uint32_t>(std::max(1, static_cast<int>(std::ceil(w))));
+  }
+
+  [[nodiscard]] std::int32_t horizontalLayerMarginFromScreenMargin(int offsetX, float scale) {
+    return static_cast<std::int32_t>(offsetX) - static_cast<std::int32_t>(std::lround(Style::spaceMd * scale));
   }
 
   [[nodiscard]] std::uint32_t osdSurfaceHeight(float s, const std::string& orientation, bool showProgress) {
@@ -86,8 +90,6 @@ namespace {
 
   [[nodiscard]] float slideOffset(float s) { return Style::spaceSm * s; }
 
-  [[nodiscard]] int screenMargin(float s) { return static_cast<int>(std::lround(Style::spaceSm * s)); }
-
   [[nodiscard]] float osdCardRadius(float cw, float ch, float layoutScale) {
     const float maxR = std::min(cw, ch) * 0.5f;
     return std::min(maxR, Style::scaledRadiusXl(layoutScale));
@@ -104,17 +106,7 @@ namespace {
 
   [[nodiscard]] bool isLeftPosition(const std::string& position) { return position.ends_with("_left"); }
 
-  [[nodiscard]] bool isRightPosition(const std::string& position) { return position.ends_with("_right"); }
-
-  float cardBaseXForPosition(const std::string& position, float surfaceWidth, float cardW) {
-    if (isCenterPosition(position) && isLeftPosition(position)) {
-      return 0.0f;
-    }
-    if (isCenterPosition(position) && isRightPosition(position)) {
-      return std::max(0.0f, surfaceWidth - cardW);
-    }
-    return (surfaceWidth - cardW) * 0.5f;
-  }
+  float cardBaseX(float surfaceWidth, float cardW) { return (surfaceWidth - cardW) * 0.5f; }
 
   float cardBaseYForPosition(const std::string& position, float surfaceHeight, float cardH) {
     if (isBottomPosition(position)) {
@@ -191,6 +183,48 @@ void OsdOverlay::show(const OsdContent& content) {
   }
 }
 
+OsdOverlay::SurfaceMargins OsdOverlay::surfaceMarginsForPosition(const std::string& position) const {
+  const int marginH = (m_config != nullptr) ? std::max(0, m_config->config().osd.offsetX) : 0;
+  const int marginV = (m_config != nullptr) ? std::max(0, m_config->config().osd.offsetY) : 0;
+  const float layoutScale = osdUiScale(m_config);
+  const std::int32_t sideMargin = horizontalLayerMarginFromScreenMargin(marginH, layoutScale);
+
+  SurfaceMargins margins{
+      .top = marginV,
+      .right = sideMargin,
+      .bottom = 0,
+      .left = 0,
+  };
+
+  if (position == "top_left") {
+    margins.right = 0;
+    margins.left = sideMargin;
+  } else if (position == "top_center") {
+    margins.right = 0;
+  } else if (position == "bottom_left") {
+    margins.top = 0;
+    margins.right = 0;
+    margins.bottom = marginV;
+    margins.left = sideMargin;
+  } else if (position == "bottom_center") {
+    margins.top = 0;
+    margins.right = 0;
+    margins.bottom = marginV;
+  } else if (position == "bottom_right") {
+    margins.top = 0;
+    margins.bottom = marginV;
+  } else if (position == "center_left") {
+    margins.top = 0;
+    margins.right = 0;
+    margins.left = sideMargin;
+  } else if (position == "center_right") {
+    margins.top = 0;
+    margins.bottom = 0;
+  }
+
+  return margins;
+}
+
 void OsdOverlay::ensureSurfaces() {
   if (m_wayland == nullptr || m_renderContext == nullptr) {
     return;
@@ -217,6 +251,19 @@ void OsdOverlay::ensureSurfaces() {
     destroySurfaces();
   }
 
+  if (!m_instances.empty()) {
+    for (auto& inst : m_instances) {
+      if (inst->surface == nullptr) {
+        continue;
+      }
+      const SurfaceMargins margins = surfaceMarginsForPosition(position);
+      if (inst->surface->marginTop() != margins.top || inst->surface->marginRight() != margins.right ||
+          inst->surface->marginBottom() != margins.bottom || inst->surface->marginLeft() != margins.left) {
+        inst->surface->setMargins(margins.top, margins.right, margins.bottom, margins.left);
+      }
+    }
+  }
+
   if (!m_instances.empty() && m_instances.size() != m_wayland->outputs().size()) {
     destroySurfaces();
   }
@@ -232,51 +279,30 @@ void OsdOverlay::ensureSurfaces() {
 
   const auto surfaceWidth = osdSurfaceWidth(layoutScale, orientation);
   const auto surfaceHeight = osdSurfaceHeight(layoutScale, orientation, showProgress);
-  const int margin = screenMargin(layoutScale);
 
   for (const auto& output : m_wayland->outputs()) {
     auto inst = std::make_unique<Instance>();
     inst->output = output.output;
     inst->scale = output.scale;
     inst->uiLayoutScale = layoutScale;
+    const SurfaceMargins margins = surfaceMarginsForPosition(position);
 
     std::uint32_t anchor = LayerShellAnchor::Top | LayerShellAnchor::Right;
-    std::int32_t marginTop = margin;
-    std::int32_t marginRight = margin;
-    std::int32_t marginBottom = 0;
-    std::int32_t marginLeft = 0;
 
     if (position == "top_left") {
       anchor = LayerShellAnchor::Top | LayerShellAnchor::Left;
-      marginRight = 0;
-      marginLeft = margin;
     } else if (position == "top_center") {
       anchor = LayerShellAnchor::Top;
-      marginRight = 0;
     } else if (position == "bottom_left") {
       anchor = LayerShellAnchor::Bottom | LayerShellAnchor::Left;
-      marginTop = 0;
-      marginRight = 0;
-      marginBottom = margin;
-      marginLeft = margin;
     } else if (position == "bottom_center") {
       anchor = LayerShellAnchor::Bottom;
-      marginTop = 0;
-      marginRight = 0;
-      marginBottom = margin;
     } else if (position == "bottom_right") {
       anchor = LayerShellAnchor::Bottom | LayerShellAnchor::Right;
-      marginTop = 0;
-      marginBottom = margin;
     } else if (position == "center_left") {
       anchor = LayerShellAnchor::Left;
-      marginTop = 0;
-      marginRight = 0;
-      marginLeft = margin;
     } else if (position == "center_right") {
       anchor = LayerShellAnchor::Right;
-      marginTop = 0;
-      marginBottom = 0;
     }
 
     auto surfaceConfig = LayerSurfaceConfig{
@@ -286,10 +312,10 @@ void OsdOverlay::ensureSurfaces() {
         .width = surfaceWidth,
         .height = surfaceHeight,
         .exclusiveZone = 0,
-        .marginTop = marginTop,
-        .marginRight = marginRight,
-        .marginBottom = marginBottom,
-        .marginLeft = marginLeft,
+        .marginTop = margins.top,
+        .marginRight = margins.right,
+        .marginBottom = margins.bottom,
+        .marginLeft = margins.left,
         .keyboard = LayerShellKeyboard::None,
         .defaultWidth = surfaceWidth,
         .defaultHeight = surfaceHeight,
@@ -392,7 +418,7 @@ void OsdOverlay::buildScene(Instance& inst, std::uint32_t width, std::uint32_t h
   inst.sceneRoot->setOpacity(0.0f);
   inst.surface->setSceneRoot(inst.sceneRoot.get());
 
-  const float cardX = cardBaseXForPosition(m_lastPosition, w, cw);
+  const float cardX = cardBaseX(w, cw);
   const float cardY = cardBaseYForPosition(m_lastPosition, h, ch);
 
   auto background = std::make_unique<Box>();
@@ -504,7 +530,7 @@ void OsdOverlay::animateInstance(Instance& inst) {
   const float s = inst.uiLayoutScale;
   const float cw = cardWidth(s, m_lastOrientation);
   const float ch = cardHeight(s, m_lastOrientation, m_lastShowProgress);
-  const float baseX = cardBaseXForPosition(m_lastPosition, inst.sceneRoot->width(), cw);
+  const float baseX = cardBaseX(inst.sceneRoot->width(), cw);
   const float baseY = cardBaseYForPosition(m_lastPosition, inst.sceneRoot->height(), ch);
   const SlideVector slide = cardSlideVectorForPosition(m_lastPosition, slideOffset(s));
   if (!inst.visible) {

--- a/src/shell/osd/osd_overlay.h
+++ b/src/shell/osd/osd_overlay.h
@@ -41,6 +41,13 @@ public:
   void show(const OsdContent& content);
 
 private:
+  struct SurfaceMargins {
+    std::int32_t top = 0;
+    std::int32_t right = 0;
+    std::int32_t bottom = 0;
+    std::int32_t left = 0;
+  };
+
   struct Instance {
     wl_output* output = nullptr;
     std::int32_t scale = 1;
@@ -65,6 +72,7 @@ private:
     float appliedCornerRadiusScale = -1.0f;
   };
 
+  [[nodiscard]] SurfaceMargins surfaceMarginsForPosition(const std::string& position) const;
   void ensureSurfaces();
   void destroySurfaces();
   void prepareFrame(Instance& inst, bool needsUpdate, bool needsLayout);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1083,6 +1083,18 @@ namespace settings {
         "hud overlay volume brightness size scale multiplier"
     ));
     entries.push_back(makeEntry(
+        "popups", "osd", tr("settings.schema.shell.osd-offset-x.label"),
+        tr("settings.schema.shell.osd-offset-x.description"), {"osd", "offset_x"},
+        StepperSetting{.value = cfg.osd.offsetX, .minValue = 0, .maxValue = 200, .step = 1, .valueSuffix = "px"},
+        "hud overlay horizontal margin"
+    ));
+    entries.push_back(makeEntry(
+        "popups", "osd", tr("settings.schema.shell.osd-offset-y.label"),
+        tr("settings.schema.shell.osd-offset-y.description"), {"osd", "offset_y"},
+        StepperSetting{.value = cfg.osd.offsetY, .minValue = 0, .maxValue = 200, .step = 1, .valueSuffix = "px"},
+        "hud overlay vertical margin"
+    ));
+    entries.push_back(makeEntry(
         "popups", "osd", tr("settings.schema.shell.osd-lock-keys.label"),
         tr("settings.schema.shell.osd-lock-keys.description"), {"osd", "lock_keys"}, ToggleSetting{cfg.osd.lockKeys},
         "hud overlay caps num scroll keyboard"


### PR DESCRIPTION
Adds a config setting for OSD margins similar to what notifications have.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on Hyprland
- [x] Tested with different bar positions
- [x] Tested at different interface scaling values

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated