### PR TITLE
feat(weather): add independent temperature and wind speed units with kelvin, ms, kn and bft

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1080,9 +1080,17 @@
         "overlay": "Overlay"
       },
       "weather": {
-        "unit": {
-          "metric": "Metric",
-          "imperial": "Imperial"
+        "temperature_unit": {
+          "celsius": "Celsius",
+          "fahrenheit": "Fahrenheit",
+          "kelvin": "Kelvin"
+        },
+        "wind_speed_unit": {
+          "kmh": "km/h",
+          "mph": "mph",
+          "ms": "m/s",
+          "kn": "knots",
+          "bft": "Beaufort"
         }
       },
       "wallpaper": {
@@ -2188,9 +2196,13 @@
           "label": "Auto-Locate",
           "description": "Automatically detect location for weather"
         },
-        "weather-unit": {
-          "label": "Units",
-          "description": "Unit system for weather display"
+        "weather-temperature-unit": {
+          "label": "Temperature Unit",
+          "description": "Unit for temperature display"
+        },
+        "weather-wind-speed-unit": {
+          "label": "Wind Speed Unit",
+          "description": "Unit for wind speed display"
         },
         "weather-address": {
           "label": "Address",

--- a/example.toml
+++ b/example.toml
@@ -148,7 +148,8 @@ enabled         = false
 auto_locate     = false             # resolve location from IP when true
 address         = "Toronto, ON"     # geocoded when auto_locate = false
 refresh_minutes = 30
-unit            = "celsius"         # celsius | fahrenheit
+temperature_unit = "celsius"        # celsius | fahrenheit | kelvin
+wind_speed_unit  = "kmh"            # kmh | mph | ms | kn | bft
 
 # ── Audio ─────────────────────────────────────────────────────────────────────
 

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -712,7 +712,8 @@ namespace config_export {
     weather.insert_or_assign("effects", config.weather.effects);
     weather.insert_or_assign("address", config.weather.address);
     weather.insert_or_assign("refresh_minutes", static_cast<std::int64_t>(config.weather.refreshMinutes));
-    weather.insert_or_assign("unit", config.weather.unit);
+    weather.insert_or_assign("temperature_unit", config.weather.temperatureUnit);
+    weather.insert_or_assign("wind_speed_unit", config.weather.windSpeedUnit);
     root.insert_or_assign("weather", std::move(weather));
 
     toml::table audio;

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -513,7 +513,8 @@ namespace {
         && a.weather.effects == b.weather.effects
         && a.weather.address == b.weather.address
         && a.weather.refreshMinutes == b.weather.refreshMinutes
-        && a.weather.unit == b.weather.unit
+        && a.weather.temperatureUnit == b.weather.temperatureUnit
+        && a.weather.windSpeedUnit == b.weather.windSpeedUnit
         && a.system.monitor.enabled == b.system.monitor.enabled
         && a.system.monitor.cpuPollSeconds == b.system.monitor.cpuPollSeconds
         && a.system.monitor.gpuPollSeconds == b.system.monitor.gpuPollSeconds

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -2056,8 +2056,10 @@ void ConfigService::parseTableInto(const toml::table& tbl, Config& config, bool 
       weather.address = *v;
     if (auto v = (*weatherTbl)["refresh_minutes"].value<int64_t>())
       weather.refreshMinutes = static_cast<std::int32_t>(*v);
-    if (auto v = (*weatherTbl)["unit"].value<std::string>())
-      weather.unit = *v;
+    if (auto v = (*weatherTbl)["temperature_unit"].value<std::string>())
+      weather.temperatureUnit = *v;
+    if (auto v = (*weatherTbl)["wind_speed_unit"].value<std::string>())
+      weather.windSpeedUnit = *v;
   }
 
   // Parse [system]

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -667,7 +667,8 @@ struct WeatherConfig {
   bool effects = true;
   std::string address;
   std::int32_t refreshMinutes = 30;
-  std::string unit = "metric";
+  std::string temperatureUnit = "celsius";
+  std::string windSpeedUnit = "kmh";
 };
 
 struct SystemConfig {

--- a/src/shell/control_center/weather_tab.cpp
+++ b/src/shell/control_center/weather_tab.cpp
@@ -662,10 +662,8 @@ void WeatherTab::sync(Renderer& renderer) {
   );
   m_statusLabel->setVisible(!status.empty());
   if (m_windLabel != nullptr) {
-    const bool imperial = m_weather->useImperial();
-    const double windSpeed = imperial ? snapshot.current.windSpeedKmh * 0.621371 : snapshot.current.windSpeedKmh;
-    const char* windUnit =
-        imperial ? "mph" : (snapshot.currentUnits.windSpeed.empty() ? "km/h" : snapshot.currentUnits.windSpeed.c_str());
+    const double windSpeed = m_weather->displayWindSpeed(snapshot.current.windSpeedKmh);
+    const char* windUnit = m_weather->displayWindSpeedUnit();
     m_windLabel->setText(
         std::format(
             "{} {} {}", static_cast<int>(std::lround(windSpeed)), windUnit,
@@ -707,9 +705,8 @@ void WeatherTab::sync(Renderer& renderer) {
     }
   }
   if (m_elevationLabel != nullptr) {
-    const bool imperial = m_weather->useImperial();
-    const int elevation = static_cast<int>(imperial ? snapshot.elevationM * 3.28084 : snapshot.elevationM);
-    m_elevationLabel->setText(std::format("{}{}", elevation, imperial ? "ft" : "m"));
+    const int elevation = static_cast<int>(std::lround(m_weather->displayElevation(snapshot.elevationM)));
+    m_elevationLabel->setText(std::format("{}{}", elevation, m_weather->displayElevationUnit()));
   }
   if (m_timeZoneLabel != nullptr) {
     // Use the last component of the IANA path ("America/Toronto" → "Toronto") to keep

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1264,14 +1264,32 @@ namespace settings {
     }
     {
       auto e = makeEntry(
-          "services", "weather", tr("settings.schema.services.weather-unit.label"),
-          tr("settings.schema.services.weather-unit.description"), {"weather", "unit"},
+          "services", "weather", tr("settings.schema.services.weather-temperature-unit.label"),
+          tr("settings.schema.services.weather-temperature-unit.description"), {"weather", "temperature_unit"},
           asSegmented(plainSelect(
-              {{"metric", "settings.options.weather.unit.metric"},
-               {"imperial", "settings.options.weather.unit.imperial"}},
-              cfg.weather.unit
+              {{"celsius", "settings.options.weather.temperature_unit.celsius"},
+               {"fahrenheit", "settings.options.weather.temperature_unit.fahrenheit"},
+               {"kelvin", "settings.options.weather.temperature_unit.kelvin"}},
+              cfg.weather.temperatureUnit
           )),
           "temperature"
+      );
+      e.visibleWhen = weatherOn;
+      entries.push_back(std::move(e));
+    }
+    {
+      auto e = makeEntry(
+          "services", "weather", tr("settings.schema.services.weather-wind-speed-unit.label"),
+          tr("settings.schema.services.weather-wind-speed-unit.description"), {"weather", "wind_speed_unit"},
+          plainSelect(
+              {{"kmh", "settings.options.weather.wind_speed_unit.kmh"},
+               {"mph", "settings.options.weather.wind_speed_unit.mph"},
+               {"ms", "settings.options.weather.wind_speed_unit.ms"},
+               {"kn", "settings.options.weather.wind_speed_unit.kn"},
+               {"bft", "settings.options.weather.wind_speed_unit.bft"}},
+              cfg.weather.windSpeedUnit
+          ),
+          "speed"
       );
       e.visibleWhen = weatherOn;
       entries.push_back(std::move(e));

--- a/src/system/weather_service.cpp
+++ b/src/system/weather_service.cpp
@@ -32,7 +32,8 @@ namespace {
         && lhs.effects == rhs.effects
         && lhs.address == rhs.address
         && lhs.refreshMinutes == rhs.refreshMinutes
-        && lhs.unit == rhs.unit;
+        && lhs.temperatureUnit == rhs.temperatureUnit
+        && lhs.windSpeedUnit == rhs.windSpeedUnit;
   }
 
   bool weatherLocationConfigEqual(const WeatherConfig& lhs, const WeatherConfig& rhs) {
@@ -283,16 +284,72 @@ std::optional<WeatherCoordinates> WeatherService::resolvedCoordinates() const no
   return WeatherCoordinates{.latitude = m_resolvedLatitude, .longitude = m_resolvedLongitude};
 }
 
-bool WeatherService::useImperial() const noexcept { return m_activeConfig.unit == "imperial"; }
+bool WeatherService::useImperialTemperature() const noexcept { return m_activeConfig.temperatureUnit == "fahrenheit"; }
+
+bool WeatherService::useImperialWindSpeed() const noexcept { return m_activeConfig.windSpeedUnit == "mph"; }
 
 double WeatherService::displayTemperature(double celsius) const noexcept {
-  if (!useImperial()) {
-    return celsius;
+  if (m_activeConfig.temperatureUnit == "fahrenheit") {
+    return 32.0 + (celsius * 1.8);
   }
-  return 32.0 + (celsius * 1.8);
+  if (m_activeConfig.temperatureUnit == "kelvin") {
+    return celsius + 273.15;
+  }
+  return celsius;
 }
 
-const char* WeatherService::displayTemperatureUnit() const noexcept { return useImperial() ? "\u00b0F" : "\u00b0C"; }
+const char* WeatherService::displayTemperatureUnit() const noexcept {
+  if (m_activeConfig.temperatureUnit == "fahrenheit") {
+    return "\u00b0F";
+  }
+  if (m_activeConfig.temperatureUnit == "kelvin") {
+    return "K";
+  }
+  return "\u00b0C";
+}
+
+double WeatherService::displayWindSpeed(double kmh) const noexcept {
+  if (m_activeConfig.windSpeedUnit == "mph") {
+    return kmh * 0.621371;
+  }
+  if (m_activeConfig.windSpeedUnit == "ms") {
+    return kmh / 3.6;
+  }
+  if (m_activeConfig.windSpeedUnit == "kn") {
+    return kmh / 1.852;
+  }
+  if (m_activeConfig.windSpeedUnit == "bft") {
+    if (kmh < 1.0)
+      return 0.0;
+    return std::round(std::pow(kmh / 3.6 / 0.836, 2.0 / 3.0));
+  }
+  return kmh;
+}
+
+const char* WeatherService::displayWindSpeedUnit() const noexcept {
+  if (m_activeConfig.windSpeedUnit == "mph") {
+    return "mph";
+  }
+  if (m_activeConfig.windSpeedUnit == "ms") {
+    return "m/s";
+  }
+  if (m_activeConfig.windSpeedUnit == "kn") {
+    return "kn";
+  }
+  if (m_activeConfig.windSpeedUnit == "bft") {
+    return "Bft";
+  }
+  return "km/h";
+}
+
+double WeatherService::displayElevation(double meters) const noexcept {
+  if (!useImperialWindSpeed()) {
+    return meters;
+  }
+  return meters * 3.28084;
+}
+
+const char* WeatherService::displayElevationUnit() const noexcept { return useImperialWindSpeed() ? "ft" : "m"; }
 
 std::string WeatherService::glyphForCode(std::int32_t code, bool isDay) {
   if (code == 0) {
@@ -408,7 +465,9 @@ void WeatherService::onConfigReload() {
     } else {
       requestRefresh(false);
     }
-    if (previousConfig.unit != m_activeConfig.unit || previousConfig.effects != m_activeConfig.effects) {
+    if (previousConfig.temperatureUnit != m_activeConfig.temperatureUnit
+        || previousConfig.windSpeedUnit != m_activeConfig.windSpeedUnit
+        || previousConfig.effects != m_activeConfig.effects) {
       notifyChanged();
     }
     return;

--- a/src/system/weather_service.h
+++ b/src/system/weather_service.h
@@ -94,9 +94,14 @@ public:
   [[nodiscard]] std::optional<WeatherCoordinates> resolvedCoordinates() const noexcept;
   [[nodiscard]] const std::string& error() const noexcept { return m_error; }
   [[nodiscard]] const WeatherSnapshot& snapshot() const noexcept { return m_snapshot; }
-  [[nodiscard]] bool useImperial() const noexcept;
+  [[nodiscard]] bool useImperialTemperature() const noexcept;
+  [[nodiscard]] bool useImperialWindSpeed() const noexcept;
   [[nodiscard]] double displayTemperature(double celsius) const noexcept;
   [[nodiscard]] const char* displayTemperatureUnit() const noexcept;
+  [[nodiscard]] double displayWindSpeed(double kmh) const noexcept;
+  [[nodiscard]] const char* displayWindSpeedUnit() const noexcept;
+  [[nodiscard]] double displayElevation(double meters) const noexcept;
+  [[nodiscard]] const char* displayElevationUnit() const noexcept;
 
   [[nodiscard]] static std::string glyphForCode(std::int32_t code, bool isDay);
   [[nodiscard]] static std::string shortDescriptionForCode(std::int32_t code);


### PR DESCRIPTION
# Pull Request

## Motivation
Where I'm from wind speed is measured in meters per second, so instead of unit selection being just metric/imperial, I split it into temperature and wind speed. Then added the wind speed option for meters per second, and in case others would want it, the temperature option for kelvin and the wind speed options for knots and beaufort scale.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.
<img width="722" height="294" alt="Screenshot from 2026-05-29 20-48-12" src="https://github.com/user-attachments/assets/1078f94f-e574-429f-9b0d-c68f83e81fc9" />
<img width="321" height="191" alt="Screenshot from 2026-05-29 20-50-40" src="https://github.com/user-attachments/assets/e31830d4-13c6-4700-9679-6132d592df37" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
