### PR TITLE
notification: track unread history with per-entry seen state

### DIFF
--- a/src/notification/notification_history_store.cpp
+++ b/src/notification/notification_history_store.cpp
@@ -650,6 +650,7 @@ bool loadNotificationHistoryFromFile(const std::filesystem::path& path, std::deq
     NotificationHistoryEntry he;
     he.notification = notificationFromJson(item.at("notification"), path);
     he.active = item.value("active", false);
+    he.seen = item.value("seen", true);
     if (item.contains("close_reason") && !item["close_reason"].is_null()) {
       const auto crs = item["close_reason"].get<std::string>();
       he.closeReason = closeReasonFrom(crs);
@@ -686,6 +687,7 @@ bool saveNotificationHistoryToFile(const std::filesystem::path& path,
     nlohmann::json je;
     je["notification"] = notificationToJson(he.notification, path);
     je["active"] = he.active;
+    je["seen"] = he.seen;
     if (he.closeReason.has_value()) {
       je["close_reason"] = std::string(closeReasonStr(*he.closeReason));
     } else {

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -7,6 +7,7 @@
 #include "util/file_utils.h"
 #include "util/string_utils.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <string_view>
 
@@ -99,13 +100,16 @@ void NotificationManager::rebuildHistoryIndex() {
 
 void NotificationManager::upsertHistory(const Notification& notification, bool active,
                                         std::optional<CloseReason> closeReason) {
+  bool seen = false;
   if (const auto it = m_historyIndex.find(notification.id); it != m_historyIndex.end()) {
+    seen = m_history[it->second].seen;
     m_history.erase(m_history.begin() + static_cast<std::ptrdiff_t>(it->second));
   }
 
   m_history.push_back(NotificationHistoryEntry{
       .notification = notification,
       .active = active,
+      .seen = seen,
       .closeReason = closeReason,
       .eventSerial = ++m_changeSerial,
   });
@@ -129,6 +133,20 @@ int NotificationManager::addEventCallback(EventCallback callback) {
 
 void NotificationManager::removeEventCallback(int token) {
   std::erase_if(m_eventCallbacks, [token](const auto& pair) { return pair.first == token; });
+}
+
+bool NotificationManager::computeHasUnreadNotificationHistory() const noexcept {
+  return std::any_of(m_history.begin(), m_history.end(),
+                     [](const NotificationHistoryEntry& entry) { return !entry.seen; });
+}
+
+void NotificationManager::notifyUnreadStateChangedIfNeeded(bool previousUnreadState) {
+  if (m_stateCallback == nullptr) {
+    return;
+  }
+  if (computeHasUnreadNotificationHistory() != previousUnreadState) {
+    m_stateCallback();
+  }
 }
 
 uint32_t NotificationManager::addOrReplace(uint32_t replacesId, std::string appName, std::string summary,
@@ -174,7 +192,9 @@ uint32_t NotificationManager::addOrReplace(uint32_t replacesId, std::string appN
 
       logNotification(n, "updated");
       if (shouldTrackHistory(n.origin, n.urgency)) {
+        const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
         upsertHistory(n, true, std::nullopt);
+        notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
       } else {
         removeHistoryEntry(n.id);
       }
@@ -223,8 +243,9 @@ uint32_t NotificationManager::addOrReplace(uint32_t replacesId, std::string appN
   const auto& n = m_notifications.back();
   logNotification(n, "added");
   if (shouldTrackHistory(n.origin, n.urgency)) {
+    const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
     upsertHistory(n, true, std::nullopt);
-    m_unreadSinceHistoryVisit = true;
+    notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
   }
 
   for (auto& [token, cb] : m_eventCallbacks) {
@@ -338,6 +359,9 @@ bool NotificationManager::close(uint32_t id, CloseReason reason) {
 
   const size_t index = it->second;
   const Notification closed = m_notifications[index];
+  const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
+  const bool historyHandledUnreadChange =
+      shouldTrackHistory(closed.origin, closed.urgency) && reason == CloseReason::Dismissed;
   const char* reasonStr = (reason == CloseReason::Expired)     ? "expired"
                           : (reason == CloseReason::Dismissed) ? "dismissed"
                                                                : "closed";
@@ -368,6 +392,10 @@ bool NotificationManager::close(uint32_t id, CloseReason reason) {
     m_closeCallback(id, reason);
   }
 
+  if (!historyHandledUnreadChange) {
+    notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
+  }
+
   return true;
 }
 
@@ -383,6 +411,7 @@ void NotificationManager::removeHistoryEntry(uint32_t id, std::optional<CloseRea
     return;
   }
 
+  const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
   const CloseReason reason =
       dbusCloseReason.value_or(m_history[it->second].closeReason.value_or(CloseReason::Dismissed));
   emitPendingDBusClose(id, reason);
@@ -390,6 +419,7 @@ void NotificationManager::removeHistoryEntry(uint32_t id, std::optional<CloseRea
   ++m_changeSerial;
   rebuildHistoryIndex();
   schedulePersistHistory();
+  notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
 }
 
 void NotificationManager::clearHistory() {
@@ -486,16 +516,20 @@ void NotificationManager::setStateCallback(StateCallback callback) { m_stateCall
 
 void NotificationManager::setSoundPlayer(SoundPlayer* soundPlayer) { m_soundPlayer = soundPlayer; }
 
-bool NotificationManager::hasUnreadNotificationHistory() const noexcept { return m_unreadSinceHistoryVisit; }
+bool NotificationManager::hasUnreadNotificationHistory() const noexcept {
+  return computeHasUnreadNotificationHistory();
+}
 
 void NotificationManager::markNotificationHistorySeen() {
-  if (!m_unreadSinceHistoryVisit) {
+  const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
+  if (!hadUnreadBefore) {
     return;
   }
-  m_unreadSinceHistoryVisit = false;
-  if (m_stateCallback) {
-    m_stateCallback();
+  for (auto& entry : m_history) {
+    entry.seen = true;
   }
+  schedulePersistHistory();
+  notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
 }
 
 void NotificationManager::schedulePersistHistory() {

--- a/src/notification/notification_manager.h
+++ b/src/notification/notification_manager.h
@@ -19,6 +19,7 @@ enum class NotificationEvent {
 struct NotificationHistoryEntry {
   Notification notification;
   bool active = true;
+  bool seen = false;
   std::optional<CloseReason> closeReason;
   std::uint64_t eventSerial = 0;
 };
@@ -120,6 +121,8 @@ private:
   void schedulePersistHistory();
   void persistHistoryToDisk();
   void emitPendingDBusClose(uint32_t id, CloseReason reason);
+  [[nodiscard]] bool computeHasUnreadNotificationHistory() const noexcept;
+  void notifyUnreadStateChangedIfNeeded(bool previousUnreadState);
 
   bool m_persistScheduled = false;
 
@@ -137,6 +140,5 @@ private:
   uint32_t m_nextId{1};
   std::uint64_t m_changeSerial{0};
   bool m_doNotDisturb = false;
-  bool m_unreadSinceHistoryVisit = false;
   class SoundPlayer* m_soundPlayer = nullptr;
 };


### PR DESCRIPTION
## Motivation
Previously, the notification widget’s "Hide When No New" behavior was driven by `m_unreadSinceHistoryVisit`. That broke down in two ways:
- The widget could stay visible even after the only new notification had been dismissed or otherwise removed from history.
- If an active notification was marked read by opening the notifications tab, it could become unread again when the popup later expired/closed and its history entry was rewritten.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
