### PR TITLE
improve helix template readability

### DIFF
--- a/assets/templates/helix/helix.toml
+++ b/assets/templates/helix/helix.toml
@@ -11,15 +11,15 @@
 "constant.character" = "secondaryContainer"
 "constant.character.escape" = "tertiaryContainer"
 
-"string" = { fg = "tertiary", bg = "surfaceContainerHigh" }
-"string.regexp" = { fg = "tertiaryContainer", bg = "surfaceContainerHigh" }
-"string.special" = { fg = "tertiary", bg = "surfaceContainerHigh" }
-"string.special.symbol" = { fg = "tertiary", bg = "surfaceContainerHigh" }
+"string" = { fg = "tertiary"}
+"string.regexp" = { fg = "tertiaryContainer" }
+"string.special" = { fg = "tertiary" }
+"string.special.symbol" = { fg = "tertiary" }
 "string.special.path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
 
 "path" = { fg = "secondary", underline = { color = "secondary", style = "line" } }
 
-"comment" = { fg = "outline", bg = "surfaceContainerHigh", modifiers = ["italic"] }
+"comment" = { fg = "outline", modifiers = ["italic"] }
 
 "variable" = "onSurface"
 "variable.builtin" = "secondary"


### PR DESCRIPTION
# Pull Request

## Motivation
Perhaps this is a personal stylistic choice but i feel other helix users would agree which is why i went ahead with the PR anyway. The current helix template has a background over strings and comments which makes it harder to read and a bit distracting

Before:
<img width="808" height="447" alt="Screenshot from 2026-06-03 10-45-49" src="https://github.com/user-attachments/assets/32108b99-a453-43c8-9425-ee687d13ca49" />
<img width="859" height="422" alt="Screenshot from 2026-06-03 10-46-23" src="https://github.com/user-attachments/assets/c0d6e11d-ec46-42b9-9812-999ff470814b" />
 After
<img width="904" height="479" alt="Screenshot from 2026-06-03 10-48-44" src="https://github.com/user-attachments/assets/a09a4845-bd00-4db1-9d5e-2220788f624c" />
<img width="1023" height="490" alt="Screenshot from 2026-06-03 10-48-26" src="https://github.com/user-attachments/assets/45ff87c4-5b54-4883-9576-c0d7b18be377" />
 Text is much clearer and easier to make out now.


## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [* ] Refactoring



## Testing
Built noctalia with new helix template. Does not break helix.

- [ *] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Included above.

## Checklist
- [ *] Code follows project style guidelines
- [ *] Self-reviewed my code
- [ *] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
