### PR TITLE
fix(mango): use ~ instead of expanded path for portable source line

### DIFF
--- a/Scripts/bash/template-apply.sh
+++ b/Scripts/bash/template-apply.sh
@@ -462,7 +462,7 @@ mango)
     THEME_FILE="$CONFIG_DIR/noctalia.conf"
     BACKUP_FILE="$CONFIG_DIR/theme.conf.bak"
     # This sources the noctalia theme file
-    SOURCE_LINE="source = $THEME_FILE"
+    SOURCE_LINE="source = ~${THEME_FILE#$HOME}"
 
     # Color variables that should be moved to theme file
     COLOR_VARS="shadowscolor|rootcolor|bordercolor|focuscolor|maximizescreencolor|urgentcolor|scratchpadcolor|globalcolor|overlaycolor"
@@ -470,8 +470,8 @@ mango)
     # Create config directory if it doesn't exist
     mkdir -p "$CONFIG_DIR"
 
-    # Check if theme is already sourced in main config
-    if [ -f "$MAIN_CONFIG" ] && grep -qF "$SOURCE_LINE" "$MAIN_CONFIG"; then
+    # Check if theme is already sourced in main config (matches $HOME, ~, or expanded paths)
+    if [ -f "$MAIN_CONFIG" ] && grep -qE 'source\s*=\s*.*noctalia\.conf' "$MAIN_CONFIG"; then
         : # Theme already set
     else
         # First-time setup: backup and remove legacy color definitions


### PR DESCRIPTION
Uses ~${THEME_FILE#$HOME} to keep ~ literal while stripping the $HOME prefix. General pattern works for any path under $HOME.

Mango's config parser (src/config/parse_config.h:2896-2905) only handles three path forms: ~, ./, and absolute. No $HOME variable expansion. Source confirms ~ is the correct portable form:

  if (file_path[0] == '~' && ...)
      snprintf(full_path, ..., "%s%s", getenv("HOME"), file_path + 1);

Result in config.conf:
  source = ~/.config/mango/noctalia.conf

Also widened idempotency guard to regex matching any noctalia.conf source line (~ or expanded forms), so existing users with old expanded format won't get duplicate lines on upgrade.

# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Provide a clear and concise explanation of what this PR does and why it is needed.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring

## Related Issue
Closes #2890

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
