### PR TITLE
feat(battery tooltip details): more informative battery widget tooltip

### DIFF
--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -258,6 +258,17 @@ UPowerState UPowerService::readDeviceState(sdbus::IProxy& proxy) const {
   next.timeToEmpty = getPropertyOr<std::int64_t>(proxy, kDeviceInterface, "TimeToEmpty", 0);
   next.timeToFull = getPropertyOr<std::int64_t>(proxy, kDeviceInterface, "TimeToFull", 0);
   next.energyRate = getPropertyOr<double>(proxy, kDeviceInterface, "EnergyRate", 0.0);
+  next.energy = getPropertyOr<double>(proxy, kDeviceInterface, "Energy", 0.0);
+
+  // Fallback calculation for timeToEmpty / timeToFull if they are reported as 0 or less
+  if (next.state == BatteryState::Discharging && next.timeToEmpty <= 0 && next.energyRate > 0.0 && next.energy > 0.0) {
+    next.timeToEmpty = static_cast<std::int64_t>(std::round((next.energy / next.energyRate) * 3600.0));
+  } else if (next.state == BatteryState::Charging && next.timeToFull <= 0 && next.energyRate > 0.0) {
+    const double energyFull = getPropertyOr<double>(proxy, kDeviceInterface, "EnergyFull", 0.0);
+    if (energyFull > next.energy) {
+      next.timeToFull = static_cast<std::int64_t>(std::round(((energyFull - next.energy) / next.energyRate) * 3600.0));
+    }
+  }
 
   return next;
 }

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -43,6 +43,7 @@ struct UPowerState {
   BatteryState state = BatteryState::Unknown;
   std::int64_t timeToEmpty = 0; // seconds
   std::int64_t timeToFull = 0;  // seconds
+  double energy = 0.0;          // Wh
   bool isPresent = false;
   bool onBattery = false;
 

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -330,17 +330,27 @@ void BatteryWidget::syncState(Renderer& renderer) {
 
   const auto s = m_upower->stateForDevice(m_deviceSelector);
 
+  const auto now = std::chrono::steady_clock::now();
+  const bool forceTimeRefresh = (m_lastTooltipRefreshTime == std::chrono::steady_clock::time_point{})
+      || (now - m_lastTooltipRefreshTime >= std::chrono::seconds(15));
+
   if (s.percentage == m_lastPct
       && s.state == m_lastState
       && s.isPresent == m_lastPresent
-      && m_isVertical == m_lastVertical) {
+      && s.energyRate == m_lastEnergyRate
+      && s.timeToEmpty == m_lastTimeToEmpty
+      && m_isVertical == m_lastVertical
+      && !forceTimeRefresh) {
     return;
   }
 
   m_lastPct = s.percentage;
   m_lastState = s.state;
   m_lastPresent = s.isPresent;
+  m_lastEnergyRate = s.energyRate;
+  m_lastTimeToEmpty = s.timeToEmpty;
   m_lastVertical = m_isVertical;
+  m_lastTooltipRefreshTime = now;
 
   const bool isPluggedIn = s.state == BatteryState::Charging
       || s.state == BatteryState::FullyCharged

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -5,6 +5,7 @@
 #include "shell/bar/widget.h"
 #include "ui/palette.h"
 
+#include <chrono>
 #include <string>
 
 class Box;
@@ -65,4 +66,8 @@ private:
   bool m_lastPresent = false;
   bool m_isVertical = false;
   bool m_lastVertical = false;
+
+  double m_lastEnergyRate = -1.0;
+  std::int64_t m_lastTimeToEmpty = -1;
+  std::chrono::steady_clock::time_point m_lastTooltipRefreshTime;
 };


### PR DESCRIPTION
feat(battery tooltip details): more informative tooltip with periodic updates (15s)

# Pull Request

## Motivation
I use Noctalia v5 on a laptop and time to empty for my battery is invaluable information that was available on v4.x - upower reports the other values (rate, time to empty/full, charging status) already so I included them in the tooltips report and added a 15 second force refresh to ensure the tooltip updates periodically.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
<img width="407" height="278" alt="noctaliav5-batt-tooltip" src="https://github.com/user-attachments/assets/4870006a-4181-4aa3-92bc-8f5f8227b4f4" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
