### PR TITLE
tweak(clipboard): Made clipboard buttons hidden when no entries are available

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -903,7 +903,6 @@ void ClipboardPanel::updatePreviewActions() {
   }
 
   if (m_imageActionButton == nullptr) {
-    updatePinButton();
     return;
   }
 

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -858,7 +858,14 @@ void ClipboardPanel::schedulePreviewPayloadRefresh(bool debounced) {
 
 void ClipboardPanel::updateListState() {
   const auto& history = m_clipboard != nullptr ? m_clipboard->history() : std::deque<ClipboardEntry>{};
+  const bool historyEmpty = history.empty();
   const bool empty = history.empty() || m_filteredIndices.empty();
+
+  if (m_clearHistoryButton != nullptr) {
+    m_clearHistoryButton->setVisible(!historyEmpty);
+    m_clearHistoryButton->setParticipatesInLayout(!historyEmpty);
+    m_clearHistoryButton->setEnabled(!historyEmpty);
+  }
 
   if (m_listEmptyLabel != nullptr) {
     m_listEmptyLabel->setText(
@@ -876,7 +883,27 @@ void ClipboardPanel::updateListState() {
 }
 
 void ClipboardPanel::updatePreviewActions() {
+  bool hasSelection = false;
+  if (m_clipboard != nullptr) {
+    const std::size_t historyIndex = selectedHistoryIndex();
+    const auto& history = m_clipboard->history();
+    hasSelection = historyIndex != static_cast<std::size_t>(-1) && historyIndex < history.size();
+  }
+
+  if (m_copyButton != nullptr) {
+    m_copyButton->setVisible(hasSelection);
+    m_copyButton->setParticipatesInLayout(hasSelection);
+    m_copyButton->setEnabled(hasSelection);
+  }
+
+  if (m_deleteEntryButton != nullptr) {
+    m_deleteEntryButton->setVisible(hasSelection);
+    m_deleteEntryButton->setParticipatesInLayout(hasSelection);
+    m_deleteEntryButton->setEnabled(hasSelection);
+  }
+
   if (m_imageActionButton == nullptr) {
+    updatePinButton();
     return;
   }
 


### PR DESCRIPTION
## Description
If there are no existing entries on clipboard history, hide the delete / pin / copy buttons. 

Suggested by notiant

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="704" height="147" alt="image" src="https://github.com/user-attachments/assets/d391531e-be55-424d-a57b-5ad9fb24f5ab" />

<img width="696" height="126" alt="image" src="https://github.com/user-attachments/assets/d50dabae-2c5d-4cf2-a777-28736bad57a0" />


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

