### PR TITLE
launcher panel: add "Recently Used" tab

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -86,7 +86,8 @@
       }
     },
     "categories": {
-      "all": "All"
+      "all": "All",
+      "recently-used": "Recently Used"
     },
     "empty": {
       "type-to-search": "Type to search...",

--- a/src/launcher/launcher_provider.h
+++ b/src/launcher/launcher_provider.h
@@ -22,6 +22,7 @@ struct LauncherResult {
   std::string desktopActionId;
   std::string category;
   double score = 0.0;
+  int recentlyUsedIndex = 0; // Higher is more recent. <=0 means no record or too old.
 };
 
 class LauncherProvider {

--- a/src/launcher/usage_tracker.cpp
+++ b/src/launcher/usage_tracker.cpp
@@ -2,18 +2,38 @@
 
 #include "util/file_utils.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <json.hpp>
 
+namespace {
+  constexpr std::size_t kMaxRecentlyUsedCount = 20;
+}
+
 UsageTracker::UsageTracker() {
   const std::string dir = FileUtils::stateDir();
-  m_path = (dir.empty() ? "." : dir) + "/usage_counts.json";
+  m_usageCountsPath = (dir.empty() ? "." : dir) + "/usage_counts.json";
+  m_recentlyUsedPath = (dir.empty() ? "." : dir) + "/recently_used.json";
   load();
 }
 
 void UsageTracker::record(std::string_view providerName, std::string_view resultId) {
   ++m_counts[std::string(providerName)][std::string(resultId)];
+
+  auto& recentlyUsedList = m_recentlyUsed[std::string(providerName)];
+  const auto id = std::string(resultId);
+  recentlyUsedList.erase(std::remove(recentlyUsedList.begin(), recentlyUsedList.end(), id), recentlyUsedList.end());
+  recentlyUsedList.push_front(id);
+  while (recentlyUsedList.size() > kMaxRecentlyUsedCount) {
+    recentlyUsedList.pop_back();
+  }
+  auto& indexMap = m_recentlyUsedIndex[std::string(providerName)];
+  indexMap.clear();
+  for (std::size_t i = 0; i < recentlyUsedList.size(); ++i) {
+    indexMap[recentlyUsedList[i]] = static_cast<int>(recentlyUsedList.size() - i);
+  }
+
   save();
 }
 
@@ -26,30 +46,67 @@ int UsageTracker::getCount(std::string_view providerName, std::string_view resul
   return idIt != provIt->second.end() ? idIt->second : 0;
 }
 
-void UsageTracker::load() {
-  std::ifstream file(m_path);
-  if (!file.is_open()) {
-    return;
+int UsageTracker::getRecentlyUsedIndex(std::string_view providerName, std::string_view resultId) const {
+  const auto provIt = m_recentlyUsedIndex.find(std::string(providerName));
+  if (provIt == m_recentlyUsedIndex.end()) {
+    return 0;
   }
-  try {
-    const auto json = nlohmann::json::parse(file);
-    for (const auto& [provider, ids] : json.items()) {
-      for (const auto& [id, count] : ids.items()) {
-        m_counts[provider][id] = count.get<int>();
+  const auto idIt = provIt->second.find(std::string(resultId));
+  if (idIt == provIt->second.end()) {
+    return 0;
+  }
+  return idIt != provIt->second.end() ? idIt->second : 0;
+}
+
+void UsageTracker::load() {
+  {
+    std::ifstream file(m_usageCountsPath);
+    if (file.is_open()) {
+      try {
+        const auto json = nlohmann::json::parse(file);
+        for (const auto& [provider, ids] : json.items()) {
+          for (const auto& [id, count] : ids.items()) {
+            m_counts[provider][id] = count.get<int>();
+          }
+        }
+      } catch (const nlohmann::json::exception&) {
+        // Ignore malformed file — starts fresh
       }
     }
-  } catch (const nlohmann::json::exception&) {
-    // Ignore malformed file — starts fresh
+  }
+  {
+    std::ifstream file(m_recentlyUsedPath);
+    if (file.is_open()) {
+      try {
+        const auto json = nlohmann::json::parse(file);
+        for (const auto& [provider, ids] : json.items()) {
+          for (std::size_t i = 0; i < ids.size(); ++i) {
+            const auto& id = ids[i].get<std::string>();
+            m_recentlyUsed[provider].push_back(id);
+            m_recentlyUsedIndex[provider][id] = static_cast<int>(ids.size() - i);
+          }
+        }
+      } catch (const nlohmann::json::exception&) {
+        // Ignore malformed file — starts fresh
+      }
+    }
   }
 }
 
 void UsageTracker::save() const {
   std::error_code ec;
-  std::filesystem::create_directories(std::filesystem::path(m_path).parent_path(), ec);
+  std::filesystem::create_directories(std::filesystem::path(m_usageCountsPath).parent_path(), ec);
   if (ec) {
     return;
   }
-  nlohmann::json json = m_counts;
-  std::ofstream file(m_path, std::ios::trunc);
-  file << json.dump(2) << '\n';
+  {
+    nlohmann::json json = m_counts;
+    std::ofstream file(m_usageCountsPath, std::ios::trunc);
+    file << json.dump(2) << '\n';
+  }
+  {
+    nlohmann::json json = m_recentlyUsed;
+    std::ofstream file(m_recentlyUsedPath, std::ios::trunc);
+    file << json.dump(2) << '\n';
+  }
 }

--- a/src/launcher/usage_tracker.cpp
+++ b/src/launcher/usage_tracker.cpp
@@ -55,6 +55,11 @@ int UsageTracker::getRecentlyUsedIndex(std::string_view providerName, std::strin
   return idIt != provIt->second.end() ? idIt->second : 0;
 }
 
+std::size_t UsageTracker::getRecentlyUsedCount(std::string_view providerName) const {
+  const auto provIt = m_recentlyUsed.find(std::string(providerName));
+  return provIt != m_recentlyUsed.end() ? provIt->second.size() : 0;
+}
+
 void UsageTracker::load() {
   {
     std::ifstream file(m_usageCountsPath);

--- a/src/launcher/usage_tracker.cpp
+++ b/src/launcher/usage_tracker.cpp
@@ -52,9 +52,6 @@ int UsageTracker::getRecentlyUsedIndex(std::string_view providerName, std::strin
     return 0;
   }
   const auto idIt = provIt->second.find(std::string(resultId));
-  if (idIt == provIt->second.end()) {
-    return 0;
-  }
   return idIt != provIt->second.end() ? idIt->second : 0;
 }
 

--- a/src/launcher/usage_tracker.h
+++ b/src/launcher/usage_tracker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <deque>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -13,11 +14,15 @@ public:
 
   void record(std::string_view providerName, std::string_view resultId);
   [[nodiscard]] int getCount(std::string_view providerName, std::string_view resultId) const;
+  [[nodiscard]] int getRecentlyUsedIndex(std::string_view providerName, std::string_view resultId) const;
 
 private:
   void load();
   void save() const;
 
-  std::string m_path;
+  std::string m_usageCountsPath;
+  std::string m_recentlyUsedPath;
   std::unordered_map<std::string, std::unordered_map<std::string, int>> m_counts;
+  std::unordered_map<std::string, std::deque<std::string>> m_recentlyUsed;
+  std::unordered_map<std::string, std::unordered_map<std::string, int>> m_recentlyUsedIndex;
 };

--- a/src/launcher/usage_tracker.h
+++ b/src/launcher/usage_tracker.h
@@ -15,6 +15,7 @@ public:
   void record(std::string_view providerName, std::string_view resultId);
   [[nodiscard]] int getCount(std::string_view providerName, std::string_view resultId) const;
   [[nodiscard]] int getRecentlyUsedIndex(std::string_view providerName, std::string_view resultId) const;
+  [[nodiscard]] std::size_t getRecentlyUsedCount(std::string_view providerName) const;
 
 private:
   void load();

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -723,7 +723,7 @@ void LauncherPanel::setCategoryFilterVisible(bool visible) {
   if (m_categoryFilter == nullptr) {
     return;
   }
-  const bool show = visible && !m_currentCategories.empty();
+  const bool show = visible && (!m_currentCategories.empty() || m_hasRecentlyUsed);
   m_categoryFilter->setVisible(show);
   m_categoryFilter->setParticipatesInLayout(show);
   if (m_container != nullptr) {

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -484,6 +484,7 @@ void LauncherPanel::onOpen(std::string_view context) {
   m_activeCategoryType = All;
   m_activeCategory.clear();
   m_currentCategories.clear();
+  m_hasRecentlyUsed = false;
   if (m_categoryFilter != nullptr) {
     m_categoryFilter->clearOptions();
     m_categoryFilter->setVisible(false);
@@ -515,6 +516,7 @@ void LauncherPanel::onClose() {
   m_activeCategoryType = All;
   m_activeCategory.clear();
   m_currentCategories.clear();
+  m_hasRecentlyUsed = false;
   m_selectedIndex = 0;
 
   if (m_grid != nullptr) {
@@ -584,9 +586,6 @@ void LauncherPanel::onInputChanged(const std::string& text) {
   const bool typedQuery = !queryText.empty();
 
   auto applyUsageBoost = [&](std::vector<LauncherResult>& results, const LauncherProvider& provider) {
-    if (!provider.trackUsage()) {
-      return;
-    }
     for (auto& result : results) {
       const int usageCount = m_usageTracker.getCount(provider.name(), result.id);
       result.score += usageBoostForScore(result.score, usageCount, typedQuery);
@@ -596,9 +595,16 @@ void LauncherPanel::onInputChanged(const std::string& text) {
 
   std::vector<LauncherCategory> newCategories;
 
+  bool hasRecentlyUsed = false;
+
   if (activeProvider != nullptr) {
     m_allResults = activeProvider->query(queryText);
-    applyUsageBoost(m_allResults, *activeProvider);
+    if (activeProvider->trackUsage()) {
+      applyUsageBoost(m_allResults, *activeProvider);
+      if (m_usageTracker.getRecentlyUsedCount(activeProvider->name()) > 0) {
+        hasRecentlyUsed = true;
+      }
+    }
     for (auto& result : m_allResults) {
       result.providerName = activeProvider->name();
     }
@@ -610,7 +616,12 @@ void LauncherPanel::onInputChanged(const std::string& text) {
     for (auto& provider : m_providers) {
       if (provider->prefix().empty()) {
         auto results = provider->query(queryText);
-        applyUsageBoost(results, *provider);
+        if (provider->trackUsage()) {
+          applyUsageBoost(results, *provider);
+          if (m_usageTracker.getRecentlyUsedCount(provider->name()) > 0) {
+            hasRecentlyUsed = true;
+          }
+        }
         for (auto& result : results) {
           result.providerName = provider->name();
         }
@@ -654,6 +665,12 @@ void LauncherPanel::onInputChanged(const std::string& text) {
       }
     }
   }
+
+  if (hasRecentlyUsed != m_hasRecentlyUsed) {
+    m_hasRecentlyUsed = hasRecentlyUsed;
+    categoriesChanged = true;
+  }
+
   if (categoriesChanged) {
     m_activeCategoryType = All;
     m_activeCategory.clear();
@@ -675,23 +692,27 @@ void LauncherPanel::rebuildCategoryFilter(const std::vector<LauncherCategory>& c
   }
   m_categoryFilter->addOption("", "layout-grid");
   m_categoryFilter->setOptionTooltip(0, i18n::tr("launcher.categories.all"));
-  m_categoryFilter->addOption("", "history");
-  m_categoryFilter->setOptionTooltip(1, i18n::tr("launcher.categories.recently-used"));
+  size_t categoryStartIndex = 1;
+  if (m_hasRecentlyUsed) {
+    m_categoryFilter->addOption("", "history");
+    m_categoryFilter->setOptionTooltip(1, i18n::tr("launcher.categories.recently-used"));
+    ++categoryStartIndex;
+  }
   for (std::size_t i = 0; i < categories.size(); ++i) {
     m_categoryFilter->addOption("", categories[i].glyphName);
-    m_categoryFilter->setOptionTooltip(i + 2, categories[i].label);
+    m_categoryFilter->setOptionTooltip(i + categoryStartIndex, categories[i].label);
   }
   m_categoryFilter->setSelectedIndex(0);
-  m_categoryFilter->setOnChange([this](std::size_t idx) {
+  m_categoryFilter->setOnChange([this, categoryStartIndex](std::size_t idx) {
     if (idx == 0) {
       m_activeCategoryType = All;
       m_activeCategory.clear();
-    } else if (idx == 1) {
+    } else if (m_hasRecentlyUsed && idx == 1) {
       m_activeCategoryType = RecentlyUsed;
       m_activeCategory.clear();
-    } else if (idx - 2 < m_currentCategories.size()) {
+    } else if (idx - categoryStartIndex < m_currentCategories.size()) {
       m_activeCategoryType = Category;
-      m_activeCategory = m_currentCategories[idx - 2].label;
+      m_activeCategory = m_currentCategories[idx - categoryStartIndex].label;
     }
     applyActiveCategory();
   });

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -480,6 +480,7 @@ void LauncherPanel::doLayout(Renderer& renderer, float width, float height) {
 
 void LauncherPanel::onOpen(std::string_view context) {
   m_categoryFilterVisible = m_config != nullptr && m_config->config().shell.panel.launcherCategories;
+  m_activeCategoryType = All;
   m_activeCategory.clear();
   m_currentCategories.clear();
   if (m_categoryFilter != nullptr) {
@@ -510,6 +511,7 @@ void LauncherPanel::onClose() {
   m_query.clear();
   m_results.clear();
   m_allResults.clear();
+  m_activeCategoryType = All;
   m_activeCategory.clear();
   m_currentCategories.clear();
   m_selectedIndex = 0;
@@ -587,6 +589,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
     for (auto& result : results) {
       const int usageCount = m_usageTracker.getCount(provider.name(), result.id);
       result.score += usageBoostForScore(result.score, usageCount, typedQuery);
+      result.recentlyUsedIndex = m_usageTracker.getRecentlyUsedIndex(provider.name(), result.id);
     }
   };
 
@@ -651,6 +654,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
     }
   }
   if (categoriesChanged) {
+    m_activeCategoryType = All;
     m_activeCategory.clear();
     rebuildCategoryFilter(newCategories);
   }
@@ -670,16 +674,23 @@ void LauncherPanel::rebuildCategoryFilter(const std::vector<LauncherCategory>& c
   }
   m_categoryFilter->addOption("", "layout-grid");
   m_categoryFilter->setOptionTooltip(0, i18n::tr("launcher.categories.all"));
+  m_categoryFilter->addOption("", "history");
+  m_categoryFilter->setOptionTooltip(1, i18n::tr("launcher.categories.recently-used"));
   for (std::size_t i = 0; i < categories.size(); ++i) {
     m_categoryFilter->addOption("", categories[i].glyphName);
-    m_categoryFilter->setOptionTooltip(i + 1, categories[i].label);
+    m_categoryFilter->setOptionTooltip(i + 2, categories[i].label);
   }
   m_categoryFilter->setSelectedIndex(0);
   m_categoryFilter->setOnChange([this](std::size_t idx) {
     if (idx == 0) {
+      m_activeCategoryType = All;
       m_activeCategory.clear();
-    } else if (idx - 1 < m_currentCategories.size()) {
-      m_activeCategory = m_currentCategories[idx - 1].label;
+    } else if (idx == 1) {
+      m_activeCategoryType = RecentlyUsed;
+      m_activeCategory.clear();
+    } else if (idx - 2 < m_currentCategories.size()) {
+      m_activeCategoryType = Category;
+      m_activeCategory = m_currentCategories[idx - 2].label;
     }
     applyActiveCategory();
   });
@@ -740,14 +751,35 @@ std::vector<LauncherResult> LauncherPanel::providerOverviewResults(std::string_v
 
 void LauncherPanel::applyActiveCategory() {
   m_results.clear();
-  if (m_activeCategory.empty()) {
+  switch (m_activeCategoryType) {
+  case All:
     m_results = m_allResults;
-  } else {
+    break;
+  case RecentlyUsed:
+    std::copy_if(
+        m_allResults.begin(), m_allResults.end(), std::back_inserter(m_results),
+        [this](const LauncherResult& r) { return r.recentlyUsedIndex > 0; }
+    );
+    std::sort(m_results.begin(), m_results.end(), [this](const LauncherResult& a, const LauncherResult& b) {
+      if (a.recentlyUsedIndex > b.recentlyUsedIndex) {
+        return true;
+      } else if (a.recentlyUsedIndex == b.recentlyUsedIndex) {
+        if (a.providerName < b.providerName) {
+          return true;
+        } else if (a.providerName == b.providerName) {
+          return a.id < b.id;
+        }
+      }
+      return false;
+    });
+    break;
+  case Category:
     for (const auto& r : m_allResults) {
       if (r.category == m_activeCategory) {
         m_results.push_back(r);
       }
     }
+    break;
   }
   if (!m_query.empty() && m_results.size() > kMaxResults) {
     m_results.resize(kMaxResults);

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1051,7 +1051,7 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
   if (KeybindMatcher::matches(KeybindAction::Right, sym, modifiers)) {
     if (m_categoryFilter != nullptr && m_categoryFilter->visible()) {
       const std::size_t next = m_categoryFilter->selectedIndex() + 1;
-      const std::size_t total = m_currentCategories.size() + 1;
+      const std::size_t total = m_currentCategories.size() + 2;
       if (next < total) {
         m_categoryFilter->setSelectedIndex(next);
         return true;

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -686,7 +686,7 @@ void LauncherPanel::rebuildCategoryFilter(const std::vector<LauncherCategory>& c
     return;
   }
   m_categoryFilter->clearOptions();
-  if (categories.empty()) {
+  if (categories.empty() && !m_hasRecentlyUsed) {
     setCategoryFilterVisible(false);
     return;
   }

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1072,7 +1072,8 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
   if (KeybindMatcher::matches(KeybindAction::Right, sym, modifiers)) {
     if (m_categoryFilter != nullptr && m_categoryFilter->visible()) {
       const std::size_t next = m_categoryFilter->selectedIndex() + 1;
-      const std::size_t total = m_currentCategories.size() + 2;
+      const std::size_t total = m_currentCategories.size()
+          + (m_hasRecentlyUsed ? 2 : 1); // +1 for "All" category, +2 for "Recently Used" if present
       if (next < total) {
         m_categoryFilter->setSelectedIndex(next);
         return true;

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 #include <string_view>
+#include <tuple>
 
 namespace {
 
@@ -760,17 +761,10 @@ void LauncherPanel::applyActiveCategory() {
         m_allResults.begin(), m_allResults.end(), std::back_inserter(m_results),
         [this](const LauncherResult& r) { return r.recentlyUsedIndex > 0; }
     );
-    std::sort(m_results.begin(), m_results.end(), [this](const LauncherResult& a, const LauncherResult& b) {
-      if (a.recentlyUsedIndex > b.recentlyUsedIndex) {
-        return true;
-      } else if (a.recentlyUsedIndex == b.recentlyUsedIndex) {
-        if (a.providerName < b.providerName) {
-          return true;
-        } else if (a.providerName == b.providerName) {
-          return a.id < b.id;
-        }
-      }
-      return false;
+    std::sort(m_results.begin(), m_results.end(), [](const LauncherResult& a, const LauncherResult& b) {
+      return a.recentlyUsedIndex > b.recentlyUsedIndex
+          || (a.recentlyUsedIndex == b.recentlyUsedIndex
+              && std::tie(a.providerName, a.id) < std::tie(b.providerName, b.id));
     });
     break;
   case Category:

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -45,6 +45,8 @@ public:
   [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;
 
 private:
+  enum ActiveCategoryType { All, RecentlyUsed, Category };
+
   void onPanelCardOpacityChanged(float opacity) override;
   void doLayout(Renderer& renderer, float width, float height) override;
   void onInputChanged(const std::string& text);
@@ -74,6 +76,7 @@ private:
   std::unique_ptr<LauncherResultAdapter> m_adapter;
 
   std::string m_query;
+  ActiveCategoryType m_activeCategoryType = All;
   std::string m_activeCategory;
   std::vector<LauncherCategory> m_currentCategories;
   std::size_t m_selectedIndex = 0;

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -79,6 +79,7 @@ private:
   ActiveCategoryType m_activeCategoryType = All;
   std::string m_activeCategory;
   std::vector<LauncherCategory> m_currentCategories;
+  bool m_hasRecentlyUsed = false;
   std::size_t m_selectedIndex = 0;
   bool m_categoryFilterVisible = true;
   ConfigService* m_config = nullptr;


### PR DESCRIPTION
# Pull Request

## Motivation
The stats are tracked in "recently_used.json", along with "usage_counts.json". Only the 20 most recent items are saved. I don't think the number needs to be a setting.

One problem is that the tab is visible when the provider has categories, but doesn't enable tracking (e.g., emoji). And it's invisible when the provider has no categories, but enables tracking (e.g., wallpapers). It's unclear what to do for each case.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
