### PR TITLE
refactor(dock): share pinned app matching

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -466,6 +466,7 @@ _noctalia_sources = files(
   'src/shell/dock/dock_instance.cpp',
   'src/shell/dock/dock_items.cpp',
   'src/shell/dock/dock_model.cpp',
+  'src/shell/dock/pinned_apps.cpp',
   'src/shell/desktop/desktop_widget.cpp',
   'src/shell/desktop/desktop_widget_factory.cpp',
   'src/shell/desktop/desktop_widget_settings_registry.cpp',
@@ -951,6 +952,19 @@ app_identity_test = executable('app_identity_test',
 )
 
 test('app_identity', app_identity_test)
+
+dock_pinned_apps_test = executable('dock_pinned_apps_test',
+  sources: files(
+    'tests/dock_pinned_apps_test.cpp',
+    'src/shell/dock/pinned_apps.cpp',
+    'src/system/app_identity.cpp',
+    'src/system/desktop_entry.cpp',
+    'src/core/log.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('dock_pinned_apps', dock_pinned_apps_test)
 
 wayland_toplevels_identity_test = executable('wayland_toplevels_identity_test',
   sources: files(

--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -2,6 +2,7 @@
 
 #include "compositors/compositor_platform.h"
 #include "core/log.h"
+#include "shell/dock/pinned_apps.h"
 #include "system/app_identity.h"
 #include "util/string_utils.h"
 #include "wayland/wayland_toplevels.h"
@@ -38,43 +39,7 @@ namespace shell::dock {
 
     lastPinnedConfig = cfg.pinned;
     entriesVersion = desktopEntriesVersion();
-    pinnedEntries.clear();
-
-    const auto& entries = desktopEntries();
-
-    for (const auto& pinnedId : cfg.pinned) {
-      const auto pinnedLower = StringUtils::toLower(pinnedId);
-      bool found = false;
-
-      for (const auto& entry : entries) {
-        if (entry.hidden || entry.noDisplay) {
-          continue;
-        }
-        // Match by entry ID (stem of the desktop file path, e.g. "firefox"),
-        // by StartupWMClass (lower), or by Name (lower).
-        const auto stemLower = StringUtils::toLower([&] {
-          const auto slash = entry.id.rfind('/');
-          const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
-          const auto dot = base.rfind('.');
-          return (dot == std::string::npos) ? base : base.substr(0, dot);
-        }());
-
-        if (stemLower == pinnedLower || app_identity::desktopEntryMatchesLower(entry, pinnedLower)) {
-          pinnedEntries.push_back(entry);
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        kLog.debug("pinned app not found: {}", pinnedId);
-        DesktopEntry placeholder;
-        placeholder.id = pinnedId;
-        placeholder.name = pinnedId;
-        placeholder.nameLower = pinnedLower;
-        pinnedEntries.push_back(std::move(placeholder));
-      }
-    }
+    pinnedEntries = pinned_apps::resolveEntries(cfg.pinned);
 
     ++modelSerial;
     kLog.debug("pinned app list: {} entries", pinnedEntries.size());

--- a/src/shell/dock/pinned_apps.cpp
+++ b/src/shell/dock/pinned_apps.cpp
@@ -1,0 +1,78 @@
+#include "shell/dock/pinned_apps.h"
+
+#include "core/log.h"
+#include "system/app_identity.h"
+#include "util/string_utils.h"
+
+#include <algorithm>
+
+namespace shell::dock::pinned_apps {
+  namespace {
+
+    constexpr Logger kLog("dock");
+
+    [[nodiscard]] std::string legacyStemLower(const DesktopEntry& entry) {
+      const auto slash = entry.id.rfind('/');
+      const auto base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
+      const auto dot = base.rfind('.');
+      return StringUtils::toLower((dot == std::string::npos) ? base : base.substr(0, dot));
+    }
+
+    [[nodiscard]] DesktopEntry placeholderEntry(std::string_view pinnedId, std::string_view pinnedLower) {
+      DesktopEntry placeholder;
+      placeholder.id = std::string(pinnedId);
+      placeholder.name = std::string(pinnedId);
+      placeholder.nameLower = std::string(pinnedLower);
+      return placeholder;
+    }
+
+    [[nodiscard]] bool matchesEntryLower(const DesktopEntry& entry, std::string_view pinnedLower) {
+      if (pinnedLower.empty()) {
+        return false;
+      }
+
+      return pinnedLower == legacyStemLower(entry) || app_identity::desktopEntryMatchesLower(entry, pinnedLower);
+    }
+
+  } // namespace
+
+  bool matchesEntry(const DesktopEntry& entry, std::string_view pinnedId) {
+    if (pinnedId.empty()) {
+      return false;
+    }
+
+    const std::string pinnedLower = StringUtils::toLower(std::string(pinnedId));
+    return matchesEntryLower(entry, pinnedLower);
+  }
+
+  bool containsEntry(const std::vector<std::string>& pinned, const DesktopEntry& entry) {
+    return std::ranges::any_of(pinned, [&](const std::string& pinnedId) { return matchesEntry(entry, pinnedId); });
+  }
+
+  void removeEntry(std::vector<std::string>& pinned, const DesktopEntry& entry) {
+    std::erase_if(pinned, [&](const std::string& pinnedId) { return matchesEntry(entry, pinnedId); });
+  }
+
+  std::vector<DesktopEntry> resolveEntries(const std::vector<std::string>& pinned) {
+    std::vector<DesktopEntry> resolved;
+    resolved.reserve(pinned.size());
+
+    const auto& entries = desktopEntries();
+    for (const auto& pinnedId : pinned) {
+      const std::string pinnedLower = StringUtils::toLower(pinnedId);
+      const auto match = std::ranges::find_if(entries, [&](const DesktopEntry& entry) {
+        return !entry.hidden && !entry.noDisplay && matchesEntryLower(entry, pinnedLower);
+      });
+
+      if (match != entries.end()) {
+        resolved.push_back(*match);
+      } else {
+        kLog.debug("pinned app not found: {}", pinnedId);
+        resolved.push_back(placeholderEntry(pinnedId, pinnedLower));
+      }
+    }
+
+    return resolved;
+  }
+
+} // namespace shell::dock::pinned_apps

--- a/src/shell/dock/pinned_apps.h
+++ b/src/shell/dock/pinned_apps.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "system/desktop_entry.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace shell::dock::pinned_apps {
+
+  [[nodiscard]] bool matchesEntry(const DesktopEntry& entry, std::string_view pinnedId);
+  [[nodiscard]] bool containsEntry(const std::vector<std::string>& pinned, const DesktopEntry& entry);
+  void removeEntry(std::vector<std::string>& pinned, const DesktopEntry& entry);
+  [[nodiscard]] std::vector<DesktopEntry> resolveEntries(const std::vector<std::string>& pinned);
+
+} // namespace shell::dock::pinned_apps

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -11,8 +11,8 @@
 #include "render/render_context.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "shell/dock/pinned_apps.h"
 #include "shell/panel/panel_manager.h"
-#include "system/app_identity.h"
 #include "system/desktop_entry.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu_popup.h"
@@ -120,44 +120,6 @@ namespace {
       style.compact = panel.launcherCompact;
     }
     return style;
-  }
-
-  // Must stay aligned with Dock::refreshPinnedAppsIfNeeded() matching rules.
-  [[nodiscard]] bool dockPinnedIdMatchesEntry(const DesktopEntry& entry, std::string_view pinnedId) {
-    if (pinnedId.empty()) {
-      return false;
-    }
-
-    const std::string pinnedLower = StringUtils::toLower(std::string(pinnedId));
-    const std::string idLower = StringUtils::toLower(entry.id);
-    if (pinnedLower == idLower) {
-      return true;
-    }
-
-    const auto slash = entry.id.rfind('/');
-    const std::string base = (slash == std::string::npos) ? entry.id : entry.id.substr(slash + 1);
-    const auto dot = base.rfind('.');
-    if (dot != std::string::npos) {
-      const std::string legacyStemLower = StringUtils::toLower(base.substr(0, dot));
-      if (pinnedLower == legacyStemLower) {
-        return true;
-      }
-    }
-
-    return app_identity::desktopEntryMatchesLower(entry, pinnedLower);
-  }
-
-  [[nodiscard]] bool isDockPinned(const ConfigService& config, const DesktopEntry& entry) {
-    for (const auto& pinned : config.config().dock.pinned) {
-      if (dockPinnedIdMatchesEntry(entry, pinned)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void removeDockPinForEntry(std::vector<std::string>& pinned, const DesktopEntry& entry) {
-    std::erase_if(pinned, [&](const std::string& pinnedId) { return dockPinnedIdMatchesEntry(entry, pinnedId); });
   }
 
   class LauncherResultRow final : public Node {
@@ -992,7 +954,8 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   }
 
   std::vector<DesktopAction> actionsCopy = match->actions;
-  const bool dockPinned = m_config != nullptr && isDockPinned(*m_config, *match);
+  const bool dockPinned =
+      m_config != nullptr && shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, *match);
   const bool canPinToDock = m_config != nullptr && !dockPinned;
   const bool canUnpinFromDock = m_config != nullptr && dockPinned;
 
@@ -1064,7 +1027,9 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     LauncherResult result = base;
     result.desktopActionId.clear();
     if (entry.id == kActionPinToDock) {
-      if (m_config == nullptr || entryForPin.id.empty() || isDockPinned(*m_config, entryForPin)) {
+      if (m_config == nullptr
+          || entryForPin.id.empty()
+          || shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, entryForPin)) {
         return;
       }
       std::vector<std::string> pinned = m_config->config().dock.pinned;
@@ -1077,7 +1042,7 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
         return;
       }
       std::vector<std::string> pinned = m_config->config().dock.pinned;
-      removeDockPinForEntry(pinned, entryForPin);
+      shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
       (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
       return;
     }

--- a/tests/dock_pinned_apps_test.cpp
+++ b/tests/dock_pinned_apps_test.cpp
@@ -1,0 +1,62 @@
+#include "shell/dock/pinned_apps.h"
+#include "system/internal_app_metadata.h"
+
+#include <cassert>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace internal_apps {
+
+  std::optional<AppMetadata> metadataForAppId(std::string_view /*appId*/) { return std::nullopt; }
+
+} // namespace internal_apps
+
+namespace {
+
+  DesktopEntry sampleEntry() {
+    DesktopEntry entry;
+    entry.id = "sample-chat.desktop";
+    entry.name = "Sample Chat";
+    entry.nameLower = "sample chat";
+    entry.startupWmClass = "SampleChat";
+    entry.startupWmClassLower = "samplechat";
+    entry.exec = "sample-chat";
+    entry.icon = "sample-chat";
+    return entry;
+  }
+
+  DesktopEntry pathStyleEntry() {
+    DesktopEntry entry;
+    entry.id = "/usr/share/applications/org.example.Mail.desktop";
+    entry.name = "Example Mail";
+    entry.nameLower = "example mail";
+    entry.startupWmClass = "ExampleMail";
+    entry.startupWmClassLower = "examplemail";
+    return entry;
+  }
+
+} // namespace
+
+int main() {
+  const DesktopEntry chat = sampleEntry();
+
+  assert(shell::dock::pinned_apps::matchesEntry(chat, "sample-chat.desktop"));
+  assert(shell::dock::pinned_apps::matchesEntry(chat, "SampleChat"));
+  assert(shell::dock::pinned_apps::matchesEntry(chat, "sample chat"));
+  assert(shell::dock::pinned_apps::matchesEntry(chat, "sample_chat_desktop"));
+  assert(!shell::dock::pinned_apps::matchesEntry(chat, ""));
+  assert(!shell::dock::pinned_apps::matchesEntry(chat, "calendar"));
+
+  const DesktopEntry mail = pathStyleEntry();
+  assert(shell::dock::pinned_apps::matchesEntry(mail, "org.example.Mail"));
+
+  std::vector<std::string> pinned = {"calendar", "samplechat", "sample-chat.desktop"};
+  assert(shell::dock::pinned_apps::containsEntry(pinned, chat));
+
+  shell::dock::pinned_apps::removeEntry(pinned, chat);
+  assert((pinned == std::vector<std::string>{"calendar"}));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Extract shared dock pinned app matching and resolution into `shell::dock::pinned_apps`.
- Replace duplicate launcher pin/unpin helpers with direct shared dock pinned app calls.
- Add focused pinned apps coverage and Meson test target.

## Test Plan
- [x] `meson test -C build-debug dock_pinned_apps app_identity --print-errorlogs`
- [x] `meson compile -C build-debug noctalia`
- [x] `git diff --check`