### PR TITLE
feat(volume): add "volume" as control center widget

### DIFF
--- a/Modules/Bar/Widgets/Volume.qml
+++ b/Modules/Bar/Widgets/Volume.qml
@@ -161,17 +161,8 @@ Item {
     tooltipText: {
       if (PanelService.getPanel("audioPanel", screen)?.isPanelOpen) {
         return "";
-      } else {
-        const nick = AudioService.sink?.nickname ?? "";
-        const volumeText = I18n.tr("tooltips.volume-at", {
-                                     "volume": (() => {
-                                                  const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
-                                                  const displayVolume = Math.min(maxVolume, AudioService.volume);
-                                                  return Math.round(displayVolume * 100);
-                                                })()
-                                   });
-        return nick ? volumeText + "\n" + nick : volumeText;
       }
+      return AudioService.getStatusText();
     }
 
     onWheel: function (delta) {

--- a/Modules/Panels/ControlCenter/Widgets/Volume.qml
+++ b/Modules/Panels/ControlCenter/Widgets/Volume.qml
@@ -1,0 +1,15 @@
+import Quickshell
+import qs.Services.Media
+import qs.Services.UI
+import qs.Widgets
+
+NIconButtonHot {
+  property ShellScreen screen
+
+  icon: AudioService.getOutputIcon()
+  hot: AudioService.muted
+  tooltipText: AudioService.getStatusText()
+
+  onClicked: PanelService.getPanel("audioPanel", screen)?.toggle(this)
+  onRightClicked: AudioService.setOutputMuted(!AudioService.muted)
+}

--- a/Services/Media/AudioService.qml
+++ b/Services/Media/AudioService.qml
@@ -1238,4 +1238,16 @@ Singleton {
     }
     Pipewire.preferredDefaultAudioSource = newSource;
   }
+
+  function getStatusText() {
+    const nick = sink?.nickname ?? "";
+    const volumeText = I18n.tr("tooltips.volume-at", {
+                                 "volume": (() => {
+                                              const maxVolume = Settings.data.audio.volumeOverdrive ? 1.5 : 1.0;
+                                              const displayVolume = Math.min(maxVolume, volume);
+                                              return Math.round(displayVolume * 100);
+                                            })()
+                               });
+    return nick ? volumeText + "\n" + nick : volumeText;
+  }
 }

--- a/Services/UI/ControlCenterWidgetRegistry.qml
+++ b/Services/UI/ControlCenterWidgetRegistry.qml
@@ -18,6 +18,7 @@ Singleton {
                            "NightLight": nightLightComponent,
                            "Notifications": notificationsComponent,
                            "PowerProfile": powerProfileComponent,
+                           "Volume": volumeComponent,
                            "WiFi": networkComponent,
                            "Network": networkComponent,
                            "NoctaliaPerformance": noctaliaPerformanceComponent,
@@ -63,6 +64,9 @@ Singleton {
   }
   property Component powerProfileComponent: Component {
     PowerProfile {}
+  }
+  property Component volumeComponent: Component {
+    Volume {}
   }
   property Component networkComponent: Component {
     Network {}


### PR DESCRIPTION
## Motivation
Add "volume" as a "control center" widget, matching usage of the existing "bar" widget.
Allows accessing the volume/audio devices panel without adding it to the bar.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/de8417f6-fd31-4088-8a0d-004f4107dfc8

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)