### PR TITLE
fix(render): don't yank current EGL context from mid-frame backend

### DIFF
--- a/src/render/core/async_texture_cache.cpp
+++ b/src/render/core/async_texture_cache.cpp
@@ -338,18 +338,20 @@ void AsyncTextureCache::pushResult(DecodedJob job) {
 }
 
 void AsyncTextureCache::makeCurrent() {
-  // If another backend already owns the thread's EGL context (e.g. a frame is
-  // in flight between beginFrame/endFrame on the main thread), do not yank it
-  // away. All contexts share textures via the root context's share-list, so
-  // GPU uploads/unloads work on whichever context is currently bound; switching
-  // here would leave the caller without a draw surface and break its trailing
-  // eglSwapBuffers.
-  if (eglGetCurrentContext() != EGL_NO_CONTEXT) {
-    return;
-  }
   if (m_sharedGl != nullptr) {
+    // If another backend already owns the thread's EGL context (e.g. a frame
+    // is in flight between beginFrame/endFrame on the main thread), do not
+    // yank it away. In shared-context mode uploads/unloads are valid on any
+    // context in the share group, and rebinding here would break the caller's
+    // trailing eglSwapBuffers.
+    if (eglGetCurrentContext() != EGL_NO_CONTEXT) {
+      return;
+    }
     m_sharedGl->makeCurrentSurfaceless();
   } else if (m_makeCurrentCallback) {
+    // In non-shared mode uploads must still be routed through RenderContext's
+    // dedicated EGL context, even if another isolated context is currently
+    // bound on the thread.
     m_makeCurrentCallback();
   }
 }

--- a/src/render/core/async_texture_cache.cpp
+++ b/src/render/core/async_texture_cache.cpp
@@ -338,6 +338,15 @@ void AsyncTextureCache::pushResult(DecodedJob job) {
 }
 
 void AsyncTextureCache::makeCurrent() {
+  // If another backend already owns the thread's EGL context (e.g. a frame is
+  // in flight between beginFrame/endFrame on the main thread), do not yank it
+  // away. All contexts share textures via the root context's share-list, so
+  // GPU uploads/unloads work on whichever context is currently bound; switching
+  // here would leave the caller without a draw surface and break its trailing
+  // eglSwapBuffers.
+  if (eglGetCurrentContext() != EGL_NO_CONTEXT) {
+    return;
+  }
   if (m_sharedGl != nullptr) {
     m_sharedGl->makeCurrentSurfaceless();
   } else if (m_makeCurrentCallback) {

--- a/src/render/core/shared_texture_cache.cpp
+++ b/src/render/core/shared_texture_cache.cpp
@@ -69,7 +69,16 @@ void SharedTextureCache::release(TextureHandle& handle, const std::string& path)
 }
 
 void SharedTextureCache::makeCurrent() {
-  if (m_sharedGl != nullptr) {
-    m_sharedGl->makeCurrentSurfaceless();
+  if (m_sharedGl == nullptr) {
+    return;
   }
+  // If another backend already owns the thread's EGL context (mid-frame between
+  // beginFrame/endFrame), do not yank it away. All backend contexts are created
+  // with the root context as a share-list, so texture uploads/deletes work on
+  // whichever context is currently bound. Switching here would leave the caller
+  // without a draw surface and break its trailing eglSwapBuffers.
+  if (eglGetCurrentContext() != EGL_NO_CONTEXT) {
+    return;
+  }
+  m_sharedGl->makeCurrentSurfaceless();
 }


### PR DESCRIPTION
## Summary

`SharedTextureCache::makeCurrent` and `AsyncTextureCache::makeCurrent` unconditionally called `GlSharedContext::makeCurrentSurfaceless`, which issues `eglMakeCurrent(EGL_NO_SURFACE, EGL_NO_SURFACE, root)`. When a backend is mid-frame between `beginFrame`/`endFrame`, this silently switches the thread's current context away from the backend and drops its draw surface. On NVIDIA libEGL the subsequent `eglSwapBuffers` then returns `EGL_FALSE` without setting an error (`EGL_SUCCESS` / `0x3000`), so `GlesRenderBackend::endFrame` throws and the shell exits.

Both helpers now early-return when another backend already owns the thread's EGL context (`eglGetCurrentContext() != EGL_NO_CONTEXT`). All backend contexts are created with the root context as a share-list (`GlesRenderBackend::initialize` passes `shared.rootContext()`), so GPU uploads/unloads work on whichever context is currently bound — no switch is needed.

## Root cause

Wallpaper transition completion runs `releaseTexture` from its animation finish callback. If that callback fires while another surface is mid-frame on the same thread, `SharedTextureCache::release` evicts the old wallpaper and inside `makeCurrent` issues `eglMakeCurrent(..., root)`. After release returns, the in-flight frame's `eglSwapBuffers` targets a surface that is no longer the thread's draw surface.

Observed crash from a user log on NVIDIA + niri:

```
18:09:45.514 [WRN] [render] eglCreateWindowSurface failed (EGL error 0x3003); will retry before rendering
...
18:10:20.840 [DBG] [notification] notification toast: surface created on DP-1
18:10:20.892 [INF] [texcache] evicted /home/.../wallhaven-yqg6r7.jpg
18:10:20.892 [DBG] [notification] notification toast: all surfaces destroyed
18:10:20.970 [ERR] fatal: eglSwapBuffers failed (EGL error 0x3000)
```

The `0x3000` (`EGL_SUCCESS`) reported by NVIDIA matches the spec-borderline behaviour where `eglSwapBuffers` returns `EGL_FALSE` without setting an error when the surface is no longer current.

## Reproduction (local, NVIDIA Wayland)

A standalone repro confirms the context yank on real hardware before applying the fix:

```
EGL 1.5 vendor=NVIDIA
BEFORE makeCurrentSurfaceless: current=backend
AFTER  makeCurrentSurfaceless (current code): current=root
AFTER  guardedMakeCurrentSurfaceless:         current=backend
```

## Test plan

- [x] `ninja -C build` clean
- [x] `meson test -C build` — 16/16 OK
- [x] Standalone NVIDIA repro flips from RED to GREEN with the guard
- [x] Shell running for extended period under normal notification load — no recurrence

## Update

Follow-up fix pushed in `39c6ea53b` after review:

- [x] Scope the `AsyncTextureCache::makeCurrent()` early-return to shared-context mode only.
- [x] Preserve `m_makeCurrentCallback()` rebinding when `shared_gl_context = false`, so async uploads still land on `RenderContext` instead of another isolated EGL context.
- [x] Re-verified with `meson compile -C build`, `meson test -C build --print-errorlogs` (16/16 OK), and a focused local non-shared regression check.
