### PR TITLE
control_center: add screen recorder shortcut

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -251,6 +251,7 @@
       "sysmon": "System",
       "screen-time": "Screen Time",
       "wallpaper": "Wallpaper",
+      "screen-recorder": "Recorder",
       "session": "Session",
       "clipboard": "Clipboard"
     },

--- a/example.toml
+++ b/example.toml
@@ -321,6 +321,8 @@ enabled = false
 # [[control_center.shortcuts]]
 # type = "wallpaper"
 # [[control_center.shortcuts]]
+# type = "screen_recorder"
+# [[control_center.shortcuts]]
 # type = "session"
 
 # ── Hooks ─────────────────────────────────────────────────────────────────────

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1168,7 +1168,7 @@ void Application::initUi() {
           &m_weatherService, m_pipewireSpectrum.get(), m_upowerService.get(), m_powerProfilesService.get(),
           m_networkService.get(), m_networkSecretAgent.get(), m_bluetoothService.get(), m_bluetoothAgent.get(),
           m_brightnessService.get(), m_systemMonitor.get(), &m_screenTimeService, &m_gammaService, &m_themeService,
-          &m_idleInhibitor, &m_dependencyService, &m_compositorPlatform, &m_wallpaper, &m_calendarService
+          &m_idleInhibitor, &m_dependencyService, &m_compositorPlatform, &m_ipcService, &m_wallpaper, &m_calendarService
       )
   );
   {

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -45,7 +45,7 @@ ControlCenterPanel::ControlCenterPanel(
     BluetoothService* bluetooth, BluetoothAgent* bluetoothAgent, BrightnessService* brightness,
     SystemMonitorService* sysmon, ScreenTimeService* screenTime, GammaService* nightLight,
     noctalia::theme::ThemeService* theme, IdleInhibitor* idleInhibitor, DependencyService* dependencies,
-    CompositorPlatform* platform, Wallpaper* wallpaper, CalendarService* calendar
+    CompositorPlatform* platform, IpcService* ipc, Wallpaper* wallpaper, CalendarService* calendar
 ) {
   (void)upower;
   WaylandConnection* wayland = platform != nullptr ? &platform->wayland() : nullptr;
@@ -55,7 +55,7 @@ ControlCenterPanel::ControlCenterPanel(
   m_dependencies = dependencies;
   m_tabs[tabIndex(TabId::Home)] = std::make_unique<HomeTab>(
       mpris, httpClient, weather, audio, powerProfiles, config, network, bluetooth, nightLight, theme, notifications,
-      idleInhibitor, dependencies, platform, wallpaper
+      idleInhibitor, dependencies, platform, ipc, wallpaper
   );
   m_tabs[tabIndex(TabId::Media)] = std::make_unique<MediaTab>(
       mpris, httpClient, spectrum, config, wayland, PanelManager::instance().renderContext()

--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -29,6 +29,7 @@ class DependencyService;
 class Flex;
 class HttpClient;
 class IdleInhibitor;
+class IpcService;
 class InputArea;
 class Label;
 class MprisService;
@@ -61,8 +62,8 @@ public:
       BrightnessService* brightness = nullptr, SystemMonitorService* sysmon = nullptr,
       ScreenTimeService* screenTime = nullptr, GammaService* nightLight = nullptr,
       noctalia::theme::ThemeService* theme = nullptr, IdleInhibitor* idleInhibitor = nullptr,
-      DependencyService* dependencies = nullptr, CompositorPlatform* platform = nullptr, Wallpaper* wallpaper = nullptr,
-      CalendarService* calendar = nullptr
+      DependencyService* dependencies = nullptr, CompositorPlatform* platform = nullptr, IpcService* ipc = nullptr,
+      Wallpaper* wallpaper = nullptr, CalendarService* calendar = nullptr
   );
 
   void create() override;

--- a/src/shell/control_center/home_tab.cpp
+++ b/src/shell/control_center/home_tab.cpp
@@ -93,7 +93,8 @@ HomeTab::HomeTab(
     MprisService* mpris, HttpClient* httpClient, WeatherService* weather, PipeWireService* audio,
     PowerProfilesService* powerProfiles, ConfigService* config, INetworkService* network, BluetoothService* bluetooth,
     GammaService* nightLight, noctalia::theme::ThemeService* theme, NotificationManager* notifications,
-    IdleInhibitor* idleInhibitor, DependencyService* dependencies, CompositorPlatform* platform, Wallpaper* wallpaper
+    IdleInhibitor* idleInhibitor, DependencyService* dependencies, CompositorPlatform* platform, IpcService* ipc,
+    Wallpaper* wallpaper
 )
     : m_mpris(mpris), m_httpClient(httpClient), m_weather(weather), m_config(config), m_wallpaper(wallpaper),
       m_services{
@@ -110,6 +111,7 @@ HomeTab::HomeTab(
           .config = config,
           .dependencies = dependencies,
           .platform = platform,
+          .ipc = ipc,
       } {}
 
 HomeTab::~HomeTab() = default;

--- a/src/shell/control_center/home_tab.h
+++ b/src/shell/control_center/home_tab.h
@@ -15,6 +15,7 @@ class Button;
 class Box;
 class CompositorPlatform;
 class HttpClient;
+class IpcService;
 class ConfigService;
 class DependencyService;
 class Glyph;
@@ -38,7 +39,7 @@ public:
       MprisService* mpris, HttpClient* httpClient, WeatherService* weather, PipeWireService* audio,
       PowerProfilesService* powerProfiles, ConfigService* config, INetworkService* network, BluetoothService* bluetooth,
       GammaService* nightLight, noctalia::theme::ThemeService* theme, NotificationManager* notifications,
-      IdleInhibitor* idleInhibitor, DependencyService* dependencies, CompositorPlatform* platform,
+      IdleInhibitor* idleInhibitor, DependencyService* dependencies, CompositorPlatform* platform, IpcService* ipc,
       Wallpaper* wallpaper = nullptr
   );
   ~HomeTab() override;

--- a/src/shell/control_center/shortcut_registry.cpp
+++ b/src/shell/control_center/shortcut_registry.cpp
@@ -9,8 +9,10 @@
 #include "dbus/power/power_profiles_service.h"
 #include "i18n/i18n.h"
 #include "idle/idle_inhibitor.h"
+#include "ipc/ipc_service.h"
 #include "notification/notification_manager.h"
 #include "pipewire/pipewire_service.h"
+#include "scripting/scripted_widget_manifest.h"
 #include "shell/bar/widgets/keyboard_layout_widget.h"
 #include "shell/control_center/shortcut_services.h"
 #include "shell/panel/panel_manager.h"
@@ -26,7 +28,7 @@
 
 namespace {
 
-  constexpr std::array<ShortcutRegistry::CatalogEntry, 17> kShortcutCatalog{{
+  constexpr std::array<ShortcutRegistry::CatalogEntry, 18> kShortcutCatalog{{
       {"wifi", "control-center.shortcuts.wifi"},
       {"bluetooth", "control-center.shortcuts.bluetooth"},
       {"nightlight", "control-center.shortcuts.nightlight"},
@@ -41,6 +43,7 @@ namespace {
       {"sysmon", "control-center.shortcuts.sysmon"},
       {"screen_time", "control-center.shortcuts.screen-time"},
       {"keyboard_layout", "control-center.shortcuts.keyboard-layout"},
+      {"screen_recorder", "control-center.shortcuts.screen-recorder"},
       {"wallpaper", "control-center.shortcuts.wallpaper"},
       {"session", "control-center.shortcuts.session"},
       {"clipboard", "control-center.shortcuts.clipboard"},
@@ -334,6 +337,25 @@ namespace {
     return KeyboardLayoutWidget::parseDisplayMode(display);
   }
 
+  bool hasScreenRecorderWidget(const ConfigService* config) {
+    if (config == nullptr) {
+      return false;
+    }
+
+    for (const auto& [name, widget] : config->config().widgets) {
+      (void)name;
+      if (widget.type != "scripted") {
+        continue;
+      }
+      const auto resolved = scripting::resolveScriptPath(widget.getString("script", ""));
+      if (resolved.filename() == "screen_recorder.lua") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   class PowerProfileShortcut final : public Shortcut {
   public:
     explicit PowerProfileShortcut(PowerProfilesService* svc) : m_svc(svc) {}
@@ -492,6 +514,34 @@ namespace {
     void onClick() override { PanelManager::instance().togglePanel("wallpaper"); }
   };
 
+  class ScreenRecorderShortcut final : public Shortcut {
+  public:
+    ScreenRecorderShortcut(ConfigService* config, IpcService* ipc) : m_config(config), m_ipc(ipc) {}
+    std::string_view id() const override { return "screen_recorder"; }
+    std::string defaultLabel() const override { return i18n::tr("control-center.shortcuts.screen-recorder"); }
+    std::string_view iconOn() const override { return "video"; }
+    std::string_view iconOff() const override { return "video"; }
+    bool enabled() const override { return m_ipc != nullptr && hasScreenRecorderWidget(m_config); }
+    void onClick() override {
+      if (!enabled()) {
+        return;
+      }
+      (void)m_ipc->execute("scripted-widget screen_recorder focused toggle");
+      PanelManager::instance().closePanel();
+    }
+    void onRightClick() override {
+      if (!enabled()) {
+        return;
+      }
+      (void)m_ipc->execute("scripted-widget screen_recorder focused replay-toggle");
+      PanelManager::instance().closePanel();
+    }
+
+  private:
+    ConfigService* m_config = nullptr;
+    IpcService* m_ipc = nullptr;
+  };
+
   class SessionShortcut final : public Shortcut {
   public:
     std::string_view id() const override { return "session"; }
@@ -555,6 +605,8 @@ std::unique_ptr<Shortcut> ShortcutRegistry::create(std::string_view type, const 
   }
   if (type == "keyboard_layout")
     return std::make_unique<KeyboardLayoutShortcut>(s.platform, s.config);
+  if (type == "screen_recorder")
+    return std::make_unique<ScreenRecorderShortcut>(s.config, s.ipc);
   if (type == "wallpaper")
     return std::make_unique<WallpaperShortcut>();
   if (type == "session")

--- a/src/shell/control_center/shortcut_services.h
+++ b/src/shell/control_center/shortcut_services.h
@@ -8,6 +8,7 @@ class IdleInhibitor;
 class INetworkService;
 class MprisService;
 class GammaService;
+class IpcService;
 class NotificationManager;
 class PipeWireService;
 class PowerProfilesService;
@@ -31,4 +32,5 @@ struct ShortcutServices {
   ConfigService* config = nullptr;
   DependencyService* dependencies = nullptr;
   CompositorPlatform* platform = nullptr;
+  IpcService* ipc = nullptr;
 };


### PR DESCRIPTION
## Motivation
The Screen Recorder bar widget has a setting "Hide widget when idle". I like that as I don't want to clutter the bar when I'm not recording. I wanted to add the screen recorder as a shortcut in control center home so I have a way to start recording without the bar widget visible.

## Type of Change
- [x] New feature

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors