### PR TITLE
feat(nix): add default.nix for compatibility with non-flake setups

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,10 @@
 let
-  inherit (builtins) fromJSON readFile;
+  inherit (builtins)
+    fromJSON
+    readFile
+    substring
+    pathExists
+    ;
 
   lock = fromJSON (readFile ./flake.lock);
   namedNode = lock.nodes.${lock.nodes.root.inputs.nixpkgs}.locked;
@@ -12,10 +17,34 @@ in
   pkgs ? import nixpkgs { },
 }:
 let
-  inherit (builtins) substring;
   inherit (pkgs.lib) cleanSource mkDefault concatStringsSep;
 
-  src = fetchGit ./.;
+  # Taken from flake-compat
+  src =
+    let
+      tryFetchGit =
+        if (pathExists ./.git) then
+          let
+            res = fetchGit ./.;
+          in
+          if res.rev == "0000000000000000000000000000000000000000" then
+            removeAttrs res [
+              "rev"
+              "shortRev"
+            ]
+          else
+            res
+        else
+          {
+            outPath = ./.;
+          };
+
+    in
+    {
+      lastModified = 0;
+      lastModifiedDate = "19700101";
+    }
+    // tryFetchGit;
 
   mkDate =
     longDate:

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,48 @@
+let
+  inherit (builtins) fromJSON readFile;
+
+  lock = fromJSON (readFile ./flake.lock);
+  namedNode = lock.nodes.${lock.nodes.root.inputs.nixpkgs}.locked;
+  nixpkgs = fetchTarball {
+    inherit (namedNode) url;
+    sha256 = namedNode.narHash;
+  };
+in
+{
+  pkgs ? import nixpkgs { },
+}:
+let
+  inherit (builtins) substring;
+  inherit (pkgs.lib) cleanSource mkDefault concatStringsSep;
+
+  src = fetchGit ./.;
+
+  mkDate =
+    longDate:
+    concatStringsSep "-" [
+      (substring 0 4 longDate)
+      (substring 4 2 longDate)
+      (substring 6 2 longDate)
+    ];
+
+  shortRev = src.shortRev or "dirty";
+
+  package = (pkgs.callPackage ./nix/package.nix { }) {
+    inherit shortRev;
+    version = mkDate (src.lastModifiedDate or "19700101") + "_" + shortRev;
+    src = cleanSource src;
+  };
+in
+{
+  hjemModule = {
+    imports = [ ./nix/hjem-module.nix ];
+    programs.noctalia.package = mkDefault package;
+  };
+
+  homeModule = {
+    imports = [ ./nix/home-module.nix ];
+    programs.noctalia.package = mkDefault package;
+  };
+
+  inherit package;
+}

--- a/default.nix
+++ b/default.nix
@@ -56,21 +56,23 @@ let
 
   shortRev = src.shortRev or "dirty";
 
-  package = (pkgs.callPackage ./nix/package.nix { }) {
+  package = pkgs.callPackage ./nix/package.nix {
     inherit shortRev;
     version = mkDate (src.lastModifiedDate or "19700101") + "_" + shortRev;
-    src = cleanSource src;
+    source = cleanSource src;
   };
 in
 {
   hjemModule = {
     imports = [ ./nix/hjem-module.nix ];
     programs.noctalia.package = mkDefault package;
+    _class = "hjem";
   };
 
   homeModule = {
     imports = [ ./nix/home-module.nix ];
     programs.noctalia.package = mkDefault package;
+    _class = "homeManager";
   };
 
   inherit package;

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,8 @@
   outputs =
     { self, nixpkgs }:
     let
-      inherit (nixpkgs) lib;
+      inherit (builtins) substring;
+      inherit (nixpkgs.lib) concatStringsSep genAttrs getExe;
 
       systems = [
         "x86_64-linux"
@@ -17,7 +18,7 @@
 
       forEachSystem =
         perSystem:
-        lib.genAttrs systems (
+        genAttrs systems (
           system:
           let
             pkgs = nixpkgs.legacyPackages.${system};
@@ -27,10 +28,10 @@
 
       mkDate =
         longDate:
-        nixpkgs.lib.concatStringsSep "-" [
-          (builtins.substring 0 4 longDate)
-          (builtins.substring 4 2 longDate)
-          (builtins.substring 6 2 longDate)
+        concatStringsSep "-" [
+          (substring 0 4 longDate)
+          (substring 4 2 longDate)
+          (substring 6 2 longDate)
         ];
 
       shortRev = self.shortRev or "dirty";
@@ -38,13 +39,17 @@
     in
     {
       overlays.default = final: prev: {
-        noctalia = final.callPackage ./nix/package.nix { inherit version shortRev; };
+        default = (final.callPackage ./nix/package.nix { }) {
+          inherit version shortRev;
+        };
       };
 
       packages = forEachSystem (
         { pkgs, ... }:
         {
-          default = pkgs.callPackage ./nix/package.nix { inherit version shortRev; };
+          default = (pkgs.callPackage ./nix/package.nix { }) {
+            inherit version shortRev;
+          };
         }
       );
 
@@ -62,7 +67,7 @@
         {
           default = {
             type = "app";
-            program = lib.getExe self.packages.${system}.default;
+            program = getExe self.packages.${system}.default;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
     in
     {
       overlays.default = final: prev: {
-        default = (final.callPackage ./nix/package.nix { }) {
+        noctalia = final.callPackage ./nix/package.nix {
           inherit version shortRev;
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
       packages = forEachSystem (
         { pkgs, ... }:
         {
-          default = (pkgs.callPackage ./nix/package.nix { }) {
+          default = pkgs.callPackage ./nix/package.nix {
             inherit version shortRev;
           };
         }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,8 +1,6 @@
 {
   lib,
   stdenv,
-  shortRev,
-  version,
   meson,
   ninja,
   pkg-config,
@@ -28,14 +26,18 @@
   librsvg,
   libqalculate,
   libxml2,
-  jemalloc
+  jemalloc,
 }:
-
+{
+  src ? lib.cleanSource ./..,
+  shortRev,
+  version,
+}:
 stdenv.mkDerivation {
   pname = "noctalia";
   inherit version;
 
-  src = lib.cleanSource ../.;
+  inherit src;
 
   postPatch = ''
     # Remove -march=native and -mtune=native for reproducible builds

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,9 +27,7 @@
   libqalculate,
   libxml2,
   jemalloc,
-}:
-{
-  src ? lib.cleanSource ./..,
+  source ? lib.cleanSource ./..,
   shortRev,
   version,
 }:
@@ -37,7 +35,7 @@ stdenv.mkDerivation {
   pname = "noctalia";
   inherit version;
 
-  inherit src;
+  src = source;
 
   postPatch = ''
     # Remove -march=native and -mtune=native for reproducible builds


### PR DESCRIPTION
## Motivation
The package is currently very cumbersome to install without flakes, unless you package it manually.
A lot of nix/nixos users don't use flakes, so I thought it'd be a nice idea to have a simpler frontend for grabbing the package and home-manager/hjem modules.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Swapped out my pin for noctalia-shell to my fork, imported it, and grabbed the package out. Worked fine.

## Additional Notes
I wasn't able to replicate the `shortRev` or `lastModifiedDate` functionality from the flake, so I marked this as a draft in case someone knows how to do it. However, the package works fine, and nix's hashing system prevent conflicts, so it's fully functional