### PR TITLE
refactor: share desktop entry launch handling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -579,6 +579,7 @@ _noctalia_sources = files(
   'src/shell/bar/widgets/workspaces_widget.cpp',
   'src/system/dependency_service.cpp',
   'src/system/desktop_entry.cpp',
+  'src/system/desktop_entry_launch.cpp',
   'src/system/brightness_service.cpp',
   'src/system/lock_keys_service.cpp',
   'src/system/distro_info.cpp',
@@ -828,6 +829,18 @@ process_test = executable('process_test',
 )
 
 test('process', process_test)
+
+desktop_entry_launch_test = executable('desktop_entry_launch_test',
+  sources: files(
+    'tests/desktop_entry_launch_test.cpp',
+    'src/system/desktop_entry_launch.cpp',
+    'src/core/process.cpp',
+    'src/core/log.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('desktop_entry_launch', desktop_entry_launch_test)
 
 string_utils_test = executable('string_utils_test',
   sources: files(

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1110,7 +1110,7 @@ void Application::initUi() {
   );
   {
     auto launcherPanel = std::make_unique<LauncherPanel>(&m_configService, &m_asyncTextureCache);
-    launcherPanel->addProvider(std::make_unique<AppProvider>(&m_configService, &m_wayland));
+    launcherPanel->addProvider(std::make_unique<AppProvider>(&m_configService, &m_compositorPlatform));
     launcherPanel->addProvider(std::make_unique<WallpaperProvider>(&m_configService, &m_wayland));
     launcherPanel->addProvider(std::make_unique<SessionProvider>(&m_configService, &m_sessionActionRunner));
     launcherPanel->addProvider(std::make_unique<MathProvider>(&m_clipboardService));

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -435,6 +435,12 @@ const compositors::niri::NiriRuntime& CompositorPlatform::niriRuntime() const no
 
 bool CompositorPlatform::hasXdgShell() const noexcept { return m_wayland.hasXdgShell(); }
 
+bool CompositorPlatform::hasXdgActivation() const noexcept { return m_wayland.hasXdgActivation(); }
+
+std::string CompositorPlatform::requestActivationToken(wl_surface* surface) const {
+  return m_wayland.requestActivationToken(surface);
+}
+
 bool CompositorPlatform::hasGammaControl() const noexcept { return m_wayland.hasGammaControl(); }
 
 const std::vector<WaylandOutput>& CompositorPlatform::outputs() const noexcept { return m_wayland.outputs(); }

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -62,6 +62,8 @@ public:
   [[nodiscard]] const WaylandConnection& wayland() const noexcept { return m_wayland; }
   [[nodiscard]] wl_display* display() const noexcept;
   [[nodiscard]] bool hasXdgShell() const noexcept;
+  [[nodiscard]] bool hasXdgActivation() const noexcept;
+  [[nodiscard]] std::string requestActivationToken(wl_surface* surface) const;
   [[nodiscard]] bool hasGammaControl() const noexcept;
   [[nodiscard]] const std::vector<WaylandOutput>& outputs() const noexcept;
   [[nodiscard]] const WaylandOutput* findOutputByWl(wl_output* output) const;

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -191,7 +191,7 @@ bool AppProvider::activate(const LauncherResult& result) {
     };
 
     if (chosen != nullptr) {
-      return desktop_entry_launch::launchAction(*chosen, entry.id, entry.workingDir, launchOptions);
+      return desktop_entry_launch::launchAction(*chosen, entry.id, entry.workingDir, entry.terminal, launchOptions);
     }
     return desktop_entry_launch::launchEntry(entry, launchOptions);
   }

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -1,18 +1,13 @@
 #include "launcher/app_provider.h"
 
 #include "config/config_service.h"
-#include "core/process.h"
-#include "util/file_utils.h"
+#include "system/desktop_entry_launch.h"
 #include "util/fuzzy_match.h"
 #include "util/string_utils.h"
 #include "wayland/wayland_connection.h"
 
 #include <algorithm>
-#include <array>
-#include <cstdlib>
-#include <cstring>
 #include <string_view>
-#include <unistd.h>
 
 namespace {
 
@@ -52,183 +47,6 @@ namespace {
     const double execScore = FuzzyMatch::score(pattern, entry.execLower);
 
     return std::max({nameScore, genericScore, keywordScore, catScore, idScore, execScore});
-  }
-
-  std::string stripFieldCodes(const std::string& exec) {
-    std::string result;
-    result.reserve(exec.size());
-    for (std::size_t i = 0; i < exec.size(); ++i) {
-      if (exec[i] == '%' && i + 1 < exec.size()) {
-        char next = exec[i + 1];
-        if (next == 'f'
-            || next == 'F'
-            || next == 'u'
-            || next == 'U'
-            || next == 'd'
-            || next == 'D'
-            || next == 'n'
-            || next == 'N'
-            || next == 'i'
-            || next == 'c'
-            || next == 'k') {
-          ++i; // Skip the field code
-          // Also skip trailing space
-          if (i + 1 < exec.size() && exec[i + 1] == ' ') {
-            ++i;
-          }
-          continue;
-        }
-        if (next == '%') {
-          result += '%';
-          ++i;
-          continue;
-        }
-      }
-      result += exec[i];
-    }
-
-    // Trim trailing whitespace
-    while (!result.empty() && result.back() == ' ') {
-      result.pop_back();
-    }
-    return result;
-  }
-
-  std::vector<std::string> tokenize(const std::string& cmd) {
-    std::vector<std::string> args;
-    std::string current;
-    bool inSingle = false;
-    bool inDouble = false;
-
-    for (std::size_t i = 0; i < cmd.size(); ++i) {
-      char c = cmd[i];
-
-      if (c == '\'' && !inDouble) {
-        inSingle = !inSingle;
-        continue;
-      }
-      if (c == '"' && !inSingle) {
-        inDouble = !inDouble;
-        continue;
-      }
-      if (c == ' ' && !inSingle && !inDouble) {
-        if (!current.empty()) {
-          args.push_back(std::move(current));
-          current.clear();
-        }
-        continue;
-      }
-      current += c;
-    }
-    if (!current.empty()) {
-      args.push_back(std::move(current));
-    }
-    return args;
-  }
-
-  std::string expandExecutablePath(std::string_view binary) {
-    if (binary.empty() || binary[0] != '~') {
-      return std::string(binary);
-    }
-    return FileUtils::expandUserPath(std::string(binary)).string();
-  }
-
-  bool isExecutableOnPath(std::string_view binary) {
-    if (binary.empty()) {
-      return false;
-    }
-    if (binary.find('/') != std::string_view::npos) {
-      const std::string expanded = expandExecutablePath(binary);
-      return access(expanded.c_str(), X_OK) == 0;
-    }
-
-    const char* pathEnv = std::getenv("PATH");
-    if (pathEnv == nullptr || pathEnv[0] == '\0') {
-      return false;
-    }
-
-    std::string_view path(pathEnv);
-    std::size_t start = 0;
-    while (start <= path.size()) {
-      const auto sep = path.find(':', start);
-      const auto segment = sep == std::string_view::npos ? path.substr(start) : path.substr(start, sep - start);
-      if (!segment.empty()) {
-        std::string candidate(segment);
-        candidate.push_back('/');
-        candidate.append(binary);
-        if (access(candidate.c_str(), X_OK) == 0) {
-          return true;
-        }
-      }
-      if (sep == std::string_view::npos) {
-        break;
-      }
-      start = sep + 1;
-    }
-    return false;
-  }
-
-  std::vector<std::string> terminalLaunchArgs(const std::string& command) {
-    std::vector<std::string> terminal;
-    if (const char* envTerminal = std::getenv("TERMINAL"); envTerminal != nullptr && envTerminal[0] != '\0') {
-      terminal = tokenize(envTerminal);
-      if (!terminal.empty() && !isExecutableOnPath(terminal.front())) {
-        terminal.clear();
-      }
-    }
-
-    if (terminal.empty()) {
-      static constexpr std::array<std::string_view, 9> kTerminalCandidates = {
-          "x-terminal-emulator", "ghostty", "kitty", "alacritty", "wezterm", "foot", "konsole",
-          "gnome-terminal",      "xterm"
-      };
-      for (const auto candidate : kTerminalCandidates) {
-        if (isExecutableOnPath(candidate)) {
-          terminal.emplace_back(candidate);
-          break;
-        }
-      }
-    }
-
-    if (terminal.empty()) {
-      return {};
-    }
-
-    const std::string& termBin = terminal.front();
-    if (termBin == "gnome-terminal" || termBin == "kgx" || termBin == "ptyxis") {
-      terminal.emplace_back("--");
-      terminal.emplace_back("sh");
-      terminal.emplace_back("-lc");
-      terminal.emplace_back(command);
-    } else {
-      terminal.emplace_back("-e");
-      terminal.emplace_back("sh");
-      terminal.emplace_back("-lc");
-      terminal.emplace_back(command);
-    }
-    return terminal;
-  }
-
-  void launchCommand(
-      const std::string& exec, bool terminal, const std::string& activationToken, const std::string& workingDir,
-      const std::string& appName, bool runAsSystemdService
-  ) {
-    std::string cleanExec = stripFieldCodes(exec);
-    std::vector<std::string> args = terminal ? terminalLaunchArgs(cleanExec) : tokenize(cleanExec);
-
-    if (!args.empty() && args.front().find('/') != std::string::npos) {
-      args.front() = expandExecutablePath(args.front());
-    }
-
-    if (args.empty()) {
-      return;
-    }
-
-    if (runAsSystemdService) {
-      process::runAsyncAsSystemdService(args, appName, activationToken, workingDir);
-    } else {
-      (void)process::runAsync(args, activationToken, workingDir);
-    }
   }
 
   std::string_view primaryCategory(std::string_view categories) {
@@ -350,9 +168,8 @@ bool AppProvider::activate(const LauncherResult& result) {
       continue;
     }
 
-    std::string execLine = entry.exec;
+    const DesktopAction* chosen = nullptr;
     if (!result.desktopActionId.empty()) {
-      const DesktopAction* chosen = nullptr;
       for (const auto& action : entry.actions) {
         if (action.id == result.desktopActionId) {
           chosen = &action;
@@ -362,18 +179,21 @@ bool AppProvider::activate(const LauncherResult& result) {
       if (chosen == nullptr || chosen->exec.empty()) {
         return false;
       }
-      execLine = chosen->exec;
     }
 
     std::string token;
     if (m_wayland != nullptr && m_wayland->hasXdgActivation()) {
       token = m_wayland->requestActivationToken(nullptr);
     }
-    launchCommand(
-        execLine, entry.terminal, token, entry.workingDir, entry.id,
-        m_config->config().shell.launchAppsAsSystemdServices
-    );
-    return true;
+    desktop_entry_launch::LaunchOptions launchOptions{
+        .activationToken = std::move(token),
+        .runAsSystemdService = m_config->config().shell.launchAppsAsSystemdServices,
+    };
+
+    if (chosen != nullptr) {
+      return desktop_entry_launch::launchAction(*chosen, entry.id, entry.workingDir, launchOptions);
+    }
+    return desktop_entry_launch::launchEntry(entry, launchOptions);
   }
   return false;
 }

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -1,10 +1,10 @@
 #include "launcher/app_provider.h"
 
+#include "compositors/compositor_platform.h"
 #include "config/config_service.h"
 #include "system/desktop_entry_launch.h"
 #include "util/fuzzy_match.h"
 #include "util/string_utils.h"
-#include "wayland/wayland_connection.h"
 
 #include <algorithm>
 #include <string_view>
@@ -91,7 +91,8 @@ namespace {
 
 } // namespace
 
-AppProvider::AppProvider(ConfigService* config, WaylandConnection* wayland) : m_config(config), m_wayland(wayland) {}
+AppProvider::AppProvider(ConfigService* config, CompositorPlatform* platform)
+    : m_config(config), m_platform(platform) {}
 
 void AppProvider::initialize() { refreshEntriesIfNeeded(); }
 
@@ -182,8 +183,8 @@ bool AppProvider::activate(const LauncherResult& result) {
     }
 
     std::string token;
-    if (m_wayland != nullptr && m_wayland->hasXdgActivation()) {
-      token = m_wayland->requestActivationToken(nullptr);
+    if (m_platform != nullptr && m_platform->hasXdgActivation()) {
+      token = m_platform->requestActivationToken(nullptr);
     }
     desktop_entry_launch::LaunchOptions launchOptions{
         .activationToken = std::move(token),

--- a/src/launcher/app_provider.h
+++ b/src/launcher/app_provider.h
@@ -7,11 +7,11 @@
 #include <vector>
 
 class ConfigService;
-class WaylandConnection;
+class CompositorPlatform;
 
 class AppProvider : public LauncherProvider {
 public:
-  explicit AppProvider(ConfigService* config, WaylandConnection* wayland = nullptr);
+  explicit AppProvider(ConfigService* config, CompositorPlatform* platform = nullptr);
 
   [[nodiscard]] std::string_view prefix() const override { return ""; }
   [[nodiscard]] std::string_view name() const override { return "Applications"; }
@@ -29,7 +29,7 @@ private:
   void refreshEntriesIfNeeded() const;
 
   ConfigService* m_config = nullptr;
-  WaylandConnection* m_wayland = nullptr;
+  CompositorPlatform* m_platform = nullptr;
   mutable std::vector<DesktopEntry> m_entries;
   mutable std::uint64_t m_entriesVersion = 0;
 };

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -874,7 +874,7 @@ bool Bar::initialize(
   m_fileWatcher = fileWatcher;
 
   m_widgetFactory = std::make_unique<WidgetFactory>(
-      *m_platform, m_config->config(), m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
+      *m_platform, *m_config, m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
       m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight, m_themeService,
       m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher
   );
@@ -921,7 +921,7 @@ void Bar::reload() {
   m_lastWidgets = m_config->config().widgets;
   m_lastShadow = m_config->config().shell.shadow;
   m_widgetFactory = std::make_unique<WidgetFactory>(
-      *m_platform, m_config->config(), m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
+      *m_platform, *m_config, m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
       m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight, m_themeService,
       m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher
   );

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -447,7 +447,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
     auto widget = std::make_unique<TaskbarWidget>(
         m_platform, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
         workspaceLabelPlacement, hideEmptyWorkspaces, workspaceGroupCapsule, focusedColor, occupiedColor, emptyColor,
-        showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow
+        showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow,
+        m_config.shell.launchAppsAsSystemdServices
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -94,18 +94,19 @@ namespace {
 } // namespace
 
 WidgetFactory::WidgetFactory(
-    CompositorPlatform& platform, const Config& config, NotificationManager* notifications, TrayService* tray,
+    CompositorPlatform& platform, ConfigService& config, NotificationManager* notifications, TrayService* tray,
     PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon, PowerProfilesService* powerProfiles,
     INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum,
     HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
     noctalia::theme::ThemeService* themeService, BluetoothService* bluetooth, BrightnessService* brightness,
     LockKeysService* lockKeys, ClipboardService* clipboard, FileWatcher* fileWatcher
 )
-    : m_platform(platform), m_config(config), m_notifications(notifications), m_tray(tray), m_audio(audio),
-      m_upower(upower), m_sysmon(sysmon), m_powerProfiles(powerProfiles), m_network(network),
-      m_idleInhibitor(idleInhibitor), m_mpris(mpris), m_audioSpectrum(audioSpectrum), m_httpClient(httpClient),
-      m_weather(weather), m_nightLight(nightLight), m_themeService(themeService), m_bluetooth(bluetooth),
-      m_brightness(brightness), m_lockKeys(lockKeys), m_clipboard(clipboard), m_fileWatcher(fileWatcher) {}
+    : m_platform(platform), m_configService(config), m_config(config.config()), m_notifications(notifications),
+      m_tray(tray), m_audio(audio), m_upower(upower), m_sysmon(sysmon), m_powerProfiles(powerProfiles),
+      m_network(network), m_idleInhibitor(idleInhibitor), m_mpris(mpris), m_audioSpectrum(audioSpectrum),
+      m_httpClient(httpClient), m_weather(weather), m_nightLight(nightLight), m_themeService(themeService),
+      m_bluetooth(bluetooth), m_brightness(brightness), m_lockKeys(lockKeys), m_clipboard(clipboard),
+      m_fileWatcher(fileWatcher) {}
 
 WidgetFactory::~WidgetFactory() = default;
 
@@ -446,7 +447,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const float windowTitleMaxWidth =
         static_cast<float>(wc != nullptr ? wc->getDouble("window_title_max_width", 100.0) : 100.0);
     auto widget = std::make_unique<TaskbarWidget>(
-        m_platform, m_config, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
+        m_platform, m_configService, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
         workspaceLabelPlacement, hideEmptyWorkspaces, workspaceGroupCapsule, focusedColor, occupiedColor, emptyColor,
         showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow
     );

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -445,10 +445,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const float windowTitleMaxWidth =
         static_cast<float>(wc != nullptr ? wc->getDouble("window_title_max_width", 100.0) : 100.0);
     auto widget = std::make_unique<TaskbarWidget>(
-        m_platform, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
+        m_platform, m_config, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
         workspaceLabelPlacement, hideEmptyWorkspaces, workspaceGroupCapsule, focusedColor, occupiedColor, emptyColor,
-        showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow,
-        m_config.shell.launchAppsAsSystemdServices
+        showWindowTitle, windowTitleMaxWidth, barPosition, m_config.shell.shadow
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widget_factory.h
+++ b/src/shell/bar/widget_factory.h
@@ -6,6 +6,7 @@
 #include <string>
 
 struct Config;
+class ConfigService;
 class FileWatcher;
 class CompositorPlatform;
 class NotificationManager;
@@ -33,7 +34,7 @@ namespace noctalia::theme {
 class WidgetFactory {
 public:
   WidgetFactory(
-      CompositorPlatform& platform, const Config& config, NotificationManager* notifications, TrayService* tray,
+      CompositorPlatform& platform, ConfigService& config, NotificationManager* notifications, TrayService* tray,
       PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon, PowerProfilesService* powerProfiles,
       INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum,
       HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
@@ -49,6 +50,7 @@ public:
 
 private:
   CompositorPlatform& m_platform;
+  ConfigService& m_configService;
   const Config& m_config;
   NotificationManager* m_notifications;
   TrayService* m_tray;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -3,7 +3,6 @@
 #include "compositors/compositor_detect.h"
 #include "compositors/workspace_backend.h"
 #include "core/deferred_call.h"
-#include "core/process.h"
 #include "i18n/i18n.h"
 #include "render/core/color.h"
 #include "render/core/renderer.h"
@@ -11,6 +10,7 @@
 #include "shell/panel/panel_manager.h"
 #include "system/app_identity.h"
 #include "system/desktop_entry.h"
+#include "system/desktop_entry_launch.h"
 #include "system/internal_app_metadata.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu.h"
@@ -25,7 +25,6 @@ struct ext_foreign_toplevel_handle_v1;
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
-#include <cctype>
 #include <cmath>
 #include <functional>
 #include <linux/input-event-codes.h>
@@ -147,7 +146,7 @@ TaskbarWidget::TaskbarWidget(
     bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
     bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
     ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
-    ShellConfig::ShadowConfig shadowConfig
+    ShellConfig::ShadowConfig shadowConfig, bool launchAppsAsSystemdService
 )
     : m_platform(platform), m_output(output), m_groupByWorkspace(groupByWorkspace), m_showAllOutputs(showAllOutputs),
       m_onlyActiveWorkspace(onlyActiveWorkspace), m_showWorkspaceLabel(showWorkspaceLabel),
@@ -155,7 +154,8 @@ TaskbarWidget::TaskbarWidget(
       m_workspaceGroupCapsule(workspaceGroupCapsule), m_focusedColor(std::move(focusedColor)),
       m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
       m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
-      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)) {
+      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)),
+      m_launchAppsAsSystemdService(launchAppsAsSystemdService) {
   // Window title not implemented for vertical bars or workspace grouping.
   if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
     m_showWindowTitle = false;
@@ -1601,6 +1601,9 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
   m_contextMenuPrimaryHandle = task.firstHandle;
 
   std::vector<DesktopAction> entryActions;
+  std::string entryAppName = task.idLower.empty() ? task.appId : task.idLower;
+  std::string entryWorkingDir;
+  bool entryTerminal = false;
   const auto& entriesIndex = desktopEntries();
   for (const auto& entry : entriesIndex) {
     if (entry.idLower == task.idLower
@@ -1609,6 +1612,9 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
         || entry.startupWmClassLower == task.startupWmClassLower
         || entry.nameLower == task.nameLower) {
       entryActions = entry.actions;
+      entryAppName = entry.id.empty() ? entry.name : entry.id;
+      entryWorkingDir = entry.workingDir;
+      entryTerminal = entry.terminal;
       break;
     }
   }
@@ -1663,26 +1669,27 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
     m_contextMenuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), *renderContext);
   }
   m_contextMenuPopup->setShadowConfig(m_shadowConfig);
-  m_contextMenuPopup->setOnActivate([this, entryActions](const ContextMenuControlEntry& entry) {
+  m_contextMenuPopup->setOnActivate(
+      [this, entryActions, entryAppName, entryWorkingDir, entryTerminal](const ContextMenuControlEntry& entry) {
     if (entry.id >= 0) {
       const auto idx = static_cast<std::size_t>(entry.id);
       if (idx < entryActions.size()) {
-        const auto& action = entryActions[idx];
-        std::string cmd;
-        cmd.reserve(action.exec.size());
-        for (std::size_t i = 0; i < action.exec.size(); ++i) {
-          if (action.exec[i] == '%' && i + 1 < action.exec.size()) {
-            ++i;
-            continue;
-          }
-          cmd += action.exec[i];
-        }
-        while (!cmd.empty() && std::isspace(static_cast<unsigned char>(cmd.back()))) {
-          cmd.pop_back();
-        }
-        if (!cmd.empty()) {
-          DeferredCall::callLater([cmd]() { (void)process::runAsync(cmd); });
-        }
+        const auto action = entryActions[idx];
+        DeferredCall::callLater(
+            [this, action, appName = entryAppName, workingDir = entryWorkingDir, terminal = entryTerminal]() {
+              std::string token;
+              if (m_platform.hasXdgActivation()) {
+                token = m_platform.requestActivationToken(nullptr);
+              }
+              (void)desktop_entry_launch::launchAction(
+                  action, appName, workingDir, terminal,
+                  desktop_entry_launch::LaunchOptions{
+                      .activationToken = std::move(token),
+                      .runAsSystemdService = m_launchAppsAsSystemdService,
+                  }
+              );
+            }
+        );
       }
       return;
     }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -150,12 +150,13 @@ TaskbarWidget::TaskbarWidget(
     ShellConfig::ShadowConfig shadowConfig
 )
     : m_platform(platform), m_config(config), m_output(output), m_groupByWorkspace(groupByWorkspace),
-      m_showAllOutputs(showAllOutputs), m_onlyActiveWorkspace(onlyActiveWorkspace), m_showWorkspaceLabel(showWorkspaceLabel),
-      m_workspaceLabelPlacement(workspaceLabelPlacement), m_hideEmptyWorkspaces(hideEmptyWorkspaces),
-      m_workspaceGroupCapsule(workspaceGroupCapsule), m_focusedColor(std::move(focusedColor)),
-      m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
-      m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
-      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)) {
+      m_showAllOutputs(showAllOutputs), m_onlyActiveWorkspace(onlyActiveWorkspace),
+      m_showWorkspaceLabel(showWorkspaceLabel), m_workspaceLabelPlacement(workspaceLabelPlacement),
+      m_hideEmptyWorkspaces(hideEmptyWorkspaces), m_workspaceGroupCapsule(workspaceGroupCapsule),
+      m_focusedColor(std::move(focusedColor)), m_occupiedColor(std::move(occupiedColor)),
+      m_emptyColor(std::move(emptyColor)), m_showWindowTitle(showWindowTitle),
+      m_windowTitleMaxWidth(windowTitleMaxWidth), m_barPosition(std::move(barPosition)),
+      m_shadowConfig(std::move(shadowConfig)) {
   // Window title not implemented for vertical bars or workspace grouping.
   if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
     m_showWindowTitle = false;
@@ -1667,27 +1668,26 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
     m_contextMenuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), *renderContext);
   }
   m_contextMenuPopup->setShadowConfig(m_shadowConfig);
-  m_contextMenuPopup->setOnActivate(
-      [this, entryActions, entryAppName, entryWorkingDir, entryTerminal](const ContextMenuControlEntry& entry) {
+  m_contextMenuPopup->setOnActivate([this, entryActions, entryAppName, entryWorkingDir,
+                                     entryTerminal](const ContextMenuControlEntry& entry) {
     if (entry.id >= 0) {
       const auto idx = static_cast<std::size_t>(entry.id);
       if (idx < entryActions.size()) {
         const auto action = entryActions[idx];
-        DeferredCall::callLater(
-            [this, action, appName = entryAppName, workingDir = entryWorkingDir, terminal = entryTerminal]() {
-              std::string token;
-              if (m_platform.hasXdgActivation()) {
-                token = m_platform.requestActivationToken(nullptr);
+        DeferredCall::callLater([this, action, appName = entryAppName, workingDir = entryWorkingDir,
+                                 terminal = entryTerminal]() {
+          std::string token;
+          if (m_platform.hasXdgActivation()) {
+            token = m_platform.requestActivationToken(nullptr);
+          }
+          (void)desktop_entry_launch::launchAction(
+              action, appName, workingDir, terminal,
+              desktop_entry_launch::LaunchOptions{
+                  .activationToken = std::move(token),
+                  .runAsSystemdService = m_config.shell.launchAppsAsSystemdServices,
               }
-              (void)desktop_entry_launch::launchAction(
-                  action, appName, workingDir, terminal,
-                  desktop_entry_launch::LaunchOptions{
-                      .activationToken = std::move(token),
-                      .runAsSystemdService = m_config.shell.launchAppsAsSystemdServices,
-                  }
-              );
-            }
-        );
+          );
+        });
       }
       return;
     }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -2,6 +2,7 @@
 
 #include "compositors/compositor_detect.h"
 #include "compositors/workspace_backend.h"
+#include "config/config_service.h"
 #include "core/deferred_call.h"
 #include "i18n/i18n.h"
 #include "render/core/color.h"
@@ -143,13 +144,13 @@ namespace {
 } // namespace
 
 TaskbarWidget::TaskbarWidget(
-    CompositorPlatform& platform, const Config& config, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
+    CompositorPlatform& platform, ConfigService& config, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
     bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
     bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
     ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
     ShellConfig::ShadowConfig shadowConfig
 )
-    : m_platform(platform), m_config(config), m_output(output), m_groupByWorkspace(groupByWorkspace),
+    : m_platform(platform), m_configService(config), m_output(output), m_groupByWorkspace(groupByWorkspace),
       m_showAllOutputs(showAllOutputs), m_onlyActiveWorkspace(onlyActiveWorkspace),
       m_showWorkspaceLabel(showWorkspaceLabel), m_workspaceLabelPlacement(workspaceLabelPlacement),
       m_hideEmptyWorkspaces(hideEmptyWorkspaces), m_workspaceGroupCapsule(workspaceGroupCapsule),
@@ -1684,7 +1685,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
               action, appName, workingDir, terminal,
               desktop_entry_launch::LaunchOptions{
                   .activationToken = std::move(token),
-                  .runAsSystemdService = m_config.shell.launchAppsAsSystemdServices,
+                  .runAsSystemdService = m_configService.config().shell.launchAppsAsSystemdServices,
               }
           );
         });

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -25,6 +25,7 @@ struct ext_foreign_toplevel_handle_v1;
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <functional>
 #include <linux/input-event-codes.h>

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -143,20 +143,19 @@ namespace {
 } // namespace
 
 TaskbarWidget::TaskbarWidget(
-    CompositorPlatform& platform, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
+    CompositorPlatform& platform, const Config& config, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
     bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
     bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
     ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
-    ShellConfig::ShadowConfig shadowConfig, bool launchAppsAsSystemdService
+    ShellConfig::ShadowConfig shadowConfig
 )
-    : m_platform(platform), m_output(output), m_groupByWorkspace(groupByWorkspace), m_showAllOutputs(showAllOutputs),
-      m_onlyActiveWorkspace(onlyActiveWorkspace), m_showWorkspaceLabel(showWorkspaceLabel),
+    : m_platform(platform), m_config(config), m_output(output), m_groupByWorkspace(groupByWorkspace),
+      m_showAllOutputs(showAllOutputs), m_onlyActiveWorkspace(onlyActiveWorkspace), m_showWorkspaceLabel(showWorkspaceLabel),
       m_workspaceLabelPlacement(workspaceLabelPlacement), m_hideEmptyWorkspaces(hideEmptyWorkspaces),
       m_workspaceGroupCapsule(workspaceGroupCapsule), m_focusedColor(std::move(focusedColor)),
       m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
       m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
-      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)),
-      m_launchAppsAsSystemdService(launchAppsAsSystemdService) {
+      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)) {
   // Window title not implemented for vertical bars or workspace grouping.
   if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
     m_showWindowTitle = false;
@@ -1686,7 +1685,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
                   action, appName, workingDir, terminal,
                   desktop_entry_launch::LaunchOptions{
                       .activationToken = std::move(token),
-                      .runAsSystemdService = m_launchAppsAsSystemdService,
+                      .runAsSystemdService = m_config.shell.launchAppsAsSystemdServices,
                   }
               );
             }

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -32,7 +32,7 @@ public:
       bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
       bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
       ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
-      ShellConfig::ShadowConfig shadowConfig
+      ShellConfig::ShadowConfig shadowConfig, bool launchAppsAsSystemdService
   );
   ~TaskbarWidget() override;
 
@@ -111,6 +111,7 @@ private:
   float m_windowTitleMaxWidth = 100.0;
   std::string m_barPosition;
   ShellConfig::ShadowConfig m_shadowConfig;
+  bool m_launchAppsAsSystemdService = false;
   bool m_rebuildPending = true;
   bool m_vertical = false;
   std::uint64_t m_textMetricsGeneration = 0;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -13,9 +13,9 @@
 #include <vector>
 
 class ContextMenuPopup;
+class ConfigService;
 class Flex;
 class InputArea;
-struct Config;
 struct wl_output;
 struct zwlr_foreign_toplevel_handle_v1;
 struct PointerEvent;
@@ -29,11 +29,11 @@ enum class WorkspaceLabelPlacement {
 class TaskbarWidget : public Widget {
 public:
   TaskbarWidget(
-      CompositorPlatform& platform, const Config& config, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
-      bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
-      bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
-      ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
-      ShellConfig::ShadowConfig shadowConfig
+      CompositorPlatform& platform, ConfigService& config, wl_output* output, bool groupByWorkspace,
+      bool showAllOutputs, bool onlyActiveWorkspace, bool showWorkspaceLabel,
+      WorkspaceLabelPlacement workspaceLabelPlacement, bool hideEmptyWorkspaces, bool workspaceGroupCapsule,
+      ColorSpec focusedColor, ColorSpec occupiedColor, ColorSpec emptyColor, bool showWindowTitle,
+      float windowTitleMaxWidth, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
   );
   ~TaskbarWidget() override;
 
@@ -97,7 +97,7 @@ private:
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
 
   CompositorPlatform& m_platform;
-  const Config& m_config;
+  ConfigService& m_configService;
   wl_output* m_output = nullptr;
   bool m_groupByWorkspace = false;
   bool m_showAllOutputs = false;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -15,6 +15,7 @@
 class ContextMenuPopup;
 class Flex;
 class InputArea;
+struct Config;
 struct wl_output;
 struct zwlr_foreign_toplevel_handle_v1;
 struct PointerEvent;
@@ -28,11 +29,11 @@ enum class WorkspaceLabelPlacement {
 class TaskbarWidget : public Widget {
 public:
   TaskbarWidget(
-      CompositorPlatform& platform, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
+      CompositorPlatform& platform, const Config& config, wl_output* output, bool groupByWorkspace, bool showAllOutputs,
       bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
       bool hideEmptyWorkspaces, bool workspaceGroupCapsule, ColorSpec focusedColor, ColorSpec occupiedColor,
       ColorSpec emptyColor, bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition,
-      ShellConfig::ShadowConfig shadowConfig, bool launchAppsAsSystemdService
+      ShellConfig::ShadowConfig shadowConfig
   );
   ~TaskbarWidget() override;
 
@@ -96,6 +97,7 @@ private:
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
 
   CompositorPlatform& m_platform;
+  const Config& m_config;
   wl_output* m_output = nullptr;
   bool m_groupByWorkspace = false;
   bool m_showAllOutputs = false;
@@ -111,7 +113,6 @@ private:
   float m_windowTitleMaxWidth = 100.0;
   std::string m_barPosition;
   ShellConfig::ShadowConfig m_shadowConfig;
-  bool m_launchAppsAsSystemdService = false;
   bool m_rebuildPending = true;
   bool m_vertical = false;
   std::uint64_t m_textMetricsGeneration = 0;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -85,9 +85,8 @@ namespace {
     return instanceOutput;
   }
 
-  desktop_entry_launch::LaunchOptions dockLaunchOptions(
-      const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface
-  ) {
+  desktop_entry_launch::LaunchOptions
+  dockLaunchOptions(const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface) {
     std::string token;
     if (platform.hasXdgActivation()) {
       token = platform.requestActivationToken(activationSurface);
@@ -1553,9 +1552,7 @@ void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
 
   if (windows.empty()) {
     wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
-    (void)desktop_entry_launch::launchEntry(
-        item.entry, dockLaunchOptions(*m_platform, *m_config, activationSurface)
-    );
+    (void)desktop_entry_launch::launchEntry(item.entry, dockLaunchOptions(*m_platform, *m_config, activationSurface));
     return;
   }
 
@@ -1897,8 +1894,7 @@ void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
   menu->surface->setConfigureCallback([menuPtr](std::uint32_t /*w*/, std::uint32_t /*h*/) {
     menuPtr->surface->requestLayout();
   });
-  menu->surface->setPrepareFrameCallback([this, menuPtr, entries,
-                                          entryActions, entryId, entryWorkingDir,
+  menu->surface->setPrepareFrameCallback([this, menuPtr, entries, entryActions, entryId, entryWorkingDir,
                                           entryTerminal](bool /*needsUpdate*/, bool needsLayout) {
     if (m_renderContext == nullptr || menuPtr->surface == nullptr) {
       return;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -4,7 +4,6 @@
 #include "config/config_service.h"
 #include "core/deferred_call.h"
 #include "core/log.h"
-#include "core/process.h"
 #include "core/ui_phase.h"
 #include "i18n/i18n.h"
 #include "ipc/ipc_service.h"
@@ -16,6 +15,7 @@
 #include "shell/tooltip/tooltip_manager.h"
 #include "system/app_identity.h"
 #include "system/desktop_entry.h"
+#include "system/desktop_entry_launch.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu.h"
 #include "ui/palette.h"
@@ -83,6 +83,19 @@ namespace {
       return nullptr;
     }
     return instanceOutput;
+  }
+
+  desktop_entry_launch::LaunchOptions dockLaunchOptions(
+      const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface
+  ) {
+    std::string token;
+    if (platform.hasXdgActivation()) {
+      token = platform.requestActivationToken(activationSurface);
+    }
+    return desktop_entry_launch::LaunchOptions{
+        .activationToken = std::move(token),
+        .runAsSystemdService = config.config().shell.launchAppsAsSystemdServices,
+    };
   }
 
   zwlr_foreign_toplevel_handle_v1* nextActivatableWindowHandle(
@@ -1529,28 +1542,6 @@ std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
   return areaNode;
 }
 
-void Dock::launchEntry(const DesktopEntry& entry) {
-  if (entry.exec.empty()) {
-    kLog.warn("no exec for {}", entry.name);
-    return;
-  }
-  // Strip desktop-entry field codes (%u, %f, %F, %U, …).
-  std::string cmd;
-  cmd.reserve(entry.exec.size());
-  for (std::size_t i = 0; i < entry.exec.size(); ++i) {
-    if (entry.exec[i] == '%' && i + 1 < entry.exec.size()) {
-      ++i; // skip field code char
-      continue;
-    }
-    cmd += entry.exec[i];
-  }
-  while (!cmd.empty() && std::isspace(static_cast<unsigned char>(cmd.back()))) {
-    cmd.pop_back();
-  }
-  kLog.info("launching: {}", cmd);
-  (void)process::runAsync(cmd);
-}
-
 // ── Private: click handling ───────────────────────────────────────────────────
 
 void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
@@ -1561,7 +1552,10 @@ void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
   );
 
   if (windows.empty()) {
-    launchEntry(item.entry);
+    wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
+    (void)desktop_entry_launch::launchEntry(
+        item.entry, dockLaunchOptions(*m_platform, *m_config, activationSurface)
+    );
     return;
   }
 
@@ -1704,28 +1698,6 @@ void Dock::closeItemMenu() {
     }
     startHideFadeOut(*owner);
   }
-}
-
-void Dock::launchAction(const DesktopAction& action) {
-  if (action.exec.empty()) {
-    kLog.warn("no exec for action {}", action.name);
-    return;
-  }
-  // Strip desktop-entry field codes (%u, %f, %F, %U, …).
-  std::string cmd;
-  cmd.reserve(action.exec.size());
-  for (std::size_t i = 0; i < action.exec.size(); ++i) {
-    if (action.exec[i] == '%' && i + 1 < action.exec.size()) {
-      ++i;
-      continue;
-    }
-    cmd += action.exec[i];
-  }
-  while (!cmd.empty() && std::isspace(static_cast<unsigned char>(cmd.back()))) {
-    cmd.pop_back();
-  }
-  kLog.info("launching action: {}", cmd);
-  (void)process::runAsync(cmd);
 }
 
 void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
@@ -1918,12 +1890,16 @@ void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
 
   // Capture actions by value — item may be rebuilt before the callback fires.
   auto entryActions = item.entry.actions;
+  const std::string entryId = item.entry.id;
+  const std::string entryWorkingDir = item.entry.workingDir;
+  const bool entryTerminal = item.entry.terminal;
 
   menu->surface->setConfigureCallback([menuPtr](std::uint32_t /*w*/, std::uint32_t /*h*/) {
     menuPtr->surface->requestLayout();
   });
   menu->surface->setPrepareFrameCallback([this, menuPtr, entries,
-                                          entryActions](bool /*needsUpdate*/, bool needsLayout) {
+                                          entryActions, entryId, entryWorkingDir,
+                                          entryTerminal](bool /*needsUpdate*/, bool needsLayout) {
     if (m_renderContext == nullptr || menuPtr->surface == nullptr) {
       return;
     }
@@ -1962,11 +1938,13 @@ void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
       if (menuPtr->surface)
         menuPtr->surface->requestRedraw();
     });
-    ctrl->setOnActivate([this, menuPtr, entryActions](const ContextMenuControlEntry& e) {
+    ctrl->setOnActivate([this, menuPtr, entryActions, entryId, entryWorkingDir,
+                         entryTerminal](const ContextMenuControlEntry& e) {
       const std::int32_t id = e.id;
       auto menuHandles = menuPtr->handles;
       auto closingHandles = menuPtr->handles;
-      DeferredCall::callLater([this, id, entryActions, menuHandles = std::move(menuHandles),
+      DeferredCall::callLater([this, id, entryActions, entryId, entryWorkingDir, entryTerminal,
+                               menuHandles = std::move(menuHandles),
                                closingHandles = std::move(closingHandles)]() mutable {
         if (id <= kMenuWindowBaseId) {
           const auto idx = static_cast<std::size_t>(kMenuWindowBaseId - id);
@@ -1976,7 +1954,10 @@ void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
         } else if (id >= 0) {
           const auto idx = static_cast<std::size_t>(id);
           if (idx < entryActions.size()) {
-            launchAction(entryActions[idx]);
+            (void)desktop_entry_launch::launchAction(
+                entryActions[idx], entryId, entryWorkingDir, entryTerminal,
+                dockLaunchOptions(*m_platform, *m_config, nullptr)
+            );
           }
         } else if (id == kMenuCloseId && !closingHandles.empty()) {
           m_platform->closeToplevel(closingHandles[0]);

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -119,8 +119,6 @@ private:
   void updateVisuals(DockInstance& instance);
   void applyPanelPalette(DockInstance& instance);
   std::unique_ptr<InputArea> createLauncherButton(DockInstance& instance);
-  void launchEntry(const DesktopEntry& entry);
-  void launchAction(const DesktopAction& action);
   void handleItemClick(DockInstance& instance, DockItemView& item);
   void openItemMenu(DockInstance& instance, DockItemView& item);
   void closeItemMenu();

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -7,8 +7,8 @@
 #include <array>
 #include <cstdlib>
 #include <string>
-#include <utility>
 #include <unistd.h>
+#include <utility>
 
 namespace {
 
@@ -140,8 +140,8 @@ namespace {
     }
 
     static constexpr std::array<std::string_view, 11> kTerminalCandidates = {
-        "x-terminal-emulator", "ghostty",        "kitty", "alacritty", "wezterm", "foot",
-        "konsole",             "gnome-terminal", "kgx",   "ptyxis",    "xterm",
+        "x-terminal-emulator", "ghostty", "kitty",  "alacritty", "wezterm", "foot", "konsole",
+        "gnome-terminal",      "kgx",     "ptyxis", "xterm",
     };
     for (const auto candidate : kTerminalCandidates) {
       if (isExecutableOnPath(candidate)) {
@@ -182,9 +182,8 @@ namespace {
 
 namespace desktop_entry_launch {
 
-  std::optional<PreparedCommand> prepareCommand(
-      std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options
-  ) {
+  std::optional<PreparedCommand>
+  prepareCommand(std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options) {
     (void)workingDir;
 
     std::string cleanExec = stripFieldCodes(exec);

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -216,9 +216,10 @@ namespace desktop_entry_launch {
   }
 
   bool launchAction(
-      const DesktopAction& action, std::string_view appName, std::string_view workingDir, const LaunchOptions& options
+      const DesktopAction& action, std::string_view appName, std::string_view workingDir, bool terminal,
+      const LaunchOptions& options
   ) {
-    auto prepared = prepareCommand(action.exec, false, workingDir);
+    auto prepared = prepareCommand(action.exec, terminal, workingDir);
     if (!prepared.has_value()) {
       log.warn("Failed to prepare launch command for desktop action '{}'", action.id.empty() ? action.name : action.id);
       return false;

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -182,10 +182,7 @@ namespace {
 
 namespace desktop_entry_launch {
 
-  std::optional<PreparedCommand>
-  prepareCommand(std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options) {
-    (void)workingDir;
-
+  std::optional<PreparedCommand> prepareCommand(std::string_view exec, bool terminal, const PrepareOptions& options) {
     std::string cleanExec = stripFieldCodes(exec);
     std::vector<std::string> args = terminal ? terminalLaunchArgs(cleanExec, options) : tokenize(cleanExec);
 
@@ -200,7 +197,7 @@ namespace desktop_entry_launch {
   }
 
   bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options) {
-    auto prepared = prepareCommand(entry.exec, entry.terminal, entry.workingDir);
+    auto prepared = prepareCommand(entry.exec, entry.terminal);
     if (!prepared.has_value()) {
       log.warn("Failed to prepare launch command for desktop entry '{}'", entry.id.empty() ? entry.name : entry.id);
       return false;
@@ -218,7 +215,7 @@ namespace desktop_entry_launch {
       const DesktopAction& action, std::string_view appName, std::string_view workingDir, bool terminal,
       const LaunchOptions& options
   ) {
-    auto prepared = prepareCommand(action.exec, terminal, workingDir);
+    auto prepared = prepareCommand(action.exec, terminal);
     if (!prepared.has_value()) {
       log.warn("Failed to prepare launch command for desktop action '{}'", action.id.empty() ? action.name : action.id);
       return false;

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -126,7 +126,13 @@ namespace {
 
   std::vector<std::string> discoverTerminal(const desktop_entry_launch::PrepareOptions& options) {
     if (!options.terminalCandidates.empty()) {
-      return options.terminalCandidates;
+      for (const auto& candidate : options.terminalCandidates) {
+        std::vector<std::string> terminal = tokenize(candidate);
+        if (!terminal.empty() && isExecutableOnPath(terminal.front())) {
+          return terminal;
+        }
+      }
+      return {};
     }
     if (!options.useSystemTerminalDiscovery) {
       return {};

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -1,0 +1,236 @@
+#include "system/desktop_entry_launch.h"
+
+#include "core/log.h"
+#include "core/process.h"
+#include "util/file_utils.h"
+
+#include <array>
+#include <cstdlib>
+#include <string>
+#include <utility>
+#include <unistd.h>
+
+namespace {
+
+  const Logger log("desktop_entry_launch");
+
+  std::string stripFieldCodes(std::string_view exec) {
+    std::string result;
+    result.reserve(exec.size());
+    for (std::size_t i = 0; i < exec.size(); ++i) {
+      if (exec[i] == '%' && i + 1 < exec.size()) {
+        const char next = exec[i + 1];
+        if (next == 'f'
+            || next == 'F'
+            || next == 'u'
+            || next == 'U'
+            || next == 'd'
+            || next == 'D'
+            || next == 'n'
+            || next == 'N'
+            || next == 'i'
+            || next == 'c'
+            || next == 'k') {
+          ++i;
+          if (i + 1 < exec.size() && exec[i + 1] == ' ') {
+            ++i;
+          }
+          continue;
+        }
+        if (next == '%') {
+          result += '%';
+          ++i;
+          continue;
+        }
+      }
+      result += exec[i];
+    }
+
+    while (!result.empty() && result.back() == ' ') {
+      result.pop_back();
+    }
+    return result;
+  }
+
+  std::vector<std::string> tokenize(std::string_view cmd) {
+    std::vector<std::string> args;
+    std::string current;
+    bool inSingle = false;
+    bool inDouble = false;
+
+    for (const char c : cmd) {
+      if (c == '\'' && !inDouble) {
+        inSingle = !inSingle;
+        continue;
+      }
+      if (c == '"' && !inSingle) {
+        inDouble = !inDouble;
+        continue;
+      }
+      if (c == ' ' && !inSingle && !inDouble) {
+        if (!current.empty()) {
+          args.push_back(std::move(current));
+          current.clear();
+        }
+        continue;
+      }
+      current += c;
+    }
+    if (!current.empty()) {
+      args.push_back(std::move(current));
+    }
+    return args;
+  }
+
+  std::string expandExecutablePath(std::string_view binary) {
+    if (binary.empty() || binary.front() != '~') {
+      return std::string(binary);
+    }
+    return FileUtils::expandUserPath(std::string(binary)).string();
+  }
+
+  bool isExecutableOnPath(std::string_view binary) {
+    if (binary.empty()) {
+      return false;
+    }
+    if (binary.find('/') != std::string_view::npos) {
+      const std::string expanded = expandExecutablePath(binary);
+      return access(expanded.c_str(), X_OK) == 0;
+    }
+
+    const char* pathEnv = std::getenv("PATH");
+    if (pathEnv == nullptr || pathEnv[0] == '\0') {
+      return false;
+    }
+
+    std::string_view path(pathEnv);
+    std::size_t start = 0;
+    while (start <= path.size()) {
+      const auto sep = path.find(':', start);
+      const auto segment = sep == std::string_view::npos ? path.substr(start) : path.substr(start, sep - start);
+      if (!segment.empty()) {
+        std::string candidate(segment);
+        candidate.push_back('/');
+        candidate.append(binary);
+        if (access(candidate.c_str(), X_OK) == 0) {
+          return true;
+        }
+      }
+      if (sep == std::string_view::npos) {
+        break;
+      }
+      start = sep + 1;
+    }
+    return false;
+  }
+
+  std::vector<std::string> discoverTerminal(const desktop_entry_launch::PrepareOptions& options) {
+    if (!options.terminalCandidates.empty()) {
+      return options.terminalCandidates;
+    }
+    if (!options.useSystemTerminalDiscovery) {
+      return {};
+    }
+
+    if (const char* envTerminal = std::getenv("TERMINAL"); envTerminal != nullptr && envTerminal[0] != '\0') {
+      std::vector<std::string> terminal = tokenize(envTerminal);
+      if (!terminal.empty() && isExecutableOnPath(terminal.front())) {
+        return terminal;
+      }
+    }
+
+    static constexpr std::array<std::string_view, 11> kTerminalCandidates = {
+        "x-terminal-emulator", "ghostty",        "kitty", "alacritty", "wezterm", "foot",
+        "konsole",             "gnome-terminal", "kgx",   "ptyxis",    "xterm",
+    };
+    for (const auto candidate : kTerminalCandidates) {
+      if (isExecutableOnPath(candidate)) {
+        return {std::string(candidate)};
+      }
+    }
+    return {};
+  }
+
+  bool usesCommandSeparator(std::string_view terminal) {
+    return terminal == "gnome-terminal" || terminal == "kgx" || terminal == "ptyxis";
+  }
+
+  std::vector<std::string>
+  terminalLaunchArgs(std::string_view command, const desktop_entry_launch::PrepareOptions& options) {
+    std::vector<std::string> terminal = discoverTerminal(options);
+    if (terminal.empty()) {
+      return {};
+    }
+
+    const std::string termBin = terminal.front();
+    if (usesCommandSeparator(termBin)) {
+      terminal.emplace_back("--");
+    } else {
+      terminal.emplace_back("-e");
+    }
+    terminal.emplace_back("sh");
+    terminal.emplace_back("-lc");
+    terminal.emplace_back(command);
+    return terminal;
+  }
+
+  std::string appNameOrDefault(std::string_view appName) {
+    return appName.empty() ? "desktop-entry" : std::string(appName);
+  }
+
+} // namespace
+
+namespace desktop_entry_launch {
+
+  std::optional<PreparedCommand> prepareCommand(
+      std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options
+  ) {
+    (void)workingDir;
+
+    std::string cleanExec = stripFieldCodes(exec);
+    std::vector<std::string> args = terminal ? terminalLaunchArgs(cleanExec, options) : tokenize(cleanExec);
+
+    if (!args.empty() && args.front().find('/') != std::string::npos) {
+      args.front() = expandExecutablePath(args.front());
+    }
+
+    if (args.empty()) {
+      return std::nullopt;
+    }
+    return PreparedCommand{std::move(args)};
+  }
+
+  bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options) {
+    auto prepared = prepareCommand(entry.exec, entry.terminal, entry.workingDir);
+    if (!prepared.has_value()) {
+      log.warn("Failed to prepare launch command for desktop entry '{}'", entry.id.empty() ? entry.name : entry.id);
+      return false;
+    }
+
+    const std::string appName = !entry.id.empty() ? entry.id : appNameOrDefault(entry.name);
+    if (options.runAsSystemdService) {
+      process::runAsyncAsSystemdService(prepared->args, appName, options.activationToken, entry.workingDir);
+      return true;
+    }
+    return process::runAsync(prepared->args, options.activationToken, entry.workingDir);
+  }
+
+  bool launchAction(
+      const DesktopAction& action, std::string_view appName, std::string_view workingDir, const LaunchOptions& options
+  ) {
+    auto prepared = prepareCommand(action.exec, false, workingDir);
+    if (!prepared.has_value()) {
+      log.warn("Failed to prepare launch command for desktop action '{}'", action.id.empty() ? action.name : action.id);
+      return false;
+    }
+
+    if (options.runAsSystemdService) {
+      process::runAsyncAsSystemdService(
+          prepared->args, appNameOrDefault(appName), options.activationToken, std::string(workingDir)
+      );
+      return true;
+    }
+    return process::runAsync(prepared->args, options.activationToken, std::string(workingDir));
+  }
+
+} // namespace desktop_entry_launch

--- a/src/system/desktop_entry_launch.h
+++ b/src/system/desktop_entry_launch.h
@@ -23,9 +23,8 @@ namespace desktop_entry_launch {
     std::vector<std::string> args;
   };
 
-  [[nodiscard]] std::optional<PreparedCommand> prepareCommand(
-      std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options = {}
-  );
+  [[nodiscard]] std::optional<PreparedCommand>
+  prepareCommand(std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options = {});
 
   [[nodiscard]] bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options = {});
 

--- a/src/system/desktop_entry_launch.h
+++ b/src/system/desktop_entry_launch.h
@@ -30,7 +30,7 @@ namespace desktop_entry_launch {
   [[nodiscard]] bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options = {});
 
   [[nodiscard]] bool launchAction(
-      const DesktopAction& action, std::string_view appName, std::string_view workingDir,
+      const DesktopAction& action, std::string_view appName, std::string_view workingDir, bool terminal,
       const LaunchOptions& options = {}
   );
 

--- a/src/system/desktop_entry_launch.h
+++ b/src/system/desktop_entry_launch.h
@@ -24,7 +24,7 @@ namespace desktop_entry_launch {
   };
 
   [[nodiscard]] std::optional<PreparedCommand>
-  prepareCommand(std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options = {});
+  prepareCommand(std::string_view exec, bool terminal, const PrepareOptions& options = {});
 
   [[nodiscard]] bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options = {});
 

--- a/src/system/desktop_entry_launch.h
+++ b/src/system/desktop_entry_launch.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "system/desktop_entry.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace desktop_entry_launch {
+
+  struct LaunchOptions {
+    std::string activationToken;
+    bool runAsSystemdService = false;
+  };
+
+  struct PrepareOptions {
+    std::vector<std::string> terminalCandidates;
+    bool useSystemTerminalDiscovery = true;
+  };
+
+  struct PreparedCommand {
+    std::vector<std::string> args;
+  };
+
+  [[nodiscard]] std::optional<PreparedCommand> prepareCommand(
+      std::string_view exec, bool terminal, std::string_view workingDir, const PrepareOptions& options = {}
+  );
+
+  [[nodiscard]] bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options = {});
+
+  [[nodiscard]] bool launchAction(
+      const DesktopAction& action, std::string_view appName, std::string_view workingDir,
+      const LaunchOptions& options = {}
+  );
+
+} // namespace desktop_entry_launch

--- a/tests/desktop_entry_launch_test.cpp
+++ b/tests/desktop_entry_launch_test.cpp
@@ -43,38 +43,38 @@ int main() {
   bool ok = true;
 
   ok = expectArgs(
-           desktop_entry_launch::prepareCommand("sample --name %% --file %f --url %U --keep", false, ""),
+           desktop_entry_launch::prepareCommand("sample --name %% --file %f --url %U --keep", false),
            {"sample", "--name", "%", "--file", "--url", "--keep"}, "field codes should be removed"
        )
-       && ok;
+      && ok;
 
   ok = expectArgs(
-           desktop_entry_launch::prepareCommand("sample --title \"Hello World\" --single 'Two Words'", false, ""),
+           desktop_entry_launch::prepareCommand("sample --title \"Hello World\" --single 'Two Words'", false),
            {"sample", "--title", "Hello World", "--single", "Two Words"}, "quoted arguments should stay together"
        )
-       && ok;
+      && ok;
 
   desktop_entry_launch::PrepareOptions terminalOptions;
   terminalOptions.terminalCandidates = {"test-terminal"};
   ok = expectArgs(
-           desktop_entry_launch::prepareCommand("sample --flag", true, "", terminalOptions),
+           desktop_entry_launch::prepareCommand("sample --flag", true, terminalOptions),
            {"test-terminal", "-e", "sh", "-lc", "sample --flag"}, "terminal candidates should wrap the command"
        )
-       && ok;
+      && ok;
 
   desktop_entry_launch::PrepareOptions noTerminalDiscovery;
   noTerminalDiscovery.useSystemTerminalDiscovery = false;
   ok = expect(
-           !desktop_entry_launch::prepareCommand("sample --flag", true, "", noTerminalDiscovery).has_value(),
+           !desktop_entry_launch::prepareCommand("sample --flag", true, noTerminalDiscovery).has_value(),
            "terminal preparation should fail when discovery is disabled and no candidates are provided"
        )
-       && ok;
+      && ok;
 
   ok = expect(
-           !desktop_entry_launch::prepareCommand(" %f %U ", false, "").has_value(),
+           !desktop_entry_launch::prepareCommand(" %f %U ", false).has_value(),
            "field-code-only command should not prepare an empty argv"
        )
-       && ok;
+      && ok;
 
   return ok ? 0 : 1;
 }

--- a/tests/desktop_entry_launch_test.cpp
+++ b/tests/desktop_entry_launch_test.cpp
@@ -1,7 +1,10 @@
 #include "system/desktop_entry_launch.h"
 
 #include <cstdio>
+#include <cstdlib>
 #include <string>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 namespace {
@@ -37,6 +40,16 @@ namespace {
     return false;
   }
 
+  std::string makeExecutableFixture() {
+    char path[] = "/tmp/noctalia-terminal-fixture-XXXXXX";
+    const int fd = mkstemp(path);
+    if (fd >= 0) {
+      close(fd);
+      chmod(path, 0700);
+    }
+    return path;
+  }
+
 } // namespace
 
 int main() {
@@ -55,12 +68,15 @@ int main() {
       && ok;
 
   desktop_entry_launch::PrepareOptions terminalOptions;
-  terminalOptions.terminalCandidates = {"test-terminal"};
+  const std::string fakeTerminal = makeExecutableFixture();
+  terminalOptions.terminalCandidates = {"missing-terminal-candidate", fakeTerminal};
   ok = expectArgs(
            desktop_entry_launch::prepareCommand("sample --flag", true, terminalOptions),
-           {"test-terminal", "-e", "sh", "-lc", "sample --flag"}, "terminal candidates should wrap the command"
+           {fakeTerminal, "-e", "sh", "-lc", "sample --flag"},
+           "terminal candidates should use the first executable candidate"
        )
       && ok;
+  std::remove(fakeTerminal.c_str());
 
   desktop_entry_launch::PrepareOptions noTerminalDiscovery;
   noTerminalDiscovery.useSystemTerminalDiscovery = false;

--- a/tests/desktop_entry_launch_test.cpp
+++ b/tests/desktop_entry_launch_test.cpp
@@ -1,0 +1,80 @@
+#include "system/desktop_entry_launch.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::fprintf(stderr, "desktop_entry_launch_test: %s\n", message);
+    }
+    return condition;
+  }
+
+  bool expectArgs(
+      const std::optional<desktop_entry_launch::PreparedCommand>& command, const std::vector<std::string>& expected,
+      const char* message
+  ) {
+    if (!expect(command.has_value(), message)) {
+      return false;
+    }
+    if (command->args == expected) {
+      return true;
+    }
+
+    std::fprintf(stderr, "desktop_entry_launch_test: %s\n", message);
+    std::fprintf(stderr, "  expected:");
+    for (const auto& arg : expected) {
+      std::fprintf(stderr, " [%s]", arg.c_str());
+    }
+    std::fprintf(stderr, "\n  actual:");
+    for (const auto& arg : command->args) {
+      std::fprintf(stderr, " [%s]", arg.c_str());
+    }
+    std::fprintf(stderr, "\n");
+    return false;
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  ok = expectArgs(
+           desktop_entry_launch::prepareCommand("sample --name %% --file %f --url %U --keep", false, ""),
+           {"sample", "--name", "%", "--file", "--url", "--keep"}, "field codes should be removed"
+       )
+       && ok;
+
+  ok = expectArgs(
+           desktop_entry_launch::prepareCommand("sample --title \"Hello World\" --single 'Two Words'", false, ""),
+           {"sample", "--title", "Hello World", "--single", "Two Words"}, "quoted arguments should stay together"
+       )
+       && ok;
+
+  desktop_entry_launch::PrepareOptions terminalOptions;
+  terminalOptions.terminalCandidates = {"test-terminal"};
+  ok = expectArgs(
+           desktop_entry_launch::prepareCommand("sample --flag", true, "", terminalOptions),
+           {"test-terminal", "-e", "sh", "-lc", "sample --flag"}, "terminal candidates should wrap the command"
+       )
+       && ok;
+
+  desktop_entry_launch::PrepareOptions noTerminalDiscovery;
+  noTerminalDiscovery.useSystemTerminalDiscovery = false;
+  ok = expect(
+           !desktop_entry_launch::prepareCommand("sample --flag", true, "", noTerminalDiscovery).has_value(),
+           "terminal preparation should fail when discovery is disabled and no candidates are provided"
+       )
+       && ok;
+
+  ok = expect(
+           !desktop_entry_launch::prepareCommand(" %f %U ", false, "").has_value(),
+           "field-code-only command should not prepare an empty argv"
+       )
+       && ok;
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add a shared desktop entry launch helper for Exec parsing, terminal wrapping, systemd-run mode, working directory, and activation tokens.
- Migrate launcher, dock, and taskbar desktop-entry action launches to the shared helper.
- Remove duplicated dock/taskbar launch wrappers while preserving live config behavior for taskbar launches.

## Test Plan
- [x] meson test -C build --print-errorlogs
- [x] meson compile -C build noctalia
- [x] duplicate launch scan confirms only the shared helper owns desktop-entry launch handling