### PR TITLE
feat(clock_widget): Added a customizable tooltip on mouse hover

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1496,7 +1496,7 @@
           "label": "Type",
           "description": "Built-in widget type for this named widget"
         },
-        "tooltipFormat" : {
+        "tooltip_format" : {
           "label": "Tooltip Format",
           "description": "Optional format for the tooltip"
         },

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1496,9 +1496,9 @@
           "label": "Type",
           "description": "Built-in widget type for this named widget"
         },
-        "tooltip_format" : {
+        "tooltipFormat" : {
           "label": "Tooltip Format",
-          "description": "Optional tooltip text format for the clock"
+          "description": "Optional format for the tooltip"
         },
         "vertical_format": {
           "label": "Vertical Format",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1496,6 +1496,10 @@
           "label": "Type",
           "description": "Built-in widget type for this named widget"
         },
+        "tooltip_format" : {
+          "label": "Tooltip Format",
+          "description": "Optional tooltip text format for the clock"
+        },
         "vertical_format": {
           "label": "Vertical Format",
           "description": "Optional format used on vertical bars"

--- a/example.toml
+++ b/example.toml
@@ -358,6 +358,6 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # [widget.clock]
 # format = "{:%H:%M}\n{:%d/%m}"
 # vertical_format = "{:%H\n%M}"
-# tooltipFormat = "{:%A, %B %d, %Y}"
+# tooltip_format = "{:%A, %B %d, %Y}"
 # scale = 1.0                         # multiplies the bar scale for this widget only
 # font_weight = 700

--- a/example.toml
+++ b/example.toml
@@ -358,5 +358,6 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # [widget.clock]
 # format = "{:%H:%M}\n{:%d/%m}"
 # vertical_format = "{:%H\n%M}"
+# tooltip_format = "{:%A, %B %d, %Y}"
 # scale = 1.0                         # multiplies the bar scale for this widget only
 # font_weight = 700

--- a/example.toml
+++ b/example.toml
@@ -358,6 +358,6 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # [widget.clock]
 # format = "{:%H:%M}\n{:%d/%m}"
 # vertical_format = "{:%H\n%M}"
-# tooltip_format = "{:%A, %B %d, %Y}"
+# tooltipFormat = "{:%A, %B %d, %Y}"
 # scale = 1.0                         # multiplies the bar scale for this widget only
 # font_weight = 700

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -197,8 +197,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "clock") {
     std::string format = wc != nullptr ? wc->getString("format", "{:%H:%M}") : std::string("{:%H:%M}");
     std::string verticalFormat = wc != nullptr ? wc->getString("vertical_format", "") : std::string{};
-    std::string tooltip_format = wc != nullptr ? wc->getSTring("tooltip_format", "") : std::string{};
-    auto widget = std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltip_format));
+    std::string tooltip_format = wc != nullptr ? wc->getString("tooltip_format", "") : std::string{};
+    auto widget =
+        std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltip_format));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -197,7 +197,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "clock") {
     std::string format = wc != nullptr ? wc->getString("format", "{:%H:%M}") : std::string("{:%H:%M}");
     std::string verticalFormat = wc != nullptr ? wc->getString("vertical_format", "") : std::string{};
-    std::string tooltipFormat = wc != nullptr ? wc->getString("tooltipFormat", "") : std::string{};
+    std::string tooltipFormat = wc != nullptr ? wc->getString("tooltip_format", "") : std::string{};
     auto widget =
         std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltipFormat));
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -197,9 +197,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "clock") {
     std::string format = wc != nullptr ? wc->getString("format", "{:%H:%M}") : std::string("{:%H:%M}");
     std::string verticalFormat = wc != nullptr ? wc->getString("vertical_format", "") : std::string{};
-    std::string tooltip_format = wc != nullptr ? wc->getString("tooltip_format", "") : std::string{};
+    std::string tooltipFormat = wc != nullptr ? wc->getString("tooltipFormat", "") : std::string{};
     auto widget =
-        std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltip_format));
+        std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltipFormat));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -197,7 +197,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "clock") {
     std::string format = wc != nullptr ? wc->getString("format", "{:%H:%M}") : std::string("{:%H:%M}");
     std::string verticalFormat = wc != nullptr ? wc->getString("vertical_format", "") : std::string{};
-    auto widget = std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat));
+    std::string tooltip_format = wc != nullptr ? wc->getSTring("tooltip_format", "") : std::string{};
+    auto widget = std::make_unique<ClockWidget>(output, std::move(format), std::move(verticalFormat), std::move(tooltip_format));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/clock_widget.cpp
+++ b/src/shell/bar/widgets/clock_widget.cpp
@@ -1,6 +1,5 @@
 #include "shell/bar/widgets/clock_widget.h"
 
-#include "notification/notification.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
@@ -28,10 +27,10 @@ namespace {
 } // namespace
 
 ClockWidget::ClockWidget(
-    wl_output* /*output*/, std::string format, std::string verticalFormat, std::string tooltip_format
+    wl_output* /*output*/, std::string format, std::string verticalFormat, std::string tooltipFormat
 )
     : m_format(std::move(format)), m_verticalFormat(std::move(verticalFormat)),
-      m_tooltipFormat(std::move(tooltip_format)) {}
+      m_tooltipFormat(std::move(tooltipFormat)) {}
 
 std::string ClockWidget::formatTimeText() const {
   if (!m_isVertical) {

--- a/src/shell/bar/widgets/clock_widget.cpp
+++ b/src/shell/bar/widgets/clock_widget.cpp
@@ -1,5 +1,6 @@
 #include "shell/bar/widgets/clock_widget.h"
 
+#include "notification/notification.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
@@ -26,7 +27,9 @@ namespace {
   }
 } // namespace
 
-ClockWidget::ClockWidget(wl_output* /*output*/, std::string format, std::string verticalFormat, std::string tooltip_format)
+ClockWidget::ClockWidget(
+    wl_output* /*output*/, std::string format, std::string verticalFormat, std::string tooltip_format
+)
     : m_format(std::move(format)), m_verticalFormat(std::move(verticalFormat)),
       m_tooltipFormat(std::move(tooltip_format)) {}
 
@@ -63,6 +66,14 @@ std::string ClockWidget::formatTimeText() const {
     out.pop_back();
   }
   return out;
+}
+
+std::string ClockWidget::formatTooltipText() const {
+  if (m_tooltipFormat.empty()) {
+    return {};
+  }
+
+  return formatLocalTime(m_tooltipFormat.c_str());
 }
 
 void ClockWidget::create() {

--- a/src/shell/bar/widgets/clock_widget.cpp
+++ b/src/shell/bar/widgets/clock_widget.cpp
@@ -26,8 +26,9 @@ namespace {
   }
 } // namespace
 
-ClockWidget::ClockWidget(wl_output* /*output*/, std::string format, std::string verticalFormat)
-    : m_format(std::move(format)), m_verticalFormat(std::move(verticalFormat)) {}
+ClockWidget::ClockWidget(wl_output* /*output*/, std::string format, std::string verticalFormat, std::string tooltip_format)
+    : m_format(std::move(format)), m_verticalFormat(std::move(verticalFormat)),
+      m_tooltipFormat(std::move(tooltip_format)) {}
 
 std::string ClockWidget::formatTimeText() const {
   if (!m_isVertical) {
@@ -190,5 +191,17 @@ void ClockWidget::doUpdate(Renderer& renderer) {
     m_lastSecondaryText = std::move(secondaryText);
     m_secondaryLabel->setText(m_lastSecondaryText);
     m_secondaryLabel->measure(renderer);
+  }
+
+  if (auto* area = static_cast<InputArea*>(root()); area != nullptr) {
+    std::string tooltipText = formatTooltipText();
+
+    if (tooltipText.empty()) {
+      m_lastTooltipText.clear();
+      area->clearTooltip();
+    } else if (tooltipText != m_lastTooltipText) {
+      m_lastTooltipText = std::move(tooltipText);
+      area->setTooltip(m_lastTooltipText);
+    }
   }
 }

--- a/src/shell/bar/widgets/clock_widget.h
+++ b/src/shell/bar/widgets/clock_widget.h
@@ -12,7 +12,7 @@ class ClockWidget : public Widget {
 public:
   ClockWidget(
       wl_output* output, std::string format = "{:%H:%M}", std::string verticalFormat = "",
-      std::string tooltip_format = ""
+      std::string tooltipFormat = ""
   );
 
   void create() override;

--- a/src/shell/bar/widgets/clock_widget.h
+++ b/src/shell/bar/widgets/clock_widget.h
@@ -10,20 +10,26 @@ struct wl_output;
 
 class ClockWidget : public Widget {
 public:
-  ClockWidget(wl_output* output, std::string format = "{:%H:%M}", std::string verticalFormat = "", std::string tooltip_format = "");
+  ClockWidget(
+      wl_output* output, std::string format = "{:%H:%M}", std::string verticalFormat = "",
+      std::string tooltip_format = ""
+  );
 
   void create() override;
 
 private:
   [[nodiscard]] std::string formatTimeText() const;
+  [[nodiscard]] std::string formatTooltipText() const;
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   std::string m_format;
   std::string m_verticalFormat;
+  std::string m_tooltipFormat;
   bool m_isVertical = false;
   Label* m_label = nullptr;
   Label* m_secondaryLabel = nullptr;
   std::string m_lastText;
   std::string m_lastPrimaryText;
   std::string m_lastSecondaryText;
+  std::string m_lastTooltipText;
 };

--- a/src/shell/bar/widgets/clock_widget.h
+++ b/src/shell/bar/widgets/clock_widget.h
@@ -10,7 +10,7 @@ struct wl_output;
 
 class ClockWidget : public Widget {
 public:
-  ClockWidget(wl_output* output, std::string format = "{:%H:%M}", std::string verticalFormat = "");
+  ClockWidget(wl_output* output, std::string format = "{:%H:%M}", std::string verticalFormat = "", std::string tooltip_format = "");
 
   void create() override;
 

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -588,7 +588,7 @@ namespace settings {
     } else if (type == "clock") {
       add(stringSpec("format", "{:%H:%M}"));
       add(stringSpec("vertical_format"));
-      add(stringSpec("tooltip_format"));
+      add(stringSpec("tooltipFormat"));
     } else if (type == "clipboard") {
       add(stringSpec("glyph", "clipboard"));
     } else if (type == "keyboard_layout") {

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -588,7 +588,7 @@ namespace settings {
     } else if (type == "clock") {
       add(stringSpec("format", "{:%H:%M}"));
       add(stringSpec("vertical_format"));
-      add(stringSpec("tooltipFormat"));
+      add(stringSpec("tooltip_format"));
     } else if (type == "clipboard") {
       add(stringSpec("glyph", "clipboard"));
     } else if (type == "keyboard_layout") {

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -588,6 +588,7 @@ namespace settings {
     } else if (type == "clock") {
       add(stringSpec("format", "{:%H:%M}"));
       add(stringSpec("vertical_format"));
+      add(stringSpec("tooltip_format"));
     } else if (type == "clipboard") {
       add(stringSpec("glyph", "clipboard"));
     } else if (type == "keyboard_layout") {


### PR DESCRIPTION
## Description
Added a customizable tooltip format for the clock widget on mouse hover using the current implementation chrono/strftime-style date formatting. 

Default example formatting is listed on `example.toml` as:
`tooltip_format = "{:%A, %B %d, %Y}"`

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Tested on Hyprland on all four bar positions.

- [ ] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="158" height="50" alt="image" src="https://github.com/user-attachments/assets/068c8590-350f-4c1d-b40b-b09db0f731ad" />
<img width="948" height="449" alt="image" src="https://github.com/user-attachments/assets/c23e2c94-e311-4cdb-8355-3a77d694e241" />



## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
I'll be working on adding the config on the documentation as well for people to easily configure this.