### PR TITLE
refactor(dock): introduce snapshot model boundary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -460,6 +460,7 @@ _noctalia_sources = files(
   'src/shell/dock/dock_geometry.cpp',
   'src/shell/dock/dock_instance.cpp',
   'src/shell/dock/dock_items.cpp',
+  'src/shell/dock/dock_model.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',
   'src/shell/desktop/desktop_widget_settings_registry.cpp',

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -523,16 +523,36 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
     return false;
   }
 
-  return shell::dock::syncInstanceModel(
-      instance,
+  auto next = shell::dock::buildDockSnapshot(
       {
           .platform = *m_platform,
-          .config = *m_config,
+          .config = m_config->config().dock,
+          .output = instance.output,
           .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
           .pinnedEntries = m_pinnedEntries,
-          .modelSerial = m_modelSerial,
+          .sourceSerial = m_modelSerial,
       }
   );
+
+  const bool filterOutputChanged = next.filterOutput != instance.lastFilterOutput;
+  const bool needRebuild = instance.modelSerial != m_modelSerial || filterOutputChanged
+      || !shell::dock::sameDockItemSet(instance.snapshot, next);
+  instance.snapshot = std::move(next);
+
+  instance.lastFilterOutput = instance.snapshot.filterOutput;
+  instance.activeAppIdLower = instance.snapshot.activeAppIdLower;
+  for (auto& item : instance.items) {
+    for (const auto& model : instance.snapshot.items) {
+      if (item.idLower == model.idLower && item.startupWmClassLower == model.startupWmClassLower) {
+        item.running = model.running;
+        item.active = model.active;
+        item.instanceCount = model.instanceCount;
+        break;
+      }
+    }
+  }
+
+  return needRebuild;
 }
 
 // ── Private: item population ──────────────────────────────────────────────────
@@ -557,6 +577,7 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
       },
+      instance.snapshot,
       {
           .pruneCachedToplevelHandles = [this]() { pruneCachedToplevelHandles(); },
           .launchOptions = [this](
@@ -590,7 +611,8 @@ void Dock::updateVisuals(shell::dock::DockInstance& instance) {
               },
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
-      }
+      },
+      instance.snapshot
   );
 }
 

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -100,6 +100,36 @@ namespace {
     return signature;
   }
 
+  zwlr_foreign_toplevel_handle_v1* nextActivatableWindowHandle(
+      const std::vector<ToplevelInfo>& windows, zwlr_foreign_toplevel_handle_v1* activeHandle,
+      zwlr_foreign_toplevel_handle_v1* preferredHandle
+  ) {
+    for (std::size_t i = 0; i < windows.size(); ++i) {
+      if (windows[i].handle != nullptr && windows[i].handle == activeHandle) {
+        for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
+          auto* nextHandle = windows[(i + offset) % windows.size()].handle;
+          if (nextHandle != nullptr) {
+            return nextHandle;
+          }
+        }
+        return nullptr;
+      }
+    }
+
+    for (const auto& window : windows) {
+      if (window.handle != nullptr && window.handle == preferredHandle) {
+        return window.handle;
+      }
+    }
+
+    for (const auto& window : windows) {
+      if (window.handle != nullptr) {
+        return window.handle;
+      }
+    }
+    return nullptr;
+  }
+
 } // namespace
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────────
@@ -552,28 +582,24 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
       {
           .model =
               {
-                  .platform = *m_platform,
                   .config = *m_config,
-                  .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
-                  .pinnedEntries = m_pinnedEntries,
-                  .modelSerial = m_modelSerial,
               },
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
       },
       instance.snapshot,
       {
-          .pruneCachedToplevelHandles = [this]() { pruneCachedToplevelHandles(); },
-          .launchOptions = [this](
-                               wl_surface* activationSurface
-                           ) { return dockLaunchOptions(*m_platform, *m_config, activationSurface); },
+          .activateOrLaunch =
+              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action) {
+                activateOrLaunchItem(inst, action);
+              },
           .toggleLauncher =
               [](shell::dock::DockInstance& inst) {
                 PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = inst.output});
               },
           .openItemMenu =
-              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& item) {
-                openItemMenu(inst, item);
+              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action) {
+                openItemMenu(inst, action);
               },
       }
   );
@@ -589,11 +615,7 @@ void Dock::updateVisuals(shell::dock::DockInstance& instance) {
       {
           .model =
               {
-                  .platform = *m_platform,
                   .config = *m_config,
-                  .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
-                  .pinnedEntries = m_pinnedEntries,
-                  .modelSerial = m_modelSerial,
               },
           .renderContext = *m_renderContext,
           .iconResolver = m_iconResolver,
@@ -619,7 +641,41 @@ void Dock::closeItemMenu() {
   }
 }
 
-void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& item) {
+void Dock::activateOrLaunchItem(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& action) {
+  assertDockInitialized(m_platform, m_config, m_renderContext);
+
+  pruneCachedToplevelHandles();
+
+  auto windows = m_platform->windowsForApp(
+      action.idLower, action.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
+  );
+
+  if (windows.empty()) {
+    wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
+    (void)desktop_entry_launch::launchEntry(action.entry, dockLaunchOptions(*m_platform, *m_config, activationSurface));
+    return;
+  }
+
+  if (windows.size() == 1) {
+    m_platform->activateToplevel(windows[0].handle);
+    return;
+  }
+
+  zwlr_foreign_toplevel_handle_v1* activeHandle = nullptr;
+  if (const auto active = m_platform->activeToplevel(); active.has_value()) {
+    activeHandle = active->handle;
+  }
+
+  auto* preferredHandle = [&]() -> zwlr_foreign_toplevel_handle_v1* {
+    const auto it = m_lastActiveHandleByAppIdLower.find(action.idLower);
+    return it != m_lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
+  }();
+  if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle); nextHandle != nullptr) {
+    m_platform->activateToplevel(nextHandle);
+  }
+}
+
+void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& action) {
   assertDockInitialized(m_platform, m_config, m_renderContext);
 
   closeItemMenu();
@@ -631,19 +687,20 @@ void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::
   m_popupOwnerInstance = &instance;
 
   auto windows = m_platform->windowsForApp(
-      item.idLower, item.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
+      action.idLower, action.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
   );
-  const std::string entryId = item.entry.id;
-  const std::string entryWorkingDir = item.entry.workingDir;
-  const bool entryTerminal = item.entry.terminal;
+  const std::string entryId = action.entry.id;
+  const std::string entryWorkingDir = action.entry.workingDir;
+  const bool entryTerminal = action.entry.terminal;
 
   shell::dock::DockMenuCallbacks callbacks{
       .activateWindow = [this](zwlr_foreign_toplevel_handle_v1* handle) { m_platform->activateToplevel(handle); },
       .closeWindow = [this](zwlr_foreign_toplevel_handle_v1* handle) { m_platform->closeToplevel(handle); },
       .launchAction =
-          [this, entryId, entryWorkingDir, entryTerminal](const DesktopAction& action) {
+          [this, entryId, entryWorkingDir, entryTerminal](const DesktopAction& desktopAction) {
             (void)desktop_entry_launch::launchAction(
-                action, entryId, entryWorkingDir, entryTerminal, dockLaunchOptions(*m_platform, *m_config, nullptr)
+                desktopAction, entryId, entryWorkingDir, entryTerminal,
+                dockLaunchOptions(*m_platform, *m_config, nullptr)
             );
           },
       .closeMenu = [this]() { closeItemMenu(); },
@@ -652,7 +709,7 @@ void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::
   auto* layerSurface =
       instance.surface != nullptr ? m_platform->layerSurfaceFor(instance.surface->wlSurface()) : nullptr;
   m_itemMenu = shell::dock::createItemMenu(
-      *m_platform, *m_config, *m_renderContext, layerSurface, instance.output, m_config->config().dock, item.entry,
+      *m_platform, *m_config, *m_renderContext, layerSurface, instance.output, m_config->config().dock, action.entry,
       windows, callbacks
   );
   if (m_itemMenu == nullptr) {

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -476,9 +476,7 @@ void Dock::createInstance(const WaylandOutput& output) {
   instance->outputName = output.name;
   instance->output = output.output;
   instance->scale = output.scale;
-  instance->activeAppIdLower = shell::dock::currentActiveEntryIdLower(*m_platform);
   instance->snapshot.output = output.output;
-  instance->snapshot.activeAppIdLower = instance->activeAppIdLower;
 
   const auto& shadowConfig = m_config->config().shell.shadow;
   LayerSurfaceConfig lsCfg = shell::dock::makeLayerSurfaceConfig(
@@ -534,23 +532,9 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
       }
   );
 
-  const bool filterOutputChanged = next.filterOutput != instance.lastFilterOutput;
-  const bool needRebuild = instance.modelSerial != m_modelSerial || filterOutputChanged
-      || !shell::dock::sameDockItemSet(instance.snapshot, next);
+  const bool needRebuild = instance.snapshot.sourceSerial != next.sourceSerial
+      || instance.snapshot.filterOutput != next.filterOutput || !shell::dock::sameDockItemSet(instance.snapshot, next);
   instance.snapshot = std::move(next);
-
-  instance.lastFilterOutput = instance.snapshot.filterOutput;
-  instance.activeAppIdLower = instance.snapshot.activeAppIdLower;
-  for (auto& item : instance.items) {
-    for (const auto& model : instance.snapshot.items) {
-      if (item.idLower == model.idLower && item.startupWmClassLower == model.startupWmClassLower) {
-        item.running = model.running;
-        item.active = model.active;
-        item.instanceCount = model.instanceCount;
-        break;
-      }
-    }
-  }
 
   return needRebuild;
 }

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -477,6 +477,8 @@ void Dock::createInstance(const WaylandOutput& output) {
   instance->output = output.output;
   instance->scale = output.scale;
   instance->activeAppIdLower = shell::dock::currentActiveEntryIdLower(*m_platform);
+  instance->snapshot.output = output.output;
+  instance->snapshot.activeAppIdLower = instance->activeAppIdLower;
 
   const auto& shadowConfig = m_config->config().shell.shadow;
   LayerSurfaceConfig lsCfg = shell::dock::makeLayerSurfaceConfig(

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -12,6 +12,7 @@
 #include "shell/dock/dock_geometry.h"
 #include "shell/dock/dock_instance.h"
 #include "shell/dock/dock_items.h"
+#include "shell/dock/dock_model.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface_shadow.h"
 #include "shell/tooltip/tooltip_manager.h"

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -551,19 +551,18 @@ bool Dock::syncInstanceModel(shell::dock::DockInstance& instance) {
     return false;
   }
 
-  auto next = shell::dock::buildDockSnapshot(
-      {
-          .platform = *m_platform,
-          .config = m_config->config().dock,
-          .output = instance.output,
-          .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
-          .pinnedEntries = m_pinnedEntries,
-          .sourceSerial = m_modelSerial,
-      }
-  );
+  auto next = shell::dock::buildDockSnapshot({
+      .platform = *m_platform,
+      .config = m_config->config().dock,
+      .output = instance.output,
+      .lastActiveHandleByAppIdLower = m_lastActiveHandleByAppIdLower,
+      .pinnedEntries = m_pinnedEntries,
+      .sourceSerial = m_modelSerial,
+  });
 
   const bool needRebuild = instance.snapshot.sourceSerial != next.sourceSerial
-      || instance.snapshot.filterOutput != next.filterOutput || !shell::dock::sameDockItemSet(instance.snapshot, next);
+      || instance.snapshot.filterOutput != next.filterOutput
+      || !shell::dock::sameDockItemSet(instance.snapshot, next);
   instance.snapshot = std::move(next);
 
   return needRebuild;
@@ -589,18 +588,16 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
       },
       instance.snapshot,
       {
-          .activateOrLaunch =
-              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action) {
-                activateOrLaunchItem(inst, action);
-              },
+          .activateOrLaunch = [this](
+                                  shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action
+                              ) { activateOrLaunchItem(inst, action); },
           .toggleLauncher =
               [](shell::dock::DockInstance& inst) {
                 PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = inst.output});
               },
-          .openItemMenu =
-              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action) {
-                openItemMenu(inst, action);
-              },
+          .openItemMenu = [this](
+                              shell::dock::DockInstance& inst, const shell::dock::DockItemAction& action
+                          ) { openItemMenu(inst, action); },
       }
   );
 }
@@ -647,7 +644,8 @@ void Dock::activateOrLaunchItem(shell::dock::DockInstance& instance, const shell
   pruneCachedToplevelHandles();
 
   auto windows = m_platform->windowsForApp(
-      action.idLower, action.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
+      action.idLower, action.startupWmClassLower,
+      shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
   );
 
   if (windows.empty()) {
@@ -687,7 +685,8 @@ void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::
   m_popupOwnerInstance = &instance;
 
   auto windows = m_platform->windowsForApp(
-      action.idLower, action.startupWmClassLower, shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
+      action.idLower, action.startupWmClassLower,
+      shell::dock::dockFilterOutput(m_config->config().dock, instance.output)
   );
   const std::string entryId = action.entry.id;
   const std::string entryWorkingDir = action.entry.workingDir;

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -588,7 +588,9 @@ void Dock::rebuildItems(shell::dock::DockInstance& instance) {
                 PanelManager::instance().togglePanel("launcher", PanelOpenRequest{.output = inst.output});
               },
           .openItemMenu =
-              [this](shell::dock::DockInstance& inst, shell::dock::DockItemView& item) { openItemMenu(inst, item); },
+              [this](shell::dock::DockInstance& inst, const shell::dock::DockItemAction& item) {
+                openItemMenu(inst, item);
+              },
       }
   );
 }
@@ -633,7 +635,7 @@ void Dock::closeItemMenu() {
   }
 }
 
-void Dock::openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item) {
+void Dock::openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& item) {
   assertDockInitialized(m_platform, m_config, m_renderContext);
 
   closeItemMenu();

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -56,7 +56,8 @@ private:
   bool syncInstanceModel(shell::dock::DockInstance& instance);
   void rebuildItems(shell::dock::DockInstance& instance);
   void updateVisuals(shell::dock::DockInstance& instance);
-  void openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& item);
+  void activateOrLaunchItem(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& action);
+  void openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& action);
   void closeItemMenu();
 
   CompositorPlatform* m_platform = nullptr;

--- a/src/shell/dock/dock.h
+++ b/src/shell/dock/dock.h
@@ -21,6 +21,7 @@ struct zwlr_foreign_toplevel_handle_v1;
 
 namespace shell::dock {
   struct DockInstance;
+  struct DockItemAction;
   struct DockItemView;
   struct DockPopup;
 } // namespace shell::dock
@@ -55,7 +56,7 @@ private:
   bool syncInstanceModel(shell::dock::DockInstance& instance);
   void rebuildItems(shell::dock::DockInstance& instance);
   void updateVisuals(shell::dock::DockInstance& instance);
-  void openItemMenu(shell::dock::DockInstance& instance, shell::dock::DockItemView& item);
+  void openItemMenu(shell::dock::DockInstance& instance, const shell::dock::DockItemAction& item);
   void closeItemMenu();
 
   CompositorPlatform* m_platform = nullptr;

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <string>
 #include <vector>
 
 class Box;
@@ -39,9 +38,6 @@ namespace shell::dock {
     Flex* row = nullptr;
     InputDispatcher inputDispatcher;
     std::vector<shell::dock::DockItemView> items;
-    std::uint64_t modelSerial = 0;
-    std::string activeAppIdLower;
-    wl_output* lastFilterOutput = nullptr;
     DockSnapshot snapshot;
     bool pointerInside = false;
     // Auto-hide: tracks visibility [0,1] driven by hover.

--- a/src/shell/dock/dock_instance.h
+++ b/src/shell/dock/dock_instance.h
@@ -3,6 +3,7 @@
 #include "config/config_types.h"
 #include "render/scene/input_dispatcher.h"
 #include "shell/dock/dock_items.h"
+#include "shell/dock/dock_model.h"
 #include "ui/signal.h"
 
 #include <cstdint>
@@ -41,6 +42,7 @@ namespace shell::dock {
     std::uint64_t modelSerial = 0;
     std::string activeAppIdLower;
     wl_output* lastFilterOutput = nullptr;
+    DockSnapshot snapshot;
     bool pointerInside = false;
     // Auto-hide: tracks visibility [0,1] driven by hover.
     float hideOpacity = 1.0f;

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -293,7 +293,6 @@ namespace shell::dock {
       DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot,
       const DockItemCallbacks& callbacks
   ) {
-    (void)snapshot;
     uiAssertNotRendering("shell::dock::rebuildItems");
     if (instance.row == nullptr) {
       return;
@@ -332,61 +331,28 @@ namespace shell::dock {
         instance.panel != nullptr ? instance.panel->addChild(std::move(freshRow))
                                   : instance.sceneRoot->addChild(std::move(freshRow))
     );
-
-    // Determine items: pinned + (optionally) running-only apps not in pinned.
-    std::vector<DesktopEntry> itemEntries = deps.model.pinnedEntries;
-    wl_output* filterOutput = dockFilterOutput(cfg, instance.output);
-    instance.lastFilterOutput = filterOutput;
-
-    if (cfg.showRunning) {
-      const auto runningIds = deps.model.platform.runningAppIds(filterOutput);
-      const auto& allEntries = desktopEntries();
-      const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
-
-      for (const auto& run : resolvedRunning) {
-        bool alreadyPresent = false;
-        for (const auto& itm : itemEntries) {
-          if (app_identity::desktopEntryMatchesLower(itm, run.runningLower)) {
-            alreadyPresent = true;
-            break;
-          }
-        }
-        if (alreadyPresent) {
-          continue;
-        }
-
-        itemEntries.push_back(run.entry);
-      }
-    }
-
-    const auto activeIdLower = instance.activeAppIdLower;
-    const auto runningIds = deps.model.platform.runningAppIds(filterOutput);
-    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
-    std::vector<std::string> runningLower;
-    runningLower.reserve(resolvedRunning.size());
-    for (const auto& run : resolvedRunning) {
-      runningLower.push_back(StringUtils::toLower(run.entry.id));
-    }
+    const auto& itemModels = snapshot.items;
 
     if (cfg.launcherPosition == "start") {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
     // Reserve up-front so emplace_back never reallocates while lambdas hold raw pointers.
-    instance.items.reserve(itemEntries.size());
+    instance.items.reserve(itemModels.size());
 
-    for (const auto& entry : itemEntries) {
+    for (const auto& model : itemModels) {
       auto& item = instance.items.emplace_back();
-      item.entry = entry;
-      item.idLower = StringUtils::toLower(entry.id);
-      item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
+      item.entry = model.entry;
+      item.idLower = model.idLower;
+      item.startupWmClassLower = model.startupWmClassLower;
+      item.active = model.active;
+      item.running = model.running;
+      item.instanceCount = model.instanceCount;
       DockItemAction action{
-          .entry = item.entry,
-          .idLower = item.idLower,
-          .startupWmClassLower = item.startupWmClassLower,
+          .entry = model.entry,
+          .idLower = model.idLower,
+          .startupWmClassLower = model.startupWmClassLower,
       };
-      item.active = matchesActiveApp(item, activeIdLower);
-      item.running = matchesRunningApp(item, runningLower);
 
       const float cellMain = iSize + 2.0f * kCellPad;
       const float cellCross = iSize + 2.0f * kCellPad;
@@ -409,8 +375,8 @@ namespace shell::dock {
       );
 
       const std::string& iconPath = [&]() -> const std::string& {
-        if (!entry.icon.empty()) {
-          const std::string& primary = deps.iconResolver.resolve(entry.icon, cfg.iconSize);
+        if (!model.entry.icon.empty()) {
+          const std::string& primary = deps.iconResolver.resolve(model.entry.icon, cfg.iconSize);
           if (!primary.empty()) {
             return primary;
           }
@@ -538,18 +504,20 @@ namespace shell::dock {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
-    instance.modelSerial = deps.model.modelSerial;
+    instance.modelSerial = snapshot.sourceSerial;
 
     shell::dock::resizeSurface(instance, cfg, deps.model.config.config().shell.shadow);
   }
 
   void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot) {
-    (void)snapshot;
     const auto& cfg = deps.model.config.config().dock;
+    const std::size_t itemCount = std::min(instance.items.size(), snapshot.items.size());
 
-    for (auto& item : instance.items) {
-      const float iconScale = item.active ? cfg.activeScale : cfg.inactiveScale;
-      const float iconOpacity = item.active ? cfg.activeOpacity : cfg.inactiveOpacity;
+    for (std::size_t itemIndex = 0; itemIndex < itemCount; ++itemIndex) {
+      auto& item = instance.items[itemIndex];
+      const auto& model = snapshot.items[itemIndex];
+      const float iconScale = model.active ? cfg.activeScale : cfg.inactiveScale;
+      const float iconOpacity = model.active ? cfg.activeOpacity : cfg.inactiveOpacity;
       Node* iconNode =
           item.iconImage != nullptr ? static_cast<Node*>(item.iconImage) : static_cast<Node*>(item.iconGlyph);
 
@@ -589,15 +557,8 @@ namespace shell::dock {
         }
       }
 
-      const bool needsWindowCount = cfg.showDots || item.badge != nullptr;
-      std::size_t count = 0;
-      if (needsWindowCount) {
-        const auto windows = deps.model.platform.windowsForApp(
-            item.idLower, item.startupWmClassLower, dockFilterOutput(cfg, instance.output)
-        );
-        count = windows.size();
-        item.instanceCount = count;
-      }
+      const std::size_t count = model.instanceCount;
+      item.instanceCount = count;
 
       if (cfg.showDots) {
         const std::size_t dotCount = std::min<std::size_t>(count, 3);

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -288,7 +288,11 @@ namespace shell::dock {
     return areaNode;
   }
 
-  void rebuildItems(DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks) {
+  void rebuildItems(
+      DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot,
+      const DockItemCallbacks& callbacks
+  ) {
+    (void)snapshot;
     uiAssertNotRendering("shell::dock::rebuildItems");
     if (instance.row == nullptr) {
       return;
@@ -533,7 +537,8 @@ namespace shell::dock {
     shell::dock::resizeSurface(instance, cfg, deps.model.config.config().shell.shadow);
   }
 
-  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps) {
+  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot) {
+    (void)snapshot;
     const auto& cfg = deps.model.config.config().dock;
 
     for (auto& item : instance.items) {

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -1,8 +1,6 @@
 #include "shell/dock/dock_items.h"
 
-#include "compositors/compositor_platform.h"
 #include "config/config_service.h"
-#include "core/log.h"
 #include "core/ui_phase.h"
 #include "render/render_context.h"
 #include "render/scene/input_area.h"
@@ -10,14 +8,11 @@
 #include "shell/dock/dock_geometry.h"
 #include "shell/dock/dock_instance.h"
 #include "shell/dock/dock_model.h"
-#include "system/app_identity.h"
 #include "system/icon_resolver.h"
 #include "ui/builders.h"
 #include "ui/palette.h"
 #include "ui/style.h"
-#include "util/string_utils.h"
 #include "wayland/layer_surface.h"
-#include "wayland/wayland_toplevels.h"
 
 #include <algorithm>
 #include <cmath>
@@ -26,8 +21,6 @@
 #include <utility>
 
 namespace {
-
-  constexpr Logger kLog("dock");
 
   // Instance-count badge geometry — scales with icon size.
   constexpr float kBadgeSizeRatio = 0.30f; // fraction of icon size
@@ -38,100 +31,14 @@ namespace {
   constexpr float kDotGap = 3.0f;
   constexpr float kCellPad = 6.0f;
 
-  zwlr_foreign_toplevel_handle_v1* nextActivatableWindowHandle(
-      const std::vector<ToplevelInfo>& windows, zwlr_foreign_toplevel_handle_v1* activeHandle,
-      zwlr_foreign_toplevel_handle_v1* preferredHandle
-  ) {
-    for (std::size_t i = 0; i < windows.size(); ++i) {
-      if (windows[i].handle != nullptr && windows[i].handle == activeHandle) {
-        for (std::size_t offset = 1; offset <= windows.size(); ++offset) {
-          auto* nextHandle = windows[(i + offset) % windows.size()].handle;
-          if (nextHandle != nullptr) {
-            return nextHandle;
-          }
-        }
-        return nullptr;
-      }
-    }
-
-    for (const auto& window : windows) {
-      if (window.handle != nullptr && window.handle == preferredHandle) {
-        return window.handle;
-      }
-    }
-
-    for (const auto& window : windows) {
-      if (window.handle != nullptr) {
-        return window.handle;
-      }
-    }
-    return nullptr;
-  }
-
 } // namespace
 
 namespace shell::dock {
 
   struct DockItemClickContext {
-    CompositorPlatform& platform;
     ConfigService& config;
-    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
     DockItemCallbacks callbacks;
   };
-
-  bool refreshPinnedAppsIfNeeded(
-      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
-      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
-  ) {
-    if (desktopEntriesVersion() == entriesVersion && cfg.pinned == lastPinnedConfig) {
-      return false;
-    }
-
-    lastPinnedConfig = cfg.pinned;
-    entriesVersion = desktopEntriesVersion();
-    pinnedEntries.clear();
-
-    const auto& entries = desktopEntries();
-
-    for (const auto& pinnedId : cfg.pinned) {
-      const auto pinnedLower = StringUtils::toLower(pinnedId);
-      bool found = false;
-
-      for (const auto& entry : entries) {
-        if (entry.hidden || entry.noDisplay) {
-          continue;
-        }
-        // Match by entry ID (stem of the desktop file path, e.g. "firefox"),
-        // by StartupWMClass (lower), or by Name (lower).
-        const auto stemLower = StringUtils::toLower([&] {
-          const auto slash = entry.id.rfind('/');
-          const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
-          const auto dot = base.rfind('.');
-          return (dot == std::string::npos) ? base : base.substr(0, dot);
-        }());
-
-        if (stemLower == pinnedLower || app_identity::desktopEntryMatchesLower(entry, pinnedLower)) {
-          pinnedEntries.push_back(entry);
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        kLog.debug("pinned app not found: {}", pinnedId);
-        // Add placeholder so the pinned slot is visible even when app is not installed.
-        DesktopEntry placeholder;
-        placeholder.id = pinnedId;
-        placeholder.name = pinnedId;
-        placeholder.nameLower = pinnedLower;
-        pinnedEntries.push_back(std::move(placeholder));
-      }
-    }
-
-    ++modelSerial;
-    kLog.debug("pinned app list: {} entries", pinnedEntries.size());
-    return true;
-  }
 
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
     return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
@@ -148,7 +55,7 @@ namespace shell::dock {
     );
   }
 
-  void handleItemClick(DockInstance& instance, const DockItemAction& item, DockItemClickContext& context);
+  void handleItemClick(DockInstance& instance, const DockItemAction& action, DockItemClickContext& context);
 
   std::unique_ptr<InputArea> createLauncherButton(
       DockInstance& instance, const DockConfig& cfg, const std::shared_ptr<DockItemClickContext>& clickContext
@@ -230,9 +137,7 @@ namespace shell::dock {
     const bool vert = shell::dock::isVerticalPosition(cfg.position);
     const float iSize = static_cast<float>(cfg.iconSize);
     auto clickContext = std::make_shared<DockItemClickContext>(DockItemClickContext{
-        .platform = deps.model.platform,
         .config = deps.model.config,
-        .lastActiveHandleByAppIdLower = deps.model.lastActiveHandleByAppIdLower,
         .callbacks = callbacks,
     });
 
@@ -529,39 +434,9 @@ namespace shell::dock {
     }
   }
 
-  void handleItemClick(DockInstance& instance, const DockItemAction& item, DockItemClickContext& context) {
-    if (context.callbacks.pruneCachedToplevelHandles) {
-      context.callbacks.pruneCachedToplevelHandles();
-    }
-
-    auto windows = context.platform.windowsForApp(
-        item.idLower, item.startupWmClassLower, dockFilterOutput(context.config.config().dock, instance.output)
-    );
-
-    if (windows.empty()) {
-      wl_surface* const activationSurface = instance.surface != nullptr ? instance.surface->wlSurface() : nullptr;
-      const auto options = context.callbacks.launchOptions ? context.callbacks.launchOptions(activationSurface)
-                                                           : desktop_entry_launch::LaunchOptions{};
-      (void)desktop_entry_launch::launchEntry(item.entry, options);
-      return;
-    }
-
-    if (windows.size() == 1) {
-      context.platform.activateToplevel(windows[0].handle);
-      return;
-    }
-
-    zwlr_foreign_toplevel_handle_v1* activeHandle = nullptr;
-    if (const auto active = context.platform.activeToplevel(); active.has_value()) {
-      activeHandle = active->handle;
-    }
-
-    auto* preferredHandle = [&]() -> zwlr_foreign_toplevel_handle_v1* {
-      const auto it = context.lastActiveHandleByAppIdLower.find(item.idLower);
-      return it != context.lastActiveHandleByAppIdLower.end() ? it->second : nullptr;
-    }();
-    if (auto* nextHandle = nextActivatableWindowHandle(windows, activeHandle, preferredHandle); nextHandle != nullptr) {
-      context.platform.activateToplevel(nextHandle);
+  void handleItemClick(DockInstance& instance, const DockItemAction& action, DockItemClickContext& context) {
+    if (context.callbacks.activateOrLaunch) {
+      context.callbacks.activateOrLaunch(instance, action);
     }
   }
 

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -133,78 +133,6 @@ namespace shell::dock {
     return true;
   }
 
-  bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower) {
-    return !activeAppIdLower.empty() && activeAppIdLower == item.idLower;
-  }
-
-  bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower) {
-    for (const auto& rid : runningLower) {
-      if (!rid.empty() && rid == item.idLower) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  bool syncInstanceModel(DockInstance& instance, DockItemModelDependencies deps) {
-    const auto& cfg = deps.config.config().dock;
-    const std::string globalActiveIdLower = currentActiveEntryIdLower(deps.platform);
-    if (!globalActiveIdLower.empty()) {
-      if (const auto active = deps.platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
-        deps.lastActiveHandleByAppIdLower[globalActiveIdLower] = active->handle;
-      }
-    }
-    wl_output* const activeOutput = deps.platform.activeToplevelOutput();
-    wl_output* filterOutput = dockFilterOutput(cfg, instance.output);
-    const bool filterOutputChanged = (filterOutput != instance.lastFilterOutput);
-    instance.lastFilterOutput = filterOutput;
-
-    // When filtering by active monitor, inactive monitors' docks should not
-    // highlight the globally-active app — it isn't on them.
-    const std::string activeIdLower =
-        (cfg.activeMonitorOnly && activeOutput != instance.output) ? std::string{} : globalActiveIdLower;
-    instance.activeAppIdLower = activeIdLower;
-
-    const auto runningIds = cfg.showRunning ? deps.platform.runningAppIds(filterOutput) : std::vector<std::string>{};
-    const auto& allEntries = desktopEntries();
-    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, allEntries);
-    std::vector<std::string> runningLower;
-    runningLower.reserve(resolvedRunning.size());
-    for (const auto& run : resolvedRunning) {
-      runningLower.push_back(StringUtils::toLower(run.entry.id));
-    }
-
-    bool needRebuild = (instance.modelSerial != deps.modelSerial) || filterOutputChanged;
-    if (!needRebuild && cfg.showRunning) {
-      const std::size_t expectedTotal = [&] {
-        std::vector<DesktopEntry> entries = deps.pinnedEntries;
-        for (const auto& run : resolvedRunning) {
-          bool present = false;
-          for (const auto& entry : entries) {
-            if (app_identity::desktopEntryMatchesLower(entry, run.runningLower)) {
-              present = true;
-              break;
-            }
-          }
-          if (!present) {
-            entries.push_back(run.entry);
-          }
-        }
-        return entries.size();
-      }();
-      if (expectedTotal != instance.items.size()) {
-        needRebuild = true;
-      }
-    }
-
-    for (auto& item : instance.items) {
-      item.running = matchesRunningApp(item, runningLower);
-      item.active = matchesActiveApp(item, activeIdLower);
-    }
-
-    return needRebuild;
-  }
-
   std::string_view dockLauncherIconGlyph(const DockConfig& cfg) {
     return cfg.launcherIcon.empty() ? "grid-dots" : std::string_view{cfg.launcherIcon};
   }
@@ -342,12 +270,6 @@ namespace shell::dock {
 
     for (const auto& model : itemModels) {
       auto& item = instance.items.emplace_back();
-      item.entry = model.entry;
-      item.idLower = model.idLower;
-      item.startupWmClassLower = model.startupWmClassLower;
-      item.active = model.active;
-      item.running = model.running;
-      item.instanceCount = model.instanceCount;
       DockItemAction action{
           .entry = model.entry,
           .idLower = model.idLower,
@@ -504,8 +426,6 @@ namespace shell::dock {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
-    instance.modelSerial = snapshot.sourceSerial;
-
     shell::dock::resizeSurface(instance, cfg, deps.model.config.config().shell.shadow);
   }
 
@@ -558,7 +478,6 @@ namespace shell::dock {
       }
 
       const std::size_t count = model.instanceCount;
-      item.instanceCount = count;
 
       if (cfg.showDots) {
         const std::size_t dotCount = std::min<std::size_t>(count, 3);

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -9,6 +9,7 @@
 #include "render/scene/node.h"
 #include "shell/dock/dock_geometry.h"
 #include "shell/dock/dock_instance.h"
+#include "shell/dock/dock_model.h"
 #include "system/app_identity.h"
 #include "system/icon_resolver.h"
 #include "ui/builders.h"
@@ -76,20 +77,6 @@ namespace shell::dock {
     std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
     DockItemCallbacks callbacks;
   };
-
-  std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
-    if (const auto active = platform.activeToplevel(); active.has_value()) {
-      return StringUtils::toLower(app_identity::resolveRunningDesktopEntry(active->appId, desktopEntries()).id);
-    }
-    return {};
-  }
-
-  wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput) {
-    if (!cfg.activeMonitorOnly) {
-      return nullptr;
-    }
-    return instanceOutput;
-  }
 
   bool refreshPinnedAppsIfNeeded(
       const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <linux/input-event-codes.h>
 #include <memory>
+#include <utility>
 
 namespace {
 
@@ -219,7 +220,7 @@ namespace shell::dock {
     );
   }
 
-  void handleItemClick(DockInstance& instance, DockItemView& item, DockItemClickContext& context);
+  void handleItemClick(DockInstance& instance, const DockItemAction& item, DockItemClickContext& context);
 
   std::unique_ptr<InputArea> createLauncherButton(
       DockInstance& instance, const DockConfig& cfg, const std::shared_ptr<DockItemClickContext>& clickContext
@@ -379,6 +380,11 @@ namespace shell::dock {
       item.entry = entry;
       item.idLower = StringUtils::toLower(entry.id);
       item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
+      DockItemAction action{
+          .entry = item.entry,
+          .idLower = item.idLower,
+          .startupWmClassLower = item.startupWmClassLower,
+      };
       item.active = matchesActiveApp(item, activeIdLower);
       item.running = matchesRunningApp(item, runningLower);
 
@@ -517,11 +523,11 @@ namespace shell::dock {
         }
       });
       areaNode->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
-      areaNode->setOnClick([itemPtr, instPtr, clickContext](const InputArea::PointerData& d) {
+      areaNode->setOnClick([action = std::move(action), instPtr, clickContext](const InputArea::PointerData& d) {
         if (d.button == BTN_LEFT) {
-          handleItemClick(*instPtr, *itemPtr, *clickContext);
+          handleItemClick(*instPtr, action, *clickContext);
         } else if (d.button == BTN_RIGHT && clickContext->callbacks.openItemMenu) {
-          clickContext->callbacks.openItemMenu(*instPtr, *itemPtr);
+          clickContext->callbacks.openItemMenu(*instPtr, action);
         }
       });
 
@@ -643,7 +649,7 @@ namespace shell::dock {
     }
   }
 
-  void handleItemClick(DockInstance& instance, DockItemView& item, DockItemClickContext& context) {
+  void handleItemClick(DockInstance& instance, const DockItemAction& item, DockItemClickContext& context) {
     if (context.callbacks.pruneCachedToplevelHandles) {
       context.callbacks.pruneCachedToplevelHandles();
     }

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -2,6 +2,7 @@
 
 #include "config/config_types.h"
 #include "render/animation/animation_manager.h"
+#include "shell/dock/dock_model.h"
 #include "system/desktop_entry.h"
 #include "system/desktop_entry_launch.h"
 
@@ -84,7 +85,10 @@ namespace shell::dock {
 
   [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
   [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);
-  void rebuildItems(DockInstance& instance, DockItemSceneDependencies deps, const DockItemCallbacks& callbacks);
-  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps);
+  void rebuildItems(
+      DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot,
+      const DockItemCallbacks& callbacks
+  );
+  void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot);
 
 } // namespace shell::dock

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -4,19 +4,14 @@
 #include "render/animation/animation_manager.h"
 #include "shell/dock/dock_model.h"
 #include "system/desktop_entry.h"
-#include "system/desktop_entry_launch.h"
 
 #include <array>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <unordered_map>
-#include <vector>
 
 class Box;
-class CompositorPlatform;
 class ConfigService;
 class Flex;
 class Glyph;
@@ -25,9 +20,6 @@ class Image;
 class InputArea;
 class Label;
 class RenderContext;
-struct wl_output;
-struct wl_surface;
-struct zwlr_foreign_toplevel_handle_v1;
 
 namespace shell::dock {
 
@@ -55,11 +47,7 @@ namespace shell::dock {
   };
 
   struct DockItemModelDependencies {
-    CompositorPlatform& platform;
     ConfigService& config;
-    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
-    const std::vector<DesktopEntry>& pinnedEntries;
-    std::uint64_t modelSerial = 0;
   };
 
   struct DockItemSceneDependencies {
@@ -69,16 +57,10 @@ namespace shell::dock {
   };
 
   struct DockItemCallbacks {
-    std::function<void()> pruneCachedToplevelHandles;
-    std::function<desktop_entry_launch::LaunchOptions(wl_surface*)> launchOptions;
+    std::function<void(DockInstance&, const DockItemAction&)> activateOrLaunch;
     std::function<void(DockInstance&)> toggleLauncher;
     std::function<void(DockInstance&, const DockItemAction&)> openItemMenu;
   };
-
-  [[nodiscard]] bool refreshPinnedAppsIfNeeded(
-      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
-      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
-  );
 
   [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
   [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -34,9 +34,6 @@ namespace shell::dock {
   struct DockInstance;
 
   struct DockItemView {
-    DesktopEntry entry;
-    std::string idLower;
-    std::string startupWmClassLower;
     InputArea* area = nullptr;
     Box* background = nullptr;
     std::array<Box*, 3> dotIndicators{};
@@ -45,13 +42,10 @@ namespace shell::dock {
     Image* iconImage = nullptr;
     Glyph* iconGlyph = nullptr;
     bool hovered = false;
-    bool running = false;
-    bool active = false;
     float visualScale = -1.0f;
     float visualOpacity = -1.0f;
     AnimationManager::Id scaleAnimId = 0;
     AnimationManager::Id opacityAnimId = 0;
-    std::size_t instanceCount = 0;
   };
 
   struct DockItemAction {
@@ -85,9 +79,6 @@ namespace shell::dock {
       const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
       std::uint64_t& modelSerial, std::uint64_t& entriesVersion
   );
-  [[nodiscard]] bool matchesActiveApp(const DockItemView& item, std::string_view activeAppIdLower);
-  [[nodiscard]] bool matchesRunningApp(const DockItemView& item, const std::vector<std::string>& runningLower);
-  [[nodiscard]] bool syncInstanceModel(DockInstance& instance, DockItemModelDependencies deps);
 
   [[nodiscard]] std::string_view dockLauncherIconGlyph(const DockConfig& cfg);
   [[nodiscard]] std::unique_ptr<Flex> makeDockItemRow(const DockConfig& cfg, bool vertical);

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -54,6 +54,12 @@ namespace shell::dock {
     std::size_t instanceCount = 0;
   };
 
+  struct DockItemAction {
+    DesktopEntry entry;
+    std::string idLower;
+    std::string startupWmClassLower;
+  };
+
   struct DockItemModelDependencies {
     CompositorPlatform& platform;
     ConfigService& config;
@@ -72,7 +78,7 @@ namespace shell::dock {
     std::function<void()> pruneCachedToplevelHandles;
     std::function<desktop_entry_launch::LaunchOptions(wl_surface*)> launchOptions;
     std::function<void(DockInstance&)> toggleLauncher;
-    std::function<void(DockInstance&, DockItemView&)> openItemMenu;
+    std::function<void(DockInstance&, const DockItemAction&)> openItemMenu;
   };
 
   [[nodiscard]] bool refreshPinnedAppsIfNeeded(

--- a/src/shell/dock/dock_items.h
+++ b/src/shell/dock/dock_items.h
@@ -74,8 +74,6 @@ namespace shell::dock {
     std::function<void(DockInstance&, DockItemView&)> openItemMenu;
   };
 
-  [[nodiscard]] std::string currentActiveEntryIdLower(const CompositorPlatform& platform);
-  [[nodiscard]] wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput);
   [[nodiscard]] bool refreshPinnedAppsIfNeeded(
       const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
       std::uint64_t& modelSerial, std::uint64_t& entriesVersion

--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -1,9 +1,16 @@
 #include "shell/dock/dock_model.h"
 
 #include "compositors/compositor_platform.h"
+#include "core/log.h"
 #include "system/app_identity.h"
 #include "util/string_utils.h"
 #include "wayland/wayland_toplevels.h"
+
+namespace {
+
+  constexpr Logger kLog("dock");
+
+} // namespace
 
 namespace shell::dock {
 
@@ -19,6 +26,59 @@ namespace shell::dock {
       return StringUtils::toLower(app_identity::resolveRunningDesktopEntry(active->appId, desktopEntries()).id);
     }
     return {};
+  }
+
+  bool refreshPinnedAppsIfNeeded(
+      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
+      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
+  ) {
+    if (desktopEntriesVersion() == entriesVersion && cfg.pinned == lastPinnedConfig) {
+      return false;
+    }
+
+    lastPinnedConfig = cfg.pinned;
+    entriesVersion = desktopEntriesVersion();
+    pinnedEntries.clear();
+
+    const auto& entries = desktopEntries();
+
+    for (const auto& pinnedId : cfg.pinned) {
+      const auto pinnedLower = StringUtils::toLower(pinnedId);
+      bool found = false;
+
+      for (const auto& entry : entries) {
+        if (entry.hidden || entry.noDisplay) {
+          continue;
+        }
+        // Match by entry ID (stem of the desktop file path, e.g. "firefox"),
+        // by StartupWMClass (lower), or by Name (lower).
+        const auto stemLower = StringUtils::toLower([&] {
+          const auto slash = entry.id.rfind('/');
+          const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
+          const auto dot = base.rfind('.');
+          return (dot == std::string::npos) ? base : base.substr(0, dot);
+        }());
+
+        if (stemLower == pinnedLower || app_identity::desktopEntryMatchesLower(entry, pinnedLower)) {
+          pinnedEntries.push_back(entry);
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        kLog.debug("pinned app not found: {}", pinnedId);
+        DesktopEntry placeholder;
+        placeholder.id = pinnedId;
+        placeholder.name = pinnedId;
+        placeholder.nameLower = pinnedLower;
+        pinnedEntries.push_back(std::move(placeholder));
+      }
+    }
+
+    ++modelSerial;
+    kLog.debug("pinned app list: {} entries", pinnedEntries.size());
+    return true;
   }
 
   namespace {
@@ -81,17 +141,17 @@ namespace shell::dock {
 
     snapshot.items.reserve(itemEntries.size());
     for (const auto& entry : itemEntries) {
-      DockItemModel item;
-      item.entry = entry;
-      item.idLower = StringUtils::toLower(entry.id);
-      item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
-      item.running = containsRunningEntry(runningLower, item.idLower);
-      item.active = !snapshot.activeAppIdLower.empty() && snapshot.activeAppIdLower == item.idLower;
+      DockItemModel dockItem;
+      dockItem.entry = entry;
+      dockItem.idLower = StringUtils::toLower(entry.id);
+      dockItem.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
+      dockItem.running = containsRunningEntry(runningLower, dockItem.idLower);
+      dockItem.active = !snapshot.activeAppIdLower.empty() && snapshot.activeAppIdLower == dockItem.idLower;
       if (deps.config.showDots || deps.config.showInstanceCount) {
-        item.instanceCount =
-            deps.platform.windowsForApp(item.idLower, item.startupWmClassLower, snapshot.filterOutput).size();
+        dockItem.instanceCount =
+            deps.platform.windowsForApp(dockItem.idLower, dockItem.startupWmClassLower, snapshot.filterOutput).size();
       }
-      snapshot.items.push_back(std::move(item));
+      snapshot.items.push_back(std::move(dockItem));
     }
 
     return snapshot;

--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -1,0 +1,118 @@
+#include "shell/dock/dock_model.h"
+
+#include "compositors/compositor_platform.h"
+#include "system/app_identity.h"
+#include "util/string_utils.h"
+#include "wayland/wayland_toplevels.h"
+
+namespace shell::dock {
+
+  wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput) {
+    if (!cfg.activeMonitorOnly) {
+      return nullptr;
+    }
+    return instanceOutput;
+  }
+
+  std::string currentActiveEntryIdLower(const CompositorPlatform& platform) {
+    if (const auto active = platform.activeToplevel(); active.has_value()) {
+      return StringUtils::toLower(app_identity::resolveRunningDesktopEntry(active->appId, desktopEntries()).id);
+    }
+    return {};
+  }
+
+  namespace {
+
+    bool containsEntryForRunningId(const std::vector<DesktopEntry>& entries, const std::string& runningLower) {
+      for (const auto& entry : entries) {
+        if (app_identity::desktopEntryMatchesLower(entry, runningLower)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    bool containsRunningEntry(const std::vector<std::string>& runningLower, const std::string& idLower) {
+      for (const auto& id : runningLower) {
+        if (!id.empty() && id == idLower) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+  } // namespace
+
+  DockSnapshot buildDockSnapshot(DockModelDependencies deps) {
+    DockSnapshot snapshot;
+    snapshot.output = deps.output;
+    snapshot.filterOutput = dockFilterOutput(deps.config, deps.output);
+    snapshot.sourceSerial = deps.sourceSerial;
+
+    const std::string globalActiveIdLower = currentActiveEntryIdLower(deps.platform);
+    if (!globalActiveIdLower.empty()) {
+      if (const auto active = deps.platform.activeToplevel(); active.has_value() && active->handle != nullptr) {
+        deps.lastActiveHandleByAppIdLower[globalActiveIdLower] = active->handle;
+      }
+    }
+
+    wl_output* const activeOutput = deps.platform.activeToplevelOutput();
+    snapshot.activeAppIdLower =
+        (deps.config.activeMonitorOnly && activeOutput != deps.output) ? std::string{} : globalActiveIdLower;
+
+    const auto runningIds =
+        deps.config.showRunning ? deps.platform.runningAppIds(snapshot.filterOutput) : std::vector<std::string>{};
+    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
+
+    std::vector<DesktopEntry> itemEntries = deps.pinnedEntries;
+    if (deps.config.showRunning) {
+      for (const auto& run : resolvedRunning) {
+        if (!containsEntryForRunningId(itemEntries, run.runningLower)) {
+          itemEntries.push_back(run.entry);
+        }
+      }
+    }
+
+    std::vector<std::string> runningLower;
+    runningLower.reserve(resolvedRunning.size());
+    for (const auto& run : resolvedRunning) {
+      runningLower.push_back(StringUtils::toLower(run.entry.id));
+    }
+
+    snapshot.items.reserve(itemEntries.size());
+    for (const auto& entry : itemEntries) {
+      DockItemModel item;
+      item.entry = entry;
+      item.idLower = StringUtils::toLower(entry.id);
+      item.startupWmClassLower = StringUtils::toLower(entry.startupWmClass);
+      item.running = containsRunningEntry(runningLower, item.idLower);
+      item.active = !snapshot.activeAppIdLower.empty() && snapshot.activeAppIdLower == item.idLower;
+      if (deps.config.showDots || deps.config.showInstanceCount) {
+        item.instanceCount =
+            deps.platform.windowsForApp(item.idLower, item.startupWmClassLower, snapshot.filterOutput).size();
+      }
+      snapshot.items.push_back(std::move(item));
+    }
+
+    return snapshot;
+  }
+
+  bool sameDockItemSet(const DockSnapshot& a, const DockSnapshot& b) {
+    if (a.items.size() != b.items.size()) {
+      return false;
+    }
+    for (std::size_t i = 0; i < a.items.size(); ++i) {
+      if (a.items[i].entry.id != b.items[i].entry.id) {
+        return false;
+      }
+      if (a.items[i].idLower != b.items[i].idLower) {
+        return false;
+      }
+      if (a.items[i].startupWmClassLower != b.items[i].startupWmClassLower) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+} // namespace shell::dock

--- a/src/shell/dock/dock_model.h
+++ b/src/shell/dock/dock_model.h
@@ -43,6 +43,10 @@ namespace shell::dock {
 
   [[nodiscard]] wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput);
   [[nodiscard]] std::string currentActiveEntryIdLower(const CompositorPlatform& platform);
+  [[nodiscard]] bool refreshPinnedAppsIfNeeded(
+      const DockConfig& cfg, std::vector<std::string>& lastPinnedConfig, std::vector<DesktopEntry>& pinnedEntries,
+      std::uint64_t& modelSerial, std::uint64_t& entriesVersion
+  );
   [[nodiscard]] DockSnapshot buildDockSnapshot(DockModelDependencies deps);
   [[nodiscard]] bool sameDockItemSet(const DockSnapshot& a, const DockSnapshot& b);
 

--- a/src/shell/dock/dock_model.h
+++ b/src/shell/dock/dock_model.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "config/config_types.h"
+#include "system/desktop_entry.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class CompositorPlatform;
+struct wl_output;
+struct zwlr_foreign_toplevel_handle_v1;
+
+namespace shell::dock {
+
+  struct DockItemModel {
+    DesktopEntry entry;
+    std::string idLower;
+    std::string startupWmClassLower;
+    bool running = false;
+    bool active = false;
+    std::size_t instanceCount = 0;
+  };
+
+  struct DockSnapshot {
+    wl_output* output = nullptr;
+    wl_output* filterOutput = nullptr;
+    std::string activeAppIdLower;
+    std::vector<DockItemModel> items;
+    std::uint64_t sourceSerial = 0;
+  };
+
+  struct DockModelDependencies {
+    CompositorPlatform& platform;
+    const DockConfig& config;
+    wl_output* output = nullptr;
+    std::unordered_map<std::string, zwlr_foreign_toplevel_handle_v1*>& lastActiveHandleByAppIdLower;
+    const std::vector<DesktopEntry>& pinnedEntries;
+    std::uint64_t sourceSerial = 0;
+  };
+
+  [[nodiscard]] wl_output* dockFilterOutput(const DockConfig& cfg, wl_output* instanceOutput);
+  [[nodiscard]] std::string currentActiveEntryIdLower(const CompositorPlatform& platform);
+  [[nodiscard]] DockSnapshot buildDockSnapshot(DockModelDependencies deps);
+  [[nodiscard]] bool sameDockItemSet(const DockSnapshot& a, const DockSnapshot& b);
+
+} // namespace shell::dock


### PR DESCRIPTION
## Summary
- Introduce a DockSnapshot model boundary for dock item identity, active/running state, output filtering, and instance counts.
- Move app/window discovery out of dock_items so rendering consumes prepared snapshot data.
- Make DockItemView UI-only and use copied DockItemAction data for launch/menu callbacks.

## Problem solved
The dock rendering layer previously mixed UI construction with domain-model discovery: it resolved desktop entries, queried running apps/windows, tracked active state, and owned click/menu identity directly in DockItemView. That made the dock hard to reason about, tightly coupled rendering to compositor/app services, and increased the risk of stale state or lifetime issues when item views were rebuilt.

This refactor separates those responsibilities: dock_model builds the snapshot, Dock orchestrates sync/actions/menus, and dock_items renders from the prepared data.

## Verification
- git diff --check cc1b0a8fa071ab4f6bba30ad5db3b618810630d2..HEAD
- rg checks confirmed dock_items no longer performs app/window discovery or stores domain state in DockItemView
- just build: not available in this environment (just: command not found)
- meson compile -C build-debug
- meson test -C build-debug --print-errorlogs (12/12 passed)