### PR TITLE
refactor: type dock configuration enums

### DIFF
--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -390,32 +390,83 @@ struct LockscreenConfig {
   bool operator==(const LockscreenConfig&) const = default;
 };
 
+template <typename T> struct EnumOption {
+  T value;
+  std::string_view key;
+  std::string_view labelKey;
+};
+
+template <typename T, std::size_t N>
+constexpr std::optional<T> enumFromKey(const EnumOption<T> (&options)[N], std::string_view key) {
+  for (const auto& opt : options) {
+    if (opt.key == key) {
+      return opt.value;
+    }
+  }
+  return std::nullopt;
+}
+
+template <typename T, std::size_t N> constexpr std::string_view enumToKey(const EnumOption<T> (&options)[N], T value) {
+  for (const auto& opt : options) {
+    if (opt.value == value) {
+      return opt.key;
+    }
+  }
+  return {};
+}
+
+enum class DockEdge : std::uint8_t {
+  Top = 0,
+  Bottom = 1,
+  Left = 2,
+  Right = 3,
+};
+
+constexpr EnumOption<DockEdge> kDockEdges[] = {
+    {DockEdge::Top, "top", "settings.options.edge.top"},
+    {DockEdge::Bottom, "bottom", "settings.options.edge.bottom"},
+    {DockEdge::Left, "left", "settings.options.edge.left"},
+    {DockEdge::Right, "right", "settings.options.edge.right"},
+};
+
+enum class DockLauncherPosition : std::uint8_t {
+  None = 0,
+  Start = 1,
+  End = 2,
+};
+
+constexpr EnumOption<DockLauncherPosition> kDockLauncherPositions[] = {
+    {DockLauncherPosition::None, "none", "settings.options.dock-launcher-position.none"},
+    {DockLauncherPosition::Start, "start", "settings.options.dock-launcher-position.start"},
+    {DockLauncherPosition::End, "end", "settings.options.dock-launcher-position.end"},
+};
+
 struct DockConfig {
-  bool enabled = false;            // opt-in; dock is hidden by default
-  std::string position = "bottom"; // top | bottom | left | right
-  bool activeMonitorOnly = false;  // render only on preferred active output
-  std::int32_t iconSize = 48;      // icon size in pixels (before ui_scale)
-  std::int32_t padding = 8;        // inner padding around the icon row
-  std::int32_t itemSpacing = 6;    // gap between items
+  bool enabled = false; // opt-in; dock is hidden by default
+  DockEdge position = DockEdge::Bottom;
+  bool activeMonitorOnly = false; // render only on preferred active output
+  std::int32_t iconSize = 48;     // icon size in pixels (before ui_scale)
+  std::int32_t padding = 8;       // inner padding around the icon row
+  std::int32_t itemSpacing = 6;   // gap between items
   float backgroundOpacity = 0.88f;
-  std::int32_t radius = 16;               // dock background corner radius
-  std::int32_t radiusTopLeft = 16;        // dock background top-left corner radius
-  std::int32_t radiusTopRight = 16;       // dock background top-right corner radius
-  std::int32_t radiusBottomLeft = 16;     // dock background bottom-left corner radius
-  std::int32_t radiusBottomRight = 16;    // dock background bottom-right corner radius
-  std::int32_t marginEnds = 0;            // inset from each end of the dock along its main axis
-  std::int32_t marginEdge = 8;            // distance from the nearest screen edge (floats the dock when > 0)
-  bool shadow = true;                     // use the global shell shadow
-  bool showRunning = true;                // also show running apps not in pinned list
-  bool autoHide = false;                  // fade out when not hovered (overlay mode)
-  bool reserveSpace = false;              // keep compositor exclusive zone even while auto-hidden
-  float activeScale = 1.0f;               // focused app icon scale
-  float inactiveScale = 0.85f;            // non-focused app icon scale
-  float activeOpacity = 1.0f;             // focused app icon opacity
-  float inactiveOpacity = 0.85f;          // non-focused app icon opacity
-  bool showDots = false;                  // show optional running window dots beside app icons
-  bool showInstanceCount = true;          // show a badge with count when app has >1 window
-  std::string launcherPosition = "none";  // none | start | end
+  std::int32_t radius = 16;            // dock background corner radius
+  std::int32_t radiusTopLeft = 16;     // dock background top-left corner radius
+  std::int32_t radiusTopRight = 16;    // dock background top-right corner radius
+  std::int32_t radiusBottomLeft = 16;  // dock background bottom-left corner radius
+  std::int32_t radiusBottomRight = 16; // dock background bottom-right corner radius
+  std::int32_t marginEnds = 0;         // inset from each end of the dock along its main axis
+  std::int32_t marginEdge = 8;         // distance from the nearest screen edge (floats the dock when > 0)
+  bool shadow = true;                  // use the global shell shadow
+  bool showRunning = true;             // also show running apps not in pinned list
+  bool autoHide = false;               // fade out when not hovered (overlay mode)
+  bool reserveSpace = false;           // keep compositor exclusive zone even while auto-hidden
+  float activeScale = 1.0f;            // focused app icon scale
+  float inactiveScale = 0.85f;         // non-focused app icon scale
+  float activeOpacity = 1.0f;          // focused app icon opacity
+  float inactiveOpacity = 0.85f;       // non-focused app icon opacity
+  bool showDots = false;               // show optional running window dots beside app icons
+  bool showInstanceCount = true;       // show a badge with count when app has >1 window
+  DockLauncherPosition launcherPosition = DockLauncherPosition::None;
   std::string launcherIcon = "grid-dots"; // Tabler glyph name
   std::vector<std::string> pinned;        // desktop entry IDs to always show
   std::vector<std::string> monitors;      // connector names to show on; empty = all outputs
@@ -486,31 +537,6 @@ struct NotificationConfig {
 
   bool operator==(const NotificationConfig&) const = default;
 };
-
-template <typename T> struct EnumOption {
-  T value;
-  std::string_view key;
-  std::string_view labelKey;
-};
-
-template <typename T, std::size_t N>
-constexpr std::optional<T> enumFromKey(const EnumOption<T> (&options)[N], std::string_view key) {
-  for (const auto& opt : options) {
-    if (opt.key == key) {
-      return opt.value;
-    }
-  }
-  return std::nullopt;
-}
-
-template <typename T, std::size_t N> constexpr std::string_view enumToKey(const EnumOption<T> (&options)[N], T value) {
-  for (const auto& opt : options) {
-    if (opt.value == value) {
-      return opt.key;
-    }
-  }
-  return {};
-}
 
 constexpr EnumOption<SessionActionButtonVariant> kSessionActionButtonVariants[] = {
     {SessionActionButtonVariant::Default, "default", "settings.session-actions.variant.default"},

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -154,7 +154,7 @@ namespace noctalia::config::schema {
   const Schema<DockConfig>& dockSchema() {
     static const Schema<DockConfig> s = {
         field(&DockConfig::enabled, "enabled"),
-        field(&DockConfig::position, "position"),
+        enumField(&DockConfig::position, "position", kDockEdges),
         field(&DockConfig::activeMonitorOnly, "active_monitor_only"),
         field(&DockConfig::iconSize, "icon_size", kDockIconSizeRange),
         field(&DockConfig::padding, "padding", kDockPaddingRange),
@@ -193,23 +193,7 @@ namespace noctalia::config::schema {
         field(&DockConfig::inactiveOpacity, "inactive_opacity", kUnitRange),
         field(&DockConfig::showDots, "show_dots"),
         field(&DockConfig::showInstanceCount, "show_instance_count"),
-        // launcher_position accepts none|start|end; anything else warns and is ignored.
-        custom<DockConfig>(
-            "launcher_position",
-            [](const toml::table& tbl, DockConfig& d, std::string_view parentPath, Diagnostics& diag) {
-              if (auto v = tbl["launcher_position"].value<std::string>()) {
-                if (*v == "none" || *v == "start" || *v == "end") {
-                  d.launcherPosition = *v;
-                } else {
-                  diag.warn(
-                      joinPath(parentPath, "launcher_position"),
-                      "invalid value '" + *v + "'; expected none, start, or end"
-                  );
-                }
-              }
-            },
-            [](toml::table& tbl, const DockConfig& d) { tbl.insert_or_assign("launcher_position", d.launcherPosition); }
-        ),
+        enumField(&DockConfig::launcherPosition, "launcher_position", kDockLauncherPositions),
         field(&DockConfig::launcherIcon, "launcher_icon"),
         field(&DockConfig::pinned, "pinned"),
         field(&DockConfig::monitors, "monitors"),

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -516,7 +516,7 @@ void Dock::createInstance(const WaylandOutput& output) {
   const auto& cfg = m_config->config().dock;
   kLog.info(
       "creating dock on {} ({}) icon_size={} position={}", output.connectorName, output.description, cfg.iconSize,
-      cfg.position
+      enumToKey(kDockEdges, cfg.position)
   );
 
   auto instance = std::make_unique<shell::dock::DockInstance>();

--- a/src/shell/dock/dock_context_menu.cpp
+++ b/src/shell/dock/dock_context_menu.cpp
@@ -211,9 +211,10 @@ namespace shell::dock {
     const float menuHeight = ContextMenuControl::preferredHeight(entries, entries.size());
 
     // Determine anchor / gravity + gap based on dock position.
-    const bool isBottom = (dockConfig.position == "bottom");
-    const bool isTop = (dockConfig.position == "top");
-    const bool isRight = (dockConfig.position == "right");
+    const DockEdge edge = dockConfig.position;
+    const bool isBottom = edge == DockEdge::Bottom;
+    const bool isTop = edge == DockEdge::Top;
+    const bool isRight = edge == DockEdge::Right;
 
     std::uint32_t anchor = XDG_POSITIONER_ANCHOR_NONE;
     std::uint32_t gravity = XDG_POSITIONER_GRAVITY_NONE;

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -22,20 +22,20 @@ namespace shell::dock {
 
   } // namespace
 
-  std::uint32_t positionToAnchor(const std::string& position) {
-    if (position == "top") {
+  std::uint32_t positionToAnchor(DockEdge edge) {
+    if (edge == DockEdge::Top) {
       return LayerShellAnchor::Top;
     }
-    if (position == "left") {
+    if (edge == DockEdge::Left) {
       return LayerShellAnchor::Left;
     }
-    if (position == "right") {
+    if (edge == DockEdge::Right) {
       return LayerShellAnchor::Right;
     }
     return LayerShellAnchor::Bottom;
   }
 
-  bool isVerticalPosition(const std::string& position) { return position == "left" || position == "right"; }
+  bool isVerticalEdge(DockEdge edge) { return edge == DockEdge::Left || edge == DockEdge::Right; }
 
   std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount) {
     const auto n = static_cast<std::int32_t>(itemCount);
@@ -48,19 +48,22 @@ namespace shell::dock {
 
   std::int32_t dockThickness(const DockConfig& cfg) { return cfg.iconSize + kCellPad * 2 + cfg.padding * 2; }
 
-  std::size_t dockLauncherButtonCount(const DockConfig& cfg) {
-    return (cfg.launcherPosition == "start" || cfg.launcherPosition == "end") ? 1U : 0U;
+  std::size_t dockLauncherButtonCount(DockLauncherPosition position) {
+    return position == DockLauncherPosition::Start || position == DockLauncherPosition::End ? 1U : 0U;
   }
+
+  std::size_t dockLauncherButtonCount(const DockConfig& cfg) { return dockLauncherButtonCount(cfg.launcherPosition); }
 
   DockSurfaceGeometry
   computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount) {
-    const bool vertical = isVerticalPosition(cfg.position);
+    const DockEdge edge = cfg.position;
+    const bool vertical = isVerticalEdge(edge);
     const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
     const bool hiddenOverlayMode = cfg.autoHide && !cfg.reserveSpace;
     const auto panelW = dockContentSize(cfg, itemCount);
     const auto panelH = dockThickness(cfg);
-    const bool isBottom = (cfg.position == "bottom");
-    const bool isRight = (cfg.position == "right");
+    const bool isBottom = edge == DockEdge::Bottom;
+    const bool isRight = edge == DockEdge::Right;
     const std::int32_t mEdge = cfg.marginEdge;
     const int edgeGutter = dockAutoHideEdgeGutter(cfg);
 
@@ -135,15 +138,16 @@ namespace shell::dock {
 
   DockPanelGeometry
   computePanelGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceW, float surfaceH) {
-    const bool vertical = isVerticalPosition(cfg.position);
+    const DockEdge edge = cfg.position;
+    const bool vertical = isVerticalEdge(edge);
     const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
     const float bleedL = static_cast<float>(sb.left);
     const float bleedR = static_cast<float>(sb.right);
     const float bleedU = static_cast<float>(sb.up);
     const float bleedD = static_cast<float>(sb.down);
     const float mEdge = static_cast<float>(cfg.marginEdge);
-    const bool isBottom = (cfg.position == "bottom");
-    const bool isRight = (cfg.position == "right");
+    const bool isBottom = edge == DockEdge::Bottom;
+    const bool isRight = edge == DockEdge::Right;
     const float panelThickness = static_cast<float>(dockThickness(cfg));
 
     if (!vertical) {
@@ -197,13 +201,14 @@ namespace shell::dock {
       contentBottom = std::max(contentBottom, sy + panel.panelH);
     }
 
-    if (!isVerticalPosition(cfg.position)) {
-      if (cfg.position == "bottom") {
+    const DockEdge edge = cfg.position;
+    if (!isVerticalEdge(edge)) {
+      if (edge == DockEdge::Bottom) {
         return {0.0f, (surfaceH - contentTop) + kAutoHideSlideExtraPx};
       }
       return {0.0f, -(contentBottom + kAutoHideSlideExtraPx)};
     }
-    if (cfg.position == "right") {
+    if (edge == DockEdge::Right) {
       return {(surfaceW - contentLeft) + kAutoHideSlideExtraPx, 0.0f};
     }
     return {-(contentRight + kAutoHideSlideExtraPx), 0.0f};
@@ -212,10 +217,11 @@ namespace shell::dock {
   std::vector<InputRect>
   computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
     if (hidden) {
-      if (!isVerticalPosition(cfg.position)) {
+      const DockEdge edge = cfg.position;
+      if (!isVerticalEdge(edge)) {
         return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
       }
-      if (cfg.position == "left") {
+      if (edge == DockEdge::Left) {
         return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
       }
       return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -30,10 +29,11 @@ namespace shell::dock {
     std::int32_t exclusiveZone = 0;
   };
 
-  [[nodiscard]] std::uint32_t positionToAnchor(const std::string& position);
-  [[nodiscard]] bool isVerticalPosition(const std::string& position);
+  [[nodiscard]] std::uint32_t positionToAnchor(DockEdge edge);
+  [[nodiscard]] bool isVerticalEdge(DockEdge edge);
   [[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
   [[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
+  [[nodiscard]] std::size_t dockLauncherButtonCount(DockLauncherPosition position);
   [[nodiscard]] std::size_t dockLauncherButtonCount(const DockConfig& cfg);
   [[nodiscard]] DockSurfaceGeometry
   computeSurfaceGeometry(const DockConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::size_t itemCount);

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -115,7 +115,7 @@ namespace shell::dock {
     }
 
     const auto& cfg = deps.config.config().dock;
-    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+    const bool vert = shell::dock::isVerticalEdge(cfg.position);
 
     const float w = static_cast<float>(instance.surface->width());
     const float h = static_cast<float>(instance.surface->height());

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -68,7 +68,8 @@ namespace shell::dock {
   std::unique_ptr<InputArea> createLauncherButton(
       DockInstance& instance, const DockConfig& cfg, const std::shared_ptr<DockItemClickContext>& clickContext
   ) {
-    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+    const DockEdge edge = cfg.position;
+    const bool vert = shell::dock::isVerticalEdge(edge);
     const float iSize = static_cast<float>(cfg.iconSize);
     const float cellMain = iSize + 2.0f * kCellPad;
     const float cellCross = iSize + 2.0f * kCellPad;
@@ -141,7 +142,9 @@ namespace shell::dock {
     }
 
     const auto& cfg = deps.model.config.config().dock;
-    const bool vert = shell::dock::isVerticalPosition(cfg.position);
+    const DockEdge edge = cfg.position;
+    const DockLauncherPosition launcherPosition = cfg.launcherPosition;
+    const bool vert = shell::dock::isVerticalEdge(edge);
     const float iSize = static_cast<float>(cfg.iconSize);
     auto clickContext = std::make_shared<DockItemClickContext>(DockItemClickContext{
         .config = deps.model.config,
@@ -173,7 +176,7 @@ namespace shell::dock {
     );
     const auto& itemModels = snapshot.items;
 
-    if (cfg.launcherPosition == "start") {
+    if (launcherPosition == DockLauncherPosition::Start) {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
@@ -247,7 +250,7 @@ namespace shell::dock {
 
       if (cfg.showDots) {
         const float dot = std::max(kDotMinSize, std::round(iSize * kDotSizeRatio));
-        const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
+        const bool verticalDots = shell::dock::isVerticalEdge(edge);
 
         for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
           item.dotIndicators[dotIndex] = static_cast<Box*>(areaNode->addChild(
@@ -257,12 +260,12 @@ namespace shell::dock {
                   .width = dot,
                   .height = dot,
                   .visible = false,
-                  .configure = [verticalDots, position = cfg.position, cellMain, dot](Box& box) {
+                  .configure = [verticalDots, edge, cellMain, dot](Box& box) {
                     if (verticalDots) {
-                      const float x = position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+                      const float x = edge == DockEdge::Left ? std::round(cellMain - dot - 1.0f) : 1.0f;
                       box.setPosition(x, std::round((cellMain - dot) * 0.5f));
                     } else {
-                      const float y = position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+                      const float y = edge == DockEdge::Bottom ? 1.0f : std::round(cellMain - dot - 1.0f);
                       box.setPosition(std::round((cellMain - dot) * 0.5f), y);
                     }
                   },
@@ -335,7 +338,7 @@ namespace shell::dock {
       item.area = static_cast<InputArea*>(instance.row->addChild(std::move(areaNode)));
     }
 
-    if (cfg.launcherPosition == "end") {
+    if (launcherPosition == DockLauncherPosition::End) {
       instance.row->addChild(createLauncherButton(instance, cfg, clickContext));
     }
 
@@ -345,6 +348,7 @@ namespace shell::dock {
   void updateVisuals(DockInstance& instance, DockItemSceneDependencies deps, const DockSnapshot& snapshot) {
     const auto& cfg = deps.model.config.config().dock;
     const auto& shell = deps.model.config.config().shell;
+    const DockEdge edge = cfg.position;
     const std::size_t itemCount = std::min(instance.items.size(), snapshot.items.size());
 
     for (std::size_t itemIndex = 0; itemIndex < itemCount; ++itemIndex) {
@@ -402,7 +406,7 @@ namespace shell::dock {
         const float groupLength =
             dotCount == 0 ? dot : dot * static_cast<float>(dotCount) + kDotGap * static_cast<float>(dotCount - 1);
         const float groupStart = std::round((cellMain - groupLength) * 0.5f);
-        const bool verticalDots = shell::dock::isVerticalPosition(cfg.position);
+        const bool verticalDots = shell::dock::isVerticalEdge(edge);
 
         for (std::size_t dotIndex = 0; dotIndex < item.dotIndicators.size(); ++dotIndex) {
           if (item.dotIndicators[dotIndex] == nullptr) {
@@ -415,10 +419,10 @@ namespace shell::dock {
           if (visible) {
             const float main = groupStart + static_cast<float>(dotIndex) * (dot + kDotGap);
             if (verticalDots) {
-              const float x = cfg.position == "left" ? std::round(cellMain - dot - 1.0f) : 1.0f;
+              const float x = edge == DockEdge::Left ? std::round(cellMain - dot - 1.0f) : 1.0f;
               dotNode->setPosition(x, main);
             } else {
-              const float y = cfg.position == "bottom" ? 1.0f : std::round(cellMain - dot - 1.0f);
+              const float y = edge == DockEdge::Bottom ? 1.0f : std::round(cellMain - dot - 1.0f);
               dotNode->setPosition(main, y);
             }
           }

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -344,14 +344,6 @@ namespace settings {
           selected
       ));
     };
-    const auto launcherPositionSelect = [](std::string_view selected) {
-      return asSegmented(plainSelect(
-          {{"none", "settings.options.dock-launcher-position.none"},
-           {"start", "settings.options.dock-launcher-position.start"},
-           {"end", "settings.options.dock-launcher-position.end"}},
-          selected
-      ));
-    };
     std::vector<SettingEntry> entries;
 
     // Appearance
@@ -770,7 +762,7 @@ namespace settings {
     entries.push_back(makeEntry(
         "dock", "behavior", tr("settings.schema.dock.launcher-position.label"),
         tr("settings.schema.dock.launcher-position.description"), {"dock", "launcher_position"},
-        launcherPositionSelect(cfg.dock.launcherPosition), "launcher apps grid"
+        asSegmented(enumSelect(kDockLauncherPositions, cfg.dock.launcherPosition)), "launcher apps grid"
     ));
     entries.push_back(makeEntry(
         "dock", "behavior", tr("settings.schema.dock.launcher-icon.label"),
@@ -780,7 +772,7 @@ namespace settings {
     ));
     entries.push_back(makeEntry(
         "dock", "layout", tr("settings.schema.shared.position.label"), tr("settings.schema.dock.position.description"),
-        {"dock", "position"}, positionSelect(cfg.dock.position), "edge"
+        {"dock", "position"}, asSegmented(enumSelect(kDockEdges, cfg.dock.position)), "edge"
     ));
     entries.push_back(makeEntry(
         "dock", "layout", tr("settings.schema.dock.icon-size.label"), tr("settings.schema.dock.icon-size.description"),

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -200,14 +200,14 @@ namespace {
         12,    6,     {"DP-2"}, false,         {"discord"}, true, {"normal", "critical"},
     };
     c.dock.enabled = true;
-    c.dock.position = "left";
+    c.dock.position = DockEdge::Left;
     c.dock.iconSize = 40;
     c.dock.radius = 20;
     c.dock.radiusTopLeft = 10;
     c.dock.radiusTopRight = 12;
     c.dock.radiusBottomLeft = 14;
     c.dock.radiusBottomRight = 16;
-    c.dock.launcherPosition = "start";
+    c.dock.launcherPosition = DockLauncherPosition::Start;
     c.dock.pinned = {"firefox.desktop"};
     c.dock.monitors = {"DP-1"};
     c.brightness.enableDdcutil = true;


### PR DESCRIPTION
## Summary
- introduce typed enums for dock edge and launcher button position
- validate dock enum values during config parsing and export canonical keys
- update dock geometry, item layout, context menu, and settings registry to consume typed values

## Test Plan
- meson test -C build --print-errorlogs