### PR TITLE
refactor(dock): split dock responsibilities

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -458,6 +458,7 @@ _noctalia_sources = files(
   'src/shell/dock/dock.cpp',
   'src/shell/dock/dock_context_menu.cpp',
   'src/shell/dock/dock_geometry.cpp',
+  'src/shell/dock/dock_instance.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',
   'src/shell/desktop/desktop_widget_settings_registry.cpp',

--- a/meson.build
+++ b/meson.build
@@ -459,6 +459,7 @@ _noctalia_sources = files(
   'src/shell/dock/dock_context_menu.cpp',
   'src/shell/dock/dock_geometry.cpp',
   'src/shell/dock/dock_instance.cpp',
+  'src/shell/dock/dock_items.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',
   'src/shell/desktop/desktop_widget_settings_registry.cpp',

--- a/meson.build
+++ b/meson.build
@@ -456,6 +456,7 @@ _noctalia_sources = files(
   'src/shell/bar/bar.cpp',
   'src/shell/clipboard/clipboard_paste.cpp',
   'src/shell/dock/dock.cpp',
+  'src/shell/dock/dock_geometry.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',
   'src/shell/desktop/desktop_widget_settings_registry.cpp',

--- a/meson.build
+++ b/meson.build
@@ -456,6 +456,7 @@ _noctalia_sources = files(
   'src/shell/bar/bar.cpp',
   'src/shell/clipboard/clipboard_paste.cpp',
   'src/shell/dock/dock.cpp',
+  'src/shell/dock/dock_context_menu.cpp',
   'src/shell/dock/dock_geometry.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -44,6 +44,11 @@ namespace {
     assert(renderContext != nullptr);
   }
 
+  void assertDockCoreInitialized(const CompositorPlatform* platform, const ConfigService* config) {
+    assert(platform != nullptr);
+    assert(config != nullptr);
+  }
+
   desktop_entry_launch::LaunchOptions
   dockLaunchOptions(const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface) {
     std::string token;
@@ -508,8 +513,9 @@ void Dock::createInstance(const WaylandOutput& output) {
 // ── Private: scene building ───────────────────────────────────────────────────
 
 bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
-  assert(m_platform != nullptr);
-  assert(m_config != nullptr);
+  if (m_platform == nullptr || m_config == nullptr) {
+    return false;
+  }
 
   return shell::dock::syncInstanceModel(
       instance,
@@ -526,7 +532,10 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
 // ── Private: item population ──────────────────────────────────────────────────
 
 void Dock::rebuildItems(shell::dock::DockInstance& instance) {
-  assertDockInitialized(m_platform, m_config, m_renderContext);
+  assertDockCoreInitialized(m_platform, m_config);
+  if (m_renderContext == nullptr) {
+    return;
+  }
 
   shell::dock::rebuildItems(
       instance,

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -249,7 +249,7 @@ void Dock::pruneCachedToplevelHandles() {
   });
 }
 
-void Dock::detachInstanceState(DockInstance& inst) {
+void Dock::detachInstanceState(shell::dock::DockInstance& inst) {
   if (inst.surface != nullptr) {
     if (wl_surface* const wls = inst.surface->wlSurface()) {
       m_surfaceMap.erase(wls);
@@ -355,8 +355,9 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
           current, 1.0f, Style::animNormal, Easing::EaseOutCubic,
           [inst = m_hoveredInstance, this](float v) {
             inst->hideOpacity = v;
-            syncDockSlideLayerTransform(*inst);
-            applyDockCompositorBlur(*inst);
+            const auto& cfg = m_config->config().dock;
+            shell::dock::syncDockSlideLayerTransform(*inst, cfg);
+            shell::dock::applyDockCompositorBlur(*inst, cfg);
           },
           [inst = m_hoveredInstance]() { inst->hideAnimId = 0; }
       );
@@ -389,8 +390,8 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
         }
       }
 
-      if (m_config->config().dock.autoHide && m_popupOwnerInstance == nullptr) {
-        startHideFadeOut(*m_hoveredInstance);
+      if (m_config != nullptr && m_config->config().dock.autoHide && m_popupOwnerInstance == nullptr) {
+        shell::dock::startHideFadeOut(*m_hoveredInstance, *m_config);
       }
       m_hoveredInstance = nullptr;
     }
@@ -405,7 +406,7 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
   case PointerEvent::Type::Button: {
     auto it = m_surfaceMap.find(event.surface);
     if (it != m_surfaceMap.end()) {
-      DockInstance* targetInstance = it->second;
+      shell::dock::DockInstance* targetInstance = it->second;
       if (m_hoveredInstance != targetInstance) {
         if (m_hoveredInstance != nullptr) {
           m_hoveredInstance->pointerInside = false;
@@ -562,7 +563,7 @@ void Dock::createInstance(const WaylandOutput& output) {
       cfg.position
   );
 
-  auto instance = std::make_unique<DockInstance>();
+  auto instance = std::make_unique<shell::dock::DockInstance>();
   instance->outputName = output.name;
   instance->output = output.output;
   instance->scale = output.scale;
@@ -581,7 +582,20 @@ void Dock::createInstance(const WaylandOutput& output) {
     inst->surface->requestLayout();
   });
   instance->surface->setPrepareFrameCallback([this, inst](bool needsUpdate, bool needsLayout) {
-    prepareFrame(*inst, needsUpdate, needsLayout);
+    if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
+      return;
+    }
+    shell::dock::prepareFrame(
+        *inst, {.platform = *m_platform, .config = *m_config, .renderContext = *m_renderContext},
+        shell::dock::DockInstanceCallbacks{
+            .syncModel = [this](shell::dock::DockInstance& callbackInstance) {
+              return syncInstanceModel(callbackInstance);
+            },
+            .rebuildItems = [this](shell::dock::DockInstance& callbackInstance) { rebuildItems(callbackInstance); },
+            .updateVisuals = [this](shell::dock::DockInstance& callbackInstance) { updateVisuals(callbackInstance); },
+        },
+        needsUpdate, needsLayout
+    );
   });
   instance->surface->setAnimationManager(&instance->animations);
 
@@ -596,40 +610,7 @@ void Dock::createInstance(const WaylandOutput& output) {
 
 // ── Private: scene building ───────────────────────────────────────────────────
 
-void Dock::prepareFrame(DockInstance& instance, bool needsUpdate, bool needsLayout) {
-  if (m_renderContext == nullptr || instance.surface == nullptr) {
-    return;
-  }
-
-  const auto width = instance.surface->width();
-  const auto height = instance.surface->height();
-  if (width == 0 || height == 0) {
-    return;
-  }
-
-  m_renderContext->makeCurrent(instance.surface->renderTarget());
-
-  bool needsModelRebuild = false;
-  if (needsUpdate || instance.sceneRoot == nullptr) {
-    UiPhaseScope updatePhase(UiPhase::Update);
-    needsModelRebuild = syncInstanceModel(instance);
-  }
-
-  const bool needsSceneBuild = instance.sceneRoot == nullptr
-      || static_cast<std::uint32_t>(std::round(instance.sceneRoot->width())) != width
-      || static_cast<std::uint32_t>(std::round(instance.sceneRoot->height())) != height;
-  if (needsSceneBuild || needsLayout || needsModelRebuild) {
-    UiPhaseScope layoutPhase(UiPhase::Layout);
-    if (needsModelRebuild && instance.sceneRoot != nullptr) {
-      rebuildItems(instance);
-    }
-    buildScene(instance);
-  } else if (needsUpdate) {
-    updateVisuals(instance);
-  }
-}
-
-bool Dock::syncInstanceModel(DockInstance& instance) {
+bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
   if (m_platform == nullptr || m_config == nullptr) {
     return false;
   }
@@ -692,188 +673,9 @@ bool Dock::syncInstanceModel(DockInstance& instance) {
   return needRebuild;
 }
 
-void Dock::syncDockSlideLayerTransform(DockInstance& instance) {
-  if (instance.slideRoot == nullptr) {
-    return;
-  }
-  const auto& cfg = m_config->config().dock;
-  if (cfg.autoHide) {
-    const float t = 1.0f - instance.hideOpacity;
-    instance.slideRoot->setPosition(instance.slideHiddenDx * t, instance.slideHiddenDy * t);
-  } else {
-    instance.slideRoot->setPosition(0.0f, 0.0f);
-  }
-}
-
-void Dock::applyDockCompositorBlur(DockInstance& instance) {
-  const auto& cfg = m_config->config().dock;
-  if (instance.surface == nullptr) {
-    return;
-  }
-  // Compositor blur is independent of scene opacity — clear it while auto-hide
-  // has faded the dock out so a transparent buffer does not leave a blur halo.
-  constexpr float kBlurVisibleOpacity = 0.02f;
-  if (cfg.autoHide && instance.hideOpacity < kBlurVisibleOpacity) {
-    instance.surface->clearBlurRegion();
-    return;
-  }
-  if (instance.panel == nullptr) {
-    return;
-  }
-  float absX = 0.0f;
-  float absY = 0.0f;
-  Node::absolutePosition(instance.panel, absX, absY);
-  const int px = static_cast<int>(std::lround(absX));
-  const int py = static_cast<int>(std::lround(absY));
-  const int pw = static_cast<int>(std::lround(instance.panel->width()));
-  const int ph = static_cast<int>(std::lround(instance.panel->height()));
-  const Radii radii = shell::dock::dockCornerRadii(cfg);
-  auto blurStrips = Surface::tessellateRoundedRect(px, py, pw, ph, radii.tl, radii.tr, radii.br, radii.bl);
-  instance.surface->setBlurRegion(blurStrips);
-}
-
-void Dock::buildScene(DockInstance& instance) {
-  uiAssertNotRendering("Dock::buildScene");
-  if (m_renderContext == nullptr || instance.surface == nullptr) {
-    return;
-  }
-
-  const auto& cfg = m_config->config().dock;
-  const bool vert = shell::dock::isVerticalPosition(cfg.position);
-
-  const float w = static_cast<float>(instance.surface->width());
-  const float h = static_cast<float>(instance.surface->height());
-
-  const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto panelGeometry = shell::dock::computePanelGeometry(cfg, shadowConfig, w, h);
-  const Radii radii = shell::dock::dockCornerRadii(cfg);
-
-  if (instance.sceneRoot == nullptr) {
-    instance.sceneRoot = std::make_unique<Node>();
-    instance.sceneRoot->setAnimationManager(&instance.animations);
-    instance.sceneRoot->setSize(w, h);
-    instance.sceneRoot->setOpacity(1.0f);
-
-    auto slide = std::make_unique<Node>();
-    slide->setParticipatesInLayout(false);
-    instance.slideRoot = instance.sceneRoot->addChild(std::move(slide));
-
-    // Shadow
-    if (shell::surface_shadow::enabled(cfg.shadow, shadowConfig)) {
-      instance.shadow = static_cast<Box*>(instance.slideRoot->addChild(ui::box()));
-    }
-
-    // Panel background
-    instance.panel = static_cast<Box*>(instance.slideRoot->addChild(
-        ui::box({
-            .configure = [radii](Box& box) { box.setRadii(radii); },
-        })
-    ));
-
-    // Item row
-    instance.row = static_cast<Flex*>(instance.panel->addChild(makeDockItemRow(cfg, vert)));
-
-    // Wire up InputDispatcher.
-    instance.inputDispatcher.setSceneRoot(instance.sceneRoot.get());
-    instance.inputDispatcher.setCursorShapeCallback([this](std::uint32_t serial, std::uint32_t shape) {
-      m_platform->setCursorShape(serial, shape);
-    });
-    instance.inputDispatcher.setHoverChangeCallback([inst = &instance](InputArea* /*old*/, InputArea* next) {
-      TooltipManager::instance().onHoverChange(next, inst->surface->layerSurface(), inst->output);
-    });
-
-    // Populate items and wire up palette reactivity.
-    rebuildItems(instance);
-
-    if (cfg.autoHide) {
-      // Start off-screen (slide); opacity stays at 1 so the compositor blur matches the panel.
-      instance.slideRoot->setOpacity(1.0f);
-      instance.hideOpacity = 0.0f;
-    } else {
-      instance.slideRoot->setOpacity(0.0f);
-      instance.hideOpacity = 1.0f;
-      instance.animations.animate(
-          0.0f, 1.0f, Style::animSlow, Easing::EaseOutCubic,
-          [slide = instance.slideRoot](float v) { slide->setOpacity(v); }, {}, instance.slideRoot
-      );
-    }
-
-    instance.surface->setSceneRoot(instance.sceneRoot.get());
-  }
-
-  // Update root size on reconfigure.
-  instance.sceneRoot->setSize(w, h);
-  if (instance.slideRoot != nullptr) {
-    instance.slideRoot->setSize(w, h);
-  }
-
-  // Shadow
-  if (instance.shadow != nullptr) {
-    const float shadowOffsetX = static_cast<float>(shadowConfig.offsetX);
-    const float shadowOffsetY = static_cast<float>(shadowConfig.offsetY);
-    const RoundedRectStyle shadowStyle = shell::surface_shadow::style(
-        shadowConfig, cfg.backgroundOpacity, shell::surface_shadow::Shape{.radius = radii}
-    );
-    instance.shadow->setStyle(shadowStyle);
-    instance.shadow->setZIndex(-1);
-    instance.shadow->setPosition(panelGeometry.panelX + shadowOffsetX, panelGeometry.panelY + shadowOffsetY);
-    instance.shadow->setSize(panelGeometry.panelW, panelGeometry.panelH);
-  }
-
-  // Panel
-  applyPanelPalette(instance);
-  instance.panel->setPosition(panelGeometry.panelX, panelGeometry.panelY);
-  instance.panel->setSize(panelGeometry.panelW, panelGeometry.panelH);
-
-  // Row fills panel (padding already applied via Flex::setPadding).
-  instance.row->setPosition(0.0f, 0.0f);
-  instance.row->setSize(panelGeometry.panelW, panelGeometry.panelH);
-  instance.row->layout(*m_renderContext);
-
-  if (cfg.autoHide) {
-    const auto hiddenDelta = shell::dock::computeHiddenSlideDelta(cfg, shadowConfig, w, h, panelGeometry);
-    instance.slideHiddenDx = hiddenDelta.first;
-    instance.slideHiddenDy = hiddenDelta.second;
-  } else {
-    instance.slideHiddenDx = 0.0f;
-    instance.slideHiddenDy = 0.0f;
-  }
-  syncDockSlideLayerTransform(instance);
-
-  // Input region: trigger strip when hidden (autoHide), full panel otherwise.
-  const bool hiddenInputRegion = cfg.autoHide && instance.hideOpacity < 0.5f;
-  auto inputPanelGeometry = panelGeometry;
-  if (!hiddenInputRegion && instance.slideRoot != nullptr) {
-    inputPanelGeometry.panelX += instance.slideRoot->x();
-    inputPanelGeometry.panelY += instance.slideRoot->y();
-  }
-  instance.surface->setInputRegion(shell::dock::computeInputRegion(
-      cfg, inputPanelGeometry, static_cast<int>(w), static_cast<int>(h), hiddenInputRegion
-  ));
-
-  applyDockCompositorBlur(instance);
-
-  // Palette reactivity.
-  instance.paletteConn = paletteChanged().connect([inst = &instance, this] {
-    applyPanelPalette(*inst);
-    if (inst->surface)
-      inst->surface->requestRedraw();
-  });
-
-  updateVisuals(instance);
-}
-
-void Dock::applyPanelPalette(DockInstance& instance) {
-  if (instance.panel == nullptr)
-    return;
-  const float opacity = m_config->config().dock.backgroundOpacity;
-  instance.panel->setFill(colorSpecFromRole(ColorRole::Surface, opacity));
-  instance.panel->setBorder(colorSpecFromRole(ColorRole::Outline), 0.0f);
-}
-
 // ── Private: item population ──────────────────────────────────────────────────
 
-void Dock::rebuildItems(DockInstance& instance) {
+void Dock::rebuildItems(shell::dock::DockInstance& instance) {
   uiAssertNotRendering("Dock::rebuildItems");
   if (instance.row == nullptr || m_renderContext == nullptr) {
     return;
@@ -1115,27 +917,12 @@ void Dock::rebuildItems(DockInstance& instance) {
   instance.modelSerial = m_modelSerial;
 
   // Force surface resize when item count changes.
-  resizeSurface(instance);
-}
-
-void Dock::resizeSurface(DockInstance& instance) {
-  if (instance.surface == nullptr) {
-    return;
-  }
-
-  const auto& cfg = m_config->config().dock;
-  const auto surfaceGeometry = shell::dock::computeSurfaceGeometry(
-      cfg, m_config->config().shell.shadow, instance.items.size() + shell::dock::dockLauncherButtonCount(cfg)
-  );
-
-  if (instance.surface->width() != surfaceGeometry.surfaceW || instance.surface->height() != surfaceGeometry.surfaceH) {
-    instance.surface->requestSize(surfaceGeometry.surfaceW, surfaceGeometry.surfaceH);
-  }
+  shell::dock::resizeSurface(instance, cfg, m_config->config().shell.shadow);
 }
 
 // ── Private: visual update ────────────────────────────────────────────────────
 
-void Dock::updateVisuals(DockInstance& instance) {
+void Dock::updateVisuals(shell::dock::DockInstance& instance) {
   const auto& cfg = m_config->config().dock;
 
   for (auto& item : instance.items) {
@@ -1246,11 +1033,13 @@ void Dock::updateVisuals(DockInstance& instance) {
 
 // ── Private: helpers ──────────────────────────────────────────────────────────
 
-bool Dock::matchesActiveApp(const DockItemView& item, std::string_view activeIdLower) const {
+bool Dock::matchesActiveApp(const shell::dock::DockItemView& item, std::string_view activeIdLower) const {
   return !activeIdLower.empty() && activeIdLower == item.idLower;
 }
 
-bool Dock::matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) const {
+bool Dock::matchesRunningApp(
+    const shell::dock::DockItemView& item, const std::vector<std::string>& runningLower
+) const {
   for (const auto& rid : runningLower) {
     if (!rid.empty() && rid == item.idLower) {
       return true;
@@ -1259,7 +1048,7 @@ bool Dock::matchesRunningApp(const DockItemView& item, const std::vector<std::st
   return false;
 }
 
-std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
+std::unique_ptr<InputArea> Dock::createLauncherButton(shell::dock::DockInstance& instance) {
   const auto& cfg = m_config->config().dock;
   const bool vert = shell::dock::isVerticalPosition(cfg.position);
   const float iSize = static_cast<float>(cfg.iconSize);
@@ -1328,7 +1117,7 @@ std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
 
 // ── Private: click handling ───────────────────────────────────────────────────
 
-void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
+void Dock::handleItemClick(shell::dock::DockInstance& instance, shell::dock::DockItemView& item) {
   pruneCachedToplevelHandles();
 
   auto windows = m_platform->windowsForApp(
@@ -1362,55 +1151,22 @@ void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
 
 // ── Private: item context menu (right-click) ──────────────────────────────────
 
-void Dock::startHideFadeOut(DockInstance& inst) {
-  if (inst.hideAnimId != 0) {
-    inst.animations.cancel(inst.hideAnimId);
-    inst.hideAnimId = 0;
-  }
-  const float current = inst.hideOpacity;
-  inst.hideAnimId = inst.animations.animate(
-      current, 0.0f, Style::animSlow, Easing::EaseInQuad,
-      [&inst, this](float v) {
-        inst.hideOpacity = v;
-        syncDockSlideLayerTransform(inst);
-        applyDockCompositorBlur(inst);
-      },
-      [&inst, this]() {
-        inst.hideAnimId = 0;
-        if (inst.surface == nullptr)
-          return;
-        const auto& cfg = m_config->config().dock;
-        const bool vert = shell::dock::isVerticalPosition(cfg.position);
-        const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-        const auto panelW = shell::dock::dockContentSize(cfg, inst.items.size());
-        const auto panelH = shell::dock::dockThickness(cfg);
-        const auto surfW = static_cast<int>(vert ? (sb.left + panelH + sb.right) : (panelW + sb.left + sb.right));
-        const auto surfH = static_cast<int>(vert ? (panelW + sb.up + sb.down) : (sb.up + panelH + cfg.marginEdge));
-        inst.surface->setInputRegion(
-            shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, surfW, surfH, true)
-        );
-      }
-  );
-  if (inst.surface)
-    inst.surface->requestRedraw();
-}
-
 void Dock::closeItemMenu() {
-  DockInstance* owner = m_popupOwnerInstance;
+  shell::dock::DockInstance* owner = m_popupOwnerInstance;
   m_popupOwnerInstance = nullptr;
   m_itemMenu.reset();
   // Fade the owner out — the pointer left the dock to interact with the menu,
   // whether or not the compositor sent a Leave event at that time.
-  if (m_config->config().dock.autoHide && owner != nullptr && owner->hideOpacity > 0.0f) {
+  if (m_config != nullptr && m_config->config().dock.autoHide && owner != nullptr && owner->hideOpacity > 0.0f) {
     owner->pointerInside = false;
     if (m_hoveredInstance == owner) {
       m_hoveredInstance = nullptr;
     }
-    startHideFadeOut(*owner);
+    shell::dock::startHideFadeOut(*owner, *m_config);
   }
 }
 
-void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
+void Dock::openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item) {
   if (m_config == nullptr) {
     m_popupOwnerInstance = nullptr;
     m_itemMenu.reset();

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -10,6 +10,7 @@
 #include "render/render_context.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "shell/dock/dock_geometry.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"
 #include "shell/tooltip/tooltip_manager.h"
@@ -44,32 +45,6 @@ namespace {
   constexpr float kDotSizeRatio = 0.09f;
   constexpr float kDotMinSize = 4.0f;
   constexpr float kDotGap = 3.0f;
-
-  // Thin strip (px) kept in the input region when auto-hide is in the hidden
-  // state, so the pointer can re-trigger show on approach to the screen edge.
-  constexpr std::int32_t kAutoHideTriggerPx = 2;
-  constexpr float kAutoHideSlideExtraPx = 16.0f;
-
-  // Slide the whole dock chrome (panel ± shadow) completely past the layer buffer edge, same
-  // idea as notification toasts driving `reveal` until the full card width has cleared the surface.
-  std::pair<float, float> computeAutoHideHiddenDelta(
-      bool vert, bool isBottom, bool isRight, float w, float h, float contentLeft, float contentTop, float contentRight,
-      float contentBottom
-  ) {
-    const float k = kAutoHideSlideExtraPx;
-    if (!vert) {
-      if (isBottom) {
-        // After slide: contentTop + dy >= h (+ slack) so nothing remains inside the buffer.
-        return {0.0f, (h - contentTop) + k};
-      }
-      // Top-anchored: move up until contentBottom + dy <= 0.
-      return {0.0f, -(contentBottom + k)};
-    }
-    if (isRight) {
-      return {(w - contentLeft) + k, 0.0f};
-    }
-    return {-(contentRight + k), 0.0f};
-  }
 
   std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
     if (const auto active = platform.activeToplevel(); active.has_value()) {
@@ -183,32 +158,8 @@ namespace {
     return signature;
   }
 
-  // Returns an anchor bitmask for the given position string.
-  std::uint32_t positionToAnchor(const std::string& pos) {
-    if (pos == "top")
-      return LayerShellAnchor::Top;
-    if (pos == "left")
-      return LayerShellAnchor::Left;
-    if (pos == "right")
-      return LayerShellAnchor::Right;
-    return LayerShellAnchor::Bottom; // default
-  }
-
-  std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
-    return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
-  }
-
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
     return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
-  }
-
-  Radii dockCornerRadii(const DockConfig& cfg) {
-    return Radii{
-        static_cast<float>(cfg.radiusTopLeft),
-        static_cast<float>(cfg.radiusTopRight),
-        static_cast<float>(cfg.radiusBottomRight),
-        static_cast<float>(cfg.radiusBottomLeft),
-    };
   }
 
   std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical) {
@@ -522,29 +473,6 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
   return m_hoveredInstance != nullptr;
 }
 
-// ── Private: geometry helpers ─────────────────────────────────────────────────
-
-bool Dock::isVertical() const {
-  const auto& pos = m_config->config().dock.position;
-  return pos == "left" || pos == "right";
-}
-
-std::int32_t Dock::dockThickness() const {
-  const auto& cfg = m_config->config().dock;
-  constexpr std::int32_t kCellPad = 6;
-  return cfg.iconSize + kCellPad * 2 + cfg.padding * 2;
-}
-
-std::int32_t Dock::dockContentSize(std::size_t itemCount) const {
-  const auto& cfg = m_config->config().dock;
-  const auto n = static_cast<std::int32_t>(itemCount);
-  constexpr std::int32_t kCellPad = 6;
-  const std::int32_t cellSize = cfg.iconSize + kCellPad * 2;
-  if (n == 0)
-    return cellSize + cfg.padding * 2;
-  return n * cellSize + std::max(0, n - 1) * cfg.itemSpacing + cfg.padding * 2;
-}
-
 // ── Private: instance management ─────────────────────────────────────────────
 
 bool Dock::refreshPinnedAppsIfNeeded() {
@@ -603,7 +531,7 @@ void Dock::syncInstances() {
   const auto& outputs = m_platform->outputs();
   const auto& cfg = m_config->config().dock;
   const auto& selectedMonitors = cfg.monitors;
-  const bool hasStaticContent = !cfg.pinned.empty() || dockLauncherButtonCount(cfg) > 0;
+  const bool hasStaticContent = !cfg.pinned.empty() || shell::dock::dockLauncherButtonCount(cfg) > 0;
   // When activeMonitorOnly is off, the running-apps check is identical for every output, so hoist it.
   const bool anyRunningGlobal = (!hasStaticContent && cfg.showRunning && !cfg.activeMonitorOnly)
       ? !m_platform->runningAppIds(nullptr).empty()
@@ -665,67 +593,10 @@ void Dock::createInstance(const WaylandOutput& output) {
   instance->scale = output.scale;
   instance->activeAppIdLower = currentActiveEntryIdLower(*m_platform);
 
-  const bool vert = isVertical();
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadowConfig);
-  const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
-  const auto panelW = dockContentSize(cfg.pinned.size() + dockLauncherButtonCount(cfg));
-  const auto panelH = dockThickness();
-  const auto anchor = positionToAnchor(cfg.position);
-  const bool isBottom = (cfg.position == "bottom");
-  const bool isRight = (cfg.position == "right");
-
-  // Surface dimensions incorporate shadow bleed + margin.
-  std::uint32_t surfW, surfH;
-  std::int32_t mL = 0, mR = 0, mT = 0, mB = 0;
-  std::int32_t exclusiveZone = 0;
-
-  if (!vert) {
-    // Horizontal dock (top / bottom): ends inset = left/right, edge gap = top/bottom.
-    surfW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
-    surfH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
-    if (isBottom) {
-      mB = std::max(0, cfg.marginEdge - sb.down);
-      surfH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
-      exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.down));
-    } else {
-      mT = std::max(0, cfg.marginEdge - sb.up);
-      surfH = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.up) + panelH + sb.down);
-      exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.up) + panelH);
-    }
-    // marginEnds is applied symmetrically as compositor side margins.
-    mL = cfg.marginEnds;
-    mR = cfg.marginEnds;
-  } else {
-    // Vertical dock (left / right): ends inset = top/bottom, edge gap = left/right.
-    surfH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
-    if (isRight) {
-      mR = std::max(0, cfg.marginEdge - sb.right);
-      surfW = static_cast<std::uint32_t>(sb.left + panelH + std::min(cfg.marginEdge, sb.right));
-      exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.right));
-    } else {
-      mL = std::max(0, cfg.marginEdge - sb.left);
-      surfW = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.left) + panelH + sb.right);
-      exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.left) + panelH);
-    }
-    mT = cfg.marginEnds;
-    mB = cfg.marginEnds;
-  }
-
-  LayerSurfaceConfig lsCfg{
-      .nameSpace = "noctalia-dock",
-      .layer = LayerShellLayer::Top,
-      .anchor = anchor,
-      .width = surfW,
-      .height = surfH,
-      .exclusiveZone = exclusiveZone,
-      .marginTop = mT,
-      .marginRight = mR,
-      .marginBottom = mB,
-      .marginLeft = mL,
-      .defaultWidth = surfW,
-      .defaultHeight = surfH,
-  };
+  LayerSurfaceConfig lsCfg = shell::dock::makeLayerSurfaceConfig(
+      cfg, shadowConfig, cfg.pinned.size() + shell::dock::dockLauncherButtonCount(cfg)
+  );
 
   instance->surface = std::make_unique<LayerSurface>(m_platform->wayland(), std::move(lsCfg));
   instance->surface->setRenderContext(m_renderContext);
@@ -881,7 +752,7 @@ void Dock::applyDockCompositorBlur(DockInstance& instance) {
   const int py = static_cast<int>(std::lround(absY));
   const int pw = static_cast<int>(std::lround(instance.panel->width()));
   const int ph = static_cast<int>(std::lround(instance.panel->height()));
-  const Radii radii = dockCornerRadii(cfg);
+  const Radii radii = shell::dock::dockCornerRadii(cfg);
   auto blurStrips = Surface::tessellateRoundedRect(px, py, pw, ph, radii.tl, radii.tr, radii.br, radii.bl);
   instance.surface->setBlurRegion(blurStrips);
 }
@@ -893,36 +764,14 @@ void Dock::buildScene(DockInstance& instance) {
   }
 
   const auto& cfg = m_config->config().dock;
-  const bool vert = isVertical();
+  const bool vert = shell::dock::isVerticalPosition(cfg.position);
 
   const float w = static_cast<float>(instance.surface->width());
   const float h = static_cast<float>(instance.surface->height());
 
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadowConfig);
-  const float bleedL = static_cast<float>(sb.left);
-  const float bleedR = static_cast<float>(sb.right);
-  const float bleedU = static_cast<float>(sb.up);
-  const float bleedD = static_cast<float>(sb.down);
-  const float mEdge = static_cast<float>(cfg.marginEdge);
-  const bool isBottom = (cfg.position == "bottom");
-  const bool isRight = (cfg.position == "right");
-
-  // Panel visual area within the surface.
-  float panelX, panelY, panelW, panelH;
-  if (!vert) {
-    panelX = bleedL;
-    panelY = isBottom ? bleedU : std::min(mEdge, bleedU);
-    panelW = w - bleedL - bleedR;
-    panelH = static_cast<float>(dockThickness());
-  } else {
-    panelX = isRight ? bleedL : std::min(mEdge, bleedL);
-    panelY = bleedU;
-    panelW = static_cast<float>(dockThickness());
-    panelH = h - bleedU - bleedD;
-  }
-
-  const Radii radii = dockCornerRadii(cfg);
+  const auto panelGeometry = shell::dock::computePanelGeometry(cfg, shadowConfig, w, h);
+  const Radii radii = shell::dock::dockCornerRadii(cfg);
 
   if (instance.sceneRoot == nullptr) {
     instance.sceneRoot = std::make_unique<Node>();
@@ -992,35 +841,22 @@ void Dock::buildScene(DockInstance& instance) {
     );
     instance.shadow->setStyle(shadowStyle);
     instance.shadow->setZIndex(-1);
-    instance.shadow->setPosition(panelX + shadowOffsetX, panelY + shadowOffsetY);
-    instance.shadow->setSize(panelW, panelH);
+    instance.shadow->setPosition(panelGeometry.panelX + shadowOffsetX, panelGeometry.panelY + shadowOffsetY);
+    instance.shadow->setSize(panelGeometry.panelW, panelGeometry.panelH);
   }
 
   // Panel
   applyPanelPalette(instance);
-  instance.panel->setPosition(panelX, panelY);
-  instance.panel->setSize(panelW, panelH);
+  instance.panel->setPosition(panelGeometry.panelX, panelGeometry.panelY);
+  instance.panel->setSize(panelGeometry.panelW, panelGeometry.panelH);
 
   // Row fills panel (padding already applied via Flex::setPadding).
   instance.row->setPosition(0.0f, 0.0f);
-  instance.row->setSize(panelW, panelH);
+  instance.row->setSize(panelGeometry.panelW, panelGeometry.panelH);
   instance.row->layout(*m_renderContext);
 
   if (cfg.autoHide) {
-    float contentLeft = panelX;
-    float contentTop = panelY;
-    float contentRight = panelX + panelW;
-    float contentBottom = panelY + panelH;
-    if (instance.shadow != nullptr) {
-      const float sx = panelX + static_cast<float>(shadowConfig.offsetX);
-      const float sy = panelY + static_cast<float>(shadowConfig.offsetY);
-      contentLeft = std::min(contentLeft, sx);
-      contentTop = std::min(contentTop, sy);
-      contentRight = std::max(contentRight, sx + panelW);
-      contentBottom = std::max(contentBottom, sy + panelH);
-    }
-    const auto hiddenDelta =
-        computeAutoHideHiddenDelta(vert, isBottom, isRight, w, h, contentLeft, contentTop, contentRight, contentBottom);
+    const auto hiddenDelta = shell::dock::computeHiddenSlideDelta(cfg, shadowConfig, w, h, panelGeometry);
     instance.slideHiddenDx = hiddenDelta.first;
     instance.slideHiddenDy = hiddenDelta.second;
   } else {
@@ -1030,27 +866,15 @@ void Dock::buildScene(DockInstance& instance) {
   syncDockSlideLayerTransform(instance);
 
   // Input region: trigger strip when hidden (autoHide), full panel otherwise.
-  if (cfg.autoHide && instance.hideOpacity < 0.5f) {
-    const int surfW = static_cast<int>(w);
-    const int surfH = static_cast<int>(h);
-    if (!vert) {
-      instance.surface->setInputRegion({InputRect{0, surfH - kAutoHideTriggerPx, surfW, kAutoHideTriggerPx}});
-    } else if (cfg.position == "left") {
-      instance.surface->setInputRegion({InputRect{surfW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfH}});
-    } else {
-      instance.surface->setInputRegion({InputRect{0, 0, kAutoHideTriggerPx, surfH}});
-    }
-  } else {
-    float absX = 0.0f;
-    float absY = 0.0f;
-    Node::absolutePosition(instance.panel, absX, absY);
-    instance.surface->setInputRegion({InputRect{
-        static_cast<int>(std::lround(absX)),
-        static_cast<int>(std::lround(absY)),
-        static_cast<int>(std::lround(instance.panel->width())),
-        static_cast<int>(std::lround(instance.panel->height())),
-    }});
+  const bool hiddenInputRegion = cfg.autoHide && instance.hideOpacity < 0.5f;
+  auto inputPanelGeometry = panelGeometry;
+  if (!hiddenInputRegion && instance.slideRoot != nullptr) {
+    inputPanelGeometry.panelX += instance.slideRoot->x();
+    inputPanelGeometry.panelY += instance.slideRoot->y();
   }
+  instance.surface->setInputRegion(shell::dock::computeInputRegion(
+      cfg, inputPanelGeometry, static_cast<int>(w), static_cast<int>(h), hiddenInputRegion
+  ));
 
   applyDockCompositorBlur(instance);
 
@@ -1081,7 +905,7 @@ void Dock::rebuildItems(DockInstance& instance) {
   }
 
   const auto& cfg = m_config->config().dock;
-  const bool vert = isVertical();
+  const bool vert = shell::dock::isVerticalPosition(cfg.position);
   const float iSize = static_cast<float>(cfg.iconSize);
 
   for (auto& item : instance.items) {
@@ -1221,7 +1045,7 @@ void Dock::rebuildItems(DockInstance& instance) {
 
     if (cfg.showDots) {
       const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
-      const bool verticalDots = cfg.position == "left" || cfg.position == "right";
+      const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
 
       for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
         item.dotIndicators[dotIndex] = static_cast<Box*>(areaNode->addChild(
@@ -1325,26 +1149,12 @@ void Dock::resizeSurface(DockInstance& instance) {
   }
 
   const auto& cfg = m_config->config().dock;
-  const bool vert = isVertical();
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-  const auto panelW = dockContentSize(instance.items.size() + dockLauncherButtonCount(cfg));
-  const auto panelH = dockThickness();
-  const bool isBottom = (cfg.position == "bottom");
+  const auto surfaceGeometry = shell::dock::computeSurfaceGeometry(
+      cfg, m_config->config().shell.shadow, instance.items.size() + shell::dock::dockLauncherButtonCount(cfg)
+  );
 
-  std::uint32_t surfW, surfH;
-  if (!vert) {
-    surfW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
-    surfH = isBottom ? static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down))
-                     : static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.up) + panelH + sb.down);
-  } else {
-    const bool isRight = (cfg.position == "right");
-    surfW = isRight ? static_cast<std::uint32_t>(sb.left + panelH + std::min(cfg.marginEdge, sb.right))
-                    : static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.left) + panelH + sb.right);
-    surfH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
-  }
-
-  if (instance.surface->width() != surfW || instance.surface->height() != surfH) {
-    instance.surface->requestSize(surfW, surfH);
+  if (instance.surface->width() != surfaceGeometry.surfaceW || instance.surface->height() != surfaceGeometry.surfaceH) {
+    instance.surface->requestSize(surfaceGeometry.surfaceW, surfaceGeometry.surfaceH);
   }
 }
 
@@ -1414,7 +1224,7 @@ void Dock::updateVisuals(DockInstance& instance) {
       const float groupLength =
           dotCount == 0 ? dot : dot * static_cast<float>(dotCount) + kDotGap * static_cast<float>(dotCount - 1);
       const float groupStart = std::round((cellMain - groupLength) * 0.5f);
-      const bool verticalDots = cfg.position == "left" || cfg.position == "right";
+      const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
 
       for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
         if (item.dotIndicators[dotIndex] == nullptr) {
@@ -1476,7 +1286,7 @@ bool Dock::matchesRunningApp(const DockItemView& item, const std::vector<std::st
 
 std::unique_ptr<InputArea> Dock::createLauncherButton(DockInstance& instance) {
   const auto& cfg = m_config->config().dock;
-  const bool vert = isVertical();
+  const bool vert = shell::dock::isVerticalPosition(cfg.position);
   const float iSize = static_cast<float>(cfg.iconSize);
   constexpr float kCellPad = 6.0f;
   const float cellMain = iSize + 2.0f * kCellPad;
@@ -1663,19 +1473,15 @@ void Dock::startHideFadeOut(DockInstance& inst) {
         if (inst.surface == nullptr)
           return;
         const auto& cfg = m_config->config().dock;
-        const bool vert = isVertical();
+        const bool vert = shell::dock::isVerticalPosition(cfg.position);
         const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-        const auto panelW = dockContentSize(inst.items.size());
-        const auto panelH = dockThickness();
+        const auto panelW = shell::dock::dockContentSize(cfg, inst.items.size());
+        const auto panelH = shell::dock::dockThickness(cfg);
         const auto surfW = static_cast<int>(vert ? (sb.left + panelH + sb.right) : (panelW + sb.left + sb.right));
         const auto surfH = static_cast<int>(vert ? (panelW + sb.up + sb.down) : (sb.up + panelH + cfg.marginEdge));
-        if (!vert) {
-          inst.surface->setInputRegion({InputRect{0, surfH - kAutoHideTriggerPx, surfW, kAutoHideTriggerPx}});
-        } else if (cfg.position == "left") {
-          inst.surface->setInputRegion({InputRect{surfW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfH}});
-        } else {
-          inst.surface->setInputRegion({InputRect{0, 0, kAutoHideTriggerPx, surfH}});
-        }
+        inst.surface->setInputRegion(
+            shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, surfW, surfH, true)
+        );
       }
   );
   if (inst.surface)
@@ -1826,7 +1632,7 @@ void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
   }
 
   const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-  const std::int32_t panelThk = dockThickness();
+  const std::int32_t panelThk = shell::dock::dockThickness(cfg);
   const std::int32_t ptrX = static_cast<std::int32_t>(m_platform->lastPointerX());
   const std::int32_t ptrY = static_cast<std::int32_t>(m_platform->lastPointerY());
   const std::int32_t halfCell = cfg.iconSize / 2;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -10,6 +10,7 @@
 #include "render/scene/node.h"
 #include "shell/dock/dock_context_menu.h"
 #include "shell/dock/dock_geometry.h"
+#include "shell/dock/dock_items.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"
 #include "shell/tooltip/tooltip_manager.h"
@@ -33,28 +34,6 @@ namespace {
 
   constexpr Logger kLog("dock");
 
-  // Instance-count badge geometry — scales with icon size.
-  constexpr float kBadgeSizeRatio = 0.30f; // fraction of icon size
-  constexpr float kBadgeMinSize = 16.0f;   // minimum diameter in px
-  constexpr float kBadgeFontRatio = 0.72f; // font size relative to badge diameter
-  constexpr float kDotSizeRatio = 0.09f;
-  constexpr float kDotMinSize = 4.0f;
-  constexpr float kDotGap = 3.0f;
-
-  std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
-    if (const auto active = platform.activeToplevel(); active.has_value()) {
-      return StringUtils::toLower(app_identity::resolveRunningDesktopEntry(active->appId, desktopEntries()).id);
-    }
-    return {};
-  }
-
-  wl_output* currentDockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput) {
-    if (!cfg.activeMonitorOnly) {
-      return nullptr;
-    }
-    return instanceOutput;
-  }
-
   desktop_entry_launch::LaunchOptions
   dockLaunchOptions(const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface) {
     std::string token;
@@ -65,36 +44,6 @@ namespace {
         .activationToken = std::move(token),
         .runAsSystemdService = config.config().shell.launchAppsAsSystemdServices,
     };
-  }
-
-  zwlr_foreign_toplevel_handle_v1* nextActivatableWindowHandle(
-      const std::vector<ToplevelInfo>& windows, zwlr_foreign_toplevel_handle_v1* activeHandle,
-      zwlr_foreign_toplevel_handle_v1* preferredHandle
-  ) {
-    for (std::size_t i = 0; i < windows.size(); ++i) {
-      if (windows[i].handle != nullptr && windows[i].handle == activeHandle) {
-        for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
-          auto* nextHandle = windows[(i + offset) % windows.size()].handle;
-          if (nextHandle != nullptr) {
-            return nextHandle;
-          }
-        }
-        return nullptr;
-      }
-    }
-
-    for (const auto& window : windows) {
-      if (window.handle != nullptr && window.handle == preferredHandle) {
-        return window.handle;
-      }
-    }
-
-    for (const auto& window : windows) {
-      if (window.handle != nullptr) {
-        return window.handle;
-      }
-    }
-    return nullptr;
   }
 
   template <typename T> void appendOptionalStackPart(std::string& out, const std::optional<T>& value) {
@@ -130,21 +79,6 @@ namespace {
     }
 
     return signature;
-  }
-
-  std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
-    return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
-  }
-
-  std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical) {
-    return ui::flex(
-        vertical ? FlexDirection::Vertical : FlexDirection::Horizontal,
-        {
-            .align = FlexAlign::Center,
-            .gap = static_cast<float>(cfg.itemSpacing),
-            .padding = static_cast<float>(cfg.padding),
-        }
-    );
   }
 
 } // namespace
@@ -452,55 +386,9 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
 // ── Private: instance management ─────────────────────────────────────────────
 
 bool Dock::refreshPinnedAppsIfNeeded() {
-  if (desktopEntriesVersion() == m_entriesVersion && m_config->config().dock.pinned == m_lastPinnedConfig) {
-    return false;
-  }
-
-  m_lastPinnedConfig = m_config->config().dock.pinned;
-  m_entriesVersion = desktopEntriesVersion();
-  m_pinnedEntries.clear();
-
-  const auto& entries = desktopEntries();
-
-  for (const auto& pinnedId : m_config->config().dock.pinned) {
-    const auto pinnedLower = StringUtils::toLower(pinnedId);
-    bool found = false;
-
-    for (const auto& entry : entries) {
-      if (entry.hidden || entry.noDisplay) {
-        continue;
-      }
-      // Match by entry ID (stem of the desktop file path, e.g. "firefox"),
-      // by StartupWMClass (lower), or by Name (lower).
-      const auto stemLower = StringUtils::toLower([&] {
-        // Extract stem: "org.mozilla.firefox.desktop" → "firefox" (last component, no ext)
-        const auto slash = entry.id.rfind('/');
-        const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
-        const auto dot = base.rfind('.');
-        return (dot == std::string::npos) ? base : base.substr(0, dot);
-      }());
-
-      if (stemLower == pinnedLower || app_identity::desktopEntryMatchesLower(entry, pinnedLower)) {
-        m_pinnedEntries.push_back(entry);
-        found = true;
-        break;
-      }
-    }
-
-    if (!found) {
-      kLog.debug("pinned app not found: {}", pinnedId);
-      // Add placeholder so the pinned slot is visible even when app is not installed.
-      DesktopEntry placeholder;
-      placeholder.id = pinnedId;
-      placeholder.name = pinnedId;
-      placeholder.nameLower = pinnedLower;
-      m_pinnedEntries.push_back(std::move(placeholder));
-    }
-  }
-
-  ++m_modelSerial;
-  kLog.debug("pinned app list: {} entries", m_pinnedEntries.size());
-  return true;
+  return shell::dock::refreshPinnedAppsIfNeeded(
+      m_config->config().dock, m_lastPinnedConfig, m_pinnedEntries, m_modelSerial, m_entriesVersion
+  );
 }
 
 void Dock::syncInstances() {
@@ -567,7 +455,7 @@ void Dock::createInstance(const WaylandOutput& output) {
   instance->outputName = output.name;
   instance->output = output.output;
   instance->scale = output.scale;
-  instance->activeAppIdLower = currentActiveEntryIdLower(*m_platform);
+  instance->activeAppIdLower = shell::dock::currentActiveEntryIdLower(*m_platform);
 
   const auto& shadowConfig = m_config->config().shell.shadow;
   LayerSurfaceConfig lsCfg = shell::dock::makeLayerSurfaceConfig(
@@ -615,538 +503,72 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
     return false;
   }
 
-  const auto& cfg = m_config->config().dock;
-  const std::string globalActiveIdLower = currentActiveEntryIdLower(*m_platform);
-  if (!globalActiveIdLower.empty()) {
-    if (const auto active = m_platform->activeToplevel(); active.has_value() && active->handle != nullptr) {
-      m_lastActiveHandleByAppIdLower[globalActiveIdLower] = active->handle;
-    }
-  }
-  wl_output* const activeOutput = m_platform->activeToplevelOutput();
-  wl_output* filterOutput = currentDockFilterOutput(cfg, instance.output);
-  const bool filterOutputChanged = (filterOutput != instance.lastFilterOutput);
-  instance.lastFilterOutput = filterOutput;
-
-  // When filtering by active monitor, inactive monitors' docks should not
-  // highlight the globally-active app — it isn't on them.
-  const std::string activeIdLower =
-      (cfg.activeMonitorOnly && activeOutput != instance.output) ? std::string{} : globalActiveIdLower;
-  instance.activeAppIdLower = activeIdLower;
-
-  const auto runningIds = cfg.showRunning ? m_platform->runningAppIds(filterOutput) : std::vector<std::string>{};
-  const auto& allEntries = desktopEntries();
-  const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
-  std::vector<std::string> runningLower;
-  runningLower.reserve(resolvedRunning.size());
-  for (const auto& run : resolvedRunning) {
-    runningLower.push_back(StringUtils::toLower(run.entry.id));
-  }
-
-  bool needRebuild = (instance.modelSerial != m_modelSerial) || filterOutputChanged;
-  if (!needRebuild && cfg.showRunning) {
-    const std::size_t expectedTotal = [&] {
-      std::vector<DesktopEntry> entries = m_pinnedEntries;
-      for (const auto& run : resolvedRunning) {
-        bool present = false;
-        for (const auto& entry : entries) {
-          if (app_identity::desktopEntryMatchesLower(entry, run.runningLower)) {
-            present = true;
-            break;
-          }
-        }
-        if (!present) {
-          entries.push_back(run.entry);
-        }
+  return shell::dock::syncInstanceModel(
+      instance,
+      {
+          .platform = *m_platform,
+          .config = *m_config,
+          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+          .pinnedEntries = m_pinnedEntries,
+          .modelSerial = m_modelSerial,
       }
-      return entries.size();
-    }();
-    if (expectedTotal != instance.items.size()) {
-      needRebuild = true;
-    }
-  }
-
-  for (auto& item : instance.items) {
-    item.running = matchesRunningApp(item, runningLower);
-    item.active = matchesActiveApp(item, activeIdLower);
-  }
-
-  return needRebuild;
+  );
 }
 
 // ── Private: item population ──────────────────────────────────────────────────
 
 void Dock::rebuildItems(shell::dock::DockInstance& instance) {
-  uiAssertNotRendering("Dock::rebuildItems");
-  if (instance.row == nullptr || m_renderContext == nullptr) {
+  if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
     return;
   }
 
-  const auto& cfg = m_config->config().dock;
-  const bool vert = shell::dock::isVerticalPosition(cfg.position);
-  const float iSize = static_cast<float>(cfg.iconSize);
-
-  for (auto& item : instance.items) {
-    if (item.scaleAnimId != 0) {
-      instance.animations.cancel(item.scaleAnimId);
-      item.scaleAnimId = 0;
-    }
-    if (item.opacityAnimId != 0) {
-      instance.animations.cancel(item.opacityAnimId);
-      item.opacityAnimId = 0;
-    }
-  }
-
-  // Clear previous items by recreating the row.
-  if (instance.row != nullptr && instance.panel != nullptr) {
-    instance.panel->removeChild(instance.row);
-    instance.row = nullptr;
-  }
-  instance.items.clear();
-
-  // Create a fresh row.
-  auto freshRow = makeDockItemRow(cfg, vert);
-  instance.row = static_cast<Flex*>(
-      instance.panel != nullptr ? instance.panel->addChild(std::move(freshRow))
-                                : instance.sceneRoot->addChild(std::move(freshRow))
+  shell::dock::rebuildItems(
+      instance,
+      {
+          .platform = *m_platform,
+          .config = *m_config,
+          .renderContext = *m_renderContext,
+          .iconResolver = m_iconResolver,
+          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+          .pinnedEntries = m_pinnedEntries,
+          .modelSerial = m_modelSerial,
+      },
+      {
+          .pruneCachedToplevelHandles = [this]() { pruneCachedToplevelHandles(); },
+          .launchOptions =
+              [this](wl_surface* activationSurface) {
+                return dockLaunchOptions(*m_platform, *m_config, activationSurface);
+              },
+          .toggleLauncher =
+              [](shell::dock::DockInstance& inst) {
+                PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = inst.output});
+              },
+          .openItemMenu = [this](shell::dock::DockInstance& inst, shell::dock::DockItemView& item) {
+            openItemMenu(inst, item);
+          },
+      }
   );
-
-  // Determine items: pinned + (optionally) running-only apps not in pinned.
-  std::vector<DesktopEntry> itemEntries = m_pinnedEntries;
-  wl_output* filterOutput = currentDockFilterOutput(cfg, instance.output);
-  instance.lastFilterOutput = filterOutput;
-
-  if (cfg.showRunning) {
-    const auto runningIds = m_platform->runningAppIds(filterOutput);
-    const auto& allEntries = desktopEntries();
-    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
-
-    for (const auto& run : resolvedRunning) {
-      // Skip if already in itemEntries (covers pinned entries).
-      bool alreadyPresent = false;
-      for (const auto& itm : itemEntries) {
-        if (app_identity::desktopEntryMatchesLower(itm, run.runningLower)) {
-          alreadyPresent = true;
-          break;
-        }
-      }
-      if (alreadyPresent)
-        continue;
-
-      itemEntries.push_back(run.entry);
-    }
-  }
-
-  const auto activeIdLower = instance.activeAppIdLower;
-  const auto runningIds = m_platform->runningAppIds(filterOutput);
-  const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
-  std::vector<std::string> runningLower;
-  runningLower.reserve(resolvedRunning.size());
-  for (const auto& run : resolvedRunning) {
-    runningLower.push_back(StringUtils::toLower(run.entry.id));
-  }
-
-  if (cfg.launcherPosition == "start") {
-    instance.row->addChild(createLauncherButton(instance));
-  }
-
-  // Reserve up-front so emplace_back never reallocates while lambdas hold raw pointers.
-  instance.items.reserve(itemEntries.size());
-
-  for (const auto& entry : itemEntries) {
-    auto& item = instance.items.emplace_back();
-    item.entry = entry;
-    item.idLower = StringUtils::toLower(entry.id);
-    item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
-    item.active = matchesActiveApp(item, activeIdLower);
-    item.running = matchesRunningApp(item, runningLower);
-
-    // Cell is icon + kCellPad on each side; hover bg fills the full cell.
-    constexpr float kCellPad = 6.0f; // px extra on each side
-    const float cellMain = iSize + 2.0f * kCellPad;
-    const float cellCross = iSize + 2.0f * kCellPad;
-    auto areaNode = std::make_unique<InputArea>();
-    if (!vert) {
-      areaNode->setSize(cellMain, cellCross);
-    } else {
-      areaNode->setSize(cellCross, cellMain);
-    }
-
-    // Hover background — fills cell, radius matches dock panel.
-    areaNode->addChild(
-        ui::box({
-            .out = &item.background,
-            .fill = clearColorSpec(),
-            .radius = static_cast<float>(cfg.radius),
-            .width = cellMain,
-            .height = cellMain, // square — excludes indicator strip
-            .configure = [](Box& box) { box.setPosition(0.0f, 0.0f); },
-        })
-    );
-
-    // Icon centred inside the padded cell.
-    const std::string& iconPath = [&]() -> const std::string& {
-      if (!entry.icon.empty()) {
-        const std::string& primary = m_iconResolver.resolve(entry.icon, cfg.iconSize);
-        if (!primary.empty()) {
-          return primary;
-        }
-      }
-      return m_iconResolver.resolve("application-x-executable", cfg.iconSize);
-    }();
-    auto iconImg = ui::image({
-        .width = iSize,
-        .height = iSize,
-        .configure = [this, &iconPath, &cfg, kCellPad](Image& image) {
-          if (!iconPath.empty() && m_renderContext != nullptr) {
-            image.setSourceFile(*m_renderContext, iconPath, cfg.iconSize, true);
-          }
-          image.setPosition(kCellPad, kCellPad);
-        },
-    });
-
-    if (iconImg->hasImage()) {
-      item.iconImage = static_cast<Image*>(areaNode->addChild(std::move(iconImg)));
-    } else {
-      // Fallback: Tabler app-window glyph (matches launcher when theme icons are unavailable).
-      item.iconGlyph = static_cast<Glyph*>(areaNode->addChild(
-          ui::glyph({
-              .glyph = "app-window",
-              .glyphSize = iSize,
-              .color = colorSpecFromRole(ColorRole::OnSurface),
-              .width = iSize,
-              .height = iSize,
-              .configure = [kCellPad](Glyph& glyph) { glyph.setPosition(kCellPad, kCellPad); },
-          })
-      ));
-    }
-
-    if (cfg.showDots) {
-      const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
-      const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
-
-      for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
-        item.dotIndicators[dotIndex] = static_cast<Box*>(areaNode->addChild(
-            ui::box({
-                .fill = colorSpecFromRole(ColorRole::Secondary),
-                .radius = dot * 0.5f,
-                .width = dot,
-                .height = dot,
-                .visible = false,
-                .configure = [verticalDots, position = cfg.position, cellMain, dot](Box& box) {
-                  if (verticalDots) {
-                    const float x = position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
-                    box.setPosition(x, std::round((cellMain - dot) * 0.5f));
-                  } else {
-                    const float y = position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
-                    box.setPosition(std::round((cellMain - dot) * 0.5f), y);
-                  }
-                },
-            })
-        ));
-      }
-    }
-
-    // Instance-count badge — top-right corner of the icon, initially hidden.
-    if (cfg.showInstanceCount) {
-      const float bd = std::max(kBadgeMinSize, iSize * kBadgeSizeRatio);
-      const float badgeX = kCellPad + iSize - bd * 0.55f;
-      const float badgeY = kCellPad - bd * 0.45f;
-
-      areaNode->addChild(
-          ui::box({
-              .out = &item.badge,
-              .radius = bd * 0.5f,
-              .width = bd,
-              .height = bd,
-              .visible = false,
-              .configure = [badgeX, badgeY](Box& box) { box.setPosition(badgeX, badgeY); },
-          })
-      );
-
-      item.badge->addChild(
-          ui::label({
-              .out = &item.badgeLabel,
-              .fontSize = bd * kBadgeFontRatio,
-              .maxLines = 1,
-              .fontWeight = FontWeight::Bold,
-              .visible = false,
-          })
-      );
-    }
-
-    // Pointer callbacks.
-    auto* itemPtr = &item;
-    auto* instPtr = &instance;
-
-    areaNode->setOnEnter([itemPtr, instPtr](const InputArea::PointerData&) {
-      if (!itemPtr->hovered) {
-        itemPtr->hovered = true;
-        if (itemPtr->background) {
-          itemPtr->background->setFill(colorSpecFromRole(ColorRole::Hover));
-        }
-        if (instPtr->sceneRoot)
-          instPtr->sceneRoot->markPaintDirty();
-      }
-    });
-    areaNode->setOnLeave([itemPtr, instPtr]() {
-      if (itemPtr->hovered) {
-        itemPtr->hovered = false;
-        if (itemPtr->background) {
-          itemPtr->background->setFill(clearColorSpec());
-        }
-        if (instPtr->sceneRoot)
-          instPtr->sceneRoot->markPaintDirty();
-      }
-    });
-    areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
-    areaNode->setOnClick([itemPtr, instPtr, this](const InputArea::PointerData& d) {
-      if (d.button == BTN_LEFT) {
-        handleItemClick(*instPtr, *itemPtr);
-      } else if (d.button == BTN_RIGHT) {
-        openItemMenu(*instPtr, *itemPtr);
-      }
-    });
-
-    item.area = static_cast<InputArea*>(instance.row->addChild(std::move(areaNode)));
-  }
-
-  if (cfg.launcherPosition == "end") {
-    instance.row->addChild(createLauncherButton(instance));
-  }
-
-  instance.modelSerial = m_modelSerial;
-
-  // Force surface resize when item count changes.
-  shell::dock::resizeSurface(instance, cfg, m_config->config().shell.shadow);
 }
 
 // ── Private: visual update ────────────────────────────────────────────────────
 
 void Dock::updateVisuals(shell::dock::DockInstance& instance) {
-  const auto& cfg = m_config->config().dock;
-
-  for (auto& item : instance.items) {
-    const float iconScale = item.active ? cfg.activeScale : cfg.inactiveScale;
-    const float iconOpacity = item.active ? cfg.activeOpacity : cfg.inactiveOpacity;
-    Node* iconNode =
-        item.iconImage != nullptr ? static_cast<Node*>(item.iconImage) : static_cast<Node*>(item.iconGlyph);
-
-    if (iconNode != nullptr) {
-      if (item.visualScale < 0.0f) {
-        item.visualScale = iconScale;
-        iconNode->setScale(iconScale);
-      } else if (std::abs(item.visualScale - iconScale) > 0.001f) {
-        if (item.scaleAnimId != 0) {
-          instance.animations.cancel(item.scaleAnimId);
-        }
-        item.scaleAnimId = instance.animations.animate(
-            item.visualScale, iconScale, Style::animNormal, Easing::EaseOutCubic,
-            [node = iconNode, itemPtr = &item](float value) {
-              itemPtr->visualScale = value;
-              node->setScale(value);
-            },
-            [itemPtr = &item] { itemPtr->scaleAnimId = 0; }
-        );
-      }
-
-      if (item.visualOpacity < 0.0f) {
-        item.visualOpacity = iconOpacity;
-        iconNode->setOpacity(iconOpacity);
-      } else if (std::abs(item.visualOpacity - iconOpacity) > 0.001f) {
-        if (item.opacityAnimId != 0) {
-          instance.animations.cancel(item.opacityAnimId);
-        }
-        item.opacityAnimId = instance.animations.animate(
-            item.visualOpacity, iconOpacity, Style::animNormal, Easing::EaseOutCubic,
-            [node = iconNode, itemPtr = &item](float value) {
-              itemPtr->visualOpacity = value;
-              node->setOpacity(value);
-            },
-            [itemPtr = &item] { itemPtr->opacityAnimId = 0; }
-        );
-      }
-    }
-
-    const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
-    std::size_t count = 0;
-    if (needsWindowCount) {
-      const auto windows = m_platform->windowsForApp(
-          item.idLower, item.startupWmClassLower, currentDockFilterOutput(cfg, instance.output)
-      );
-      count = windows.size();
-      item.instanceCount = count;
-    }
-
-    if (cfg.showDots) {
-      const std::size_t dotCount = std::min<std::size_t>(count, 3);
-      const float iSize = static_cast<float>(cfg.iconSize);
-      constexpr float kCellPad = 6.0f;
-      const float cellMain = iSize + 2.0f * kCellPad;
-      const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
-      const float groupLength =
-          dotCount == 0 ? dot : dot * static_cast<float>(dotCount) + kDotGap * static_cast<float>(dotCount - 1);
-      const float groupStart = std::round((cellMain - groupLength) * 0.5f);
-      const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
-
-      for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
-        if (item.dotIndicators[dotIndex] == nullptr) {
-          continue;
-        }
-        Box* dotNode = item.dotIndicators[dotIndex];
-        const bool visible = dotIndex < dotCount;
-        dotNode->setVisible(visible);
-        dotNode->setFill(colorSpecFromRole(ColorRole::Secondary));
-        if (visible) {
-          const float main = groupStart + static_cast<float>(dotIndex) * (dot + kDotGap);
-          if (verticalDots) {
-            const float x = cfg.position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
-            dotNode->setPosition(x, main);
-          } else {
-            const float y = cfg.position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
-            dotNode->setPosition(main, y);
-          }
-        }
-      }
-    }
-
-    // Instance-count badge.
-    if (item.badge != nullptr && item.badgeLabel != nullptr) {
-      const bool show = count >= 2;
-      item.badge->setVisible(show);
-      item.badgeLabel->setVisible(show);
-      if (show) {
-        const std::string label = (count > 9) ? "9+" : std::to_string(count);
-        item.badgeLabel->setText(label);
-        item.badgeLabel->setColor(colorSpecFromRole(ColorRole::OnPrimary));
-        item.badge->setFill(colorSpecFromRole(ColorRole::Primary));
-        if (m_renderContext != nullptr) {
-          const float bd = std::max(kBadgeMinSize, static_cast<float>(cfg.iconSize) * kBadgeSizeRatio);
-          item.badgeLabel->measure(*m_renderContext);
-          item.badgeLabel->setPosition(
-              std::round((bd - item.badgeLabel->width()) * 0.5f), std::round((bd - item.badgeLabel->height()) * 0.5f)
-          );
-        }
-      }
-    }
-  }
-}
-
-// ── Private: helpers ──────────────────────────────────────────────────────────
-
-bool Dock::matchesActiveApp(const shell::dock::DockItemView& item, std::string_view activeIdLower) const {
-  return !activeIdLower.empty() && activeIdLower == item.idLower;
-}
-
-bool Dock::matchesRunningApp(
-    const shell::dock::DockItemView& item, const std::vector<std::string>& runningLower
-) const {
-  for (const auto& rid : runningLower) {
-    if (!rid.empty() && rid == item.idLower) {
-      return true;
-    }
-  }
-  return false;
-}
-
-std::unique_ptr<InputArea> Dock::createLauncherButton(shell::dock::DockInstance& instance) {
-  const auto& cfg = m_config->config().dock;
-  const bool vert = shell::dock::isVerticalPosition(cfg.position);
-  const float iSize = static_cast<float>(cfg.iconSize);
-  constexpr float kCellPad = 6.0f;
-  const float cellMain = iSize + 2.0f * kCellPad;
-  const float cellCross = iSize + 2.0f * kCellPad;
-  const float glyphSize = iSize * 0.8f;
-  const float glyphOffsetY = kCellPad + (iSize - glyphSize) * 0.5f;
-
-  auto areaNode = std::make_unique<InputArea>();
-  if (!vert) {
-    areaNode->setSize(cellMain, cellCross);
-  } else {
-    areaNode->setSize(cellCross, cellMain);
-  }
-
-  Box* bgPtr = nullptr;
-  areaNode->addChild(
-      ui::box({
-          .out = &bgPtr,
-          .fill = clearColorSpec(),
-          .radius = static_cast<float>(cfg.radius),
-          .width = cellMain,
-          .height = cellMain,
-          .configure = [](Box& box) { box.setPosition(0.0f, 0.0f); },
-      })
-  );
-
-  areaNode->addChild(
-      ui::glyph({
-          .glyphSize = glyphSize,
-          .color = colorSpecFromRole(ColorRole::OnSurface),
-          .width = iSize,
-          .height = iSize,
-          .configure = [&cfg, kCellPad, glyphOffsetY](Glyph& glyph) {
-            if (!glyph.setGlyph(dockLauncherIconGlyph(cfg))) {
-              glyph.setGlyph("grid-dots");
-            }
-            glyph.setPosition(kCellPad, glyphOffsetY);
-          },
-      })
-  );
-
-  auto* instPtr = &instance;
-  areaNode->setOnEnter([bgPtr, instPtr](const InputArea::PointerData&) {
-    bgPtr->setFill(colorSpecFromRole(ColorRole::Hover));
-    if (instPtr->sceneRoot != nullptr) {
-      instPtr->sceneRoot->markPaintDirty();
-    }
-  });
-  areaNode->setOnLeave([bgPtr, instPtr]() {
-    bgPtr->setFill(clearColorSpec());
-    if (instPtr->sceneRoot != nullptr) {
-      instPtr->sceneRoot->markPaintDirty();
-    }
-  });
-  areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT}));
-  areaNode->setOnClick([instPtr](const InputArea::PointerData& d) {
-    if (d.button == BTN_LEFT) {
-      PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = instPtr->output});
-    }
-  });
-
-  return areaNode;
-}
-
-// ── Private: click handling ───────────────────────────────────────────────────
-
-void Dock::handleItemClick(shell::dock::DockInstance& instance, shell::dock::DockItemView& item) {
-  pruneCachedToplevelHandles();
-
-  auto windows = m_platform->windowsForApp(
-      item.idLower, item.startupWmClassLower, currentDockFilterOutput(m_config->config().dock, instance.output)
-  );
-
-  if (windows.empty()) {
-    wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
-    (void)desktop_entry_launch::launchEntry(item.entry, dockLaunchOptions(*m_platform, *m_config, activationSurface));
+  if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
     return;
   }
 
-  if (windows.size() == 1) {
-    m_platform->activateToplevel(windows[0].handle);
-    return;
-  }
-
-  zwlr_foreign_toplevel_handle_v1* activeHandle = nullptr;
-  if (const auto active = m_platform->activeToplevel(); active.has_value()) {
-    activeHandle = active->handle;
-  }
-
-  auto* preferredHandle = [&]() -> zwlr_foreign_toplevel_handle_v1* {
-    const auto it = m_lastActiveHandleByAppIdLower.find(item.idLower);
-    return it != m_lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
-  }();
-  if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle); nextHandle != nullptr) {
-    m_platform->activateToplevel(nextHandle);
-  }
+  shell::dock::updateVisuals(
+      instance,
+      {
+          .platform = *m_platform,
+          .config = *m_config,
+          .renderContext = *m_renderContext,
+          .iconResolver = m_iconResolver,
+          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+          .pinnedEntries = m_pinnedEntries,
+          .modelSerial = m_modelSerial,
+      }
+  );
 }
 
 // ── Private: item context menu (right-click) ──────────────────────────────────
@@ -1182,7 +604,7 @@ void Dock::openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockIt
   m_popupOwnerInstance = &instance;
 
   auto windows = m_platform->windowsForApp(
-      item.idLower, item.startupWmClassLower, currentDockFilterOutput(m_config->config().dock, instance.output)
+      item.idLower, item.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
   );
   const std::string entryId = item.entry.id;
   const std::string entryWorkingDir = item.entry.workingDir;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -10,6 +10,7 @@
 #include "render/scene/node.h"
 #include "shell/dock/dock_context_menu.h"
 #include "shell/dock/dock_geometry.h"
+#include "shell/dock/dock_instance.h"
 #include "shell/dock/dock_items.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -540,13 +540,16 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
   shell::dock::rebuildItems(
       instance,
       {
-          .platform = *m_platform,
-          .config = *m_config,
+          .model =
+              {
+                  .platform = *m_platform,
+                  .config = *m_config,
+                  .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+                  .pinnedEntries = m_pinnedEntries,
+                  .modelSerial = m_modelSerial,
+              },
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
-          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
-          .pinnedEntries = m_pinnedEntries,
-          .modelSerial = m_modelSerial,
       },
       {
           .pruneCachedToplevelHandles = [this]() { pruneCachedToplevelHandles(); },
@@ -571,13 +574,16 @@ void Dock::updateVisuals(shell::dock::DockInstance& instance) {
   shell::dock::updateVisuals(
       instance,
       {
-          .platform = *m_platform,
-          .config = *m_config,
+          .model =
+              {
+                  .platform = *m_platform,
+                  .config = *m_config,
+                  .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+                  .pinnedEntries = m_pinnedEntries,
+                  .modelSerial = m_modelSerial,
+              },
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
-          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
-          .pinnedEntries = m_pinnedEntries,
-          .modelSerial = m_modelSerial,
       }
   );
 }

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -2,14 +2,13 @@
 
 #include "compositors/compositor_platform.h"
 #include "config/config_service.h"
-#include "core/deferred_call.h"
 #include "core/log.h"
 #include "core/ui_phase.h"
-#include "i18n/i18n.h"
 #include "ipc/ipc_service.h"
 #include "render/render_context.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "shell/dock/dock_context_menu.h"
 #include "shell/dock/dock_geometry.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"
@@ -18,16 +17,12 @@
 #include "system/desktop_entry.h"
 #include "system/desktop_entry_launch.h"
 #include "ui/builders.h"
-#include "ui/controls/context_menu.h"
 #include "ui/palette.h"
-#include "ui/popup_chrome.h"
 #include "ui/style.h"
 #include "util/string_utils.h"
 #include "wayland/layer_surface.h"
-#include "wayland/popup_surface.h"
 #include "wayland/surface.h"
 #include "wayland/wayland_toplevels.h"
-#include "xdg-shell-client-protocol.h"
 
 #include <cerrno>
 #include <format>
@@ -102,27 +97,6 @@ namespace {
     return nullptr;
   }
 
-  popup_chrome::Attachment popupAttachmentForDockPosition(bool isBottom, bool isTop, bool isRight) {
-    if (isBottom) {
-      return popup_chrome::Attachment{
-          .horizontal = popup_chrome::HorizontalAttachment::Center, .vertical = popup_chrome::VerticalAttachment::Bottom
-      };
-    }
-    if (isTop) {
-      return popup_chrome::Attachment{
-          .horizontal = popup_chrome::HorizontalAttachment::Center, .vertical = popup_chrome::VerticalAttachment::Top
-      };
-    }
-    if (isRight) {
-      return popup_chrome::Attachment{
-          .horizontal = popup_chrome::HorizontalAttachment::Right, .vertical = popup_chrome::VerticalAttachment::Center
-      };
-    }
-    return popup_chrome::Attachment{
-        .horizontal = popup_chrome::HorizontalAttachment::Left, .vertical = popup_chrome::VerticalAttachment::Center
-    };
-  }
-
   template <typename T> void appendOptionalStackPart(std::string& out, const std::optional<T>& value) {
     out += value.has_value() ? std::format("{}", *value) : "-";
     out.push_back('\x1f');
@@ -178,6 +152,7 @@ namespace {
 // ── Lifecycle ─────────────────────────────────────────────────────────────────
 
 Dock::Dock() = default;
+Dock::~Dock() = default;
 
 bool Dock::initialize(CompositorPlatform& platform, ConfigService* config, RenderContext* renderContext) {
   m_platform = &platform;
@@ -349,7 +324,7 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
   // If a pointer press is not consumed by the popup, close it and let the same
   // event continue to dock item hit-testing.
   if (m_itemMenu != nullptr) {
-    const bool consumed = routePopupEvent(m_itemMenu.get(), event);
+    const bool consumed = shell::dock::routePopupEvent(*m_itemMenu, event);
     if (consumed) {
       return true;
     }
@@ -1385,74 +1360,6 @@ void Dock::handleItemClick(DockInstance& instance, DockItemView& item) {
   }
 }
 
-// ── Private: item context menu constants ─────────────────────────────────────
-
-static constexpr float kMenuWidth = 240.0f;
-static constexpr std::int32_t kMenuCloseId = -1;
-static constexpr std::int32_t kMenuCloseAllId = -2;
-static constexpr std::int32_t kMenuSeparatorId = -3;
-static constexpr std::int32_t kMenuWindowBaseId = -1000;
-
-// ── Private: generic popup routing ───────────────────────────────────────────
-
-bool Dock::routePopupEvent(DockPopup* popup, const PointerEvent& event) {
-  const bool onPopup = (event.surface != nullptr && event.surface == popup->wlSurface);
-  bool consumed = false;
-
-  switch (event.type) {
-  case PointerEvent::Type::Enter:
-    if (onPopup) {
-      popup->pointerInside = true;
-      popup->inputDispatcher.pointerEnter(static_cast<float>(event.sx), static_cast<float>(event.sy), event.serial);
-    }
-    break;
-  case PointerEvent::Type::Leave:
-    if (onPopup) {
-      popup->pointerInside = false;
-      popup->inputDispatcher.pointerLeave();
-    }
-    break;
-  case PointerEvent::Type::Motion:
-    if (onPopup || popup->pointerInside) {
-      if (onPopup) {
-        popup->pointerInside = true;
-      }
-      popup->inputDispatcher.pointerMotion(static_cast<float>(event.sx), static_cast<float>(event.sy), 0);
-      consumed = true;
-    }
-    break;
-  case PointerEvent::Type::Button:
-    if (onPopup || popup->pointerInside) {
-      if (onPopup) {
-        popup->pointerInside = true;
-      }
-      // Keep hover state synced before click dispatch so stationary pointers can
-      // still activate rows even if Enter/Motion ordering is flaky.
-      popup->inputDispatcher.pointerMotion(static_cast<float>(event.sx), static_cast<float>(event.sy), event.serial);
-      const bool pressed = (event.state == 1);
-      popup->inputDispatcher.pointerButton(
-          static_cast<float>(event.sx), static_cast<float>(event.sy), event.button, pressed
-      );
-      consumed = true;
-    }
-    break;
-  case PointerEvent::Type::Axis:
-    break;
-  }
-
-  if (popup->surface != nullptr
-      && popup->sceneRoot != nullptr
-      && (popup->sceneRoot->paintDirty() || popup->sceneRoot->layoutDirty())) {
-    if (popup->sceneRoot->layoutDirty()) {
-      popup->surface->requestLayout();
-    } else {
-      popup->surface->requestRedraw();
-    }
-  }
-
-  return consumed;
-}
-
 // ── Private: item context menu (right-click) ──────────────────────────────────
 
 void Dock::startHideFadeOut(DockInstance& inst) {
@@ -1504,296 +1411,48 @@ void Dock::closeItemMenu() {
 }
 
 void Dock::openItemMenu(DockInstance& instance, DockItemView& item) {
-  if (!m_platform->hasXdgShell())
+  if (m_config == nullptr) {
+    m_popupOwnerInstance = nullptr;
+    m_itemMenu.reset();
     return;
+  }
 
-  // Close the existing popup before opening the new one.
   closeItemMenu();
 
-  m_popupOwnerInstance = &instance;
-  auto menu = std::make_unique<DockPopup>();
+  if (m_platform == nullptr || m_renderContext == nullptr || !m_platform->hasXdgShell()) {
+    return;
+  }
 
-  // Collect running windows for "Close" / "Close All" entries.
+  m_popupOwnerInstance = &instance;
+
   auto windows = m_platform->windowsForApp(
       item.idLower, item.startupWmClassLower, currentDockFilterOutput(m_config->config().dock, instance.output)
   );
-  for (const auto& w : windows) {
-    menu->handles.push_back(w.handle);
-  }
-
-  // IDs 0..N-1 → desktop actions; negative constants → windows / close commands.
-  std::vector<ContextMenuControlEntry> entries;
-  entries.reserve(windows.size() + item.entry.actions.size() + 4);
-
-  for (std::size_t i = 0; i < windows.size(); ++i) {
-    const auto& title = windows[i].title.empty() ? item.entry.name : windows[i].title;
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = kMenuWindowBaseId - static_cast<std::int32_t>(i),
-            .label = title,
-            .enabled = windows[i].handle != nullptr,
-            .separator = false,
-            .hasSubmenu = false,
-        }
-    );
-  }
-
-  const bool hasWindowEntries = !windows.empty();
-  const bool hasActionEntries = !item.entry.actions.empty();
-  const bool hasCloseEntries = !menu->handles.empty();
-  if (hasWindowEntries && (hasActionEntries || hasCloseEntries)) {
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = kMenuSeparatorId, .label = {}, .enabled = false, .separator = true, .hasSubmenu = false
-        }
-    );
-  }
-
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(item.entry.actions.size()); ++i) {
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = i,
-            .label = item.entry.actions[static_cast<std::size_t>(i)].name,
-            .enabled = true,
-            .separator = false,
-            .hasSubmenu = false,
-        }
-    );
-  }
-
-  const std::size_t runCount = menu->handles.size();
-  if (runCount > 0) {
-    if (hasActionEntries) {
-      // Separator between app actions and window-management entries.
-      entries.push_back(
-          ContextMenuControlEntry{
-              .id = kMenuSeparatorId, .label = {}, .enabled = false, .separator = true, .hasSubmenu = false
-          }
-      );
-    }
-    if (runCount == 1) {
-      entries.push_back(
-          ContextMenuControlEntry{
-              .id = kMenuCloseId,
-              .label = i18n::tr("dock.actions.close"),
-              .enabled = true,
-              .separator = false,
-              .hasSubmenu = false
-          }
-      );
-    } else {
-      entries.push_back(
-          ContextMenuControlEntry{
-              .id = kMenuCloseAllId,
-              .label = i18n::tr("dock.actions.close-all"),
-              .enabled = true,
-              .separator = false,
-              .hasSubmenu = false
-          }
-      );
-    }
-  }
-
-  if (entries.empty())
-    return; // nothing to show
-
-  // Compute popup height.
-  const float menuHeight = ContextMenuControl::preferredHeight(entries, entries.size());
-
-  // Determine anchor / gravity + gap based on dock position.
-  const auto& cfg = m_config->config().dock;
-  const bool isBottom = (cfg.position == "bottom");
-  const bool isTop = (cfg.position == "top");
-  const bool isRight = (cfg.position == "right");
-
-  std::uint32_t anchor = XDG_POSITIONER_ANCHOR_NONE;
-  std::uint32_t gravity = XDG_POSITIONER_GRAVITY_NONE;
-  std::int32_t offsetX = 0;
-  std::int32_t offsetY = 0;
-  const std::int32_t kGapBottom = std::max(2, static_cast<std::int32_t>(Style::spaceLg));
-  const std::int32_t kGap = std::max(2, static_cast<std::int32_t>(Style::spaceMd));
-
-  if (isBottom) {
-    anchor = XDG_POSITIONER_ANCHOR_TOP;
-    gravity = XDG_POSITIONER_GRAVITY_TOP;
-    offsetY = -kGapBottom;
-  } else if (isTop) {
-    anchor = XDG_POSITIONER_ANCHOR_BOTTOM;
-    gravity = XDG_POSITIONER_GRAVITY_BOTTOM;
-    offsetY = kGap;
-  } else if (isRight) {
-    anchor = XDG_POSITIONER_ANCHOR_LEFT;
-    gravity = XDG_POSITIONER_GRAVITY_LEFT;
-    offsetX = -kGap;
-  } else { // left
-    anchor = XDG_POSITIONER_ANCHOR_RIGHT;
-    gravity = XDG_POSITIONER_GRAVITY_RIGHT;
-    offsetX = kGap;
-  }
-
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, m_config->config().shell.shadow);
-  const std::int32_t panelThk = shell::dock::dockThickness(cfg);
-  const std::int32_t ptrX = static_cast<std::int32_t>(m_platform->lastPointerX());
-  const std::int32_t ptrY = static_cast<std::int32_t>(m_platform->lastPointerY());
-  const std::int32_t halfCell = cfg.iconSize / 2;
-
-  // Anchor rect: pointer-centred on main axis × panel face on cross axis.
-  std::int32_t aX, aY, aW, aH;
-  if (isBottom) {
-    // Panel top face is at sb.up.
-    aX = ptrX - halfCell;
-    aY = sb.up;
-    aW = halfCell * 2;
-    aH = panelThk;
-  } else if (isTop) {
-    const std::int32_t panelFace = std::min(cfg.marginEdge, sb.up) + panelThk;
-    aX = ptrX - halfCell;
-    aY = 0;
-    aW = halfCell * 2;
-    aH = panelFace;
-  } else if (isRight) {
-    aX = sb.left;
-    aY = ptrY - halfCell;
-    aW = panelThk;
-    aH = halfCell * 2;
-  } else { // left
-    const std::int32_t panelFace = std::min(cfg.marginEdge, sb.left) + panelThk;
-    aX = 0;
-    aY = ptrY - halfCell;
-    aW = panelFace;
-    aH = halfCell * 2;
-  }
-
-  const auto menuChrome = popup_chrome::computeGeometry(kMenuWidth, menuHeight, m_config->config().shell.shadow);
-  PopupSurfaceConfig popupCfg{
-      .anchorX = aX,
-      .anchorY = aY,
-      .anchorWidth = std::max(1, aW),
-      .anchorHeight = std::max(1, aH),
-      .width = menuChrome.surfaceWidth,
-      .height = menuChrome.surfaceHeight,
-      .anchor = anchor,
-      .gravity = gravity,
-      .constraintAdjustment = XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X
-          | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y
-          | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X
-          | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y,
-      .offsetX = offsetX,
-      .offsetY = offsetY,
-      .serial = m_platform->lastInputSerial(),
-      .grab = true,
-  };
-  popup_chrome::applyToConfig(popupCfg, menuChrome, popupAttachmentForDockPosition(isBottom, isTop, isRight));
-
-  menu->surface = std::make_unique<PopupSurface>(m_platform->wayland());
-  menu->surface->setRenderContext(m_renderContext);
-  menu->chrome = menuChrome;
-
-  auto* menuPtr = menu.get();
-
-  // Capture actions by value — item may be rebuilt before the callback fires.
-  auto entryActions = item.entry.actions;
   const std::string entryId = item.entry.id;
   const std::string entryWorkingDir = item.entry.workingDir;
   const bool entryTerminal = item.entry.terminal;
 
-  menu->surface->setConfigureCallback([menuPtr](std::uint32_t /*w*/, std::uint32_t /*h*/) {
-    menuPtr->surface->requestLayout();
-  });
-  menu->surface->setPrepareFrameCallback([this, menuPtr, entries, entryActions, entryId, entryWorkingDir,
-                                          entryTerminal](bool /*needsUpdate*/, bool needsLayout) {
-    if (m_renderContext == nullptr || menuPtr->surface == nullptr) {
-      return;
-    }
-
-    const auto width = menuPtr->surface->width();
-    const auto height = menuPtr->surface->height();
-    if (width == 0 || height == 0) {
-      return;
-    }
-
-    m_renderContext->makeCurrent(menuPtr->surface->renderTarget());
-
-    const bool needsSceneBuild = menuPtr->sceneRoot == nullptr
-        || static_cast<std::uint32_t>(std::round(menuPtr->sceneRoot->width())) != width
-        || static_cast<std::uint32_t>(std::round(menuPtr->sceneRoot->height())) != height;
-    if (!needsSceneBuild && !needsLayout) {
-      return;
-    }
-
-    UiPhaseScope layoutPhase(UiPhase::Layout);
-
-    const auto fw = static_cast<float>(width);
-    const auto fh = static_cast<float>(height);
-
-    menuPtr->sceneRoot = std::make_unique<Node>();
-    menuPtr->sceneRoot->setSize(fw, fh);
-    (void)popup_chrome::addShadow(
-        *menuPtr->sceneRoot, menuPtr->chrome, m_config->config().shell.shadow, Style::scaledRadiusLg()
-    );
-
-    auto ctrl = std::make_unique<ContextMenuControl>();
-    ctrl->setMenuWidth(menuPtr->chrome.contentWidth);
-    ctrl->setMaxVisible(entries.size());
-    ctrl->setEntries(entries);
-    ctrl->setRedrawCallback([menuPtr]() {
-      if (menuPtr->surface)
-        menuPtr->surface->requestRedraw();
-    });
-    ctrl->setOnActivate([this, menuPtr, entryActions, entryId, entryWorkingDir,
-                         entryTerminal](const ContextMenuControlEntry& e) {
-      const std::int32_t id = e.id;
-      auto menuHandles = menuPtr->handles;
-      auto closingHandles = menuPtr->handles;
-      DeferredCall::callLater([this, id, entryActions, entryId, entryWorkingDir, entryTerminal,
-                               menuHandles = std::move(menuHandles),
-                               closingHandles = std::move(closingHandles)]() mutable {
-        if (id <= kMenuWindowBaseId) {
-          const auto idx = static_cast<std::size_t>(kMenuWindowBaseId - id);
-          if (idx < menuHandles.size() && menuHandles[idx] != nullptr) {
-            m_platform->activateToplevel(menuHandles[idx]);
-          }
-        } else if (id >= 0) {
-          const auto idx = static_cast<std::size_t>(id);
-          if (idx < entryActions.size()) {
+  shell::dock::DockMenuCallbacks callbacks{
+      .activateWindow = [this](zwlr_foreign_toplevel_handle_v1* handle) { m_platform->activateToplevel(handle); },
+      .closeWindow = [this](zwlr_foreign_toplevel_handle_v1* handle) { m_platform->closeToplevel(handle); },
+      .launchAction =
+          [this, entryId, entryWorkingDir, entryTerminal](const DesktopAction& action) {
             (void)desktop_entry_launch::launchAction(
-                entryActions[idx], entryId, entryWorkingDir, entryTerminal,
-                dockLaunchOptions(*m_platform, *m_config, nullptr)
+                action, entryId, entryWorkingDir, entryTerminal, dockLaunchOptions(*m_platform, *m_config, nullptr)
             );
-          }
-        } else if (id == kMenuCloseId && !closingHandles.empty()) {
-          m_platform->closeToplevel(closingHandles[0]);
-        } else if (id == kMenuCloseAllId) {
-          for (auto* handle : closingHandles) {
-            m_platform->closeToplevel(handle);
-          }
-        }
-        closeItemMenu();
-      });
-    });
-    ctrl->setPosition(menuPtr->chrome.contentX(), menuPtr->chrome.contentY());
-    ctrl->setSize(menuPtr->chrome.contentWidth, menuPtr->chrome.contentHeight);
-    ctrl->layout(*m_renderContext);
+          },
+      .closeMenu = [this]() { closeItemMenu(); },
+  };
 
-    menuPtr->sceneRoot->addChild(std::move(ctrl));
-    menuPtr->inputDispatcher.setSceneRoot(menuPtr->sceneRoot.get());
-    menuPtr->inputDispatcher.setCursorShapeCallback([this](std::uint32_t serial, std::uint32_t shape) {
-      m_platform->setCursorShape(serial, shape);
-    });
-    menuPtr->surface->setSceneRoot(menuPtr->sceneRoot.get());
-  });
-
-  menu->surface->setDismissedCallback([this]() { closeItemMenu(); });
-
-  auto* layerSurface = m_platform->layerSurfaceFor(instance.surface->wlSurface());
-  if (layerSurface == nullptr || !menu->surface->initialize(layerSurface, instance.output, popupCfg)) {
-    kLog.warn("dock: failed to create item-menu popup");
-    return;
+  auto* layerSurface =
+      instance.surface != nullptr ? m_platform->layerSurfaceFor(instance.surface->wlSurface()) : nullptr;
+  m_itemMenu = shell::dock::createItemMenu(
+      *m_platform, *m_config, *m_renderContext, layerSurface, instance.output, m_config->config().dock, item.entry,
+      windows, callbacks
+  );
+  if (m_itemMenu == nullptr) {
+    m_popupOwnerInstance = nullptr;
   }
-
-  popup_chrome::setContentInputRegion(*menu->surface, menu->chrome);
-  menu->wlSurface = menu->surface->wlSurface();
-  m_itemMenu = std::move(menu);
 }
 
 void Dock::registerIpc(IpcService& ipc) {

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -26,6 +26,7 @@
 #include "wayland/surface.h"
 #include "wayland/wayland_toplevels.h"
 
+#include <cassert>
 #include <cerrno>
 #include <format>
 #include <optional>
@@ -34,6 +35,14 @@
 namespace {
 
   constexpr Logger kLog("dock");
+
+  void assertDockInitialized(
+      const CompositorPlatform* platform, const ConfigService* config, const RenderContext* renderContext
+  ) {
+    assert(platform != nullptr);
+    assert(config != nullptr);
+    assert(renderContext != nullptr);
+  }
 
   desktop_entry_launch::LaunchOptions
   dockLaunchOptions(const CompositorPlatform& platform, const ConfigService& config, wl_surface* activationSurface) {
@@ -325,7 +334,7 @@ bool Dock::onPointerEvent(const PointerEvent& event) {
         }
       }
 
-      if (m_config != nullptr && m_config->config().dock.autoHide && m_popupOwnerInstance == nullptr) {
+      if (m_config->config().dock.autoHide && m_popupOwnerInstance == nullptr) {
         shell::dock::startHideFadeOut(*m_hoveredInstance, *m_config);
       }
       m_hoveredInstance = nullptr;
@@ -446,6 +455,8 @@ void Dock::syncInstances() {
 }
 
 void Dock::createInstance(const WaylandOutput& output) {
+  assertDockInitialized(m_platform, m_config, m_renderContext);
+
   const auto& cfg = m_config->config().dock;
   kLog.info(
       "creating dock on {} ({}) icon_size={} position={}", output.connectorName, output.description, cfg.iconSize,
@@ -471,9 +482,7 @@ void Dock::createInstance(const WaylandOutput& output) {
     inst->surface->requestLayout();
   });
   instance->surface->setPrepareFrameCallback([this, inst](bool needsUpdate, bool needsLayout) {
-    if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
-      return;
-    }
+    assertDockInitialized(m_platform, m_config, m_renderContext);
     shell::dock::prepareFrame(
         *inst, {.platform = *m_platform, .config = *m_config, .renderContext = *m_renderContext},
         shell::dock::DockInstanceCallbacks{
@@ -499,9 +508,8 @@ void Dock::createInstance(const WaylandOutput& output) {
 // ── Private: scene building ───────────────────────────────────────────────────
 
 bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
-  if (m_platform == nullptr || m_config == nullptr) {
-    return false;
-  }
+  assert(m_platform != nullptr);
+  assert(m_config != nullptr);
 
   return shell::dock::syncInstanceModel(
       instance,
@@ -518,9 +526,7 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
 // ── Private: item population ──────────────────────────────────────────────────
 
 void Dock::rebuildItems(shell::dock::DockInstance& instance) {
-  if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
-    return;
-  }
+  assertDockInitialized(m_platform, m_config, m_renderContext);
 
   shell::dock::rebuildItems(
       instance,
@@ -551,9 +557,7 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
 // ── Private: visual update ────────────────────────────────────────────────────
 
 void Dock::updateVisuals(shell::dock::DockInstance& instance) {
-  if (m_platform == nullptr || m_config == nullptr || m_renderContext == nullptr) {
-    return;
-  }
+  assertDockInitialized(m_platform, m_config, m_renderContext);
 
   shell::dock::updateVisuals(
       instance,
@@ -577,7 +581,7 @@ void Dock::closeItemMenu() {
   m_itemMenu.reset();
   // Fade the owner out — the pointer left the dock to interact with the menu,
   // whether or not the compositor sent a Leave event at that time.
-  if (m_config != nullptr && m_config->config().dock.autoHide && owner != nullptr && owner->hideOpacity > 0.0f) {
+  if (owner != nullptr && owner->hideOpacity > 0.0f && m_config->config().dock.autoHide) {
     owner->pointerInside = false;
     if (m_hoveredInstance == owner) {
       m_hoveredInstance = nullptr;
@@ -587,15 +591,11 @@ void Dock::closeItemMenu() {
 }
 
 void Dock::openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item) {
-  if (m_config == nullptr) {
-    m_popupOwnerInstance = nullptr;
-    m_itemMenu.reset();
-    return;
-  }
+  assertDockInitialized(m_platform, m_config, m_renderContext);
 
   closeItemMenu();
 
-  if (m_platform == nullptr || m_renderContext == nullptr || !m_platform->hasXdgShell()) {
+  if (!m_platform->hasXdgShell()) {
     return;
   }
 

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -477,9 +477,8 @@ void Dock::createInstance(const WaylandOutput& output) {
     shell::dock::prepareFrame(
         *inst, {.platform = *m_platform, .config = *m_config, .renderContext = *m_renderContext},
         shell::dock::DockInstanceCallbacks{
-            .syncModel = [this](shell::dock::DockInstance& callbackInstance) {
-              return syncInstanceModel(callbackInstance);
-            },
+            .syncModel =
+                [this](shell::dock::DockInstance& callbackInstance) { return syncInstanceModel(callbackInstance); },
             .rebuildItems = [this](shell::dock::DockInstance& callbackInstance) { rebuildItems(callbackInstance); },
             .updateVisuals = [this](shell::dock::DockInstance& callbackInstance) { updateVisuals(callbackInstance); },
         },
@@ -536,17 +535,15 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
       },
       {
           .pruneCachedToplevelHandles = [this]() { pruneCachedToplevelHandles(); },
-          .launchOptions =
-              [this](wl_surface* activationSurface) {
-                return dockLaunchOptions(*m_platform, *m_config, activationSurface);
-              },
+          .launchOptions = [this](
+                               wl_surface* activationSurface
+                           ) { return dockLaunchOptions(*m_platform, *m_config, activationSurface); },
           .toggleLauncher =
               [](shell::dock::DockInstance& inst) {
                 PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = inst.output});
               },
-          .openItemMenu = [this](shell::dock::DockInstance& inst, shell::dock::DockItemView& item) {
-            openItemMenu(inst, item);
-          },
+          .openItemMenu =
+              [this](shell::dock::DockInstance& inst, shell::dock::DockItemView& item) { openItemMenu(inst, item); },
       }
   );
 }

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -1,13 +1,9 @@
 #pragma once
 
 #include "config/config_service.h"
-#include "render/animation/animation_manager.h"
-#include "render/scene/input_dispatcher.h"
-#include "system/desktop_entry.h"
+#include "shell/dock/dock_instance.h"
 #include "system/icon_resolver.h"
-#include "ui/signal.h"
 
-#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -18,17 +14,11 @@ class Box;
 class CompositorPlatform;
 class ConfigService;
 class Flex;
-class IpcService;
-class Glyph;
-class Image;
 class InputArea;
-class Label;
+class IpcService;
 class RenderContext;
-class LayerSurface;
-class Node;
 struct PointerEvent;
 struct WaylandOutput;
-struct wl_output;
 struct wl_surface;
 struct zwlr_foreign_toplevel_handle_v1;
 
@@ -55,53 +45,6 @@ public:
   void registerIpc(IpcService& ipc);
 
 private:
-  struct DockItemView {
-    DesktopEntry entry;
-    std::string idLower;
-    std::string startupWmClassLower;
-    InputArea* area = nullptr;
-    Box* background = nullptr;
-    std::array<Box*, 3> dotIndicators{};
-    Box* badge = nullptr;
-    Label* badgeLabel = nullptr;
-    Image* iconImage = nullptr;
-    Glyph* iconGlyph = nullptr;
-    bool hovered = false;
-    bool running = false;
-    bool active = false;
-    float visualScale = -1.0f;
-    float visualOpacity = -1.0f;
-    AnimationManager::Id scaleAnimId = 0;
-    AnimationManager::Id opacityAnimId = 0;
-    std::size_t instanceCount = 0;
-  };
-
-  struct DockInstance {
-    std::uint32_t outputName = 0;
-    wl_output* output = nullptr;
-    std::int32_t scale = 1;
-    std::unique_ptr<LayerSurface> surface;
-    // sceneRoot must be destroyed before `animations` — ~Node() calls cancelForOwner().
-    AnimationManager animations;
-    std::unique_ptr<Node> sceneRoot;
-    Node* slideRoot = nullptr;
-    float slideHiddenDx = 0.0f;
-    float slideHiddenDy = 0.0f;
-    Box* shadow = nullptr;
-    Box* panel = nullptr;
-    Flex* row = nullptr;
-    InputDispatcher inputDispatcher;
-    std::vector<DockItemView> items;
-    std::uint64_t modelSerial = 0;
-    std::string activeAppIdLower;
-    wl_output* lastFilterOutput = nullptr;
-    bool pointerInside = false;
-    // Auto-hide: tracks visibility [0,1] driven by hover.
-    float hideOpacity = 1.0f;
-    AnimationManager::Id hideAnimId = 0;
-    Signal<>::ScopedConnection paletteConn;
-  };
-
   // Returns true if the item list was modified (triggers a rebuild).
   bool refreshPinnedAppsIfNeeded();
   void pruneCachedToplevelHandles();
@@ -110,24 +53,21 @@ private:
   void destroyInstance(std::uint32_t outputName);
   // Drop any references the dock keeps to an instance (surface map, hovered, popup owner)
   // before the instance is destroyed. Safe to call multiple times.
-  void detachInstanceState(DockInstance& inst);
-  void prepareFrame(DockInstance& instance, bool needsUpdate, bool needsLayout);
-  bool syncInstanceModel(DockInstance& instance);
-  void applyDockCompositorBlur(DockInstance& instance);
-  void syncDockSlideLayerTransform(DockInstance& instance);
-  void buildScene(DockInstance& instance);
-  void rebuildItems(DockInstance& instance);
-  void resizeSurface(DockInstance& instance);
-  void updateVisuals(DockInstance& instance);
-  void applyPanelPalette(DockInstance& instance);
-  std::unique_ptr<InputArea> createLauncherButton(DockInstance& instance);
-  void handleItemClick(DockInstance& instance, DockItemView& item);
-  void openItemMenu(DockInstance& instance, DockItemView& item);
+  void detachInstanceState(shell::dock::DockInstance& inst);
+  bool syncInstanceModel(shell::dock::DockInstance& instance);
+  void rebuildItems(shell::dock::DockInstance& instance);
+  void updateVisuals(shell::dock::DockInstance& instance);
+  std::unique_ptr<InputArea> createLauncherButton(shell::dock::DockInstance& instance);
+  void handleItemClick(shell::dock::DockInstance& instance, shell::dock::DockItemView& item);
+  void openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item);
   void closeItemMenu();
-  void startHideFadeOut(DockInstance& inst);
 
-  [[nodiscard]] bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower) const;
-  [[nodiscard]] bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) const;
+  [[nodiscard]] bool matchesActiveApp(
+      const shell::dock::DockItemView& item, std::string_view activeAppIdLower
+  ) const;
+  [[nodiscard]] bool matchesRunningApp(
+      const shell::dock::DockItemView& item, const std::vector<std::string>& runningLower
+  ) const;
 
   CompositorPlatform* m_platform = nullptr;
   ConfigService* m_config = nullptr;
@@ -141,9 +81,9 @@ private:
   std::uint64_t m_entriesVersion = 0;
   IconResolver m_iconResolver;
   std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*> m_lastActiveHandleByAppIdLower;
-  std::vector<std::unique_ptr<DockInstance>> m_instances;
-  std::unordered_map<wl_surface*, DockInstance*> m_surfaceMap;
-  DockInstance* m_hoveredInstance = nullptr;
-  DockInstance* m_popupOwnerInstance = nullptr;       // instance that owns the current open popup
+  std::vector<std::unique_ptr<shell::dock::DockInstance>> m_instances;
+  std::unordered_map<wl_surface*, shell::dock::DockInstance*> m_surfaceMap;
+  shell::dock::DockInstance* m_hoveredInstance = nullptr;
+  shell::dock::DockInstance* m_popupOwnerInstance = nullptr; // instance that owns the current open popup
   std::unique_ptr<shell::dock::DockPopup> m_itemMenu; // right-click context menu
 };

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -14,7 +14,6 @@ class Box;
 class CompositorPlatform;
 class ConfigService;
 class Flex;
-class InputArea;
 class IpcService;
 class RenderContext;
 struct PointerEvent;
@@ -57,17 +56,8 @@ private:
   bool syncInstanceModel(shell::dock::DockInstance& instance);
   void rebuildItems(shell::dock::DockInstance& instance);
   void updateVisuals(shell::dock::DockInstance& instance);
-  std::unique_ptr<InputArea> createLauncherButton(shell::dock::DockInstance& instance);
-  void handleItemClick(shell::dock::DockInstance& instance, shell::dock::DockItemView& item);
   void openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item);
   void closeItemMenu();
-
-  [[nodiscard]] bool matchesActiveApp(
-      const shell::dock::DockItemView& item, std::string_view activeAppIdLower
-  ) const;
-  [[nodiscard]] bool matchesRunningApp(
-      const shell::dock::DockItemView& item, const std::vector<std::string>& runningLower
-  ) const;
 
   CompositorPlatform* m_platform = nullptr;
   ConfigService* m_config = nullptr;

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -127,11 +127,6 @@ private:
   [[nodiscard]] bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower) const;
   [[nodiscard]] bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) const;
 
-  // Geometry helpers
-  [[nodiscard]] std::int32_t dockContentSize(std::size_t itemCount) const; // item row length (main axis)
-  [[nodiscard]] std::int32_t dockThickness() const; // cross-axis (includes icon, cell padding, dock padding)
-  [[nodiscard]] bool isVertical() const;
-
   // Generic popup for the item context menu.
   struct DockPopup {
     std::unique_ptr<PopupSurface> surface;

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "config/config_service.h"
-#include "shell/dock/dock_instance.h"
+#include "config/config_types.h"
+#include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
 
 #include <cstdint>
@@ -10,10 +10,8 @@
 #include <unordered_map>
 #include <vector>
 
-class Box;
 class CompositorPlatform;
 class ConfigService;
-class Flex;
 class IpcService;
 class RenderContext;
 struct PointerEvent;
@@ -22,6 +20,8 @@ struct wl_surface;
 struct zwlr_foreign_toplevel_handle_v1;
 
 namespace shell::dock {
+  struct DockInstance;
+  struct DockItemView;
   struct DockPopup;
 }
 
@@ -49,7 +49,6 @@ private:
   void pruneCachedToplevelHandles();
   void syncInstances();
   void createInstance(const WaylandOutput& output);
-  void destroyInstance(std::uint32_t outputName);
   // Drop any references the dock keeps to an instance (surface map, hovered, popup owner)
   // before the instance is destroyed. Safe to call multiple times.
   void detachInstanceState(shell::dock::DockInstance& inst);

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -23,7 +23,7 @@ namespace shell::dock {
   struct DockInstance;
   struct DockItemView;
   struct DockPopup;
-}
+} // namespace shell::dock
 
 class Dock {
 public:
@@ -74,5 +74,5 @@ private:
   std::unordered_map<wl_surface*, shell::dock::DockInstance*> m_surfaceMap;
   shell::dock::DockInstance* m_hoveredInstance = nullptr;
   shell::dock::DockInstance* m_popupOwnerInstance = nullptr; // instance that owns the current open popup
-  std::unique_ptr<shell::dock::DockPopup> m_itemMenu; // right-click context menu
+  std::unique_ptr<shell::dock::DockPopup> m_itemMenu;        // right-click context menu
 };

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -5,10 +5,7 @@
 #include "render/scene/input_dispatcher.h"
 #include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
-#include "ui/controls/context_menu.h"
-#include "ui/popup_chrome.h"
 #include "ui/signal.h"
-#include "wayland/popup_surface.h"
 
 #include <array>
 #include <cstdint>
@@ -35,9 +32,14 @@ struct wl_output;
 struct wl_surface;
 struct zwlr_foreign_toplevel_handle_v1;
 
+namespace shell::dock {
+  struct DockPopup;
+}
+
 class Dock {
 public:
   Dock();
+  ~Dock();
 
   bool initialize(CompositorPlatform& platform, ConfigService* config, RenderContext* renderContext);
   void reload();
@@ -127,20 +129,6 @@ private:
   [[nodiscard]] bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower) const;
   [[nodiscard]] bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) const;
 
-  // Generic popup for the item context menu.
-  struct DockPopup {
-    std::unique_ptr<PopupSurface> surface;
-    std::unique_ptr<Node> sceneRoot;
-    popup_chrome::Geometry chrome;
-    InputDispatcher inputDispatcher;
-    wl_surface* wlSurface = nullptr;
-    bool pointerInside = false;
-    std::vector<zwlr_foreign_toplevel_handle_v1*> handles;
-  };
-
-  // Route a pointer event to an open popup; returns true if consumed.
-  bool routePopupEvent(DockPopup* popup, const PointerEvent& event);
-
   CompositorPlatform* m_platform = nullptr;
   ConfigService* m_config = nullptr;
   RenderContext* m_renderContext = nullptr;
@@ -156,6 +144,6 @@ private:
   std::vector<std::unique_ptr<DockInstance>> m_instances;
   std::unordered_map<wl_surface*, DockInstance*> m_surfaceMap;
   DockInstance* m_hoveredInstance = nullptr;
-  DockInstance* m_popupOwnerInstance = nullptr; // instance that owns the current open popup
-  std::unique_ptr<DockPopup> m_itemMenu;        // right-click context menu
+  DockInstance* m_popupOwnerInstance = nullptr;       // instance that owns the current open popup
+  std::unique_ptr<shell::dock::DockPopup> m_itemMenu; // right-click context menu
 };

--- a/src/shell/dock/dock_context_menu.cpp
+++ b/src/shell/dock/dock_context_menu.cpp
@@ -391,9 +391,11 @@ namespace shell::dock {
     });
 
     menu->surface->setDismissedCallback([callbacks]() {
-      if (callbacks.closeMenu) {
-        callbacks.closeMenu();
-      }
+      DeferredCall::callLater([callbacks]() {
+        if (callbacks.closeMenu) {
+          callbacks.closeMenu();
+        }
+      });
     });
 
     if (parentLayerSurface == nullptr || !menu->surface->initialize(parentLayerSurface, output, popupCfg)) {

--- a/src/shell/dock/dock_context_menu.cpp
+++ b/src/shell/dock/dock_context_menu.cpp
@@ -1,0 +1,409 @@
+#include "shell/dock/dock_context_menu.h"
+
+#include "compositors/compositor_platform.h"
+#include "config/config_service.h"
+#include "core/deferred_call.h"
+#include "core/log.h"
+#include "core/ui_phase.h"
+#include "i18n/i18n.h"
+#include "render/render_context.h"
+#include "render/scene/node.h"
+#include "shell/dock/dock_geometry.h"
+#include "shell/surface_shadow.h"
+#include "system/desktop_entry.h"
+#include "ui/controls/context_menu.h"
+#include "ui/style.h"
+#include "wayland/popup_surface.h"
+#include "wayland/wayland_toplevels.h"
+#include "xdg-shell-client-protocol.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace shell::dock {
+  namespace {
+
+    constexpr Logger kLog("dock");
+
+    constexpr float kMenuWidth = 240.0f;
+    constexpr std::int32_t kMenuCloseId = -1;
+    constexpr std::int32_t kMenuCloseAllId = -2;
+    constexpr std::int32_t kMenuSeparatorId = -3;
+    constexpr std::int32_t kMenuWindowBaseId = -1000;
+
+    popup_chrome::Attachment popupAttachmentForDockPosition(bool isBottom, bool isTop, bool isRight) {
+      if (isBottom) {
+        return popup_chrome::Attachment{
+            .horizontal = popup_chrome::HorizontalAttachment::Center,
+            .vertical = popup_chrome::VerticalAttachment::Bottom
+        };
+      }
+      if (isTop) {
+        return popup_chrome::Attachment{
+            .horizontal = popup_chrome::HorizontalAttachment::Center, .vertical = popup_chrome::VerticalAttachment::Top
+        };
+      }
+      if (isRight) {
+        return popup_chrome::Attachment{
+            .horizontal = popup_chrome::HorizontalAttachment::Right,
+            .vertical = popup_chrome::VerticalAttachment::Center
+        };
+      }
+      return popup_chrome::Attachment{
+          .horizontal = popup_chrome::HorizontalAttachment::Left, .vertical = popup_chrome::VerticalAttachment::Center
+      };
+    }
+
+  } // namespace
+
+  DockPopup::DockPopup() = default;
+  DockPopup::~DockPopup() = default;
+
+  bool routePopupEvent(DockPopup& popup, const PointerEvent& event) {
+    const bool onPopup = (event.surface != nullptr && event.surface == popup.wlSurface);
+    bool consumed = false;
+
+    switch (event.type) {
+    case PointerEvent::Type::Enter:
+      if (onPopup) {
+        popup.pointerInside = true;
+        popup.inputDispatcher.pointerEnter(static_cast<float>(event.sx), static_cast<float>(event.sy), event.serial);
+      }
+      break;
+    case PointerEvent::Type::Leave:
+      if (onPopup) {
+        popup.pointerInside = false;
+        popup.inputDispatcher.pointerLeave();
+      }
+      break;
+    case PointerEvent::Type::Motion:
+      if (onPopup || popup.pointerInside) {
+        if (onPopup) {
+          popup.pointerInside = true;
+        }
+        popup.inputDispatcher.pointerMotion(static_cast<float>(event.sx), static_cast<float>(event.sy), 0);
+        consumed = true;
+      }
+      break;
+    case PointerEvent::Type::Button:
+      if (onPopup || popup.pointerInside) {
+        if (onPopup) {
+          popup.pointerInside = true;
+        }
+        // Keep hover state synced before click dispatch so stationary pointers can
+        // still activate rows even if Enter/Motion ordering is flaky.
+        popup.inputDispatcher.pointerMotion(static_cast<float>(event.sx), static_cast<float>(event.sy), event.serial);
+        const bool pressed = (event.state == 1);
+        popup.inputDispatcher.pointerButton(
+            static_cast<float>(event.sx), static_cast<float>(event.sy), event.button, pressed
+        );
+        consumed = true;
+      }
+      break;
+    case PointerEvent::Type::Axis:
+      break;
+    }
+
+    if (popup.surface != nullptr
+        && popup.sceneRoot != nullptr
+        && (popup.sceneRoot->paintDirty() || popup.sceneRoot->layoutDirty())) {
+      if (popup.sceneRoot->layoutDirty()) {
+        popup.surface->requestLayout();
+      } else {
+        popup.surface->requestRedraw();
+      }
+    }
+
+    return consumed;
+  }
+
+  std::unique_ptr<DockPopup> createItemMenu(
+      CompositorPlatform& platform, ConfigService& config, RenderContext& renderContext,
+      zwlr_layer_surface_v1* parentLayerSurface, wl_output* output, const DockConfig& dockConfig,
+      const DesktopEntry& entry, const std::vector<ToplevelInfo>& windows, const DockMenuCallbacks& callbacks
+  ) {
+    auto menu = std::make_unique<DockPopup>();
+
+    // Collect running windows for "Close" / "Close All" entries.
+    for (const auto& w : windows) {
+      menu->handles.push_back(w.handle);
+    }
+
+    // IDs 0..N-1 -> desktop actions; negative constants -> windows / close commands.
+    std::vector<ContextMenuControlEntry> entries;
+    entries.reserve(windows.size() + entry.actions.size() + 4);
+
+    for (std::size_t i = 0; i < windows.size(); ++i) {
+      const auto& title = windows[i].title.empty() ? entry.name : windows[i].title;
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = kMenuWindowBaseId - static_cast<std::int32_t>(i),
+              .label = title,
+              .enabled = windows[i].handle != nullptr,
+              .separator = false,
+              .hasSubmenu = false,
+          }
+      );
+    }
+
+    const bool hasWindowEntries = !windows.empty();
+    const bool hasActionEntries = !entry.actions.empty();
+    const bool hasCloseEntries = !menu->handles.empty();
+    if (hasWindowEntries && (hasActionEntries || hasCloseEntries)) {
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = kMenuSeparatorId, .label = {}, .enabled = false, .separator = true, .hasSubmenu = false
+          }
+      );
+    }
+
+    for (std::int32_t i = 0; i < static_cast<std::int32_t>(entry.actions.size()); ++i) {
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = i,
+              .label = entry.actions[static_cast<std::size_t>(i)].name,
+              .enabled = true,
+              .separator = false,
+              .hasSubmenu = false,
+          }
+      );
+    }
+
+    const std::size_t runCount = menu->handles.size();
+    if (runCount > 0) {
+      if (hasActionEntries) {
+        // Separator between app actions and window-management entries.
+        entries.push_back(
+            ContextMenuControlEntry{
+                .id = kMenuSeparatorId, .label = {}, .enabled = false, .separator = true, .hasSubmenu = false
+            }
+        );
+      }
+      if (runCount == 1) {
+        entries.push_back(
+            ContextMenuControlEntry{
+                .id = kMenuCloseId,
+                .label = i18n::tr("dock.actions.close"),
+                .enabled = true,
+                .separator = false,
+                .hasSubmenu = false
+            }
+        );
+      } else {
+        entries.push_back(
+            ContextMenuControlEntry{
+                .id = kMenuCloseAllId,
+                .label = i18n::tr("dock.actions.close-all"),
+                .enabled = true,
+                .separator = false,
+                .hasSubmenu = false
+            }
+        );
+      }
+    }
+
+    if (entries.empty()) {
+      return nullptr;
+    }
+
+    // Compute popup height.
+    const float menuHeight = ContextMenuControl::preferredHeight(entries, entries.size());
+
+    // Determine anchor / gravity + gap based on dock position.
+    const bool isBottom = (dockConfig.position == "bottom");
+    const bool isTop = (dockConfig.position == "top");
+    const bool isRight = (dockConfig.position == "right");
+
+    std::uint32_t anchor = XDG_POSITIONER_ANCHOR_NONE;
+    std::uint32_t gravity = XDG_POSITIONER_GRAVITY_NONE;
+    std::int32_t offsetX = 0;
+    std::int32_t offsetY = 0;
+    const std::int32_t kGapBottom = std::max(2, static_cast<std::int32_t>(Style::spaceLg));
+    const std::int32_t kGap = std::max(2, static_cast<std::int32_t>(Style::spaceMd));
+
+    if (isBottom) {
+      anchor = XDG_POSITIONER_ANCHOR_TOP;
+      gravity = XDG_POSITIONER_GRAVITY_TOP;
+      offsetY = -kGapBottom;
+    } else if (isTop) {
+      anchor = XDG_POSITIONER_ANCHOR_BOTTOM;
+      gravity = XDG_POSITIONER_GRAVITY_BOTTOM;
+      offsetY = kGap;
+    } else if (isRight) {
+      anchor = XDG_POSITIONER_ANCHOR_LEFT;
+      gravity = XDG_POSITIONER_GRAVITY_LEFT;
+      offsetX = -kGap;
+    } else { // left
+      anchor = XDG_POSITIONER_ANCHOR_RIGHT;
+      gravity = XDG_POSITIONER_GRAVITY_RIGHT;
+      offsetX = kGap;
+    }
+
+    const auto sb = shell::surface_shadow::bleed(dockConfig.shadow, config.config().shell.shadow);
+    const std::int32_t panelThk = shell::dock::dockThickness(dockConfig);
+    const std::int32_t ptrX = static_cast<std::int32_t>(platform.lastPointerX());
+    const std::int32_t ptrY = static_cast<std::int32_t>(platform.lastPointerY());
+    const std::int32_t halfCell = dockConfig.iconSize / 2;
+
+    // Anchor rect: pointer-centred on main axis x panel face on cross axis.
+    std::int32_t aX, aY, aW, aH;
+    if (isBottom) {
+      // Panel top face is at sb.up.
+      aX = ptrX - halfCell;
+      aY = sb.up;
+      aW = halfCell * 2;
+      aH = panelThk;
+    } else if (isTop) {
+      const std::int32_t panelFace = std::min(dockConfig.marginEdge, sb.up) + panelThk;
+      aX = ptrX - halfCell;
+      aY = 0;
+      aW = halfCell * 2;
+      aH = panelFace;
+    } else if (isRight) {
+      aX = sb.left;
+      aY = ptrY - halfCell;
+      aW = panelThk;
+      aH = halfCell * 2;
+    } else { // left
+      const std::int32_t panelFace = std::min(dockConfig.marginEdge, sb.left) + panelThk;
+      aX = 0;
+      aY = ptrY - halfCell;
+      aW = panelFace;
+      aH = halfCell * 2;
+    }
+
+    const auto menuChrome = popup_chrome::computeGeometry(kMenuWidth, menuHeight, config.config().shell.shadow);
+    PopupSurfaceConfig popupCfg{
+        .anchorX = aX,
+        .anchorY = aY,
+        .anchorWidth = std::max(1, aW),
+        .anchorHeight = std::max(1, aH),
+        .width = menuChrome.surfaceWidth,
+        .height = menuChrome.surfaceHeight,
+        .anchor = anchor,
+        .gravity = gravity,
+        .constraintAdjustment = XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X
+            | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y
+            | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X
+            | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y,
+        .offsetX = offsetX,
+        .offsetY = offsetY,
+        .serial = platform.lastInputSerial(),
+        .grab = true,
+    };
+    popup_chrome::applyToConfig(popupCfg, menuChrome, popupAttachmentForDockPosition(isBottom, isTop, isRight));
+
+    menu->surface = std::make_unique<PopupSurface>(platform.wayland());
+    menu->surface->setRenderContext(&renderContext);
+    menu->chrome = menuChrome;
+
+    auto* menuPtr = menu.get();
+
+    // Capture actions by value; the entry may be rebuilt before the callback fires.
+    auto entryActions = entry.actions;
+
+    menu->surface->setConfigureCallback([menuPtr](std::uint32_t /*w*/, std::uint32_t /*h*/) {
+      menuPtr->surface->requestLayout();
+    });
+    menu->surface->setPrepareFrameCallback([&platform, &config, &renderContext, menuPtr, entries, entryActions,
+                                            callbacks](bool /*needsUpdate*/, bool needsLayout) {
+      if (menuPtr->surface == nullptr) {
+        return;
+      }
+
+      const auto width = menuPtr->surface->width();
+      const auto height = menuPtr->surface->height();
+      if (width == 0 || height == 0) {
+        return;
+      }
+
+      renderContext.makeCurrent(menuPtr->surface->renderTarget());
+
+      const bool needsSceneBuild = menuPtr->sceneRoot == nullptr
+          || static_cast<std::uint32_t>(std::round(menuPtr->sceneRoot->width())) != width
+          || static_cast<std::uint32_t>(std::round(menuPtr->sceneRoot->height())) != height;
+      if (!needsSceneBuild && !needsLayout) {
+        return;
+      }
+
+      UiPhaseScope layoutPhase(UiPhase::Layout);
+
+      const auto fw = static_cast<float>(width);
+      const auto fh = static_cast<float>(height);
+
+      menuPtr->sceneRoot = std::make_unique<Node>();
+      menuPtr->sceneRoot->setSize(fw, fh);
+      (void)popup_chrome::addShadow(
+          *menuPtr->sceneRoot, menuPtr->chrome, config.config().shell.shadow, Style::scaledRadiusLg()
+      );
+
+      auto ctrl = std::make_unique<ContextMenuControl>();
+      ctrl->setMenuWidth(menuPtr->chrome.contentWidth);
+      ctrl->setMaxVisible(entries.size());
+      ctrl->setEntries(entries);
+      ctrl->setRedrawCallback([menuPtr]() {
+        if (menuPtr->surface)
+          menuPtr->surface->requestRedraw();
+      });
+      ctrl->setOnActivate([menuPtr, entryActions, callbacks](const ContextMenuControlEntry& e) {
+        const std::int32_t id = e.id;
+        auto menuHandles = menuPtr->handles;
+        auto closingHandles = menuPtr->handles;
+        DeferredCall::callLater([id, entryActions, callbacks, menuHandles = std::move(menuHandles),
+                                 closingHandles = std::move(closingHandles)]() mutable {
+          if (id <= kMenuWindowBaseId) {
+            const auto idx = static_cast<std::size_t>(kMenuWindowBaseId - id);
+            if (idx < menuHandles.size() && menuHandles[idx] != nullptr && callbacks.activateWindow) {
+              callbacks.activateWindow(menuHandles[idx]);
+            }
+          } else if (id >= 0) {
+            const auto idx = static_cast<std::size_t>(id);
+            if (idx < entryActions.size() && callbacks.launchAction) {
+              callbacks.launchAction(entryActions[idx]);
+            }
+          } else if (id == kMenuCloseId && !closingHandles.empty()) {
+            if (callbacks.closeWindow) {
+              callbacks.closeWindow(closingHandles[0]);
+            }
+          } else if (id == kMenuCloseAllId) {
+            if (callbacks.closeWindow) {
+              for (auto* handle : closingHandles) {
+                callbacks.closeWindow(handle);
+              }
+            }
+          }
+          if (callbacks.closeMenu) {
+            callbacks.closeMenu();
+          }
+        });
+      });
+      ctrl->setPosition(menuPtr->chrome.contentX(), menuPtr->chrome.contentY());
+      ctrl->setSize(menuPtr->chrome.contentWidth, menuPtr->chrome.contentHeight);
+      ctrl->layout(renderContext);
+
+      menuPtr->sceneRoot->addChild(std::move(ctrl));
+      menuPtr->inputDispatcher.setSceneRoot(menuPtr->sceneRoot.get());
+      menuPtr->inputDispatcher.setCursorShapeCallback([&platform](std::uint32_t serial, std::uint32_t shape) {
+        platform.setCursorShape(serial, shape);
+      });
+      menuPtr->surface->setSceneRoot(menuPtr->sceneRoot.get());
+    });
+
+    menu->surface->setDismissedCallback([callbacks]() {
+      if (callbacks.closeMenu) {
+        callbacks.closeMenu();
+      }
+    });
+
+    if (parentLayerSurface == nullptr || !menu->surface->initialize(parentLayerSurface, output, popupCfg)) {
+      kLog.warn("dock: failed to create item-menu popup");
+      return nullptr;
+    }
+
+    popup_chrome::setContentInputRegion(*menu->surface, menu->chrome);
+    menu->wlSurface = menu->surface->wlSurface();
+    return menu;
+  }
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_context_menu.h
+++ b/src/shell/dock/dock_context_menu.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "render/scene/input_dispatcher.h"
+#include "ui/popup_chrome.h"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+class CompositorPlatform;
+class ConfigService;
+class Node;
+class PopupSurface;
+class RenderContext;
+struct DesktopAction;
+struct DesktopEntry;
+struct DockConfig;
+struct PointerEvent;
+struct ToplevelInfo;
+struct wl_output;
+struct wl_surface;
+struct zwlr_foreign_toplevel_handle_v1;
+struct zwlr_layer_surface_v1;
+
+namespace shell::dock {
+
+  struct DockPopup {
+    DockPopup();
+    ~DockPopup();
+
+    std::unique_ptr<PopupSurface> surface;
+    std::unique_ptr<Node> sceneRoot;
+    popup_chrome::Geometry chrome;
+    InputDispatcher inputDispatcher;
+    wl_surface* wlSurface = nullptr;
+    bool pointerInside = false;
+    std::vector<zwlr_foreign_toplevel_handle_v1*> handles;
+  };
+
+  struct DockMenuCallbacks {
+    std::function<void(zwlr_foreign_toplevel_handle_v1*)> activateWindow;
+    std::function<void(zwlr_foreign_toplevel_handle_v1*)> closeWindow;
+    std::function<void(const DesktopAction&)> launchAction;
+    std::function<void()> closeMenu;
+  };
+
+  // Route a pointer event to an open popup; returns true if consumed.
+  bool routePopupEvent(DockPopup& popup, const PointerEvent& event);
+
+  [[nodiscard]] std::unique_ptr<DockPopup> createItemMenu(
+      CompositorPlatform& platform, ConfigService& config, RenderContext& renderContext,
+      zwlr_layer_surface_v1* parentLayerSurface, wl_output* output, const DockConfig& dockConfig,
+      const DesktopEntry& entry, const std::vector<ToplevelInfo>& windows, const DockMenuCallbacks& callbacks
+  );
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -1,0 +1,196 @@
+#include "shell/dock/dock_geometry.h"
+
+#include "shell/surface_shadow.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace shell::dock {
+namespace {
+
+  constexpr std::int32_t kCellPad = 6;
+  constexpr std::int32_t kAutoHideTriggerPx = 2;
+  constexpr float kAutoHideSlideExtraPx = 16.0f;
+
+} // namespace
+
+std::uint32_t positionToAnchor(const std::string& position) {
+  if (position == "top") {
+    return LayerShellAnchor::Top;
+  }
+  if (position == "left") {
+    return LayerShellAnchor::Left;
+  }
+  if (position == "right") {
+    return LayerShellAnchor::Right;
+  }
+  return LayerShellAnchor::Bottom;
+}
+
+bool isVerticalPosition(const std::string& position) { return position == "left" || position == "right"; }
+
+std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount) {
+  const auto n = static_cast<std::int32_t>(itemCount);
+  const std::int32_t cellSize = cfg.iconSize + kCellPad * 2;
+  if (n == 0) {
+    return cellSize + cfg.padding * 2;
+  }
+  return n * cellSize + std::max(0, n - 1) * cfg.itemSpacing + cfg.padding * 2;
+}
+
+std::int32_t dockThickness(const DockConfig& cfg) { return cfg.iconSize + kCellPad * 2 + cfg.padding * 2; }
+
+std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
+  return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
+}
+
+Radii dockCornerRadii(const DockConfig& cfg) {
+  return Radii{
+      static_cast<float>(cfg.radiusTopLeft),
+      static_cast<float>(cfg.radiusTopRight),
+      static_cast<float>(cfg.radiusBottomRight),
+      static_cast<float>(cfg.radiusBottomLeft),
+  };
+}
+
+DockSurfaceGeometry
+computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
+  const bool vertical = isVerticalPosition(cfg.position);
+  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+  const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
+  const auto panelW = dockContentSize(cfg, itemCount);
+  const auto panelH = dockThickness(cfg);
+  const bool isBottom = (cfg.position == "bottom");
+  const bool isRight = (cfg.position == "right");
+
+  DockSurfaceGeometry geometry;
+  if (!vertical) {
+    geometry.surfaceW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
+    geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
+    if (isBottom) {
+      geometry.marginBottom = std::max(0, cfg.marginEdge - sb.down);
+      geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
+      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.down));
+    } else {
+      geometry.marginTop = std::max(0, cfg.marginEdge - sb.up);
+      geometry.surfaceH = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.up) + panelH + sb.down);
+      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.up) + panelH);
+    }
+    geometry.marginLeft = cfg.marginEnds;
+    geometry.marginRight = cfg.marginEnds;
+    return geometry;
+  }
+
+  geometry.surfaceH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
+  if (isRight) {
+    geometry.marginRight = std::max(0, cfg.marginEdge - sb.right);
+    geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + std::min(cfg.marginEdge, sb.right));
+    geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.right));
+  } else {
+    geometry.marginLeft = std::max(0, cfg.marginEdge - sb.left);
+    geometry.surfaceW = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.left) + panelH + sb.right);
+    geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.left) + panelH);
+  }
+  geometry.marginTop = cfg.marginEnds;
+  geometry.marginBottom = cfg.marginEnds;
+  return geometry;
+}
+
+LayerSurfaceConfig
+makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
+  const auto geometry = computeSurfaceGeometry(cfg, shadow, itemCount);
+  return LayerSurfaceConfig{
+      .nameSpace = "noctalia-dock",
+      .layer = LayerShellLayer::Top,
+      .anchor = positionToAnchor(cfg.position),
+      .width = geometry.surfaceW,
+      .height = geometry.surfaceH,
+      .exclusiveZone = geometry.exclusiveZone,
+      .marginTop = geometry.marginTop,
+      .marginRight = geometry.marginRight,
+      .marginBottom = geometry.marginBottom,
+      .marginLeft = geometry.marginLeft,
+      .defaultWidth = geometry.surfaceW,
+      .defaultHeight = geometry.surfaceH,
+  };
+}
+
+DockPanelGeometry
+computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH) {
+  const bool vertical = isVerticalPosition(cfg.position);
+  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+  const float bleedL = static_cast<float>(sb.left);
+  const float bleedR = static_cast<float>(sb.right);
+  const float bleedU = static_cast<float>(sb.up);
+  const float bleedD = static_cast<float>(sb.down);
+  const float mEdge = static_cast<float>(cfg.marginEdge);
+  const bool isBottom = (cfg.position == "bottom");
+  const bool isRight = (cfg.position == "right");
+
+  if (!vertical) {
+    return DockPanelGeometry{
+        .panelX = bleedL,
+        .panelY = isBottom ? bleedU : std::min(mEdge, bleedU),
+        .panelW = surfaceW - bleedL - bleedR,
+        .panelH = static_cast<float>(dockThickness(cfg)),
+    };
+  }
+
+  return DockPanelGeometry{
+      .panelX = isRight ? bleedL : std::min(mEdge, bleedL),
+      .panelY = bleedU,
+      .panelW = static_cast<float>(dockThickness(cfg)),
+      .panelH = surfaceH - bleedU - bleedD,
+  };
+}
+
+std::pair<float, float> computeHiddenSlideDelta(
+    const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
+    const DockPanelGeometry& panel
+) {
+  float contentLeft = panel.panelX;
+  float contentTop = panel.panelY;
+  float contentRight = panel.panelX + panel.panelW;
+  float contentBottom = panel.panelY + panel.panelH;
+  if (shell::surface_shadow::enabled(cfg.shadow, shadow)) {
+    const float sx = panel.panelX + static_cast<float>(shadow.offsetX);
+    const float sy = panel.panelY + static_cast<float>(shadow.offsetY);
+    contentLeft = std::min(contentLeft, sx);
+    contentTop = std::min(contentTop, sy);
+    contentRight = std::max(contentRight, sx + panel.panelW);
+    contentBottom = std::max(contentBottom, sy + panel.panelH);
+  }
+
+  if (!isVerticalPosition(cfg.position)) {
+    if (cfg.position == "bottom") {
+      return {0.0f, (surfaceH - contentTop) + kAutoHideSlideExtraPx};
+    }
+    return {0.0f, -(contentBottom + kAutoHideSlideExtraPx)};
+  }
+  if (cfg.position == "right") {
+    return {(surfaceW - contentLeft) + kAutoHideSlideExtraPx, 0.0f};
+  }
+  return {-(contentRight + kAutoHideSlideExtraPx), 0.0f};
+}
+
+std::vector<InputRect>
+computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
+  if (hidden) {
+    if (!isVerticalPosition(cfg.position)) {
+      return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
+    }
+    if (cfg.position == "left") {
+      return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
+    }
+    return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+  }
+
+  return {InputRect{
+      static_cast<int>(std::lround(panel.panelX)),
+      static_cast<int>(std::lround(panel.panelY)),
+      static_cast<int>(std::lround(panel.panelW)),
+      static_cast<int>(std::lround(panel.panelH)),
+  }};
+}
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -1,6 +1,7 @@
 #include "shell/dock/dock_geometry.h"
 
 #include "shell/surface_shadow.h"
+#include "wayland/layer_surface.h"
 
 #include <algorithm>
 #include <cmath>
@@ -42,15 +43,6 @@ std::int32_t dockThickness(const DockConfig& cfg) { return cfg.iconSize + kCellP
 
 std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
   return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
-}
-
-Radii dockCornerRadii(const DockConfig& cfg) {
-  return Radii{
-      static_cast<float>(cfg.radiusTopLeft),
-      static_cast<float>(cfg.radiusTopRight),
-      static_cast<float>(cfg.radiusBottomRight),
-      static_cast<float>(cfg.radiusBottomLeft),
-  };
 }
 
 DockSurfaceGeometry

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -7,182 +7,182 @@
 #include <cmath>
 
 namespace shell::dock {
-namespace {
+  namespace {
 
-  constexpr std::int32_t kCellPad = 6;
-  constexpr std::int32_t kAutoHideTriggerPx = 2;
-  constexpr float kAutoHideSlideExtraPx = 16.0f;
+    constexpr std::int32_t kCellPad = 6;
+    constexpr std::int32_t kAutoHideTriggerPx = 2;
+    constexpr float kAutoHideSlideExtraPx = 16.0f;
 
-} // namespace
+  } // namespace
 
-std::uint32_t positionToAnchor(const std::string& position) {
-  if (position == "top") {
-    return LayerShellAnchor::Top;
-  }
-  if (position == "left") {
-    return LayerShellAnchor::Left;
-  }
-  if (position == "right") {
-    return LayerShellAnchor::Right;
-  }
-  return LayerShellAnchor::Bottom;
-}
-
-bool isVerticalPosition(const std::string& position) { return position == "left" || position == "right"; }
-
-std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount) {
-  const auto n = static_cast<std::int32_t>(itemCount);
-  const std::int32_t cellSize = cfg.iconSize + kCellPad * 2;
-  if (n == 0) {
-    return cellSize + cfg.padding * 2;
-  }
-  return n * cellSize + std::max(0, n - 1) * cfg.itemSpacing + cfg.padding * 2;
-}
-
-std::int32_t dockThickness(const DockConfig& cfg) { return cfg.iconSize + kCellPad * 2 + cfg.padding * 2; }
-
-std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
-  return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
-}
-
-DockSurfaceGeometry
-computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
-  const bool vertical = isVerticalPosition(cfg.position);
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
-  const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
-  const auto panelW = dockContentSize(cfg, itemCount);
-  const auto panelH = dockThickness(cfg);
-  const bool isBottom = (cfg.position == "bottom");
-  const bool isRight = (cfg.position == "right");
-
-  DockSurfaceGeometry geometry;
-  if (!vertical) {
-    geometry.surfaceW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
-    geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
-    if (isBottom) {
-      geometry.marginBottom = std::max(0, cfg.marginEdge - sb.down);
-      geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
-      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.down));
-    } else {
-      geometry.marginTop = std::max(0, cfg.marginEdge - sb.up);
-      geometry.surfaceH = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.up) + panelH + sb.down);
-      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.up) + panelH);
+  std::uint32_t positionToAnchor(const std::string& position) {
+    if (position == "top") {
+      return LayerShellAnchor::Top;
     }
-    geometry.marginLeft = cfg.marginEnds;
-    geometry.marginRight = cfg.marginEnds;
+    if (position == "left") {
+      return LayerShellAnchor::Left;
+    }
+    if (position == "right") {
+      return LayerShellAnchor::Right;
+    }
+    return LayerShellAnchor::Bottom;
+  }
+
+  bool isVerticalPosition(const std::string& position) { return position == "left" || position == "right"; }
+
+  std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount) {
+    const auto n = static_cast<std::int32_t>(itemCount);
+    const std::int32_t cellSize = cfg.iconSize + kCellPad * 2;
+    if (n == 0) {
+      return cellSize + cfg.padding * 2;
+    }
+    return n * cellSize + std::max(0, n - 1) * cfg.itemSpacing + cfg.padding * 2;
+  }
+
+  std::int32_t dockThickness(const DockConfig& cfg) { return cfg.iconSize + kCellPad * 2 + cfg.padding * 2; }
+
+  std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
+    return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
+  }
+
+  DockSurfaceGeometry
+  computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
+    const bool vertical = isVerticalPosition(cfg.position);
+    const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+    const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
+    const auto panelW = dockContentSize(cfg, itemCount);
+    const auto panelH = dockThickness(cfg);
+    const bool isBottom = (cfg.position == "bottom");
+    const bool isRight = (cfg.position == "right");
+
+    DockSurfaceGeometry geometry;
+    if (!vertical) {
+      geometry.surfaceW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
+      geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
+      if (isBottom) {
+        geometry.marginBottom = std::max(0, cfg.marginEdge - sb.down);
+        geometry.surfaceH = static_cast<std::uint32_t>(sb.up + panelH + std::min(cfg.marginEdge, sb.down));
+        geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.down));
+      } else {
+        geometry.marginTop = std::max(0, cfg.marginEdge - sb.up);
+        geometry.surfaceH = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.up) + panelH + sb.down);
+        geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.up) + panelH);
+      }
+      geometry.marginLeft = cfg.marginEnds;
+      geometry.marginRight = cfg.marginEnds;
+      return geometry;
+    }
+
+    geometry.surfaceH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
+    if (isRight) {
+      geometry.marginRight = std::max(0, cfg.marginEdge - sb.right);
+      geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + std::min(cfg.marginEdge, sb.right));
+      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.right));
+    } else {
+      geometry.marginLeft = std::max(0, cfg.marginEdge - sb.left);
+      geometry.surfaceW = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.left) + panelH + sb.right);
+      geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.left) + panelH);
+    }
+    geometry.marginTop = cfg.marginEnds;
+    geometry.marginBottom = cfg.marginEnds;
     return geometry;
   }
 
-  geometry.surfaceH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
-  if (isRight) {
-    geometry.marginRight = std::max(0, cfg.marginEdge - sb.right);
-    geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + std::min(cfg.marginEdge, sb.right));
-    geometry.exclusiveZone = hiddenOverlayMode ? 0 : (panelH + std::min(cfg.marginEdge, sb.right));
-  } else {
-    geometry.marginLeft = std::max(0, cfg.marginEdge - sb.left);
-    geometry.surfaceW = static_cast<std::uint32_t>(std::min(cfg.marginEdge, sb.left) + panelH + sb.right);
-    geometry.exclusiveZone = hiddenOverlayMode ? 0 : (std::min(cfg.marginEdge, sb.left) + panelH);
-  }
-  geometry.marginTop = cfg.marginEnds;
-  geometry.marginBottom = cfg.marginEnds;
-  return geometry;
-}
-
-LayerSurfaceConfig
-makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
-  const auto geometry = computeSurfaceGeometry(cfg, shadow, itemCount);
-  return LayerSurfaceConfig{
-      .nameSpace = "noctalia-dock",
-      .layer = LayerShellLayer::Top,
-      .anchor = positionToAnchor(cfg.position),
-      .width = geometry.surfaceW,
-      .height = geometry.surfaceH,
-      .exclusiveZone = geometry.exclusiveZone,
-      .marginTop = geometry.marginTop,
-      .marginRight = geometry.marginRight,
-      .marginBottom = geometry.marginBottom,
-      .marginLeft = geometry.marginLeft,
-      .defaultWidth = geometry.surfaceW,
-      .defaultHeight = geometry.surfaceH,
-  };
-}
-
-DockPanelGeometry
-computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH) {
-  const bool vertical = isVerticalPosition(cfg.position);
-  const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
-  const float bleedL = static_cast<float>(sb.left);
-  const float bleedR = static_cast<float>(sb.right);
-  const float bleedU = static_cast<float>(sb.up);
-  const float bleedD = static_cast<float>(sb.down);
-  const float mEdge = static_cast<float>(cfg.marginEdge);
-  const bool isBottom = (cfg.position == "bottom");
-  const bool isRight = (cfg.position == "right");
-
-  if (!vertical) {
-    return DockPanelGeometry{
-        .panelX = bleedL,
-        .panelY = isBottom ? bleedU : std::min(mEdge, bleedU),
-        .panelW = surfaceW - bleedL - bleedR,
-        .panelH = static_cast<float>(dockThickness(cfg)),
+  LayerSurfaceConfig
+  makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
+    const auto geometry = computeSurfaceGeometry(cfg, shadow, itemCount);
+    return LayerSurfaceConfig{
+        .nameSpace = "noctalia-dock",
+        .layer = LayerShellLayer::Top,
+        .anchor = positionToAnchor(cfg.position),
+        .width = geometry.surfaceW,
+        .height = geometry.surfaceH,
+        .exclusiveZone = geometry.exclusiveZone,
+        .marginTop = geometry.marginTop,
+        .marginRight = geometry.marginRight,
+        .marginBottom = geometry.marginBottom,
+        .marginLeft = geometry.marginLeft,
+        .defaultWidth = geometry.surfaceW,
+        .defaultHeight = geometry.surfaceH,
     };
   }
 
-  return DockPanelGeometry{
-      .panelX = isRight ? bleedL : std::min(mEdge, bleedL),
-      .panelY = bleedU,
-      .panelW = static_cast<float>(dockThickness(cfg)),
-      .panelH = surfaceH - bleedU - bleedD,
-  };
-}
+  DockPanelGeometry
+  computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH) {
+    const bool vertical = isVerticalPosition(cfg.position);
+    const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+    const float bleedL = static_cast<float>(sb.left);
+    const float bleedR = static_cast<float>(sb.right);
+    const float bleedU = static_cast<float>(sb.up);
+    const float bleedD = static_cast<float>(sb.down);
+    const float mEdge = static_cast<float>(cfg.marginEdge);
+    const bool isBottom = (cfg.position == "bottom");
+    const bool isRight = (cfg.position == "right");
 
-std::pair<float, float> computeHiddenSlideDelta(
-    const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
-    const DockPanelGeometry& panel
-) {
-  float contentLeft = panel.panelX;
-  float contentTop = panel.panelY;
-  float contentRight = panel.panelX + panel.panelW;
-  float contentBottom = panel.panelY + panel.panelH;
-  if (shell::surface_shadow::enabled(cfg.shadow, shadow)) {
-    const float sx = panel.panelX + static_cast<float>(shadow.offsetX);
-    const float sy = panel.panelY + static_cast<float>(shadow.offsetY);
-    contentLeft = std::min(contentLeft, sx);
-    contentTop = std::min(contentTop, sy);
-    contentRight = std::max(contentRight, sx + panel.panelW);
-    contentBottom = std::max(contentBottom, sy + panel.panelH);
-  }
-
-  if (!isVerticalPosition(cfg.position)) {
-    if (cfg.position == "bottom") {
-      return {0.0f, (surfaceH - contentTop) + kAutoHideSlideExtraPx};
+    if (!vertical) {
+      return DockPanelGeometry{
+          .panelX = bleedL,
+          .panelY = isBottom ? bleedU : std::min(mEdge, bleedU),
+          .panelW = surfaceW - bleedL - bleedR,
+          .panelH = static_cast<float>(dockThickness(cfg)),
+      };
     }
-    return {0.0f, -(contentBottom + kAutoHideSlideExtraPx)};
-  }
-  if (cfg.position == "right") {
-    return {(surfaceW - contentLeft) + kAutoHideSlideExtraPx, 0.0f};
-  }
-  return {-(contentRight + kAutoHideSlideExtraPx), 0.0f};
-}
 
-std::vector<InputRect>
-computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
-  if (hidden) {
+    return DockPanelGeometry{
+        .panelX = isRight ? bleedL : std::min(mEdge, bleedL),
+        .panelY = bleedU,
+        .panelW = static_cast<float>(dockThickness(cfg)),
+        .panelH = surfaceH - bleedU - bleedD,
+    };
+  }
+
+  std::pair<float, float> computeHiddenSlideDelta(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
+      const DockPanelGeometry& panel
+  ) {
+    float contentLeft = panel.panelX;
+    float contentTop = panel.panelY;
+    float contentRight = panel.panelX + panel.panelW;
+    float contentBottom = panel.panelY + panel.panelH;
+    if (shell::surface_shadow::enabled(cfg.shadow, shadow)) {
+      const float sx = panel.panelX + static_cast<float>(shadow.offsetX);
+      const float sy = panel.panelY + static_cast<float>(shadow.offsetY);
+      contentLeft = std::min(contentLeft, sx);
+      contentTop = std::min(contentTop, sy);
+      contentRight = std::max(contentRight, sx + panel.panelW);
+      contentBottom = std::max(contentBottom, sy + panel.panelH);
+    }
+
     if (!isVerticalPosition(cfg.position)) {
-      return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
+      if (cfg.position == "bottom") {
+        return {0.0f, (surfaceH - contentTop) + kAutoHideSlideExtraPx};
+      }
+      return {0.0f, -(contentBottom + kAutoHideSlideExtraPx)};
     }
-    if (cfg.position == "left") {
-      return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
+    if (cfg.position == "right") {
+      return {(surfaceW - contentLeft) + kAutoHideSlideExtraPx, 0.0f};
     }
-    return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+    return {-(contentRight + kAutoHideSlideExtraPx), 0.0f};
   }
 
-  return {InputRect{
-      static_cast<int>(std::lround(panel.panelX)),
-      static_cast<int>(std::lround(panel.panelY)),
-      static_cast<int>(std::lround(panel.panelW)),
-      static_cast<int>(std::lround(panel.panelH)),
-  }};
-}
+  std::vector<InputRect>
+  computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
+    if (hidden) {
+      if (!isVerticalPosition(cfg.position)) {
+        return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
+      }
+      if (cfg.position == "left") {
+        return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
+      }
+      return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+    }
+
+    return {InputRect{
+        static_cast<int>(std::lround(panel.panelX)),
+        static_cast<int>(std::lround(panel.panelY)),
+        static_cast<int>(std::lround(panel.panelW)),
+        static_cast<int>(std::lround(panel.panelH)),
+    }};
+  }
 
 } // namespace shell::dock

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include "config/config_types.h"
-#include "render/core/render_styles.h"
-#include "wayland/layer_surface.h"
 
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
+
+struct InputRect;
+struct LayerSurfaceConfig;
 
 namespace shell::dock {
 
@@ -34,7 +35,6 @@ struct DockSurfaceGeometry {
 [[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
 [[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
 [[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
-[[nodiscard]] Radii dockCornerRadii(const DockConfig& cfg);
 [[nodiscard]] DockSurfaceGeometry
 computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
 [[nodiscard]] LayerSurfaceConfig

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "config/config_types.h"
+#include "render/core/render_styles.h"
+#include "wayland/layer_surface.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace shell::dock {
+
+struct DockPanelGeometry {
+  float panelX = 0.0f;
+  float panelY = 0.0f;
+  float panelW = 0.0f;
+  float panelH = 0.0f;
+};
+
+struct DockSurfaceGeometry {
+  std::uint32_t surfaceW = 0;
+  std::uint32_t surfaceH = 0;
+  std::int32_t marginTop = 0;
+  std::int32_t marginRight = 0;
+  std::int32_t marginBottom = 0;
+  std::int32_t marginLeft = 0;
+  std::int32_t exclusiveZone = 0;
+};
+
+[[nodiscard]] std::uint32_t positionToAnchor(const std::string& position);
+[[nodiscard]] bool isVerticalPosition(const std::string& position);
+[[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
+[[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
+[[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
+[[nodiscard]] Radii dockCornerRadii(const DockConfig& cfg);
+[[nodiscard]] DockSurfaceGeometry
+computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
+[[nodiscard]] LayerSurfaceConfig
+makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
+[[nodiscard]] DockPanelGeometry
+computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH);
+[[nodiscard]] std::pair<float, float> computeHiddenSlideDelta(
+    const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
+    const DockPanelGeometry& panel
+);
+[[nodiscard]] std::vector<InputRect>
+computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden);
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -13,39 +13,39 @@ struct LayerSurfaceConfig;
 
 namespace shell::dock {
 
-struct DockPanelGeometry {
-  float panelX = 0.0f;
-  float panelY = 0.0f;
-  float panelW = 0.0f;
-  float panelH = 0.0f;
-};
+  struct DockPanelGeometry {
+    float panelX = 0.0f;
+    float panelY = 0.0f;
+    float panelW = 0.0f;
+    float panelH = 0.0f;
+  };
 
-struct DockSurfaceGeometry {
-  std::uint32_t surfaceW = 0;
-  std::uint32_t surfaceH = 0;
-  std::int32_t marginTop = 0;
-  std::int32_t marginRight = 0;
-  std::int32_t marginBottom = 0;
-  std::int32_t marginLeft = 0;
-  std::int32_t exclusiveZone = 0;
-};
+  struct DockSurfaceGeometry {
+    std::uint32_t surfaceW = 0;
+    std::uint32_t surfaceH = 0;
+    std::int32_t marginTop = 0;
+    std::int32_t marginRight = 0;
+    std::int32_t marginBottom = 0;
+    std::int32_t marginLeft = 0;
+    std::int32_t exclusiveZone = 0;
+  };
 
-[[nodiscard]] std::uint32_t positionToAnchor(const std::string& position);
-[[nodiscard]] bool isVerticalPosition(const std::string& position);
-[[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
-[[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
-[[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
-[[nodiscard]] DockSurfaceGeometry
-computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
-[[nodiscard]] LayerSurfaceConfig
-makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
-[[nodiscard]] DockPanelGeometry
-computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH);
-[[nodiscard]] std::pair<float, float> computeHiddenSlideDelta(
-    const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
-    const DockPanelGeometry& panel
-);
-[[nodiscard]] std::vector<InputRect>
-computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden);
+  [[nodiscard]] std::uint32_t positionToAnchor(const std::string& position);
+  [[nodiscard]] bool isVerticalPosition(const std::string& position);
+  [[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
+  [[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
+  [[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
+  [[nodiscard]] DockSurfaceGeometry
+  computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
+  [[nodiscard]] LayerSurfaceConfig
+  makeLayerSurfaceConfig(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);
+  [[nodiscard]] DockPanelGeometry
+  computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH);
+  [[nodiscard]] std::pair<float, float> computeHiddenSlideDelta(
+      const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH,
+      const DockPanelGeometry& panel
+  );
+  [[nodiscard]] std::vector<InputRect>
+  computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden);
 
 } // namespace shell::dock

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -285,12 +285,15 @@ namespace {
           if (inst.surface == nullptr)
             return;
           const auto& cfg = config.config().dock;
-          const bool vert = shell::dock::isVerticalPosition(cfg.position);
-          const auto sb = shell::surface_shadow::bleed(cfg.shadow, config.config().shell.shadow);
-          const auto panelW = shell::dock::dockContentSize(cfg, inst.items.size());
-          const auto panelH = shell::dock::dockThickness(cfg);
-          const auto surfW = static_cast<int>(vert ? (sb.left + panelH + sb.right) : (panelW + sb.left + sb.right));
-          const auto surfH = static_cast<int>(vert ? (panelW + sb.up + sb.down) : (sb.up + panelH + cfg.marginEdge));
+          int surfW = static_cast<int>(inst.surface->width());
+          int surfH = static_cast<int>(inst.surface->height());
+          if (surfW <= 0 || surfH <= 0) {
+            const auto surfaceGeometry = shell::dock::computeSurfaceGeometry(
+                cfg, config.config().shell.shadow, inst.items.size() + shell::dock::dockLauncherButtonCount(cfg)
+            );
+            surfW = static_cast<int>(surfaceGeometry.surfaceW);
+            surfH = static_cast<int>(surfaceGeometry.surfaceH);
+          }
           inst.surface->setInputRegion(
               shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, surfW, surfH, true)
           );

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -1,0 +1,304 @@
+#include "shell/dock/dock_instance.h"
+
+#include "compositors/compositor_platform.h"
+#include "config/config_service.h"
+#include "core/ui_phase.h"
+#include "render/render_context.h"
+#include "render/scene/node.h"
+#include "shell/dock/dock_geometry.h"
+#include "shell/surface_shadow.h"
+#include "shell/tooltip/tooltip_manager.h"
+#include "ui/builders.h"
+#include "ui/palette.h"
+#include "ui/style.h"
+#include "wayland/layer_surface.h"
+#include "wayland/surface.h"
+
+#include <cmath>
+
+namespace {
+
+  std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical) {
+    return ui::flex(
+        vertical ? FlexDirection::Vertical : FlexDirection::Horizontal,
+        {
+            .align = FlexAlign::Center,
+            .gap = static_cast<float>(cfg.itemSpacing),
+            .padding = static_cast<float>(cfg.padding),
+        }
+    );
+  }
+
+} // namespace
+
+namespace shell::dock {
+
+  void prepareFrame(
+      DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks, bool needsUpdate,
+      bool needsLayout
+  ) {
+    if (instance.surface == nullptr) {
+      return;
+    }
+
+    const auto width = instance.surface->width();
+    const auto height = instance.surface->height();
+    if (width == 0 || height == 0) {
+      return;
+    }
+
+    deps.renderContext.makeCurrent(instance.surface->renderTarget());
+
+    bool needsModelRebuild = false;
+    if (needsUpdate || instance.sceneRoot == nullptr) {
+      UiPhaseScope updatePhase(UiPhase::Update);
+      if (callbacks.syncModel) {
+        needsModelRebuild = callbacks.syncModel(instance);
+      }
+    }
+
+    const bool needsSceneBuild = instance.sceneRoot == nullptr
+        || static_cast<std::uint32_t>(std::round(instance.sceneRoot->width())) != width
+        || static_cast<std::uint32_t>(std::round(instance.sceneRoot->height())) != height;
+    if (needsSceneBuild || needsLayout || needsModelRebuild) {
+      UiPhaseScope layoutPhase(UiPhase::Layout);
+      if (needsModelRebuild && instance.sceneRoot != nullptr && callbacks.rebuildItems) {
+        callbacks.rebuildItems(instance);
+      }
+      buildScene(instance, deps, callbacks);
+    } else if (needsUpdate && callbacks.updateVisuals) {
+      callbacks.updateVisuals(instance);
+    }
+  }
+
+  void syncDockSlideLayerTransform(DockInstance& instance, const DockConfig& cfg) {
+    if (instance.slideRoot == nullptr) {
+      return;
+    }
+    if (cfg.autoHide) {
+      const float t = 1.0f - instance.hideOpacity;
+      instance.slideRoot->setPosition(instance.slideHiddenDx * t, instance.slideHiddenDy * t);
+    } else {
+      instance.slideRoot->setPosition(0.0f, 0.0f);
+    }
+  }
+
+  void applyDockCompositorBlur(DockInstance& instance, const DockConfig& cfg) {
+    if (instance.surface == nullptr) {
+      return;
+    }
+    // Compositor blur is independent of scene opacity — clear it while auto-hide
+    // has faded the dock out so a transparent buffer does not leave a blur halo.
+    constexpr float kBlurVisibleOpacity = 0.02f;
+    if (cfg.autoHide && instance.hideOpacity < kBlurVisibleOpacity) {
+      instance.surface->clearBlurRegion();
+      return;
+    }
+    if (instance.panel == nullptr) {
+      return;
+    }
+    float absX = 0.0f;
+    float absY = 0.0f;
+    Node::absolutePosition(instance.panel, absX, absY);
+    const int px = static_cast<int>(std::lround(absX));
+    const int py = static_cast<int>(std::lround(absY));
+    const int pw = static_cast<int>(std::lround(instance.panel->width()));
+    const int ph = static_cast<int>(std::lround(instance.panel->height()));
+    const Radii radii = shell::dock::dockCornerRadii(cfg);
+    auto blurStrips = Surface::tessellateRoundedRect(px, py, pw, ph, radii.tl, radii.tr, radii.br, radii.bl);
+    instance.surface->setBlurRegion(blurStrips);
+  }
+
+  void buildScene(DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks) {
+    uiAssertNotRendering("shell::dock::buildScene");
+    if (instance.surface == nullptr) {
+      return;
+    }
+
+    const auto& cfg = deps.config.config().dock;
+    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+
+    const float w = static_cast<float>(instance.surface->width());
+    const float h = static_cast<float>(instance.surface->height());
+
+    const auto& shadowConfig = deps.config.config().shell.shadow;
+    const auto panelGeometry = shell::dock::computePanelGeometry(cfg, shadowConfig, w, h);
+    const Radii radii = shell::dock::dockCornerRadii(cfg);
+
+    if (instance.sceneRoot == nullptr) {
+      instance.sceneRoot = std::make_unique<Node>();
+      instance.sceneRoot->setAnimationManager(&instance.animations);
+      instance.sceneRoot->setSize(w, h);
+      instance.sceneRoot->setOpacity(1.0f);
+
+      auto slide = std::make_unique<Node>();
+      slide->setParticipatesInLayout(false);
+      instance.slideRoot = instance.sceneRoot->addChild(std::move(slide));
+
+      // Shadow
+      if (shell::surface_shadow::enabled(cfg.shadow, shadowConfig)) {
+        instance.shadow = static_cast<Box*>(instance.slideRoot->addChild(ui::box()));
+      }
+
+      // Panel background
+      instance.panel = static_cast<Box*>(instance.slideRoot->addChild(
+          ui::box({
+              .configure = [radii](Box& box) { box.setRadii(radii); },
+          })
+      ));
+
+      // Item row
+      instance.row = static_cast<Flex*>(instance.panel->addChild(makeDockItemRow(cfg, vert)));
+
+      // Wire up InputDispatcher.
+      instance.inputDispatcher.setSceneRoot(instance.sceneRoot.get());
+      instance.inputDispatcher.setCursorShapeCallback([&platform = deps.platform](
+                                                          std::uint32_t serial, std::uint32_t shape
+                                                      ) { platform.setCursorShape(serial, shape); });
+      instance.inputDispatcher.setHoverChangeCallback([inst = &instance](InputArea* /*old*/, InputArea* next) {
+        TooltipManager::instance().onHoverChange(next, inst->surface->layerSurface(), inst->output);
+      });
+
+      // Populate items and wire up palette reactivity.
+      if (callbacks.rebuildItems) {
+        callbacks.rebuildItems(instance);
+      }
+
+      if (cfg.autoHide) {
+        // Start off-screen (slide); opacity stays at 1 so the compositor blur matches the panel.
+        instance.slideRoot->setOpacity(1.0f);
+        instance.hideOpacity = 0.0f;
+      } else {
+        instance.slideRoot->setOpacity(0.0f);
+        instance.hideOpacity = 1.0f;
+        instance.animations.animate(
+            0.0f, 1.0f, Style::animSlow, Easing::EaseOutCubic,
+            [slide = instance.slideRoot](float v) { slide->setOpacity(v); }, {}, instance.slideRoot
+        );
+      }
+
+      instance.surface->setSceneRoot(instance.sceneRoot.get());
+    }
+
+    // Update root size on reconfigure.
+    instance.sceneRoot->setSize(w, h);
+    if (instance.slideRoot != nullptr) {
+      instance.slideRoot->setSize(w, h);
+    }
+
+    // Shadow
+    if (instance.shadow != nullptr) {
+      const float shadowOffsetX = static_cast<float>(shadowConfig.offsetX);
+      const float shadowOffsetY = static_cast<float>(shadowConfig.offsetY);
+      const RoundedRectStyle shadowStyle = shell::surface_shadow::style(
+          shadowConfig, cfg.backgroundOpacity, shell::surface_shadow::Shape{.radius = radii}
+      );
+      instance.shadow->setStyle(shadowStyle);
+      instance.shadow->setZIndex(-1);
+      instance.shadow->setPosition(panelGeometry.panelX + shadowOffsetX, panelGeometry.panelY + shadowOffsetY);
+      instance.shadow->setSize(panelGeometry.panelW, panelGeometry.panelH);
+    }
+
+    // Panel
+    applyPanelPalette(instance, cfg);
+    instance.panel->setPosition(panelGeometry.panelX, panelGeometry.panelY);
+    instance.panel->setSize(panelGeometry.panelW, panelGeometry.panelH);
+
+    // Row fills panel (padding already applied via Flex::setPadding).
+    instance.row->setPosition(0.0f, 0.0f);
+    instance.row->setSize(panelGeometry.panelW, panelGeometry.panelH);
+    instance.row->layout(deps.renderContext);
+
+    if (cfg.autoHide) {
+      const auto hiddenDelta = shell::dock::computeHiddenSlideDelta(cfg, shadowConfig, w, h, panelGeometry);
+      instance.slideHiddenDx = hiddenDelta.first;
+      instance.slideHiddenDy = hiddenDelta.second;
+    } else {
+      instance.slideHiddenDx = 0.0f;
+      instance.slideHiddenDy = 0.0f;
+    }
+    syncDockSlideLayerTransform(instance, cfg);
+
+    // Input region: trigger strip when hidden (autoHide), full panel otherwise.
+    const bool hiddenInputRegion = cfg.autoHide && instance.hideOpacity < 0.5f;
+    auto inputPanelGeometry = panelGeometry;
+    if (!hiddenInputRegion && instance.slideRoot != nullptr) {
+      inputPanelGeometry.panelX += instance.slideRoot->x();
+      inputPanelGeometry.panelY += instance.slideRoot->y();
+    }
+    instance.surface->setInputRegion(shell::dock::computeInputRegion(
+        cfg, inputPanelGeometry, static_cast<int>(w), static_cast<int>(h), hiddenInputRegion
+    ));
+
+    applyDockCompositorBlur(instance, cfg);
+
+    // Palette reactivity.
+    instance.paletteConn = paletteChanged().connect([inst = &instance, &config = deps.config] {
+      applyPanelPalette(*inst, config.config().dock);
+      if (inst->surface)
+        inst->surface->requestRedraw();
+    });
+
+    if (callbacks.updateVisuals) {
+      callbacks.updateVisuals(instance);
+    }
+  }
+
+  void applyPanelPalette(DockInstance& instance, const DockConfig& cfg) {
+    if (instance.panel == nullptr)
+      return;
+    const float opacity = cfg.backgroundOpacity;
+    instance.panel->setFill(colorSpecFromRole(ColorRole::Surface, opacity));
+    instance.panel->setBorder(colorSpecFromRole(ColorRole::Outline), 0.0f);
+  }
+
+  void resizeSurface(DockInstance& instance, const DockConfig& cfg, const ShellConfig::ShadowConfig& shadowConfig) {
+    if (instance.surface == nullptr) {
+      return;
+    }
+
+    const auto surfaceGeometry = shell::dock::computeSurfaceGeometry(
+        cfg, shadowConfig, instance.items.size() + shell::dock::dockLauncherButtonCount(cfg)
+    );
+
+    if (instance.surface->width() != surfaceGeometry.surfaceW
+        || instance.surface->height() != surfaceGeometry.surfaceH) {
+      instance.surface->requestSize(surfaceGeometry.surfaceW, surfaceGeometry.surfaceH);
+    }
+  }
+
+  void startHideFadeOut(DockInstance& inst, ConfigService& config) {
+    if (inst.hideAnimId != 0) {
+      inst.animations.cancel(inst.hideAnimId);
+      inst.hideAnimId = 0;
+    }
+    const float current = inst.hideOpacity;
+    inst.hideAnimId = inst.animations.animate(
+        current, 0.0f, Style::animSlow, Easing::EaseInQuad,
+        [&inst, &config](float v) {
+          inst.hideOpacity = v;
+          const auto& cfg = config.config().dock;
+          syncDockSlideLayerTransform(inst, cfg);
+          applyDockCompositorBlur(inst, cfg);
+        },
+        [&inst, &config]() {
+          inst.hideAnimId = 0;
+          if (inst.surface == nullptr)
+            return;
+          const auto& cfg = config.config().dock;
+          const bool vert = shell::dock::isVerticalPosition(cfg.position);
+          const auto sb = shell::surface_shadow::bleed(cfg.shadow, config.config().shell.shadow);
+          const auto panelW = shell::dock::dockContentSize(cfg, inst.items.size());
+          const auto panelH = shell::dock::dockThickness(cfg);
+          const auto surfW = static_cast<int>(vert ? (sb.left + panelH + sb.right) : (panelW + sb.left + sb.right));
+          const auto surfH = static_cast<int>(vert ? (panelW + sb.up + sb.down) : (sb.up + panelH + cfg.marginEdge));
+          inst.surface->setInputRegion(
+              shell::dock::computeInputRegion(cfg, shell::dock::DockPanelGeometry{}, surfW, surfH, true)
+          );
+        }
+    );
+    if (inst.surface)
+      inst.surface->requestRedraw();
+  }
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -3,6 +3,7 @@
 #include "compositors/compositor_platform.h"
 #include "config/config_service.h"
 #include "core/ui_phase.h"
+#include "render/core/render_styles.h"
 #include "render/render_context.h"
 #include "render/scene/node.h"
 #include "shell/dock/dock_geometry.h"
@@ -18,6 +19,18 @@
 #include <cmath>
 
 namespace shell::dock {
+namespace {
+
+  Radii dockCornerRadii(const DockConfig& cfg) {
+    return Radii{
+        static_cast<float>(cfg.radiusTopLeft),
+        static_cast<float>(cfg.radiusTopRight),
+        static_cast<float>(cfg.radiusBottomRight),
+        static_cast<float>(cfg.radiusBottomLeft),
+    };
+  }
+
+} // namespace
 
   void prepareFrame(
       DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks, bool needsUpdate,
@@ -90,7 +103,7 @@ namespace shell::dock {
     const int py = static_cast<int>(std::lround(absY));
     const int pw = static_cast<int>(std::lround(instance.panel->width()));
     const int ph = static_cast<int>(std::lround(instance.panel->height()));
-    const Radii radii = shell::dock::dockCornerRadii(cfg);
+    const Radii radii = dockCornerRadii(cfg);
     auto blurStrips = Surface::tessellateRoundedRect(px, py, pw, ph, radii.tl, radii.tr, radii.br, radii.bl);
     instance.surface->setBlurRegion(blurStrips);
   }
@@ -109,7 +122,7 @@ namespace shell::dock {
 
     const auto& shadowConfig = deps.config.config().shell.shadow;
     const auto panelGeometry = shell::dock::computePanelGeometry(cfg, shadowConfig, w, h);
-    const Radii radii = shell::dock::dockCornerRadii(cfg);
+    const Radii radii = dockCornerRadii(cfg);
 
     if (instance.sceneRoot == nullptr) {
       instance.sceneRoot = std::make_unique<Node>();

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -6,6 +6,7 @@
 #include "render/render_context.h"
 #include "render/scene/node.h"
 #include "shell/dock/dock_geometry.h"
+#include "shell/dock/dock_items.h"
 #include "shell/surface_shadow.h"
 #include "shell/tooltip/tooltip_manager.h"
 #include "ui/builders.h"
@@ -15,21 +16,6 @@
 #include "wayland/surface.h"
 
 #include <cmath>
-
-namespace {
-
-  std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical) {
-    return ui::flex(
-        vertical ? FlexDirection::Vertical : FlexDirection::Horizontal,
-        {
-            .align = FlexAlign::Center,
-            .gap = static_cast<float>(cfg.itemSpacing),
-            .padding = static_cast<float>(cfg.padding),
-        }
-    );
-  }
-
-} // namespace
 
 namespace shell::dock {
 

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -19,18 +19,18 @@
 #include <cmath>
 
 namespace shell::dock {
-namespace {
+  namespace {
 
-  Radii dockCornerRadii(const DockConfig& cfg) {
-    return Radii{
-        static_cast<float>(cfg.radiusTopLeft),
-        static_cast<float>(cfg.radiusTopRight),
-        static_cast<float>(cfg.radiusBottomRight),
-        static_cast<float>(cfg.radiusBottomLeft),
-    };
-  }
+    Radii dockCornerRadii(const DockConfig& cfg) {
+      return Radii{
+          static_cast<float>(cfg.radiusTopLeft),
+          static_cast<float>(cfg.radiusTopRight),
+          static_cast<float>(cfg.radiusBottomRight),
+          static_cast<float>(cfg.radiusBottomLeft),
+      };
+    }
 
-} // namespace
+  } // namespace
 
   void prepareFrame(
       DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks, bool needsUpdate,
@@ -151,9 +151,10 @@ namespace {
 
       // Wire up InputDispatcher.
       instance.inputDispatcher.setSceneRoot(instance.sceneRoot.get());
-      instance.inputDispatcher.setCursorShapeCallback([&platform = deps.platform](
-                                                          std::uint32_t serial, std::uint32_t shape
-                                                      ) { platform.setCursorShape(serial, shape); });
+      instance.inputDispatcher.setCursorShapeCallback([&platform =
+                                                           deps.platform](std::uint32_t serial, std::uint32_t shape) {
+        platform.setCursorShape(serial, shape);
+      });
       instance.inputDispatcher.setHoverChangeCallback([inst = &instance](InputArea* /*old*/, InputArea* next) {
         TooltipManager::instance().onHoverChange(next, inst->surface->layerSurface(), inst->output);
       });
@@ -225,9 +226,11 @@ namespace {
       inputPanelGeometry.panelX += instance.slideRoot->x();
       inputPanelGeometry.panelY += instance.slideRoot->y();
     }
-    instance.surface->setInputRegion(shell::dock::computeInputRegion(
-        cfg, inputPanelGeometry, static_cast<int>(w), static_cast<int>(h), hiddenInputRegion
-    ));
+    instance.surface->setInputRegion(
+        shell::dock::computeInputRegion(
+            cfg, inputPanelGeometry, static_cast<int>(w), static_cast<int>(h), hiddenInputRegion
+        )
+    );
 
     applyDockCompositorBlur(instance, cfg);
 

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "config/config_types.h"
+#include "render/animation/animation_manager.h"
+#include "render/scene/input_dispatcher.h"
+#include "system/desktop_entry.h"
+#include "ui/signal.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+class Box;
+class CompositorPlatform;
+class ConfigService;
+class Flex;
+class Glyph;
+class Image;
+class InputArea;
+class Label;
+class LayerSurface;
+class Node;
+class RenderContext;
+struct wl_output;
+
+namespace shell::dock {
+
+  struct DockItemView {
+    DesktopEntry entry;
+    std::string idLower;
+    std::string startupWmClassLower;
+    InputArea* area = nullptr;
+    Box* background = nullptr;
+    std::array<Box*, 3> dotIndicators{};
+    Box* badge = nullptr;
+    Label* badgeLabel = nullptr;
+    Image* iconImage = nullptr;
+    Glyph* iconGlyph = nullptr;
+    bool hovered = false;
+    bool running = false;
+    bool active = false;
+    float visualScale = -1.0f;
+    float visualOpacity = -1.0f;
+    AnimationManager::Id scaleAnimId = 0;
+    AnimationManager::Id opacityAnimId = 0;
+    std::size_t instanceCount = 0;
+  };
+
+  struct DockInstance {
+    std::uint32_t outputName = 0;
+    wl_output* output = nullptr;
+    std::int32_t scale = 1;
+    std::unique_ptr<LayerSurface> surface;
+    // sceneRoot must be destroyed before `animations` — ~Node() calls cancelForOwner().
+    AnimationManager animations;
+    std::unique_ptr<Node> sceneRoot;
+    Node* slideRoot = nullptr;
+    float slideHiddenDx = 0.0f;
+    float slideHiddenDy = 0.0f;
+    Box* shadow = nullptr;
+    Box* panel = nullptr;
+    Flex* row = nullptr;
+    InputDispatcher inputDispatcher;
+    std::vector<DockItemView> items;
+    std::uint64_t modelSerial = 0;
+    std::string activeAppIdLower;
+    wl_output* lastFilterOutput = nullptr;
+    bool pointerInside = false;
+    // Auto-hide: tracks visibility [0,1] driven by hover.
+    float hideOpacity = 1.0f;
+    AnimationManager::Id hideAnimId = 0;
+    Signal<>::ScopedConnection paletteConn;
+  };
+
+  struct DockInstanceDependencies {
+    CompositorPlatform& platform;
+    ConfigService& config;
+    RenderContext& renderContext;
+  };
+
+  struct DockInstanceCallbacks {
+    std::function<bool(DockInstance&)> syncModel;
+    std::function<void(DockInstance&)> rebuildItems;
+    std::function<void(DockInstance&)> updateVisuals;
+  };
+
+  void prepareFrame(
+      DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks, bool needsUpdate,
+      bool needsLayout
+  );
+  void buildScene(DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks);
+  void resizeSurface(
+      DockInstance& instance, const DockConfig& cfg, const ShellConfig::ShadowConfig& shadowConfig
+  );
+  void applyPanelPalette(DockInstance& instance, const DockConfig& cfg);
+  void syncDockSlideLayerTransform(DockInstance& instance, const DockConfig& cfg);
+  void applyDockCompositorBlur(DockInstance& instance, const DockConfig& cfg);
+  void startHideFadeOut(DockInstance& instance, ConfigService& config);
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include "config/config_types.h"
-#include "render/animation/animation_manager.h"
 #include "render/scene/input_dispatcher.h"
-#include "system/desktop_entry.h"
+#include "shell/dock/dock_items.h"
 #include "ui/signal.h"
 
-#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -17,37 +15,12 @@ class Box;
 class CompositorPlatform;
 class ConfigService;
 class Flex;
-class Glyph;
-class Image;
-class InputArea;
-class Label;
 class LayerSurface;
 class Node;
 class RenderContext;
 struct wl_output;
 
 namespace shell::dock {
-
-  struct DockItemView {
-    DesktopEntry entry;
-    std::string idLower;
-    std::string startupWmClassLower;
-    InputArea* area = nullptr;
-    Box* background = nullptr;
-    std::array<Box*, 3> dotIndicators{};
-    Box* badge = nullptr;
-    Label* badgeLabel = nullptr;
-    Image* iconImage = nullptr;
-    Glyph* iconGlyph = nullptr;
-    bool hovered = false;
-    bool running = false;
-    bool active = false;
-    float visualScale = -1.0f;
-    float visualOpacity = -1.0f;
-    AnimationManager::Id scaleAnimId = 0;
-    AnimationManager::Id opacityAnimId = 0;
-    std::size_t instanceCount = 0;
-  };
 
   struct DockInstance {
     std::uint32_t outputName = 0;
@@ -64,7 +37,7 @@ namespace shell::dock {
     Box* panel = nullptr;
     Flex* row = nullptr;
     InputDispatcher inputDispatcher;
-    std::vector<DockItemView> items;
+    std::vector<shell::dock::DockItemView> items;
     std::uint64_t modelSerial = 0;
     std::string activeAppIdLower;
     wl_output* lastFilterOutput = nullptr;

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -65,9 +65,7 @@ namespace shell::dock {
       bool needsLayout
   );
   void buildScene(DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks);
-  void resizeSurface(
-      DockInstance& instance, const DockConfig& cfg, const ShellConfig::ShadowConfig& shadowConfig
-  );
+  void resizeSurface(DockInstance& instance, const DockConfig& cfg, const ShellConfig::ShadowConfig& shadowConfig);
   void applyPanelPalette(DockInstance& instance, const DockConfig& cfg);
   void syncDockSlideLayerTransform(DockInstance& instance, const DockConfig& cfg);
   void applyDockCompositorBlur(DockInstance& instance, const DockConfig& cfg);

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -1,0 +1,677 @@
+#include "shell/dock/dock_items.h"
+
+#include "compositors/compositor_platform.h"
+#include "config/config_service.h"
+#include "core/log.h"
+#include "core/ui_phase.h"
+#include "render/render_context.h"
+#include "render/scene/input_area.h"
+#include "render/scene/node.h"
+#include "shell/dock/dock_geometry.h"
+#include "shell/dock/dock_instance.h"
+#include "system/app_identity.h"
+#include "system/icon_resolver.h"
+#include "ui/builders.h"
+#include "ui/palette.h"
+#include "ui/style.h"
+#include "util/string_utils.h"
+#include "wayland/layer_surface.h"
+#include "wayland/wayland_toplevels.h"
+
+#include <algorithm>
+#include <cmath>
+#include <linux/input-event-codes.h>
+
+namespace {
+
+  constexpr Logger kLog("dock");
+
+  // Instance-count badge geometry — scales with icon size.
+  constexpr float kBadgeSizeRatio = 0.30f; // fraction of icon size
+  constexpr float kBadgeMinSize = 16.0f;   // minimum diameter in px
+  constexpr float kBadgeFontRatio = 0.72f; // font size relative to badge diameter
+  constexpr float kDotSizeRatio = 0.09f;
+  constexpr float kDotMinSize = 4.0f;
+  constexpr float kDotGap = 3.0f;
+  constexpr float kCellPad = 6.0f;
+
+  zwlr_foreign_toplevel_handle_v1* nextActivatableWindowHandle(
+      const std::vector<ToplevelInfo>& windows, zwlr_foreign_toplevel_handle_v1* activeHandle,
+      zwlr_foreign_toplevel_handle_v1* preferredHandle
+  ) {
+    for (std::size_t i = 0; i < windows.size(); ++i) {
+      if (windows[i].handle != nullptr && windows[i].handle == activeHandle) {
+        for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
+          auto* nextHandle = windows[(i + offset) % windows.size()].handle;
+          if (nextHandle != nullptr) {
+            return nextHandle;
+          }
+        }
+        return nullptr;
+      }
+    }
+
+    for (const auto& window : windows) {
+      if (window.handle != nullptr && window.handle == preferredHandle) {
+        return window.handle;
+      }
+    }
+
+    for (const auto& window : windows) {
+      if (window.handle != nullptr) {
+        return window.handle;
+      }
+    }
+    return nullptr;
+  }
+
+} // namespace
+
+namespace shell::dock {
+
+  std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
+    if (const auto active = platform.activeToplevel(); active.has_value()) {
+      return StringUtils::toLower(app_identity::resolveRunningDesktopEntry(active->appId, desktopEntries()).id);
+    }
+    return {};
+  }
+
+  wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput) {
+    if (!cfg.activeMonitorOnly) {
+      return nullptr;
+    }
+    return instanceOutput;
+  }
+
+  bool refreshPinnedAppsIfNeeded(
+      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
+      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
+  ) {
+    if (desktopEntriesVersion() == entriesVersion && cfg.pinned == lastPinnedConfig) {
+      return false;
+    }
+
+    lastPinnedConfig = cfg.pinned;
+    entriesVersion = desktopEntriesVersion();
+    pinnedEntries.clear();
+
+    const auto& entries = desktopEntries();
+
+    for (const auto& pinnedId : cfg.pinned) {
+      const auto pinnedLower = StringUtils::toLower(pinnedId);
+      bool found = false;
+
+      for (const auto& entry : entries) {
+        if (entry.hidden || entry.noDisplay) {
+          continue;
+        }
+        // Match by entry ID (stem of the desktop file path, e.g. "firefox"),
+        // by StartupWMClass (lower), or by Name (lower).
+        const auto stemLower = StringUtils::toLower([&] {
+          const auto slash = entry.id.rfind('/');
+          const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
+          const auto dot = base.rfind('.');
+          return (dot == std::string::npos) ? base : base.substr(0, dot);
+        }());
+
+        if (stemLower == pinnedLower || app_identity::desktopEntryMatchesLower(entry, pinnedLower)) {
+          pinnedEntries.push_back(entry);
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        kLog.debug("pinned app not found: {}", pinnedId);
+        // Add placeholder so the pinned slot is visible even when app is not installed.
+        DesktopEntry placeholder;
+        placeholder.id = pinnedId;
+        placeholder.name = pinnedId;
+        placeholder.nameLower = pinnedLower;
+        pinnedEntries.push_back(std::move(placeholder));
+      }
+    }
+
+    ++modelSerial;
+    kLog.debug("pinned app list: {} entries", pinnedEntries.size());
+    return true;
+  }
+
+  bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower) {
+    return !activeAppIdLower.empty() && activeAppIdLower == item.idLower;
+  }
+
+  bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) {
+    for (const auto& rid : runningLower) {
+      if (!rid.empty() && rid == item.idLower) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool syncInstanceModel(DockInstance& instance, DockItemModelDependencies deps) {
+    const auto& cfg = deps.config.config().dock;
+    const std::string globalActiveIdLower = currentActiveEntryIdLower(deps.platform);
+    if (!globalActiveIdLower.empty()) {
+      if (const auto active = deps.platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
+        deps.lastActiveHandleByAppIdLower[globalActiveIdLower] = active->handle;
+      }
+    }
+    wl_output* const activeOutput = deps.platform.activeToplevelOutput();
+    wl_output* filterOutput = dockFilterOutput(cfg, instance.output);
+    const bool filterOutputChanged = (filterOutput != instance.lastFilterOutput);
+    instance.lastFilterOutput = filterOutput;
+
+    // When filtering by active monitor, inactive monitors' docks should not
+    // highlight the globally-active app — it isn't on them.
+    const std::string activeIdLower =
+        (cfg.activeMonitorOnly && activeOutput != instance.output) ? std::string{} : globalActiveIdLower;
+    instance.activeAppIdLower = activeIdLower;
+
+    const auto runningIds = cfg.showRunning ? deps.platform.runningAppIds(filterOutput) : std::vector<std::string>{};
+    const auto& allEntries = desktopEntries();
+    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
+    std::vector<std::string> runningLower;
+    runningLower.reserve(resolvedRunning.size());
+    for (const auto& run : resolvedRunning) {
+      runningLower.push_back(StringUtils::toLower(run.entry.id));
+    }
+
+    bool needRebuild = (instance.modelSerial != deps.modelSerial) || filterOutputChanged;
+    if (!needRebuild && cfg.showRunning) {
+      const std::size_t expectedTotal = [&] {
+        std::vector<DesktopEntry> entries = deps.pinnedEntries;
+        for (const auto& run : resolvedRunning) {
+          bool present = false;
+          for (const auto& entry : entries) {
+            if (app_identity::desktopEntryMatchesLower(entry, run.runningLower)) {
+              present = true;
+              break;
+            }
+          }
+          if (!present) {
+            entries.push_back(run.entry);
+          }
+        }
+        return entries.size();
+      }();
+      if (expectedTotal != instance.items.size()) {
+        needRebuild = true;
+      }
+    }
+
+    for (auto& item : instance.items) {
+      item.running = matchesRunningApp(item, runningLower);
+      item.active = matchesActiveApp(item, activeIdLower);
+    }
+
+    return needRebuild;
+  }
+
+  std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
+    return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
+  }
+
+  std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical) {
+    return ui::flex(
+        vertical ? FlexDirection::Vertical : FlexDirection::Horizontal,
+        {
+            .align = FlexAlign::Center,
+            .gap = static_cast<float>(cfg.itemSpacing),
+            .padding = static_cast<float>(cfg.padding),
+        }
+    );
+  }
+
+  std::unique_ptr<InputArea> createLauncherButton(
+      DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks
+  ) {
+    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+    const float iSize = static_cast<float>(cfg.iconSize);
+    const float cellMain = iSize + 2.0f * kCellPad;
+    const float cellCross = iSize + 2.0f * kCellPad;
+    const float glyphSize = iSize * 0.8f;
+    const float glyphOffsetY = kCellPad + (iSize - glyphSize) * 0.5f;
+
+    auto areaNode = std::make_unique<InputArea>();
+    if (!vert) {
+      areaNode->setSize(cellMain, cellCross);
+    } else {
+      areaNode->setSize(cellCross, cellMain);
+    }
+
+    Box* bgPtr = nullptr;
+    areaNode->addChild(
+        ui::box({
+            .out = &bgPtr,
+            .fill = clearColorSpec(),
+            .radius = static_cast<float>(cfg.radius),
+            .width = cellMain,
+            .height = cellMain,
+            .configure = [](Box& box) { box.setPosition(0.0f, 0.0f); },
+        })
+    );
+
+    areaNode->addChild(
+        ui::glyph({
+            .glyphSize = glyphSize,
+            .color = colorSpecFromRole(ColorRole::OnSurface),
+            .width = iSize,
+            .height = iSize,
+            .configure = [&cfg, glyphOffsetY](Glyph& glyph) {
+              if (!glyph.setGlyph(dockLauncherIconGlyph(cfg))) {
+                glyph.setGlyph("grid-dots");
+              }
+              glyph.setPosition(kCellPad, glyphOffsetY);
+            },
+        })
+    );
+
+    auto* instPtr = &instance;
+    areaNode->setOnEnter([bgPtr, instPtr](const InputArea::PointerData&) {
+      bgPtr->setFill(colorSpecFromRole(ColorRole::Hover));
+      if (instPtr->sceneRoot != nullptr) {
+        instPtr->sceneRoot->markPaintDirty();
+      }
+    });
+    areaNode->setOnLeave([bgPtr, instPtr]() {
+      bgPtr->setFill(clearColorSpec());
+      if (instPtr->sceneRoot != nullptr) {
+        instPtr->sceneRoot->markPaintDirty();
+      }
+    });
+    areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT}));
+    areaNode->setOnClick([instPtr, callbacks](const InputArea::PointerData& d) {
+      if (d.button == BTN_LEFT && callbacks.toggleLauncher) {
+        callbacks.toggleLauncher(*instPtr);
+      }
+    });
+
+    return areaNode;
+  }
+
+  void rebuildItems(DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks) {
+    uiAssertNotRendering("shell::dock::rebuildItems");
+    if (instance.row == nullptr) {
+      return;
+    }
+
+    const auto& cfg = deps.config.config().dock;
+    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+    const float iSize = static_cast<float>(cfg.iconSize);
+
+    for (auto& item : instance.items) {
+      if (item.scaleAnimId != 0) {
+        instance.animations.cancel(item.scaleAnimId);
+        item.scaleAnimId = 0;
+      }
+      if (item.opacityAnimId != 0) {
+        instance.animations.cancel(item.opacityAnimId);
+        item.opacityAnimId = 0;
+      }
+    }
+
+    // Clear previous items by recreating the row.
+    if (instance.row != nullptr && instance.panel != nullptr) {
+      instance.panel->removeChild(instance.row);
+      instance.row = nullptr;
+    }
+    instance.items.clear();
+
+    auto freshRow = makeDockItemRow(cfg, vert);
+    instance.row = static_cast<Flex*>(
+        instance.panel != nullptr ? instance.panel->addChild(std::move(freshRow))
+                                  : instance.sceneRoot->addChild(std::move(freshRow))
+    );
+
+    // Determine items: pinned + (optionally) running-only apps not in pinned.
+    std::vector<DesktopEntry> itemEntries = deps.pinnedEntries;
+    wl_output* filterOutput = dockFilterOutput(cfg, instance.output);
+    instance.lastFilterOutput = filterOutput;
+
+    if (cfg.showRunning) {
+      const auto runningIds = deps.platform.runningAppIds(filterOutput);
+      const auto& allEntries = desktopEntries();
+      const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
+
+      for (const auto& run : resolvedRunning) {
+        bool alreadyPresent = false;
+        for (const auto& itm : itemEntries) {
+          if (app_identity::desktopEntryMatchesLower(itm, run.runningLower)) {
+            alreadyPresent = true;
+            break;
+          }
+        }
+        if (alreadyPresent) {
+          continue;
+        }
+
+        itemEntries.push_back(run.entry);
+      }
+    }
+
+    const auto activeIdLower = instance.activeAppIdLower;
+    const auto runningIds = deps.platform.runningAppIds(filterOutput);
+    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
+    std::vector<std::string> runningLower;
+    runningLower.reserve(resolvedRunning.size());
+    for (const auto& run : resolvedRunning) {
+      runningLower.push_back(StringUtils::toLower(run.entry.id));
+    }
+
+    if (cfg.launcherPosition == "start") {
+      instance.row->addChild(createLauncherButton(instance, cfg, callbacks));
+    }
+
+    // Reserve up-front so emplace_back never reallocates while lambdas hold raw pointers.
+    instance.items.reserve(itemEntries.size());
+
+    for (const auto& entry : itemEntries) {
+      auto& item = instance.items.emplace_back();
+      item.entry = entry;
+      item.idLower = StringUtils::toLower(entry.id);
+      item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
+      item.active = matchesActiveApp(item, activeIdLower);
+      item.running = matchesRunningApp(item, runningLower);
+
+      const float cellMain = iSize + 2.0f * kCellPad;
+      const float cellCross = iSize + 2.0f * kCellPad;
+      auto areaNode = std::make_unique<InputArea>();
+      if (!vert) {
+        areaNode->setSize(cellMain, cellCross);
+      } else {
+        areaNode->setSize(cellCross, cellMain);
+      }
+
+      areaNode->addChild(
+          ui::box({
+              .out = &item.background,
+              .fill = clearColorSpec(),
+              .radius = static_cast<float>(cfg.radius),
+              .width = cellMain,
+              .height = cellMain,
+              .configure = [](Box& box) { box.setPosition(0.0f, 0.0f); },
+          })
+      );
+
+      const std::string& iconPath = [&]() -> const std::string& {
+        if (!entry.icon.empty()) {
+          const std::string& primary = deps.iconResolver.resolve(entry.icon, cfg.iconSize);
+          if (!primary.empty()) {
+            return primary;
+          }
+        }
+        return deps.iconResolver.resolve("application-x-executable", cfg.iconSize);
+      }();
+      RenderContext* renderContext = &deps.renderContext;
+      auto iconImg = ui::image({
+          .width = iSize,
+          .height = iSize,
+          .configure = [renderContext, &iconPath, &cfg](Image& image) {
+            if (!iconPath.empty() && renderContext != nullptr) {
+              image.setSourceFile(*renderContext, iconPath, cfg.iconSize, true);
+            }
+            image.setPosition(kCellPad, kCellPad);
+          },
+      });
+
+      if (iconImg->hasImage()) {
+        item.iconImage = static_cast<Image*>(areaNode->addChild(std::move(iconImg)));
+      } else {
+        item.iconGlyph = static_cast<Glyph*>(areaNode->addChild(
+            ui::glyph({
+                .glyph = "app-window",
+                .glyphSize = iSize,
+                .color = colorSpecFromRole(ColorRole::OnSurface),
+                .width = iSize,
+                .height = iSize,
+                .configure = [](Glyph& glyph) { glyph.setPosition(kCellPad, kCellPad); },
+            })
+        ));
+      }
+
+      if (cfg.showDots) {
+        const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
+        const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
+
+        for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
+          item.dotIndicators[dotIndex] = static_cast<Box*>(areaNode->addChild(
+              ui::box({
+                  .fill = colorSpecFromRole(ColorRole::Secondary),
+                  .radius = dot * 0.5f,
+                  .width = dot,
+                  .height = dot,
+                  .visible = false,
+                  .configure = [verticalDots, position = cfg.position, cellMain, dot](Box& box) {
+                    if (verticalDots) {
+                      const float x = position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+                      box.setPosition(x, std::round((cellMain - dot) * 0.5f));
+                    } else {
+                      const float y = position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+                      box.setPosition(std::round((cellMain - dot) * 0.5f), y);
+                    }
+                  },
+              })
+          ));
+        }
+      }
+
+      if (cfg.showInstanceCount) {
+        const float bd = std::max(kBadgeMinSize, iSize * kBadgeSizeRatio);
+        const float badgeX = kCellPad + iSize - bd * 0.55f;
+        const float badgeY = kCellPad - bd * 0.45f;
+
+        areaNode->addChild(
+            ui::box({
+                .out = &item.badge,
+                .radius = bd * 0.5f,
+                .width = bd,
+                .height = bd,
+                .visible = false,
+                .configure = [badgeX, badgeY](Box& box) { box.setPosition(badgeX, badgeY); },
+            })
+        );
+
+        item.badge->addChild(
+            ui::label({
+                .out = &item.badgeLabel,
+                .fontSize = bd * kBadgeFontRatio,
+                .maxLines = 1,
+                .fontWeight = FontWeight::Bold,
+                .visible = false,
+            })
+        );
+      }
+
+      auto* itemPtr = &item;
+      auto* instPtr = &instance;
+
+      areaNode->setOnEnter([itemPtr, instPtr](const InputArea::PointerData&) {
+        if (!itemPtr->hovered) {
+          itemPtr->hovered = true;
+          if (itemPtr->background) {
+            itemPtr->background->setFill(colorSpecFromRole(ColorRole::Hover));
+          }
+          if (instPtr->sceneRoot) {
+            instPtr->sceneRoot->markPaintDirty();
+          }
+        }
+      });
+      areaNode->setOnLeave([itemPtr, instPtr]() {
+        if (itemPtr->hovered) {
+          itemPtr->hovered = false;
+          if (itemPtr->background) {
+            itemPtr->background->setFill(clearColorSpec());
+          }
+          if (instPtr->sceneRoot) {
+            instPtr->sceneRoot->markPaintDirty();
+          }
+        }
+      });
+      areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
+      areaNode->setOnClick([itemPtr, instPtr, deps, callbacks](const InputArea::PointerData& d) {
+        if (d.button == BTN_LEFT) {
+          handleItemClick(*instPtr, *itemPtr, deps, callbacks);
+        } else if (d.button == BTN_RIGHT && callbacks.openItemMenu) {
+          callbacks.openItemMenu(*instPtr, *itemPtr);
+        }
+      });
+
+      item.area = static_cast<InputArea*>(instance.row->addChild(std::move(areaNode)));
+    }
+
+    if (cfg.launcherPosition == "end") {
+      instance.row->addChild(createLauncherButton(instance, cfg, callbacks));
+    }
+
+    instance.modelSerial = deps.modelSerial;
+
+    shell::dock::resizeSurface(instance, cfg, deps.config.config().shell.shadow);
+  }
+
+  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps) {
+    const auto& cfg = deps.config.config().dock;
+
+    for (auto& item : instance.items) {
+      const float iconScale = item.active ? cfg.activeScale : cfg.inactiveScale;
+      const float iconOpacity = item.active ? cfg.activeOpacity : cfg.inactiveOpacity;
+      Node* iconNode =
+          item.iconImage != nullptr ? static_cast<Node*>(item.iconImage) : static_cast<Node*>(item.iconGlyph);
+
+      if (iconNode != nullptr) {
+        if (item.visualScale < 0.0f) {
+          item.visualScale = iconScale;
+          iconNode->setScale(iconScale);
+        } else if (std::abs(item.visualScale - iconScale) > 0.001f) {
+          if (item.scaleAnimId != 0) {
+            instance.animations.cancel(item.scaleAnimId);
+          }
+          item.scaleAnimId = instance.animations.animate(
+              item.visualScale, iconScale, Style::animNormal, Easing::EaseOutCubic,
+              [node = iconNode, itemPtr = &item](float value) {
+                itemPtr->visualScale = value;
+                node->setScale(value);
+              },
+              [itemPtr = &item] { itemPtr->scaleAnimId = 0; }
+          );
+        }
+
+        if (item.visualOpacity < 0.0f) {
+          item.visualOpacity = iconOpacity;
+          iconNode->setOpacity(iconOpacity);
+        } else if (std::abs(item.visualOpacity - iconOpacity) > 0.001f) {
+          if (item.opacityAnimId != 0) {
+            instance.animations.cancel(item.opacityAnimId);
+          }
+          item.opacityAnimId = instance.animations.animate(
+              item.visualOpacity, iconOpacity, Style::animNormal, Easing::EaseOutCubic,
+              [node = iconNode, itemPtr = &item](float value) {
+                itemPtr->visualOpacity = value;
+                node->setOpacity(value);
+              },
+              [itemPtr = &item] { itemPtr->opacityAnimId = 0; }
+          );
+        }
+      }
+
+      const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
+      std::size_t count = 0;
+      if (needsWindowCount) {
+        const auto windows = deps.platform.windowsForApp(
+            item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output)
+        );
+        count = windows.size();
+        item.instanceCount = count;
+      }
+
+      if (cfg.showDots) {
+        const std::size_t dotCount = std::min<std::size_t>(count, 3);
+        const float iSize = static_cast<float>(cfg.iconSize);
+        const float cellMain = iSize + 2.0f * kCellPad;
+        const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
+        const float groupLength =
+            dotCount == 0 ? dot : dot * static_cast<float>(dotCount) + kDotGap * static_cast<float>(dotCount - 1);
+        const float groupStart = std::round((cellMain - groupLength) * 0.5f);
+        const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
+
+        for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
+          if (item.dotIndicators[dotIndex] == nullptr) {
+            continue;
+          }
+          Box* dotNode = item.dotIndicators[dotIndex];
+          const bool visible = dotIndex < dotCount;
+          dotNode->setVisible(visible);
+          dotNode->setFill(colorSpecFromRole(ColorRole::Secondary));
+          if (visible) {
+            const float main = groupStart + static_cast<float>(dotIndex) * (dot + kDotGap);
+            if (verticalDots) {
+              const float x = cfg.position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+              dotNode->setPosition(x, main);
+            } else {
+              const float y = cfg.position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+              dotNode->setPosition(main, y);
+            }
+          }
+        }
+      }
+
+      if (item.badge != nullptr && item.badgeLabel != nullptr) {
+        const bool show = count >= 2;
+        item.badge->setVisible(show);
+        item.badgeLabel->setVisible(show);
+        if (show) {
+          const std::string label = (count > 9) ? "9+" : std::to_string(count);
+          item.badgeLabel->setText(label);
+          item.badgeLabel->setColor(colorSpecFromRole(ColorRole::OnPrimary));
+          item.badge->setFill(colorSpecFromRole(ColorRole::Primary));
+          const float bd = std::max(kBadgeMinSize, static_cast<float>(cfg.iconSize) * kBadgeSizeRatio);
+          item.badgeLabel->measure(deps.renderContext);
+          item.badgeLabel->setPosition(
+              std::round((bd - item.badgeLabel->width()) * 0.5f), std::round((bd - item.badgeLabel->height()) * 0.5f)
+          );
+        }
+      }
+    }
+  }
+
+  void handleItemClick(
+      DockInstance& instance, DockItemView& item, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
+  ) {
+    if (callbacks.pruneCachedToplevelHandles) {
+      callbacks.pruneCachedToplevelHandles();
+    }
+
+    auto windows = deps.platform.windowsForApp(
+        item.idLower, item.startupWmClassLower, dockFilterOutput(deps.config.config().dock, instance.output)
+    );
+
+    if (windows.empty()) {
+      wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
+      const auto options = callbacks.launchOptions ? callbacks.launchOptions(activationSurface)
+                                                   : desktop_entry_launch::LaunchOptions{};
+      (void)desktop_entry_launch::launchEntry(item.entry, options);
+      return;
+    }
+
+    if (windows.size() == 1) {
+      deps.platform.activateToplevel(windows[0].handle);
+      return;
+    }
+
+    zwlr_foreign_toplevel_handle_v1* activeHandle = nullptr;
+    if (const auto active = deps.platform.activeToplevel(); active.has_value()) {
+      activeHandle = active->handle;
+    }
+
+    auto* preferredHandle = [&]() -> zwlr_foreign_toplevel_handle_v1* {
+      const auto it = deps.lastActiveHandleByAppIdLower.find(item.idLower);
+      return it != deps.lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
+    }();
+    if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle);
+        nextHandle != nullptr) {
+      deps.platform.activateToplevel(nextHandle);
+    }
+  }
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -307,13 +307,13 @@ namespace shell::dock {
       return;
     }
 
-    const auto& cfg = deps.config.config().dock;
+    const auto& cfg = deps.model.config.config().dock;
     const bool vert = shell::dock::isVerticalPosition(cfg.position);
     const float iSize = static_cast<float>(cfg.iconSize);
     auto clickContext = std::make_shared<DockItemClickContext>(DockItemClickContext{
-        .platform = deps.platform,
-        .config = deps.config,
-        .lastActiveHandleByAppIdLower = deps.lastActiveHandleByAppIdLower,
+        .platform = deps.model.platform,
+        .config = deps.model.config,
+        .lastActiveHandleByAppIdLower = deps.model.lastActiveHandleByAppIdLower,
         .callbacks = callbacks,
     });
 
@@ -342,12 +342,12 @@ namespace shell::dock {
     );
 
     // Determine items: pinned + (optionally) running-only apps not in pinned.
-    std::vector<DesktopEntry> itemEntries = deps.pinnedEntries;
+    std::vector<DesktopEntry> itemEntries = deps.model.pinnedEntries;
     wl_output* filterOutput = dockFilterOutput(cfg, instance.output);
     instance.lastFilterOutput = filterOutput;
 
     if (cfg.showRunning) {
-      const auto runningIds = deps.platform.runningAppIds(filterOutput);
+      const auto runningIds = deps.model.platform.runningAppIds(filterOutput);
       const auto& allEntries = desktopEntries();
       const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
 
@@ -368,7 +368,7 @@ namespace shell::dock {
     }
 
     const auto activeIdLower = instance.activeAppIdLower;
-    const auto runningIds = deps.platform.runningAppIds(filterOutput);
+    const auto runningIds = deps.model.platform.runningAppIds(filterOutput);
     const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
     std::vector<std::string> runningLower;
     runningLower.reserve(resolvedRunning.size());
@@ -541,13 +541,13 @@ namespace shell::dock {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
-    instance.modelSerial = deps.modelSerial;
+    instance.modelSerial = deps.model.modelSerial;
 
-    shell::dock::resizeSurface(instance, cfg, deps.config.config().shell.shadow);
+    shell::dock::resizeSurface(instance, cfg, deps.model.config.config().shell.shadow);
   }
 
   void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps) {
-    const auto& cfg = deps.config.config().dock;
+    const auto& cfg = deps.model.config.config().dock;
 
     for (auto& item : instance.items) {
       const float iconScale = item.active ? cfg.activeScale : cfg.inactiveScale;
@@ -594,8 +594,9 @@ namespace shell::dock {
       const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
       std::size_t count = 0;
       if (needsWindowCount) {
-        const auto windows =
-            deps.platform.windowsForApp(item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output));
+        const auto windows = deps.model.platform.windowsForApp(
+            item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output)
+        );
         count = windows.size();
         item.instanceCount = count;
       }

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <linux/input-event-codes.h>
+#include <memory>
 
 namespace {
 
@@ -68,6 +69,13 @@ namespace {
 } // namespace
 
 namespace shell::dock {
+
+  struct DockItemClickContext {
+    CompositorPlatform& platform;
+    ConfigService& config;
+    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
+    DockItemCallbacks callbacks;
+  };
 
   std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
     if (const auto active = platform.activeToplevel(); active.has_value()) {
@@ -224,8 +232,11 @@ namespace shell::dock {
     );
   }
 
-  std::unique_ptr<InputArea>
-  createLauncherButton(DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks) {
+  void handleItemClick(DockInstance& instance, DockItemView& item, DockItemClickContext& context);
+
+  std::unique_ptr<InputArea> createLauncherButton(
+      DockInstance& instance, const DockConfig& cfg, const std::shared_ptr<DockItemClickContext>& clickContext
+  ) {
     const bool vert = shell::dock::isVerticalPosition(cfg.position);
     const float iSize = static_cast<float>(cfg.iconSize);
     const float cellMain = iSize + 2.0f * kCellPad;
@@ -281,9 +292,9 @@ namespace shell::dock {
       }
     });
     areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT}));
-    areaNode->setOnClick([instPtr, callbacks](const InputArea::PointerData& d) {
-      if (d.button == BTN_LEFT && callbacks.toggleLauncher) {
-        callbacks.toggleLauncher(*instPtr);
+    areaNode->setOnClick([instPtr, clickContext](const InputArea::PointerData& d) {
+      if (d.button == BTN_LEFT && clickContext->callbacks.toggleLauncher) {
+        clickContext->callbacks.toggleLauncher(*instPtr);
       }
     });
 
@@ -299,6 +310,12 @@ namespace shell::dock {
     const auto& cfg = deps.config.config().dock;
     const bool vert = shell::dock::isVerticalPosition(cfg.position);
     const float iSize = static_cast<float>(cfg.iconSize);
+    auto clickContext = std::make_shared<DockItemClickContext>(DockItemClickContext{
+        .platform = deps.platform,
+        .config = deps.config,
+        .lastActiveHandleByAppIdLower = deps.lastActiveHandleByAppIdLower,
+        .callbacks = callbacks,
+    });
 
     for (auto& item : instance.items) {
       if (item.scaleAnimId != 0) {
@@ -360,7 +377,7 @@ namespace shell::dock {
     }
 
     if (cfg.launcherPosition == "start") {
-      instance.row->addChild(createLauncherButton(instance, cfg, callbacks));
+      instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
     // Reserve up-front so emplace_back never reallocates while lambdas hold raw pointers.
@@ -509,11 +526,11 @@ namespace shell::dock {
         }
       });
       areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
-      areaNode->setOnClick([itemPtr, instPtr, deps, callbacks](const InputArea::PointerData& d) {
+      areaNode->setOnClick([itemPtr, instPtr, clickContext](const InputArea::PointerData& d) {
         if (d.button == BTN_LEFT) {
-          handleItemClick(*instPtr, *itemPtr, deps, callbacks);
-        } else if (d.button == BTN_RIGHT && callbacks.openItemMenu) {
-          callbacks.openItemMenu(*instPtr, *itemPtr);
+          handleItemClick(*instPtr, *itemPtr, *clickContext);
+        } else if (d.button == BTN_RIGHT && clickContext->callbacks.openItemMenu) {
+          clickContext->callbacks.openItemMenu(*instPtr, *itemPtr);
         }
       });
 
@@ -521,7 +538,7 @@ namespace shell::dock {
     }
 
     if (cfg.launcherPosition == "end") {
-      instance.row->addChild(createLauncherButton(instance, cfg, callbacks));
+      instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
     instance.modelSerial = deps.modelSerial;
@@ -633,41 +650,39 @@ namespace shell::dock {
     }
   }
 
-  void handleItemClick(
-      DockInstance& instance, DockItemView& item, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
-  ) {
-    if (callbacks.pruneCachedToplevelHandles) {
-      callbacks.pruneCachedToplevelHandles();
+  void handleItemClick(DockInstance& instance, DockItemView& item, DockItemClickContext& context) {
+    if (context.callbacks.pruneCachedToplevelHandles) {
+      context.callbacks.pruneCachedToplevelHandles();
     }
 
-    auto windows = deps.platform.windowsForApp(
-        item.idLower, item.startupWmClassLower, dockFilterOutput(deps.config.config().dock, instance.output)
+    auto windows = context.platform.windowsForApp(
+        item.idLower, item.startupWmClassLower, dockFilterOutput(context.config.config().dock, instance.output)
     );
 
     if (windows.empty()) {
       wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
-      const auto options =
-          callbacks.launchOptions ? callbacks.launchOptions(activationSurface) : desktop_entry_launch::LaunchOptions{};
+      const auto options = context.callbacks.launchOptions ? context.callbacks.launchOptions(activationSurface)
+                                                           : desktop_entry_launch::LaunchOptions{};
       (void)desktop_entry_launch::launchEntry(item.entry, options);
       return;
     }
 
     if (windows.size() == 1) {
-      deps.platform.activateToplevel(windows[0].handle);
+      context.platform.activateToplevel(windows[0].handle);
       return;
     }
 
     zwlr_foreign_toplevel_handle_v1* activeHandle = nullptr;
-    if (const auto active = deps.platform.activeToplevel(); active.has_value()) {
+    if (const auto active = context.platform.activeToplevel(); active.has_value()) {
       activeHandle = active->handle;
     }
 
     auto* preferredHandle = [&]() -> zwlr_foreign_toplevel_handle_v1* {
-      const auto it = deps.lastActiveHandleByAppIdLower.find(item.idLower);
-      return it != deps.lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
+      const auto it = context.lastActiveHandleByAppIdLower.find(item.idLower);
+      return it != context.lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
     }();
     if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle); nextHandle != nullptr) {
-      deps.platform.activateToplevel(nextHandle);
+      context.platform.activateToplevel(nextHandle);
     }
   }
 

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -224,9 +224,8 @@ namespace shell::dock {
     );
   }
 
-  std::unique_ptr<InputArea> createLauncherButton(
-      DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks
-  ) {
+  std::unique_ptr<InputArea>
+  createLauncherButton(DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks) {
     const bool vert = shell::dock::isVerticalPosition(cfg.position);
     const float iSize = static_cast<float>(cfg.iconSize);
     const float cellMain = iSize + 2.0f * kCellPad;
@@ -578,9 +577,8 @@ namespace shell::dock {
       const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
       std::size_t count = 0;
       if (needsWindowCount) {
-        const auto windows = deps.platform.windowsForApp(
-            item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output)
-        );
+        const auto windows =
+            deps.platform.windowsForApp(item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output));
         count = windows.size();
         item.instanceCount = count;
       }
@@ -648,8 +646,8 @@ namespace shell::dock {
 
     if (windows.empty()) {
       wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
-      const auto options = callbacks.launchOptions ? callbacks.launchOptions(activationSurface)
-                                                   : desktop_entry_launch::LaunchOptions{};
+      const auto options =
+          callbacks.launchOptions ? callbacks.launchOptions(activationSurface) : desktop_entry_launch::LaunchOptions{};
       (void)desktop_entry_launch::launchEntry(item.entry, options);
       return;
     }
@@ -668,8 +666,7 @@ namespace shell::dock {
       const auto it = deps.lastActiveHandleByAppIdLower.find(item.idLower);
       return it != deps.lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
     }();
-    if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle);
-        nextHandle != nullptr) {
+    if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle); nextHandle != nullptr) {
       deps.platform.activateToplevel(nextHandle);
     }
   }

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "config/config_types.h"
+#include "render/animation/animation_manager.h"
+#include "system/desktop_entry.h"
+#include "system/desktop_entry_launch.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+class Box;
+class CompositorPlatform;
+class ConfigService;
+class Flex;
+class Glyph;
+class IconResolver;
+class Image;
+class InputArea;
+class Label;
+class RenderContext;
+struct wl_output;
+struct wl_surface;
+struct zwlr_foreign_toplevel_handle_v1;
+
+namespace shell::dock {
+
+  struct DockInstance;
+
+  struct DockItemView {
+    DesktopEntry entry;
+    std::string idLower;
+    std::string startupWmClassLower;
+    InputArea* area = nullptr;
+    Box* background = nullptr;
+    std::array<Box*, 3> dotIndicators{};
+    Box* badge = nullptr;
+    Label* badgeLabel = nullptr;
+    Image* iconImage = nullptr;
+    Glyph* iconGlyph = nullptr;
+    bool hovered = false;
+    bool running = false;
+    bool active = false;
+    float visualScale = -1.0f;
+    float visualOpacity = -1.0f;
+    AnimationManager::Id scaleAnimId = 0;
+    AnimationManager::Id opacityAnimId = 0;
+    std::size_t instanceCount = 0;
+  };
+
+  struct DockItemModelDependencies {
+    CompositorPlatform& platform;
+    ConfigService& config;
+    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
+    const std::vector<DesktopEntry>& pinnedEntries;
+    std::uint64_t modelSerial = 0;
+  };
+
+  struct DockItemSceneDependencies {
+    CompositorPlatform& platform;
+    ConfigService& config;
+    RenderContext& renderContext;
+    IconResolver& iconResolver;
+    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
+    const std::vector<DesktopEntry>& pinnedEntries;
+    std::uint64_t modelSerial = 0;
+  };
+
+  struct DockItemCallbacks {
+    std::function<void()> pruneCachedToplevelHandles;
+    std::function<desktop_entry_launch::LaunchOptions(wl_surface*)> launchOptions;
+    std::function<void(DockInstance&)> toggleLauncher;
+    std::function<void(DockInstance&, DockItemView&)> openItemMenu;
+  };
+
+  [[nodiscard]] std::string currentActiveEntryIdLower(const CompositorPlatform& platform);
+  [[nodiscard]] wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput);
+  [[nodiscard]] bool refreshPinnedAppsIfNeeded(
+      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
+      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
+  );
+  [[nodiscard]] bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower);
+  [[nodiscard]] bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower);
+  [[nodiscard]] bool syncInstanceModel(DockInstance& instance, DockItemModelDependencies deps);
+
+  [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
+  [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);
+  [[nodiscard]] std::unique_ptr<InputArea> createLauncherButton(
+      DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks
+  );
+  void rebuildItems(
+      DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
+  );
+  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps);
+  void handleItemClick(
+      DockInstance& instance, DockItemView& item, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
+  );
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -62,13 +62,9 @@ namespace shell::dock {
   };
 
   struct DockItemSceneDependencies {
-    CompositorPlatform& platform;
-    ConfigService& config;
+    DockItemModelDependencies model;
     RenderContext& renderContext;
     IconResolver& iconResolver;
-    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
-    const std::vector<DesktopEntry>& pinnedEntries;
-    std::uint64_t modelSerial = 0;
   };
 
   struct DockItemCallbacks {

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -90,12 +90,7 @@ namespace shell::dock {
 
   [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
   [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);
-  [[nodiscard]] std::unique_ptr<InputArea>
-  createLauncherButton(DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks);
   void rebuildItems(DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks);
   void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps);
-  void handleItemClick(
-      DockInstance& instance, DockItemView& item, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
-  );
 
 } // namespace shell::dock

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -90,12 +90,9 @@ namespace shell::dock {
 
   [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
   [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);
-  [[nodiscard]] std::unique_ptr<InputArea> createLauncherButton(
-      DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks
-  );
-  void rebuildItems(
-      DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks
-  );
+  [[nodiscard]] std::unique_ptr<InputArea>
+  createLauncherButton(DockInstance& instance, const DockConfig& cfg, const DockItemCallbacks& callbacks);
+  void rebuildItems(DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks);
   void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps);
   void handleItemClick(
       DockInstance& instance, DockItemView& item, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks


### PR DESCRIPTION
## Summary
- Split dock internals by responsibility: geometry helpers, context menu handling, instance lifecycle, and item model/scene code.
- Kept `Dock` as the public facade while reducing private implementation detail exposure from `dock.h`.
- Preserved existing dock behavior and fixed lifecycle edge cases found during review.

## Test Plan
- [x] `meson compile -C build`
- [x] `meson test -C build desktop_entry_launch app_identity wayland_toplevels_identity`
- [x] `git diff --check`
