### PR TITLE
bar: allow start/end sections to use all available space when center section is empty

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -778,7 +778,7 @@ namespace {
       endSlotMain = std::min(endNaturalMain, contentMainSpan);
       startSlotMain = std::min(startNaturalMain, contentMainSpan - endSlotMain);
       configureSlot(instance.startSlot, contentMainStart, startSlotMain);
-      configureSlot(instance.centerSlot, contentMainStart + startSlotMain, centerSlotMain);
+      configureSlot(instance.centerSlot, contentMainStart + startSlotMain, 0.0f);
       configureSlot(instance.endSlot, contentMainEnd - endSlotMain, endSlotMain);
     }
 

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -760,12 +760,27 @@ namespace {
       centerSectionOffset = (centerSlotMain - centerNaturalMain) * 0.5f;
     }
     const float centerSlotEnd = centerSlotStart + centerSlotMain;
-    const float startSlotMain = std::max(0.0f, centerSlotStart - contentMainStart);
-    const float endSlotMain = std::max(0.0f, contentMainEnd - centerSlotEnd);
+    float startSlotMain;
+    float endSlotMain;
+    if (!instance.centerWidgets.empty()) {
+      startSlotMain = std::max(0.0f, centerSlotStart - contentMainStart);
+      endSlotMain = std::max(0.0f, contentMainEnd - centerSlotEnd);
+      configureSlot(instance.startSlot, contentMainStart, startSlotMain);
+      configureSlot(instance.centerSlot, centerSlotStart, centerSlotMain);
+      configureSlot(instance.endSlot, centerSlotEnd, endSlotMain);
+    } else {
+      // Allow start/end sections to take the full width if center is empty
+      const float startNaturalMain = isVertical ? instance.startSection->height() : instance.startSection->width();
+      const float endNaturalMain = isVertical ? instance.endSection->height() : instance.endSection->width();
 
-    configureSlot(instance.startSlot, contentMainStart, startSlotMain);
-    configureSlot(instance.centerSlot, centerSlotStart, centerSlotMain);
-    configureSlot(instance.endSlot, centerSlotEnd, endSlotMain);
+      // Prioritize end section, because control center is likely to be there, and we don't
+      // want it to be clipped by a super long start section, so the user loses access to settings.
+      endSlotMain = std::min(endNaturalMain, contentMainSpan);
+      startSlotMain = std::min(startNaturalMain, contentMainSpan - endSlotMain);
+      configureSlot(instance.startSlot, contentMainStart, startSlotMain);
+      configureSlot(instance.centerSlot, contentMainStart + startSlotMain, centerSlotMain);
+      configureSlot(instance.endSlot, contentMainEnd - endSlotMain, endSlotMain);
+    }
 
     if (isVertical) {
       instance.startSection->setPosition((slotCross - instance.startSection->width()) * 0.5f, 0.0f);


### PR DESCRIPTION
# Pull Request

## Motivation
Motivation is for making room for a very-long taskbar.

End section has priority over start section, because control center is likely to be on the right side of the bar, and we don't want to clip it off.

We might want to add gaps between sections when they touch/overlap, and/or some visual indication when a section is being clipped. Both are outside the scope of this PR.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
