### PR TITLE
V5 - Update Mango output backend to use the new mmsg socket exposed in mango_runtime

### DIFF
--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -261,10 +261,6 @@ namespace {
     bool m_perOutputTargeted = false;
   };
 
-  [[nodiscard]] bool setMangoOutputPower(WaylandConnection& wayland, bool on) {
-    return compositors::mango::setOutputPower(wayland, on);
-  }
-
   [[nodiscard]] bool setGenericOutputPower(WaylandConnection& /*wayland*/, bool on) {
     return compositors::ext_workspace::setOutputPower(on);
   }
@@ -294,7 +290,9 @@ namespace {
                                                             WaylandConnection& /*wayland*/, bool on
                                                         ) { return compositors::triad::setOutputPower(runtime, on); });
     case compositors::CompositorKind::Mango:
-      return std::make_unique<LambdaOutputPowerBackend>(&setMangoOutputPower, true);
+      return std::make_unique<LambdaOutputPowerBackend>([&runtime = runtimeRegistry.mango()](
+                                                            WaylandConnection& wayland, bool on
+                                                        ) { return compositors::mango::setOutputPower(runtime, wayland, on); }, true);
     case compositors::CompositorKind::Dwl:
     case compositors::CompositorKind::Labwc:
     case compositors::CompositorKind::Unknown:

--- a/src/compositors/mango/mango_output_backend.cpp
+++ b/src/compositors/mango/mango_output_backend.cpp
@@ -1,5 +1,6 @@
 #include "compositors/mango/mango_output_backend.h"
 
+#include "compositors/mango/mango_runtime.h"
 #include "core/process.h"
 #include "wayland/wayland_connection.h"
 
@@ -7,15 +8,13 @@
 
 namespace compositors::mango {
 
-  bool setOutputPower(WaylandConnection& wayland, bool on) {
+  bool setOutputPower(MangoRuntime& runtime, WaylandConnection& wayland, bool on) {
     bool launchedAny = false;
     for (const auto& output : wayland.outputs()) {
       if (output.connectorName.empty()) {
         continue;
       }
-      if (process::runAsync(
-              {"mmsg", "-s", "-d", std::string(on ? "enable_monitor," : "disable_monitor,") + output.connectorName}
-          )) {
+      if (runtime.dispatch((std::string(on ? "enable_monitor," : "disable_monitor,") + output.connectorName))) {
         launchedAny = true;
       }
     }

--- a/src/compositors/mango/mango_output_backend.h
+++ b/src/compositors/mango/mango_output_backend.h
@@ -3,7 +3,7 @@
 class WaylandConnection;
 
 namespace compositors::mango {
-
-  [[nodiscard]] bool setOutputPower(WaylandConnection& wayland, bool on);
+  class MangoRuntime;
+  [[nodiscard]] bool setOutputPower(MangoRuntime& runtime, WaylandConnection& wayland, bool on);
 
 } // namespace compositors::mango


### PR DESCRIPTION
# Pull Request

## Motivation
This PR allows `noctalia` to be able to disable outputs in versions of `mango` post 14.0.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on Mango
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors

## Additional Notes
To be honest, this is my first PR. 
I tested the changes locally, they just allow noctalia to actually disable monitors as the current implementation uses the old mmsg format that errors on mango 14.0+. I passed along the perOutputTargeted variable as true like how it does now, but currently hotplugging in a monitor while the monitor is off does not pass the state along to the new monitor. 

Let me know if there's anything I missed or need to do. Thank you for your wonderful project, it's really great.
