### PR TITLE
feat(notifications): added compact desity

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2421,6 +2421,10 @@
           "label": "Show App Name",
           "description": "Show the sending application's name in notification toasts"
         },
+        "show-actions": {
+          "label": "Show Action Buttons",
+          "description": "Show action buttons in notification toasts; when disabled, clicking the toast triggers its default action"
+        },
         "position": {
           "label": "Screen Position",
           "description": "Screen position for notification toasts"

--- a/example.toml
+++ b/example.toml
@@ -114,6 +114,7 @@ tint_intensity         = 0.3        # 0.0 = no tint, 1.0 = opaque
 [notification]
 enable_daemon      = true
 show_app_name      = true
+show_actions       = true           # show action buttons; when false, clicking a toast triggers its default action
 layer              = "top"          # top | overlay
 scale              = 1.0            # notification size multiplier applied on top of shell.ui_scale
 background_opacity = 0.97

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -470,6 +470,7 @@ struct OsdConfig {
 struct NotificationConfig {
   bool enableDaemon = true;
   bool showAppName = true;
+  bool showActions = true;
   std::string position = "top_right";
   std::string layer = "top"; // top | overlay
   float scale = 1.0f;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -134,6 +134,7 @@ namespace noctalia::config::schema {
     static const Schema<NotificationConfig> s = {
         field(&NotificationConfig::enableDaemon, "enable_daemon"),
         field(&NotificationConfig::showAppName, "show_app_name"),
+        field(&NotificationConfig::showActions, "show_actions"),
         field(&NotificationConfig::position, "position"),
         field(&NotificationConfig::layer, "layer"),
         field(&NotificationConfig::scale, "scale", Range<float>{0.5f, 2.5f}),

--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -49,7 +49,9 @@ namespace {
   constexpr float kCloseButtonSize = 20.0f;
   constexpr float kCloseGlyphSize = 12.0f;
   constexpr float kNotificationIconSize = 45.0f;
+  constexpr float kNotificationIconSizeCompact = 38.0f;
   constexpr float kNotificationIconGlyphSize = 24.0f;
+  constexpr float kNotificationIconGlyphSizeCompact = 20.0f;
   constexpr float kNotificationIconReferenceSize = 36.0f;
   constexpr float kTopProgressInset = Style::spaceMd;
 
@@ -120,7 +122,13 @@ namespace {
 
   [[nodiscard]] float closeButtonSize(float scale) { return kCloseButtonSize * scale; }
 
-  [[nodiscard]] float notificationIconSize(float scale) { return kNotificationIconSize * scale; }
+  [[nodiscard]] float notificationIconSize(float scale, bool showActions) {
+    return (showActions ? kNotificationIconSize : kNotificationIconSizeCompact) * scale;
+  }
+
+  [[nodiscard]] float notificationIconGlyphSize(float scale, bool showActions) {
+    return (showActions ? kNotificationIconGlyphSize : kNotificationIconGlyphSizeCompact) * scale;
+  }
 
   [[nodiscard]] float iconTextGap(float scale) { return kIconTextGap * scale; }
 
@@ -253,9 +261,10 @@ namespace {
     return 0;
   }
 
-  float notificationTextMaxWidth(float scale) {
+  float notificationTextMaxWidth(float scale, bool showActions) {
     return std::max(
-        0.0f, cardWidth(scale) - cardInnerPad(scale) * 2.0f - notificationIconSize(scale) - iconTextGap(scale)
+        0.0f,
+        cardWidth(scale) - cardInnerPad(scale) * 2.0f - notificationIconSize(scale, showActions) - iconTextGap(scale)
     );
   }
 
@@ -267,6 +276,10 @@ namespace {
       return false;
     }
     return true;
+  }
+
+  bool shouldShowNotificationActions(const ConfigService* config) {
+    return config == nullptr || config->config().notification.showActions;
   }
 
   std::unique_ptr<Button> makeNotificationActionButton(std::string_view label, float scale) {
@@ -312,7 +325,7 @@ namespace {
     if (buttons.size() < 2) {
       return false;
     }
-    const float rowWidth = notificationTextMaxWidth(scale);
+    const float rowWidth = notificationTextMaxWidth(scale, true);
     float totalWidth = 0.0f;
     for (std::size_t i = 0; i < buttons.size(); ++i) {
       if (i > 0) {
@@ -342,7 +355,7 @@ namespace {
   ) {
     const bool stacked = notificationActionsPreferStack(rc, buttons, scale);
     configureNotificationActionsRow(row, stacked, scale);
-    const float rowWidth = notificationTextMaxWidth(scale);
+    const float rowWidth = notificationTextMaxWidth(scale, true);
     for (auto& button : buttons) {
       if (stacked) {
         button->setMaxWidth(0.0f);
@@ -365,7 +378,9 @@ namespace {
       int summaryLines, int bodyLines, float scale
   ) {
     const float cardW = cardWidth(scale);
-    const float textMaxWidth = notificationTextMaxWidth(scale);
+    const bool showActions = shouldShowNotificationActions(config);
+    const float iconSize = notificationIconSize(scale, showActions);
+    const float textMaxWidth = notificationTextMaxWidth(scale, showActions);
     const float topTextMaxWidth = std::max(0.0f, textMaxWidth - closeButtonSize(scale) - Style::spaceSm * scale);
     const bool showAppName = shouldShowNotificationAppName(config, appName);
 
@@ -392,8 +407,8 @@ namespace {
             .width = cardW,
         },
         ui::node({
-            .width = notificationIconSize(scale),
-            .height = notificationIconSize(scale),
+            .width = iconSize,
+            .height = iconSize,
         })
     );
 
@@ -424,7 +439,8 @@ namespace {
       );
     }
 
-    auto buttons = collectNotificationActionButtons(actions, scale);
+    auto buttons = shouldShowNotificationActions(config) ? collectNotificationActionButtons(actions, scale)
+                                                         : std::vector<std::unique_ptr<Button>>{};
     if (!buttons.empty()) {
       auto actionsRow = ui::row({
           .padding = Style::spaceXs * scale,
@@ -2044,8 +2060,11 @@ InputArea* NotificationToast::buildCard(
 ) {
   const float scale = notificationUiScale(m_config);
   const bool hasInlineReply = hasInlineReplyAction(entry.actions);
+  const bool showActions = shouldShowNotificationActions(m_config);
+  const float iconSize = notificationIconSize(scale, showActions);
+  const float iconGlyphSize = notificationIconGlyphSize(scale, showActions);
   const float cardW = cardWidth(scale);
-  const float textMaxWidth = notificationTextMaxWidth(scale);
+  const float textMaxWidth = notificationTextMaxWidth(scale, showActions);
   const float topTextMaxWidth = std::max(0.0f, textMaxWidth - closeButtonSize(scale) - Style::spaceSm * scale);
   const bool showAppName = shouldShowNotificationAppName(m_config, entry.appName);
 
@@ -2092,15 +2111,15 @@ InputArea* NotificationToast::buildCard(
   );
 
   auto contentRow = ui::row({
-      .align = FlexAlign::Start,
+      .align = FlexAlign::Center,
       .gap = iconTextGap(scale),
       .padding = cardInnerPad(scale),
       .width = cardW,
   });
 
   auto iconSlot = ui::node({
-      .width = notificationIconSize(scale),
-      .height = notificationIconSize(scale),
+      .width = iconSize,
+      .height = iconSize,
   });
 
   bool iconAssigned = false;
@@ -2115,13 +2134,12 @@ InputArea* NotificationToast::buildCard(
         iconSlot->addChild(
             ui::glyph({
                 .glyph = std::string(glyphName),
-                .glyphSize = kNotificationIconGlyphSize * scale,
+                .glyphSize = iconGlyphSize,
                 .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                .configure = [this, scale](Glyph& glyph) {
+                .configure = [this, iconSize](Glyph& glyph) {
                   glyph.measure(*m_renderContext);
                   glyph.setPosition(
-                      std::round((notificationIconSize(scale) - glyph.width()) * 0.5f),
-                      std::round((notificationIconSize(scale) - glyph.height()) * 0.5f)
+                      std::round((iconSize - glyph.width()) * 0.5f), std::round((iconSize - glyph.height()) * 0.5f)
                   );
                 },
             })
@@ -2135,14 +2153,12 @@ InputArea* NotificationToast::buildCard(
     if (!iconPath.empty()) {
       auto appIcon = ui::image({
           .fit = ImageFit::Cover,
-          .radius = notificationIconRadius(notificationIconSize(scale), scale),
-          .width = notificationIconSize(scale),
-          .height = notificationIconSize(scale),
+          .radius = notificationIconRadius(iconSize, scale),
+          .width = iconSize,
+          .height = iconSize,
           .configure = [](Image& image) { image.setPosition(0.0f, 0.0f); },
       });
-      if (appIcon->setSourceFile(
-              *m_renderContext, iconPath, static_cast<int>(std::round(notificationIconSize(scale)))
-          )) {
+      if (appIcon->setSourceFile(*m_renderContext, iconPath, static_cast<int>(std::round(iconSize)))) {
         iconSlot->addChild(std::move(appIcon));
         iconAssigned = true;
       } else {
@@ -2153,9 +2169,9 @@ InputArea* NotificationToast::buildCard(
       if (image.width > 0 && image.height > 0 && !image.data.empty()) {
         auto appIcon = ui::image({
             .fit = ImageFit::Cover,
-            .radius = notificationIconRadius(notificationIconSize(scale), scale),
-            .width = notificationIconSize(scale),
-            .height = notificationIconSize(scale),
+            .radius = notificationIconRadius(iconSize, scale),
+            .width = iconSize,
+            .height = iconSize,
             .configure = [](Image& control) { control.setPosition(0.0f, 0.0f); },
         });
         const bool validImageMetadata = image.bitsPerSample == 8
@@ -2192,13 +2208,12 @@ InputArea* NotificationToast::buildCard(
     iconSlot->addChild(
         ui::glyph({
             .glyph = "bell",
-            .glyphSize = kNotificationIconGlyphSize * scale,
+            .glyphSize = iconGlyphSize,
             .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
-            .configure = [this, scale](Glyph& glyph) {
+            .configure = [this, iconSize](Glyph& glyph) {
               glyph.measure(*m_renderContext);
               glyph.setPosition(
-                  std::round((notificationIconSize(scale) - glyph.width()) * 0.5f),
-                  std::round((notificationIconSize(scale) - glyph.height()) * 0.5f)
+                  std::round((iconSize - glyph.width()) * 0.5f), std::round((iconSize - glyph.height()) * 0.5f)
               );
             },
         })
@@ -2228,7 +2243,7 @@ InputArea* NotificationToast::buildCard(
   std::unique_ptr<Input> inlineReplyInput;
   std::unique_ptr<Button> inlineReplySendButton;
   Input* inlineReplyInputPtr = nullptr;
-  if (!entry.actions.empty()) {
+  if (showActions && !entry.actions.empty()) {
     const uint32_t notificationId = entry.notificationId;
     const int totalDuration = entry.displayDurationMs;
 
@@ -2773,7 +2788,10 @@ std::string NotificationToast::resolveNotificationIconPath(const PopupEntry& ent
   }
 
   const std::string& resolved = m_iconResolver.resolve(
-      localPath, static_cast<int>(std::round(notificationIconSize(notificationUiScale(m_config))))
+      localPath,
+      static_cast<int>(
+          std::round(notificationIconSize(notificationUiScale(m_config), shouldShowNotificationActions(m_config)))
+      )
   );
   if (!resolved.empty()) {
     return resolved;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1810,6 +1810,11 @@ namespace settings {
         ToggleSetting{cfg.notification.showAppName}, "application identity header"
     ));
     entries.push_back(makeEntry(
+        "notifications", "general", tr("settings.schema.notifications.show-actions.label"),
+        tr("settings.schema.notifications.show-actions.description"), {"notification", "show_actions"},
+        ToggleSetting{cfg.notification.showActions}, "action buttons"
+    ));
+    entries.push_back(makeEntry(
         "notifications", "toasts", tr("settings.schema.notifications.layer.label"),
         tr("settings.schema.notifications.layer.description"), {"notification", "layer"},
         asSegmented(plainSelect(

--- a/tests/config_schema_equivalence_test.cpp
+++ b/tests/config_schema_equivalence_test.cpp
@@ -209,8 +209,8 @@ namespace {
     c.location.latitude = 52.52;
     c.location.longitude = 13.405;
     c.notification = NotificationConfig{
-        false,       false, "bottom_left",          "overlay", 1.3f, 0.5f, 12, 6, {"DP-2"}, false,
-        {"discord"}, true,  {"normal", "critical"},
+        false, false, false,    "bottom_left", "overlay",   1.3f, 0.5f,
+        12,    6,     {"DP-2"}, false,         {"discord"}, true, {"normal", "critical"},
     };
     c.dock.enabled = true;
     c.dock.position = "left";


### PR DESCRIPTION
## Motivation

This change introduces a `show_actions` notification toggle and an icon-sizing/centering refinement.

## Type of Change

Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing

I tested it on multiple machines with Hyprland and Niri on 5k and 1440p monitors (27") and a 4k 13" laptop screen and haven't spotted any issues.

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

### Actions enabled (default)

<img width="842" height="426" alt="screenshot-20260602-164408" src="https://github.com/user-attachments/assets/ed5c4878-df65-48bd-b4d8-5bbb864654bd" />


### Actions disabled

<img width="798" height="478" alt="screenshot-20260602-164426" src="https://github.com/user-attachments/assets/fe5b4f05-9449-4a0d-a060-3632fd842853" />

### User settings

<img width="2032" height="472" alt="screenshot-20260602-164458" src="https://github.com/user-attachments/assets/12ff909d-25b6-4761-b414-962fb4b4bc4b" />

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)