### PR TITLE
feat(KeyboardLayout): add customLabels for user-defined display names

### DIFF
--- a/Assets/Translations/de.json
+++ b/Assets/Translations/de.json
@@ -172,7 +172,12 @@
       "wheel-update-text": "Anzeigetext beim Scrollen aktualisieren"
     },
     "keyboard-layout": {
-      "show-icon-description": "Das Tastaturlayout-Symbol anzeigen."
+      "show-icon-description": "Das Tastaturlayout-Symbol anzeigen.",
+      "custom-labels-header": "Benutzerdefinierte Bezeichnungen",
+      "custom-labels-description": "Überschreibt die automatisch erkannte Bezeichnung für ein bestimmtes Layout. Der vollständige Layoutname wird im Tooltip der Leiste angezeigt.",
+      "custom-labels-add-current": "Aktuelles Layout hinzufügen",
+      "custom-labels-placeholder": "z. B. DE",
+      "custom-labels-remove": "Zuordnung entfernen"
     },
     "lock-keys": {
       "hide-when-off-description": "Verstecke die Anzeige, wenn die Taste nicht aktiv ist.",

--- a/Assets/Translations/en.json
+++ b/Assets/Translations/en.json
@@ -172,7 +172,12 @@
       "wheel-update-text": "Update displayed text on scroll"
     },
     "keyboard-layout": {
-      "show-icon-description": "Display the keyboard layout icon."
+      "show-icon-description": "Display the keyboard layout icon.",
+      "custom-labels-header": "Custom Labels",
+      "custom-labels-description": "Override the auto-detected label for a specific layout. The full layout name is shown in the bar tooltip.",
+      "custom-labels-add-current": "Add current layout",
+      "custom-labels-placeholder": "e.g. DE",
+      "custom-labels-remove": "Remove mapping"
     },
     "lock-keys": {
       "hide-when-off-description": "Hide the indicator when the key is not active.",

--- a/Modules/Bar/Widgets/KeyboardLayout.qml
+++ b/Modules/Bar/Widgets/KeyboardLayout.qml
@@ -42,9 +42,11 @@ Item {
   readonly property bool showIcon: (widgetSettings.showIcon !== undefined) ? widgetSettings.showIcon : widgetMetadata.showIcon
   readonly property string iconColorKey: widgetSettings.iconColor !== undefined ? widgetSettings.iconColor : widgetMetadata.iconColor
   readonly property string textColorKey: widgetSettings.textColor !== undefined ? widgetSettings.textColor : widgetMetadata.textColor
+  readonly property var customLabels: widgetSettings.customLabels !== undefined ? widgetSettings.customLabels : (widgetMetadata.customLabels ?? {})
 
   // Use the shared service for keyboard layout
   property string currentLayout: KeyboardLayoutService.currentLayout
+  readonly property string displayLabel: customLabels[KeyboardLayoutService.fullLayoutName] ?? currentLayout
 
   implicitWidth: pill.width
   implicitHeight: pill.height
@@ -79,7 +81,7 @@ Item {
     customTextColor: Color.resolveColorKeyOptional(root.textColorKey)
     icon: root.showIcon ? "keyboard" : ""
     autoHide: false // Important to be false so we can hover as long as we want
-    text: isBarVertical ? currentLayout.substring(0, 3).toUpperCase() : currentLayout
+    text: isBarVertical ? displayLabel.substring(0, 3).toUpperCase() : displayLabel
     tooltipText: KeyboardLayoutService.fullLayoutName
     // When icon is disabled, always show the layout text
     forceOpen: !root.showIcon || root.displayMode === "forceOpen"

--- a/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
@@ -9,14 +9,12 @@ ColumnLayout {
   id: root
   spacing: Style.marginM
 
-  // Properties to receive data from parent
   property var screen: null
   property var widgetData: null
   property var widgetMetadata: null
 
   signal settingsChanged(var settings)
 
-  // Local state
   property string valueDisplayMode: widgetData.displayMode !== undefined ? widgetData.displayMode : widgetMetadata.displayMode
   property bool valueShowIcon: widgetData.showIcon !== undefined ? widgetData.showIcon : widgetMetadata.showIcon
   property string valueIconColor: widgetData.iconColor !== undefined ? widgetData.iconColor : widgetMetadata.iconColor
@@ -51,10 +49,7 @@ ColumnLayout {
     for (var i = 0; i < customLabelsModel.count; i++) {
       if (customLabelsModel.get(i).fullName === current) return;
     }
-    customLabelsModel.append({
-      fullName: current,
-      customLabel: valueCustomLabels[current] ?? ""
-    });
+    customLabelsModel.append({ fullName: current, customLabel: "" });
   }
 
   ListModel {
@@ -62,8 +57,15 @@ ColumnLayout {
 
     Component.onCompleted: {
       var labels = valueCustomLabels ?? {};
-      for (var key in labels) {
-        customLabelsModel.append({ fullName: key, customLabel: labels[key] });
+      var all = KeyboardLayoutService.allLayouts;
+      if (all && all.length > 0) {
+        for (var i = 0; i < all.length; i++) {
+          customLabelsModel.append({ fullName: all[i], customLabel: labels[all[i]] ?? "" });
+        }
+      } else {
+        for (var key in labels) {
+          customLabelsModel.append({ fullName: key, customLabel: labels[key] });
+        }
       }
     }
   }
@@ -74,18 +76,9 @@ ColumnLayout {
     description: I18n.tr("bar.volume.display-mode-description")
     minimumWidth: 200
     model: [
-      {
-        "key": "onhover",
-        "name": I18n.tr("display-modes.on-hover")
-      },
-      {
-        "key": "forceOpen",
-        "name": I18n.tr("display-modes.force-open")
-      },
-      {
-        "key": "alwaysHide",
-        "name": I18n.tr("display-modes.always-hide")
-      }
+      { "key": "onhover",    "name": I18n.tr("display-modes.on-hover") },
+      { "key": "forceOpen",  "name": I18n.tr("display-modes.force-open") },
+      { "key": "alwaysHide", "name": I18n.tr("display-modes.always-hide") }
     ]
     currentKey: valueDisplayMode
     onSelected: key => {
@@ -125,59 +118,54 @@ ColumnLayout {
     defaultValue: widgetMetadata.textColor
   }
 
-  NDivider {}
+  NDivider {
+    Layout.fillWidth: true
+  }
 
-  NCollapsible {
+  NLabel {
     label: I18n.tr("bar.keyboard-layout.custom-labels-header")
     description: I18n.tr("bar.keyboard-layout.custom-labels-description")
     Layout.fillWidth: true
+  }
 
-    ColumnLayout {
+  Repeater {
+    model: customLabelsModel
+
+    RowLayout {
       spacing: Style.marginS
-      width: parent.width
+      Layout.fillWidth: true
 
-      Repeater {
-        model: customLabelsModel
+      NText {
+        text: model.fullName
+        Layout.fillWidth: true
+        elide: Text.ElideMiddle
+        opacity: 0.7
+        pointSize: Style.fontSizeS
+      }
 
-        RowLayout {
-          spacing: Style.marginS
-          Layout.fillWidth: true
-
-          NLabel {
-            text: model.fullName
-            Layout.fillWidth: true
-            elide: Text.ElideMiddle
-            opacity: 0.7
-            font.pixelSize: Style.fontSizeS
-          }
-
-          NTextInput {
-            minimumWidth: 80
-            placeholderText: I18n.tr("bar.keyboard-layout.custom-labels-placeholder")
-            text: model.customLabel
-            onTextChanged: text => {
-                             customLabelsModel.setProperty(index, "customLabel", text);
-                             saveCustomLabels();
-                           }
-          }
-
-          NIconButton {
-            icon: "trash"
-            tooltipText: I18n.tr("bar.keyboard-layout.custom-labels-remove")
-            onClicked: {
-              customLabelsModel.remove(index);
-              saveCustomLabels();
-            }
-          }
+      NTextInput {
+        minimumInputWidth: 80 * Style.uiScaleRatio
+        text: model.customLabel
+        onTextChanged: {
+          customLabelsModel.setProperty(index, "customLabel", text);
+          saveCustomLabels();
         }
       }
 
-      NButton {
-        text: I18n.tr("bar.keyboard-layout.custom-labels-add-current")
-        icon: "plus"
-        Layout.alignment: Qt.AlignLeft
-        onClicked: addCurrentLayout()
+      NIconButton {
+        icon: "trash"
+        tooltipText: I18n.tr("bar.keyboard-layout.custom-labels-remove")
+        onClicked: {
+          customLabelsModel.remove(index);
+          saveCustomLabels();
+        }
       }
     }
+  }
+
+  NButton {
+    visible: !KeyboardLayoutService.allLayouts || KeyboardLayoutService.allLayouts.length === 0
+    text: I18n.tr("bar.keyboard-layout.custom-labels-add-current")
+    onClicked: addCurrentLayout()
   }
 }

--- a/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
+++ b/Modules/Panels/Settings/Bar/WidgetSettings/KeyboardLayoutSettings.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import qs.Commons
+import qs.Services.Keyboard
 import qs.Widgets
 
 ColumnLayout {
@@ -20,6 +21,7 @@ ColumnLayout {
   property bool valueShowIcon: widgetData.showIcon !== undefined ? widgetData.showIcon : widgetMetadata.showIcon
   property string valueIconColor: widgetData.iconColor !== undefined ? widgetData.iconColor : widgetMetadata.iconColor
   property string valueTextColor: widgetData.textColor !== undefined ? widgetData.textColor : widgetMetadata.textColor
+  property var valueCustomLabels: widgetData.customLabels !== undefined ? widgetData.customLabels : (widgetMetadata.customLabels ?? {})
 
   function saveSettings() {
     var settings = Object.assign({}, widgetData || {});
@@ -27,11 +29,47 @@ ColumnLayout {
     settings.showIcon = valueShowIcon;
     settings.iconColor = valueIconColor;
     settings.textColor = valueTextColor;
+    settings.customLabels = valueCustomLabels;
     settingsChanged(settings);
   }
 
+  function saveCustomLabels() {
+    var labels = {};
+    for (var i = 0; i < customLabelsModel.count; i++) {
+      var item = customLabelsModel.get(i);
+      if (item.customLabel.trim().length > 0) {
+        labels[item.fullName] = item.customLabel.trim();
+      }
+    }
+    valueCustomLabels = labels;
+    saveSettings();
+  }
+
+  function addCurrentLayout() {
+    var current = KeyboardLayoutService.fullLayoutName;
+    if (!current || current === "") return;
+    for (var i = 0; i < customLabelsModel.count; i++) {
+      if (customLabelsModel.get(i).fullName === current) return;
+    }
+    customLabelsModel.append({
+      fullName: current,
+      customLabel: valueCustomLabels[current] ?? ""
+    });
+  }
+
+  ListModel {
+    id: customLabelsModel
+
+    Component.onCompleted: {
+      var labels = valueCustomLabels ?? {};
+      for (var key in labels) {
+        customLabelsModel.append({ fullName: key, customLabel: labels[key] });
+      }
+    }
+  }
+
   NComboBox {
-    visible: valueShowIcon // Hide display mode setting when icon is disabled
+    visible: valueShowIcon
     label: I18n.tr("common.display-mode")
     description: I18n.tr("bar.volume.display-mode-description")
     minimumWidth: 200
@@ -85,5 +123,61 @@ ColumnLayout {
                   saveSettings();
                 }
     defaultValue: widgetMetadata.textColor
+  }
+
+  NDivider {}
+
+  NCollapsible {
+    label: I18n.tr("bar.keyboard-layout.custom-labels-header")
+    description: I18n.tr("bar.keyboard-layout.custom-labels-description")
+    Layout.fillWidth: true
+
+    ColumnLayout {
+      spacing: Style.marginS
+      width: parent.width
+
+      Repeater {
+        model: customLabelsModel
+
+        RowLayout {
+          spacing: Style.marginS
+          Layout.fillWidth: true
+
+          NLabel {
+            text: model.fullName
+            Layout.fillWidth: true
+            elide: Text.ElideMiddle
+            opacity: 0.7
+            font.pixelSize: Style.fontSizeS
+          }
+
+          NTextInput {
+            minimumWidth: 80
+            placeholderText: I18n.tr("bar.keyboard-layout.custom-labels-placeholder")
+            text: model.customLabel
+            onTextChanged: text => {
+                             customLabelsModel.setProperty(index, "customLabel", text);
+                             saveCustomLabels();
+                           }
+          }
+
+          NIconButton {
+            icon: "trash"
+            tooltipText: I18n.tr("bar.keyboard-layout.custom-labels-remove")
+            onClicked: {
+              customLabelsModel.remove(index);
+              saveCustomLabels();
+            }
+          }
+        }
+      }
+
+      NButton {
+        text: I18n.tr("bar.keyboard-layout.custom-labels-add-current")
+        icon: "plus"
+        Layout.alignment: Qt.AlignLeft
+        onClicked: addCurrentLayout()
+      }
+    }
   }
 }

--- a/Services/Compositor/NiriService.qml
+++ b/Services/Compositor/NiriService.qml
@@ -61,6 +61,7 @@ Item {
     }
     function onKeyboardLayoutsChanged() {
       keyboardLayouts = Niri.keyboardLayoutNames;
+      KeyboardLayoutService.setAllLayouts(keyboardLayouts);
       const layoutName = Niri.currentKeyboardLayoutName;
       if (layoutName) {
         KeyboardLayoutService.setCurrentLayout(layoutName);

--- a/Services/Keyboard/KeyboardLayoutService.qml
+++ b/Services/Keyboard/KeyboardLayoutService.qml
@@ -13,11 +13,17 @@ Singleton {
   property string fullLayoutName: I18n.tr("common.unknown")
   property string previousLayout: ""
   property bool isInitialized: false
+  property var allLayouts: []
 
   // Updates current layout from various format strings. Called by compositors
   function setCurrentLayout(layoutString) {
     root.fullLayoutName = layoutString || I18n.tr("common.unknown");
     root.currentLayout = extractLayoutCode(layoutString);
+  }
+
+  // Called by compositor backends that expose a full layout list (e.g. niri)
+  function setAllLayouts(layouts) {
+    root.allLayouts = layouts || [];
   }
 
   // Extract layout code from various format strings

--- a/Services/UI/BarWidgetRegistry.qml
+++ b/Services/UI/BarWidgetRegistry.qml
@@ -174,7 +174,8 @@ Singleton {
                                     "displayMode": "onhover",
                                     "showIcon": true,
                                     "iconColor": "none",
-                                    "textColor": "none"
+                                    "textColor": "none",
+                                    "customLabels": {}
                                   },
                                   "LockKeys": {
                                     "showCapsLock": true,


### PR DESCRIPTION
The auto-detected label from extractLayoutCode() cannot resolve ambiguity for multi-language layouts such as "German, Swedish and Finnish (US)" — a Finnish user expects "FI", a German user "DE".

Adds an optional customLabels map to the KeyboardLayout widget settings. When a full layout name matches a key in the map, that value is used as the display label instead of the auto-detected code. The automatic parsing remains as fallback.

Changes:
- BarWidgetRegistry: add customLabels: {} to default metadata
- KeyboardLayout: resolve displayLabel from customLabels before falling back to currentLayout
- KeyboardLayoutSettings: collapsible UI section to add, edit, and remove custom label mappings; "Add current layout" button pre-fills the active fullLayoutName so users never type it manually
- en.json: add i18n keys for the new UI strings
- KeyboardLayoutService: add `allLayouts` property and `setAllLayouts()` for compositor backends that expose a full layout list
- NiriService: call `setAllLayouts()` on keyboard layout changes
- KeyboardLayoutSettings: auto-populate all known layouts on open; "Add current layout" button only shown as fallback on unsupported compositors


# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

If this PR is not ready for review yet, please mark it as **Draft** until it's good to be reviewed.

## Motivation
Multi-language layouts like `us(de_se_fi)` ("German, Swedish and Finnish (US)") are used by German, Finnish, and Swedish speakers alike — each expecting a different label. The current `extractLayoutCode()` heuristic also has a priority bug where the parenthetical extractor matches `(US)` before the language name lookup finds "german" → `DE`. No parsing logic alone can resolve this ambiguity, so this PR lets users define the label explicitly.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue

## Testing
Tested on niri with two layouts (us/de_se_fi and us/altgr-intl).

- [x] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors (if applicable)

## Screenshots / Videos
<img width="470" height="47" alt="image" src="https://github.com/user-attachments/assets/20f2e76c-a872-4e10-b62e-8fa2604881de" />


## Checklist
- [ ] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
- Other translations in `Assets/Translations/` are not included — community contributions welcome. 
- The feature degrades gracefully with English strings as fallback.
-  `fullLayoutName` was chosen as the map key because it is stable across sessions and already exposed by `KeyboardLayoutService`.
