### PR TITLE
desktop_widgets_editor: fix dropdown mouse selection bug

### DIFF
--- a/src/shell/desktop/desktop_widgets_editor.cpp
+++ b/src/shell/desktop/desktop_widgets_editor.cpp
@@ -444,7 +444,7 @@ void DesktopWidgetsEditor::rebuildScene(OverlaySurface& surface) {
     if (m_config != nullptr) {
       surface.selectPopup->setShadowConfig(m_config->config().shell.shadow);
     }
-    surface.selectPopup->setParent(surface.surface->layerSurface(), surface.output);
+    surface.selectPopup->setParent(surface.surface->layerSurface(), surface.surface->wlSurface(), surface.output);
     root->setPopupContext(surface.selectPopup.get());
   }
   root->setFrameSize(static_cast<float>(surface.surface->width()), static_cast<float>(surface.surface->height()));

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -1667,7 +1667,7 @@ void PanelManager::buildScene(std::uint32_t width, std::uint32_t height) {
       if (m_config != nullptr) {
         m_selectPopup->setShadowConfig(m_config->config().shell.shadow);
       }
-      m_selectPopup->setParent(m_layerSurface->layerSurface(), m_output);
+      m_selectPopup->setParent(m_layerSurface->layerSurface(), m_wlSurface, m_output);
       m_sceneRoot->setPopupContext(m_selectPopup.get());
     }
     m_sceneRoot->setSize(w, h);

--- a/src/shell/settings/session_actions_editor_popup.cpp
+++ b/src/shell/settings/session_actions_editor_popup.cpp
@@ -206,7 +206,7 @@ namespace settings {
       if (config() != nullptr) {
         m_selectPopup->setShadowConfig(config()->config().shell.shadow);
       }
-      m_selectPopup->setParent(xdgSurface(), m_parentOutput);
+      m_selectPopup->setParent(xdgSurface(), wlSurface(), m_parentOutput);
       contentParent->setPopupContext(m_selectPopup.get());
     }
   }

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -873,7 +873,7 @@ void SettingsWindow::buildScene(std::uint32_t width, std::uint32_t height) {
   if (m_surface != nullptr && m_renderContext != nullptr && m_wayland != nullptr) {
     m_selectPopup = std::make_unique<SelectDropdownPopup>(*m_wayland, *m_renderContext);
     m_selectPopup->setShadowConfig(cfg.shell.shadow);
-    m_selectPopup->setParent(m_surface->xdgSurface(), m_output);
+    m_selectPopup->setParent(m_surface->xdgSurface(), m_surface->wlSurface(), m_output);
     m_sceneRoot->setPopupContext(m_selectPopup.get());
   }
 

--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -44,15 +44,19 @@ SelectDropdownPopup::SelectDropdownPopup(WaylandConnection& wayland, RenderConte
 
 SelectDropdownPopup::~SelectDropdownPopup() { closeSelectDropdown(); }
 
-void SelectDropdownPopup::setParent(zwlr_layer_surface_v1* layerSurface, wl_output* output) {
+void SelectDropdownPopup::setParent(
+    zwlr_layer_surface_v1* layerSurface, wl_surface* parentWlSurface, wl_output* output
+) {
   m_parentLayerSurface = layerSurface;
   m_parentXdgSurface = nullptr;
+  m_parentWlSurface = parentWlSurface;
   m_parentOutput = output;
 }
 
-void SelectDropdownPopup::setParent(xdg_surface* xdgSurface, wl_output* output) {
+void SelectDropdownPopup::setParent(xdg_surface* xdgSurface, wl_surface* parentWlSurface, wl_output* output) {
   m_parentLayerSurface = nullptr;
   m_parentXdgSurface = xdgSurface;
+  m_parentWlSurface = parentWlSurface;
   m_parentOutput = output;
 }
 
@@ -198,6 +202,7 @@ void SelectDropdownPopup::openSelectDropdown(const DropdownRequest& request, Dro
   popup_chrome::setContentInputRegion(*m_surface, chrome);
 
   m_wlSurface = m_surface->wlSurface();
+  syncPointerStateFromCurrentPosition();
 }
 
 void SelectDropdownPopup::closeSelectDropdown() {
@@ -441,65 +446,83 @@ bool SelectDropdownPopup::onPointerEvent(const PointerEvent& event) {
     return false;
   }
 
-  const bool onPopup = (event.surface != nullptr && event.surface == m_wlSurface);
   const bool captured = m_inputDispatcher.pointerCaptured();
+  float localX = 0.0f;
+  float localY = 0.0f;
+  const bool mapped = mapPointerEvent(event, localX, localY);
+  if (!mapped) {
+    if ((event.type == PointerEvent::Type::Leave && event.surface == m_parentWlSurface)
+        || (event.type == PointerEvent::Type::Motion && event.surface == m_parentWlSurface && m_pointerInside)) {
+      m_pointerInside = false;
+      m_pointerOnSurface = false;
+      if (!captured) {
+        m_inputDispatcher.pointerLeave();
+      }
+    }
+    if (m_surface != nullptr && m_sceneRoot != nullptr && m_surface->isRunning()) {
+      m_surface->requestRedraw();
+    }
+    return false;
+  }
 
   switch (event.type) {
   case PointerEvent::Type::Enter:
-    if (onPopup) {
-      m_pointerInside = true;
-      m_pointerOnSurface = true;
-      m_inputDispatcher.pointerEnter(static_cast<float>(event.sx), static_cast<float>(event.sy), event.serial);
-    } else if (captured) {
-      m_pointerOnSurface = false;
-    }
+    m_pointerInside = true;
+    m_pointerOnSurface = ownsSurface(resolveEventSurface(event));
+    m_inputDispatcher.pointerEnter(localX, localY, event.serial);
     break;
   case PointerEvent::Type::Leave:
-    if (onPopup) {
-      if (captured) {
-        m_pointerOnSurface = false;
-      } else {
-        m_pointerInside = false;
-        m_pointerOnSurface = false;
-        m_inputDispatcher.pointerLeave();
-      }
+    m_pointerInside = false;
+    m_pointerOnSurface = false;
+    if (!captured) {
+      m_inputDispatcher.pointerLeave();
     }
     break;
   case PointerEvent::Type::Motion:
-    if (m_pointerInside) {
-      auto [mx, my] = popupLocalCoords(event.sx, event.sy);
-      m_inputDispatcher.pointerMotion(mx, my, 0);
-      return true;
+    m_pointerOnSurface = ownsSurface(resolveEventSurface(event));
+    if (captured) {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
+    } else if (!m_pointerInside) {
+      m_pointerInside = true;
+      m_inputDispatcher.pointerEnter(localX, localY, event.serial);
+    } else {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
     }
-    break;
+    return true;
   case PointerEvent::Type::Button:
-    if (m_pointerInside) {
-      auto [bx, by] = popupLocalCoords(event.sx, event.sy);
-      const bool pressed = (event.state == 1);
-      m_inputDispatcher.pointerButton(bx, by, event.button, pressed);
-      if (!pressed && !m_pointerOnSurface) {
-        m_pointerInside = false;
-        m_inputDispatcher.pointerLeave();
-      }
-      return true;
+    m_pointerOnSurface = ownsSurface(resolveEventSurface(event));
+    if (captured) {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
+    } else if (!m_pointerInside) {
+      m_pointerInside = true;
+      m_inputDispatcher.pointerEnter(localX, localY, event.serial);
+    } else {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
     }
-    break;
+    m_inputDispatcher.pointerButton(localX, localY, event.button, event.state == 1);
+    return true;
   case PointerEvent::Type::Axis:
-    if (m_pointerInside) {
-      m_inputDispatcher.pointerAxis(
-          static_cast<float>(event.sx), static_cast<float>(event.sy), event.axis, event.axisSource, event.axisValue,
-          event.axisDiscrete, event.axisValue120, event.axisLines
-      );
-      return true;
+    m_pointerOnSurface = ownsSurface(resolveEventSurface(event));
+    if (captured) {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
+    } else if (!m_pointerInside) {
+      m_pointerInside = true;
+      m_inputDispatcher.pointerEnter(localX, localY, event.serial);
+    } else {
+      m_inputDispatcher.pointerMotion(localX, localY, event.serial);
     }
-    break;
+    m_inputDispatcher.pointerAxis(
+        localX, localY, event.axis, event.axisSource, event.axisValue, event.axisDiscrete, event.axisValue120,
+        event.axisLines
+    );
+    return true;
   }
 
   if (m_surface != nullptr && m_sceneRoot != nullptr && m_surface->isRunning()) {
     m_surface->requestRedraw();
   }
 
-  return onPopup;
+  return true;
 }
 
 void SelectDropdownPopup::onKeyboardEvent(const KeyboardEvent& event) {
@@ -559,14 +582,96 @@ void SelectDropdownPopup::handleKey(std::uint32_t sym, std::uint32_t /*utf32*/, 
   }
 }
 
-std::pair<float, float> SelectDropdownPopup::popupLocalCoords(double sx, double sy) const {
-  if (m_pointerOnSurface || m_surface == nullptr) {
-    return {static_cast<float>(sx), static_cast<float>(sy)};
+wl_surface* SelectDropdownPopup::wlSurface() const noexcept { return m_wlSurface; }
+
+bool SelectDropdownPopup::mapPointerEvent(const PointerEvent& event, float& localX, float& localY) const noexcept {
+  if (m_surface == nullptr) {
+    return false;
   }
-  return {
-      static_cast<float>(sx) - static_cast<float>(m_surface->configuredX()),
-      static_cast<float>(sy) - static_cast<float>(m_surface->configuredY())
-  };
+
+  wl_surface* eventSurface = resolveEventSurface(event);
+  if (eventSurface == nullptr) {
+    return false;
+  }
+
+  if (m_inputDispatcher.pointerCaptured() && event.type != PointerEvent::Type::Leave) {
+    if (ownsSurface(eventSurface)) {
+      localX = static_cast<float>(event.sx);
+      localY = static_cast<float>(event.sy);
+      return true;
+    }
+    if (eventSurface == m_parentWlSurface) {
+      localX = static_cast<float>(event.sx) - static_cast<float>(m_surface->configuredX());
+      localY = static_cast<float>(event.sy) - static_cast<float>(m_surface->configuredY());
+      return true;
+    }
+  }
+
+  if (ownsSurface(eventSurface)) {
+    localX = static_cast<float>(event.sx);
+    localY = static_cast<float>(event.sy);
+    return true;
+  }
+
+  if (eventSurface != m_parentWlSurface) {
+    return false;
+  }
+
+  localX = static_cast<float>(event.sx) - static_cast<float>(m_surface->configuredX());
+  localY = static_cast<float>(event.sy) - static_cast<float>(m_surface->configuredY());
+
+  if (event.type == PointerEvent::Type::Leave) {
+    return m_pointerInside || m_inputDispatcher.pointerCaptured();
+  }
+
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig);
+  const float left = chrome.contentX();
+  const float top = chrome.contentY();
+  const float right = chrome.contentRight();
+  const float bottom = chrome.contentBottom();
+  if (m_inputDispatcher.pointerCaptured()) {
+    return true;
+  }
+  if (event.type == PointerEvent::Type::Button && m_pointerInside) {
+    return true;
+  }
+  return localX >= left && localY >= top && localX < right && localY < bottom;
 }
 
-wl_surface* SelectDropdownPopup::wlSurface() const noexcept { return m_wlSurface; }
+wl_surface* SelectDropdownPopup::resolveEventSurface(const PointerEvent& event) const noexcept {
+  wl_surface* eventSurface = event.surface;
+  if (eventSurface == nullptr && event.type == PointerEvent::Type::Motion) {
+    eventSurface = m_wayland.lastPointerSurface();
+  }
+  return eventSurface;
+}
+
+void SelectDropdownPopup::syncPointerStateFromCurrentPosition() {
+  if (m_surface == nullptr || !m_wayland.hasPointerPosition()) {
+    return;
+  }
+
+  PointerEvent synthetic;
+  synthetic.type = PointerEvent::Type::Motion;
+  synthetic.surface = m_wayland.lastPointerSurface();
+  synthetic.sx = m_wayland.lastPointerX();
+  synthetic.sy = m_wayland.lastPointerY();
+  synthetic.serial = m_wayland.lastInputSerial();
+
+  float localX = 0.0f;
+  float localY = 0.0f;
+  if (!mapPointerEvent(synthetic, localX, localY)) {
+    return;
+  }
+
+  m_pointerInside = true;
+  m_pointerOnSurface = ownsSurface(synthetic.surface);
+  m_inputDispatcher.pointerEnter(localX, localY, synthetic.serial);
+  if (m_surface->isRunning()) {
+    m_surface->requestRedraw();
+  }
+}
+
+bool SelectDropdownPopup::ownsSurface(wl_surface* surface) const noexcept {
+  return m_surface != nullptr && surface != nullptr && surface == m_surface->wlSurface();
+}

--- a/src/ui/controls/select_dropdown_popup.h
+++ b/src/ui/controls/select_dropdown_popup.h
@@ -31,8 +31,8 @@ public:
   SelectDropdownPopup(WaylandConnection& wayland, RenderContext& renderContext);
   ~SelectDropdownPopup() override;
 
-  void setParent(zwlr_layer_surface_v1* layerSurface, wl_output* output);
-  void setParent(xdg_surface* xdgSurface, wl_output* output);
+  void setParent(zwlr_layer_surface_v1* layerSurface, wl_surface* parentWlSurface, wl_output* output);
+  void setParent(xdg_surface* xdgSurface, wl_surface* parentWlSurface, wl_output* output);
   void setShadowConfig(const ShellConfig::ShadowConfig& shadow);
 
   void openSelectDropdown(const DropdownRequest& request, DropdownCallbacks callbacks) override;
@@ -60,12 +60,16 @@ private:
   void clampScrollOffset();
   void applyHoverVisuals();
   void selectAndClose(std::size_t index);
-  [[nodiscard]] std::pair<float, float> popupLocalCoords(double sx, double sy) const;
+  [[nodiscard]] bool mapPointerEvent(const PointerEvent& event, float& localX, float& localY) const noexcept;
+  [[nodiscard]] wl_surface* resolveEventSurface(const PointerEvent& event) const noexcept;
+  void syncPointerStateFromCurrentPosition();
+  [[nodiscard]] bool ownsSurface(wl_surface* surface) const noexcept;
 
   WaylandConnection& m_wayland;
   RenderContext& m_renderContext;
   zwlr_layer_surface_v1* m_parentLayerSurface = nullptr;
   xdg_surface* m_parentXdgSurface = nullptr;
+  wl_surface* m_parentWlSurface = nullptr;
   wl_output* m_parentOutput = nullptr;
 
   std::unique_ptr<PopupSurface> m_surface;


### PR DESCRIPTION
Fix select popup pointer handling so clicks routed through the parent surface are still mapped into the dropdown correctly, allowing mouse selection to work as expected.

## Type of Change
- [x] Bug fix

## Related Issue
- Closes #2745

## Testing
- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors