### PR TITLE
ipc: add brightness-osd command to show brightness OSD without setting brightness

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1545,6 +1545,22 @@ void Application::initIpc() {
       m_brightnessOsd.suppressFor(std::chrono::milliseconds(250));
     });
   }
+  m_ipcService.registerHandler(
+      "brightness-osd",
+      [this](const std::string& args) -> std::string {
+        const auto parts = noctalia::ipc::splitWords(args);
+        if (parts.size() != 1) {
+          return "error: brightness-osd requires <value>\n";
+        }
+        const auto value = noctalia::ipc::parseNormalizedOrPercent(parts[0]);
+        if (!value.has_value()) {
+          return "error: invalid brightness value (use percent like 65 or 65%, or normalized like 0.65)\n";
+        }
+        m_brightnessOsd.showValue(*value);
+        return "ok\n";
+      },
+      "brightness-osd <value>", "Show brightness OSD without changing brightness"
+  );
   m_configService.registerIpc(m_ipcService);
   m_bar.registerIpc(m_ipcService);
   m_desktopWidgetsController.registerIpc(m_ipcService);

--- a/src/shell/osd/brightness_osd.cpp
+++ b/src/shell/osd/brightness_osd.cpp
@@ -85,3 +85,10 @@ void BrightnessOsd::onBrightnessChanged(const BrightnessService& service) {
     m_overlay->show(makeBrightnessContent(changed->brightness));
   }
 }
+
+void BrightnessOsd::showValue(float brightness) {
+  if (m_overlay == nullptr) {
+    return;
+  }
+  m_overlay->show(makeBrightnessContent(brightness));
+}

--- a/src/shell/osd/brightness_osd.h
+++ b/src/shell/osd/brightness_osd.h
@@ -13,6 +13,7 @@ public:
   void primeFromService(const BrightnessService& service);
   void suppressFor(std::chrono::milliseconds duration);
   void onBrightnessChanged(const BrightnessService& service);
+  void showValue(float brightness);
 
 private:
   struct DisplaySnapshot {


### PR DESCRIPTION
`noctalia msg brightness-osd 72` now shows the brightness osd as if brightness was just set to 72% without actually trying to set it.

## Motivation
I have a custom brightness control script for my TV, and I just want to show the noctalia OSD when my script changes the brightness.

## Type of Change
- [x] New feature
## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors