### PR TITLE
feat(launcher): add window provider to search and focus open windows

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -85,6 +85,9 @@
         "category": "Session",
         "action-subtitle": "Run session action",
         "command-subtitle": "Run configured command"
+      },
+      "window": {
+        "category": "Windows"
       }
     },
     "categories": {

--- a/meson.build
+++ b/meson.build
@@ -404,6 +404,7 @@ _noctalia_sources = files(
   'src/launcher/math_provider.cpp',
   'src/launcher/session_provider.cpp',
   'src/launcher/wallpaper_provider.cpp',
+  'src/launcher/window_provider.cpp',
   'src/launcher/usage_tracker.cpp',
   'src/main.cpp',
   'src/net/http_client.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -18,6 +18,7 @@
 #include "launcher/math_provider.h"
 #include "launcher/session_provider.h"
 #include "launcher/wallpaper_provider.h"
+#include "launcher/window_provider.h"
 #include "notification/notifications.h"
 #include "render/animation/motion_service.h"
 #include "render/core/texture_manager.h"
@@ -1140,6 +1141,7 @@ void Application::initUi() {
     auto launcherPanel = std::make_unique<LauncherPanel>(&m_configService, &m_asyncTextureCache);
     launcherPanel->addProvider(std::make_unique<AppProvider>(&m_configService, &m_compositorPlatform));
     launcherPanel->addProvider(std::make_unique<WallpaperProvider>(&m_configService, &m_wayland));
+    launcherPanel->addProvider(std::make_unique<WindowProvider>(&m_compositorPlatform));
     launcherPanel->addProvider(std::make_unique<SessionProvider>(&m_configService, &m_sessionActionRunner));
     launcherPanel->addProvider(std::make_unique<MathProvider>(&m_clipboardService));
     launcherPanel->addProvider(std::make_unique<EmojiProvider>(&m_clipboardService));

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -885,6 +885,9 @@ const char* CompositorPlatform::workspaceBackendName() const noexcept {
 }
 
 void CompositorPlatform::focusCompositorWindow(const std::string& windowId) const {
+  if (m_workspaceMetadataBackend != nullptr && m_workspaceMetadataBackend->focusWindowById(windowId)) {
+    return;
+  }
   if (m_workspaces != nullptr) {
     m_workspaces->focusWindow(windowId);
   }

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -356,6 +356,18 @@ std::vector<WorkspaceWindow> NiriWorkspaceBackend::workspaceWindows(const std::s
   return result;
 }
 
+bool NiriWorkspaceBackend::focusWindowById(const std::string& windowId) {
+  const auto id = parseUnsigned(windowId);
+  if (!id.has_value()) {
+    return false;
+  }
+  return m_runtime.requestAction(
+      nlohmann::json{
+          {"FocusWindow", nlohmann::json{{"id", *id}}},
+      }
+  );
+}
+
 void NiriWorkspaceBackend::cleanup() {
   closeSocket(false);
   const bool overviewWasOpen = m_overviewKnown && m_overviewOpen;

--- a/src/compositors/niri/niri_workspace_backend.h
+++ b/src/compositors/niri/niri_workspace_backend.h
@@ -39,6 +39,7 @@ public:
   [[nodiscard]] std::unordered_map<std::string, std::vector<std::string>>
   appIdsByWorkspace(const std::string& outputName = {}) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(const std::string& outputName = {}) const override;
+  bool focusWindowById(const std::string& windowId) override;
   void cleanup() override;
 
 private:

--- a/src/compositors/workspace_backend.h
+++ b/src/compositors/workspace_backend.h
@@ -126,6 +126,11 @@ namespace compositors {
     [[nodiscard]] virtual std::vector<WorkspaceWindow> workspaceWindows(const std::string& /*outputName*/ = {}) const {
       return {};
     }
+    // Focus a window by its compositor-specific id. Returns true if the backend
+    // handled the request (so the caller can skip other focus paths). Named
+    // distinctly from WorkspaceBackend::focusWindow so backends that implement
+    // both interfaces don't hit a conflicting-return-type override.
+    virtual bool focusWindowById(const std::string& /*windowId*/) { return false; }
     [[nodiscard]] virtual bool canTrackOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool hasOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool isOverviewOpen() const noexcept { return true; }

--- a/src/launcher/window_provider.cpp
+++ b/src/launcher/window_provider.cpp
@@ -1,0 +1,118 @@
+#include "launcher/window_provider.h"
+
+#include "compositors/compositor_platform.h"
+#include "i18n/i18n.h"
+#include "util/fuzzy_match.h"
+#include "util/string_utils.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+  constexpr std::size_t kMaxResults = 50;
+
+  struct WindowCandidate {
+    WorkspaceWindowAssignment window;
+    std::string title;
+    std::string searchable;
+  };
+
+  [[nodiscard]] std::vector<WindowCandidate> collectWindows(const CompositorPlatform* platform) {
+    std::vector<WindowCandidate> candidates;
+    if (platform == nullptr) {
+      return candidates;
+    }
+
+    // No output filter: surface windows from every monitor/workspace.
+    auto assignments = platform->workspaceWindowAssignments();
+    candidates.reserve(assignments.size());
+    for (auto& assignment : assignments) {
+      if (assignment.windowId.empty()) {
+        continue;
+      }
+      WindowCandidate candidate;
+      candidate.title = !assignment.title.empty() ? assignment.title : assignment.appId;
+      candidate.searchable = StringUtils::toLower(candidate.title + " " + assignment.appId);
+      candidate.window = std::move(assignment);
+      candidates.push_back(std::move(candidate));
+    }
+
+    std::sort(candidates.begin(), candidates.end(), [](const WindowCandidate& a, const WindowCandidate& b) {
+      return StringUtils::toLower(a.title) < StringUtils::toLower(b.title);
+    });
+    return candidates;
+  }
+
+} // namespace
+
+WindowProvider::WindowProvider(CompositorPlatform* platform) : m_platform(platform) {}
+
+std::vector<LauncherResult> WindowProvider::query(std::string_view text) const {
+  auto candidates = collectWindows(m_platform);
+  if (candidates.empty()) {
+    return {};
+  }
+
+  auto makeResult = [](const WindowCandidate& candidate, double score) {
+    LauncherResult result;
+    result.id = candidate.window.windowId;
+    result.title = candidate.title;
+    result.subtitle = candidate.window.appId;
+    result.iconName = candidate.window.appId;
+    result.glyphName = "app-window";
+    result.category = i18n::tr("launcher.providers.window.category");
+    result.score = score;
+    return result;
+  };
+
+  const std::string query = StringUtils::toLower(StringUtils::trim(text));
+  if (query.empty()) {
+    const auto limit = std::min(candidates.size(), kMaxResults);
+    std::vector<LauncherResult> results;
+    results.reserve(limit);
+    for (std::size_t i = 0; i < limit; ++i) {
+      results.push_back(makeResult(candidates[i], 0.0));
+    }
+    return results;
+  }
+
+  std::vector<std::pair<double, WindowCandidate>> scored;
+  scored.reserve(candidates.size());
+  for (auto& candidate : candidates) {
+    const double score = FuzzyMatch::score(query, candidate.searchable);
+    if (FuzzyMatch::isMatch(score)) {
+      scored.emplace_back(score, std::move(candidate));
+    }
+  }
+
+  const auto limit = std::min(scored.size(), kMaxResults);
+  std::partial_sort(
+      scored.begin(), scored.begin() + static_cast<std::ptrdiff_t>(limit), scored.end(),
+      [](const auto& a, const auto& b) { return a.first > b.first; }
+  );
+
+  std::vector<LauncherResult> results;
+  results.reserve(limit);
+  for (std::size_t i = 0; i < limit; ++i) {
+    const auto& [score, candidate] = scored[i];
+    results.push_back(makeResult(candidate, score));
+  }
+  return results;
+}
+
+bool WindowProvider::activate(const LauncherResult& result) {
+  if (m_platform == nullptr || result.id.empty()) {
+    return false;
+  }
+  if (!result.providerName.empty() && result.providerName != name()) {
+    return false;
+  }
+
+  m_platform->focusCompositorWindow(result.id);
+  return true;
+}

--- a/src/launcher/window_provider.h
+++ b/src/launcher/window_provider.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "launcher/launcher_provider.h"
+
+class CompositorPlatform;
+
+// Lists currently open windows reported by the compositor and lets the user
+// fuzzy-search them by title (or app id) and focus one. Activating a result
+// asks the compositor to focus the window, switching workspace if needed.
+class WindowProvider : public LauncherProvider {
+public:
+  explicit WindowProvider(CompositorPlatform* platform);
+
+  [[nodiscard]] std::string_view prefix() const override { return "/win"; }
+  [[nodiscard]] std::string_view name() const override { return "Windows"; }
+  [[nodiscard]] std::string_view defaultGlyphName() const override { return "app-window"; }
+
+  [[nodiscard]] std::vector<LauncherResult> query(std::string_view text) const override;
+
+  bool activate(const LauncherResult& result) override;
+
+private:
+  CompositorPlatform* m_platform = nullptr;
+};


### PR DESCRIPTION
Reintroduce the v4 ability to find any open window from the launcher by fuzzy-matching its title, which has not been ported over yet during the v5 rewrite.

## Motivation

Please note: I'm a (relatively) new noctalia user and was super happy and excited when the v5 rewrite was announced. having received a new machine last week I switched over to v5 while bootstrapping it (a vanill ubuntu 26.04 installation with niri).

I absolutely love the new v5 and the only thing I really missed was the ability to select an existing window via the launcher. So much so, that I decided to use Claude (Opus 4.8) to re-implement it for me. It was a one-shot that immediately worked.

I do not "speak" C++. I cannot judge the quality of the code produced except that it has been working for nearly a week of daily use by now on two machines with a total of five displays.

I totally understand, if the project does not want to accept this PR but I felt it would be a waste, if I didn't at least submit it. (I'm sure, it's otherwise just a matter of time anyway, until somebody who actually knows what they're doing will port this feature.)

the following is the LLM generated description of this PR with my own details added.

---snip---

Add a prefix-based WindowProvider ("/win") that lists windows reported by the compositor through CompositorPlatform::workspaceWindowAssignments(), fuzzy-matches against window title and app id, shows the app icon, and focuses the selected window on activation (switching workspace if needed).

Focusing is routed through a new WorkspaceMetadataBackend::focusWindowById() hook so metadata-only backends can handle window focus. It is implemented for niri via the FocusWindow IPC action. CompositorPlatform's focusCompositorWindow() now prefers the metadata backend and falls back to the active workspace backend (Hyprland/Mango/Triad already implement focusWindow), keeping the feature compositor-agnostic.

The method is named distinctly from WorkspaceBackend::focusWindow to avoid a conflicting-return-type override in backends that implement both interfaces (e.g. Triad).

Changes:
- src/launcher/window_provider.{h,cpp}: new launcher provider
- src/app/application.cpp: register the provider
- src/compositors/workspace_backend.h: focusWindowById() hook
- src/compositors/niri/niri_workspace_backend.{h,cpp}: niri focus impl
- src/compositors/compositor_platform.cpp: prefer metadata-backend focus
- assets/translations/en.json: launcher.providers.window.category
- meson.build: build the new source file

# Pull Request


## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [x] Existing feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [ ] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

