### PR TITLE
fix(hyprland): fix workspaces widget not showing named workspaces

### DIFF
--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -82,14 +82,17 @@ std::vector<Workspace> HyprlandWorkspaceBackend::forOutput(wl_output* output) co
   std::vector<const WorkspaceState*> ordered;
   for (const auto& workspace : m_workspaces) {
     if (workspace.monitor == outputName) {
-      if (workspace.id >= 0) {
-        ordered.push_back(&workspace);
+      // dont show special workspaces for outputs
+      if (workspace.id < 0 && workspace.name.find("special") != std::string::npos) {
+        continue;
       }
+
+      ordered.push_back(&workspace);
     }
   }
 
   std::sort(ordered.begin(), ordered.end(), [](const WorkspaceState* a, const WorkspaceState* b) {
-    return a->id < b->id;
+    return a->name.length() < b->name.length() || (a->name.length() == b->name.length() && a->id < b->id);
   });
 
   std::vector<Workspace> result;


### PR DESCRIPTION
## Motivation
I recently installed noctalia-git on Hyprland and I realized named workspaces weren't being shown in the workspaces widget.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
There is an old issue #1355, seems like this is a v5 regression.

## Testing
Describe how you tested your changes and mark the relevant items.

- [ ] Tested on niri
- [X] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
With this from `hyprctl workspaces -j`
```
{
    "id": -1337,
    "name": "browser",
    "monitor": "HDMI-A-1",
    "monitorID": 1,
    "windows": 1,
    "hasfullscreen": false,
    "lastwindow": "0x5636e9c42ad0",
    "lastwindowtitle": "Comparing noctalia-dev:v5...ikalco:v5 · noctalia-dev/noctalia-shell — LibreWolf",
    "ispersistent": false,
    "tiledLayout": "dwindle"
},
```

Before:
<img width="227" height="34" alt="image" src="https://github.com/user-attachments/assets/af31574b-9586-43ab-9140-bba2762d680b" />

After:
<img width="300" height="39" alt="image" src="https://github.com/user-attachments/assets/4560f1c3-0090-4f5b-9549-321196415319" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Everything looks fine to me, except for `left` and `right` bar modes when the named workspace gets clipped out of the bar region.
<img width="39" height="95" alt="image" src="https://github.com/user-attachments/assets/a1fc494b-4223-498e-9c6b-1e0230d79936" />

<s>I'm not very familiar with your UI, UX, or the v5 framework, so any tips?
Do you want the workspace name text be vertical? How would I make the text vertical?</s>
***Seems like this is a wider issue as I see other widgets clip as well. Up to you to merge I guess.***