### PR TITLE
nix: set `_class`, use `enableDefaultPath`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
         {
           imports = [ ./nix/home-module.nix ];
           programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          _class = "homeManager";
         };
 
       hjemModules.default =
@@ -79,6 +80,7 @@
         {
           imports = [ ./nix/hjem-module.nix ];
           programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          _class = "hjem";
         };
     };
 }

--- a/nix/hjem-module.nix
+++ b/nix/hjem-module.nix
@@ -89,7 +89,10 @@ in
       partOf = [ cfg.systemd.target ];
       after = [ cfg.systemd.target ];
       wantedBy = [ cfg.systemd.target ];
-      environment.PATH = lib.mkForce null;
+      # without this the service will have the default
+      # Environment="PATH=coreutils:…", clobbering the PATH that the DE
+      # imported into the user manager.
+      enableDefaultPath = false;
       restartTriggers = [
         cfg.package
       ]


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
IMO `enableDefaultPath = false` is cleaner than `PATH = mkForce null`. Also, setting `_class` prevents eg. accidentally using the home-manager module in hjem.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
none

## Testing
Tested on nixos by using my fork as the flake input.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
