### PR TITLE
feat(kb): shows "Neo" as an identifier for the neo Layout

### DIFF
--- a/Services/Keyboard/KeyboardLayoutService.qml
+++ b/Services/Keyboard/KeyboardLayoutService.qml
@@ -108,6 +108,7 @@ Singleton {
   // These display the variant name when it's more meaningful than the country
   property var variantMap: {
     // Alternative keyboard layouts
+    "neo": "Neo",
     "colemak": "Colemak",
     "dvorak": "Dvorak",
     "workman": "Workman",


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
When using the “neo” variant of the German keyboard layout, the keyboard layout bar shows “DE” only. This is a problem because that is the same for many German layouts. I want to have a clear indicator that I'm currently on “Neo” rather than a more standard variant.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
None

## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="76" height="53" alt="image" src="https://github.com/user-attachments/assets/350cd1a2-e354-4a32-a99c-32482f58353c" />
<img width="77" height="44" alt="image" src="https://github.com/user-attachments/assets/b209be62-6dd7-4546-a0a8-52adc404fc00" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
