### PR TITLE
taskbar: add an setting for max total width

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2556,6 +2556,10 @@
           "description": "System statistic to display",
           "label": "Stat"
         },
+        "taskbar-max-width": {
+          "description": "Maximum width in pixels in total for the taskbar",
+          "label": "Taskbar Max Width"
+        },
         "title-scroll": {
           "description": "When the widget title should scroll",
           "label": "Title Scroll"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -499,11 +499,13 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const bool showWindowTitle = wc != nullptr ? wc->getBool("show_window_title", false) : false;
     const float windowTitleMaxWidth =
         static_cast<float>(wc != nullptr ? wc->getDouble("window_title_max_width", 100.0) : 100.0);
+    const float taskbarMaxWidth =
+        static_cast<float>(wc != nullptr ? wc->getDouble("taskbar_max_width", 8192.0) : 8192.0);
     auto widget = std::make_unique<TaskbarWidget>(
         m_platform, m_configService, output, groupByWorkspace, showAllOutputs, onlyActiveWorkspace, showWorkspaceLabel,
         workspaceLabelPlacement, hideEmptyWorkspaces, workspaceGroupCapsule, groupSingleIconPerApp, showActiveIndicator,
         activeOpacity, inactiveOpacity, focusedColor, occupiedColor, emptyColor, showWindowTitle, windowTitleMaxWidth,
-        barPosition, m_config.shell.shadow
+        taskbarMaxWidth, barPosition, m_config.shell.shadow
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -149,7 +149,8 @@ TaskbarWidget::TaskbarWidget(
     bool onlyActiveWorkspace, bool showWorkspaceLabel, WorkspaceLabelPlacement workspaceLabelPlacement,
     bool hideEmptyWorkspaces, bool workspaceGroupCapsule, bool groupSingleIconPerApp, bool showActiveIndicator,
     float activeOpacity, float inactiveOpacity, ColorSpec focusedColor, ColorSpec occupiedColor, ColorSpec emptyColor,
-    bool showWindowTitle, float windowTitleMaxWidth, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
+    bool showWindowTitle, float windowTitleMaxWidth, float taskbarMaxWidth, std::string barPosition,
+    ShellConfig::ShadowConfig shadowConfig
 )
     : m_platform(platform), m_configService(config), m_output(output), m_groupByWorkspace(groupByWorkspace),
       m_showAllOutputs(showAllOutputs), m_onlyActiveWorkspace(onlyActiveWorkspace),
@@ -159,7 +160,8 @@ TaskbarWidget::TaskbarWidget(
       m_activeOpacity(activeOpacity), m_inactiveOpacity(inactiveOpacity), m_focusedColor(std::move(focusedColor)),
       m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
       m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
-      m_barPosition(std::move(barPosition)), m_shadowConfig(std::move(shadowConfig)) {
+      m_taskbarMaxWidth(taskbarMaxWidth), m_barPosition(std::move(barPosition)),
+      m_shadowConfig(std::move(shadowConfig)) {
   // Window title not implemented for vertical bars or workspace grouping.
   if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
     m_showWindowTitle = false;
@@ -303,11 +305,26 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   const float iconSize = std::round(Style::barGlyphSize * m_contentScale);
   const float tilePadding = Style::spaceXs * 0.35f * m_contentScale;
   const float tileSize = std::round(iconSize + tilePadding * 2.0f);
-  const float tileWidthWithTitle =
-      tileSize + (m_showWindowTitle ? m_windowTitleMaxWidth * m_contentScale + tilePadding : 0.0f);
+  const float tileGap = Style::spaceSm * m_contentScale;
+
   const float groupBorderInset = Style::borderWidth * m_contentScale;
   const float groupOutlineInset = m_workspaceGroupCapsule ? groupBorderInset : 0.0f;
   const FontWeight fontWeight = labelFontWeight();
+
+  const float maxTileWidth = m_tasks.empty()
+      ? m_taskbarMaxWidth * m_contentScale
+      : std::floor(
+            (m_taskbarMaxWidth * m_contentScale - tileGap * static_cast<float>(m_tasks.size() - 1))
+            / static_cast<float>(m_tasks.size())
+        );
+  // If the title text is too narrow, all it shows is "..." which isn't useful, so we hide it instead.
+  const auto metric = renderer.measureText("...", Style::fontSizeCaption * m_contentScale, fontWeight);
+  const float minWindowTitleWidth = (metric.right - metric.left) * 2;
+  const float windowTitleWidth =
+      std::min(m_windowTitleMaxWidth * m_contentScale, maxTileWidth - tileSize - tilePadding);
+  const bool showWindowTitle = m_showWindowTitle && windowTitleWidth > minWindowTitleWidth;
+  const float tileWidthWithTitle = tileSize + (showWindowTitle ? windowTitleWidth + tilePadding : 0.0f);
+
   const auto workspaceAxisHandler = [this](const InputArea::PointerData& data) -> bool {
     if (!m_groupByWorkspace) {
       return false;
@@ -427,11 +444,11 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       area->addChild(std::move(glyph));
     }
 
-    if (m_showWindowTitle) {
+    if (showWindowTitle) {
       auto label = ui::label({
           .text = task.title,
           .fontSize = Style::fontSizeCaption * m_contentScale,
-          .maxWidth = m_windowTitleMaxWidth * m_contentScale,
+          .maxWidth = windowTitleWidth,
           .fontWeight = fontWeight,
       });
       label->measure(renderer);
@@ -465,7 +482,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     if (task.active && m_showActiveIndicator) {
       const float d = std::max(4.0f, std::round(Style::barGlyphSize * 0.32f * m_contentScale));
       const float bottomInset = 0.25f * m_contentScale;
-      if (m_showWindowTitle) {
+      if (showWindowTitle) {
         const float lineThickness = d * 0.5f;
         auto indicator = ui::box({
             .fill = colorSpecFromRole(ColorRole::Primary),
@@ -897,7 +914,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   }
 
   m_taskStrip->setPadding(0.0f, 0.0f, 0.0f, 0.0f);
-  m_taskStrip->setGap(Style::spaceSm * m_contentScale);
+  m_taskStrip->setGap(tileGap);
   m_groupedAppCycleCursor.clear();
 
   for (const auto& task : m_tasks) {

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -35,7 +35,7 @@ public:
       WorkspaceLabelPlacement workspaceLabelPlacement, bool hideEmptyWorkspaces, bool workspaceGroupCapsule,
       bool groupSingleIconPerApp, bool showActiveIndicator, float activeOpacity, float inactiveOpacity,
       ColorSpec focusedColor, ColorSpec occupiedColor, ColorSpec emptyColor, bool showWindowTitle,
-      float windowTitleMaxWidth, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
+      float windowTitleMaxWidth, float taskbarMaxWidth, std::string barPosition, ShellConfig::ShadowConfig shadowConfig
   );
   ~TaskbarWidget() override;
 
@@ -119,6 +119,7 @@ private:
   ColorSpec m_emptyColor = colorSpecFromRole(ColorRole::Secondary);
   bool m_showWindowTitle = false;
   float m_windowTitleMaxWidth = 100.0;
+  float m_taskbarMaxWidth = 8192.0;
   std::string m_barPosition;
   ShellConfig::ShadowConfig m_shadowConfig;
   bool m_rebuildPending = true;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -802,8 +802,14 @@ namespace settings {
       {
         auto windowTitleMaxWidth = doubleSpec("window_title_max_width", 100.0, 10.0, 200.0, 1.0);
         windowTitleMaxWidth.visibleWhen =
-            WidgetSettingVisibility{WidgetSettingVisibilityCondition{"group_by_workspace", {"false"}}};
+            WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_window_title", {"true"}}};
         add(std::move(windowTitleMaxWidth));
+      }
+      {
+        auto taskbarMaxWidth = doubleSpec("taskbar_max_width", 8192.0, 10.0, 8192.0, 1.0);
+        taskbarMaxWidth.visibleWhen =
+            WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_window_title", {"true"}}};
+        add(std::move(taskbarMaxWidth));
       }
     } else if (type == "tray") {
       add(stringListSpec("hidden"));


### PR DESCRIPTION
# Pull Request

## Motivation
It only takes effect when show_window_title is on, where the width for window titles would automatically shrink to fit into the max total width.

When not showing window titles, there's nothing we can shrink if the total width exceeds the limit, so the setting is hidden.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

