### PR TITLE
fix(ThemeIcons): prevent short-id fuzzy/clean matches from outscoring real entries

### DIFF
--- a/Commons/ThemeIcons.qml
+++ b/Commons/ThemeIcons.qml
@@ -14,6 +14,8 @@ Singleton {
                                  "code-url-handler": "visual-studio-code",
                                  "Code": "visual-studio-code",
                                  "gnome-tweaks": "org.gnome.tweaks",
+                                 "opencode": "opencode-desktop",
+                                 "@opencode-aidesktop": "opencode-desktop",
                                  "pavucontrol-qt": "pavucontrol",
                                  "wps": "wps-office2019-kprometheus",
                                  "wpsoffice": "wps-office2019-kprometheus",
@@ -201,13 +203,21 @@ Singleton {
     if (typeof FuzzySort === 'undefined')
       return null;
 
+    // Require the matched entry id to be length-coherent with the query.
+    // Prevents a short id (e.g. "code", 4 chars) from outscoring a longer
+    // partial match (e.g. "opencode-desktop", 16 chars) when searching for
+    // "opencode" — FuzzySort normalizes score by target length, so tight
+    // short substrings otherwise dominate.
+    const minIdLen = Math.max(3, str.length - 2);
+    const lengthOk = (entry) => entry && entry.id && entry.id.length >= minIdLen;
+
     // Check filenames (IDs) first
     if (preppedIds.length > 0) {
-      let results = fuzzyQuery(str, preppedIds);
+      let results = fuzzyQuery(str, preppedIds).filter(lengthOk);
       if (results.length === 0) {
         const underscored = str.replace(/-/g, '_').toLowerCase();
         if (underscored !== str)
-          results = fuzzyQuery(underscored, preppedIds);
+          results = fuzzyQuery(underscored, preppedIds).filter(lengthOk);
       }
       if (results.length > 0)
         return results[0];
@@ -215,14 +225,14 @@ Singleton {
 
     // Then icons
     if (preppedIcons.length > 0) {
-      const results = fuzzyQuery(str, preppedIcons);
+      const results = fuzzyQuery(str, preppedIcons).filter(lengthOk);
       if (results.length > 0)
         return results[0];
     }
 
     // Then names
     if (preppedNames.length > 0) {
-      const results = fuzzyQuery(str, preppedNames);
+      const results = fuzzyQuery(str, preppedNames).filter(lengthOk);
       if (results.length > 0)
         return results[0];
     }
@@ -236,14 +246,19 @@ Singleton {
     if (typeof DesktopEntries === 'undefined' || !DesktopEntries.byId)
       return null;
 
-    // Aggressive fallback: strip all separators
+    // Aggressive fallback: strip all separators.
+    // Only match when the entry id is a superset of the query (cleaned) —
+    // never the other way around. The reverse direction (e.g. "code"
+    // matching a query of "opencode" because "opencode".includes("code"))
+    // was the source of the misresolution where VS Code's icon was shown
+    // for opencode-desktop.
     const cleanStr = str.toLowerCase().replace(/[\.\-_]/g, '');
     const list = Array.from(entryList);
 
     for (let i = 0; i < list.length; i++) {
       const entry = list[i];
       const cleanId = (entry.id || "").toLowerCase().replace(/[\.\-_]/g, '');
-      if (cleanId.includes(cleanStr) || cleanStr.includes(cleanId)) {
+      if (cleanId.includes(cleanStr)) {
         return entry;
       }
     }


### PR DESCRIPTION
Fixes #2866

## Problem

`ThemeIcons.findAppEntry` misresolves apps whose `appId` is a superset of another app's `id`. Concrete case: `opencode-desktop` (wayland `app_id = "OpenCode"`, `id = "opencode-desktop"`) was being matched to `code.desktop` (VS Code) in the dock/taskbar/active-window indicator.

Root cause is a length-normalization issue in `checkFuzzySearch` and a broken match direction in `checkCleanMatch`:

1. `checkFuzzySearch` (line 200) fuzzy-matches against `.desktop` ids. FuzzySort scores matches normalized by target length, so a tight 4-char substring like `"code"` in `"opencode"` outscores the 16-char partial match of `"opencode-desktop"`.

2. `checkCleanMatch` (line 233) uses `cleanId.includes(cleanStr) || cleanStr.includes(cleanId)`. The reverse direction (`"opencode".includes("code")`) returns the first alphabetically-sorted entry whose cleaned id is a substring of the query — `code` (VS Code) wins before `opencode-desktop` is even checked.

The same bug class affects any app whose name/id is a superset of another (e.g. `logseq` vs `log`, `kile` vs `k`, `codeberg` vs `code`).

## Changes

**`Commons/ThemeIcons.qml`:**

- `checkFuzzySearch`: add a length-coherence filter — `entry.id.length >= max(3, str.length - 2)`. A 4-char id cannot match an 8-char query.
- `checkCleanMatch`: drop the broken `cleanStr.includes(cleanId)` direction. Only accept entries whose cleaned id is a superset of the cleaned query.
- `substitutions`: add explicit entries for `opencode` and the Electron binary-name variant `@opencode-aidesktop`, mapping both to `opencode-desktop`. This is an immediate unblocker that bypasses the lookup entirely.

## Test plan

Manual repro from the linked issue:
1. Install `opencode-desktop` and launch it.
2. Open the dock / taskbar.
3. **Before:** VS Code's blue icon shows for the opencode window.
4. **After:** the dark-grey "0" icon from `/usr/share/icons/hicolor/*/apps/opencode-desktop.png` shows.

Regression checks (apps that should still resolve correctly):
- VS Code (`code.desktop`, `app_id = "code"`): still resolves to VS Code (`code.desktop.id = "code"`, length 4 ≥ `max(3, 4-2)=4`).
- Zed (`code-oss` etc., if installed): resolves as before via the `cleanId.includes(cleanStr)` direction.
- `gnome-tweaks` → `org.gnome.tweaks` substitution: still works (handled before the fuzzy stages).
- `pavucontrol-qt` → `pavucontrol` substitution: still works.