### PR TITLE
use more idiomatic and readable syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: >-
+  -clang-diagnostic-*,
+  readability-container-contains,
+  readability-container-data-pointer,
+  readability-container-size-empty,
+  readability-use-std-min-max,

--- a/justfile
+++ b/justfile
@@ -51,6 +51,19 @@ format:
     find src \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 clang-format -i
     find src \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 grep -ZlP '\s+$' | xargs -0 -r sed -i 's/[[:space:]]*$//'
 
+_clang_tidy m=mode *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    src_root="$(realpath src)"
+    run-clang-tidy -quiet -p build-{{m}} -j "$(nproc)" -header-filter="^${src_root}/.*" {{args}} "^${src_root}/.*"
+
+lint m=mode: (configure m)
+    just _clang_tidy {{m}}
+
+fix m=mode: (configure m)
+    just _clang_tidy {{m}} -fix
+    just format
+
 clean m=mode:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/src/auth/pam_authenticator.cpp
+++ b/src/auth/pam_authenticator.cpp
@@ -14,7 +14,7 @@
 namespace {
 
   void secureClear(std::string& value) {
-    volatile char* ptr = value.empty() ? nullptr : &value[0];
+    volatile char* ptr = value.empty() ? nullptr : value.data();
     for (std::size_t i = 0; i < value.size(); ++i) {
       ptr[i] = '\0';
     }

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -847,7 +847,7 @@ std::size_t ConfigService::overridePreserveDepthForPath(const std::vector<std::s
   if (path.size() > 4 && path[0] == "bar" && path[2] == "monitor" && isOverrideOnlyMonitorOverride(path[1], path[3])) {
     return 4;
   }
-  if (path.size() > 4 && path[0] == "wallpaper" && path[2] == "monitor" && path[3].size() > 0) {
+  if (path.size() > 4 && path[0] == "wallpaper" && path[2] == "monitor" && !path[3].empty()) {
     return 4;
   }
   if (path.size() > 2 && path[0] == "bar" && isOverrideOnlyBar(path[1])) {

--- a/src/config/config_types.cpp
+++ b/src/config/config_types.cpp
@@ -312,7 +312,7 @@ std::optional<ColorSpec> WidgetConfig::getOptionalColorSpec(const std::string& k
   return std::nullopt;
 }
 
-bool WidgetConfig::hasSetting(const std::string& key) const { return settings.find(key) != settings.end(); }
+bool WidgetConfig::hasSetting(const std::string& key) const { return settings.contains(key); }
 
 WidgetBarCapsuleSpec resolveWidgetBarCapsuleSpec(const BarConfig& bar, const WidgetConfig* widget) {
   WidgetBarCapsuleSpec spec{};

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -169,9 +169,7 @@ NetworkManagerService::NetworkManagerService(SystemBus& bus) : m_bus(bus) {
                 }
                 const auto lastScan =
                     getPropertyOr<std::int64_t>(*device, kNmDeviceWirelessInterface, "LastScan", std::int64_t{0});
-                if (lastScan > baseline) {
-                  baseline = lastScan;
-                }
+                baseline = std::max(lastScan, baseline);
               } catch (const sdbus::Error&) {
               }
             }
@@ -270,9 +268,7 @@ void NetworkManagerService::requestScan() {
         }
         const auto lastScan =
             getPropertyOr<std::int64_t>(*device, kNmDeviceWirelessInterface, "LastScan", std::int64_t{0});
-        if (lastScan > baseline) {
-          baseline = lastScan;
-        }
+        baseline = std::max(lastScan, baseline);
         const std::map<std::string, sdbus::Variant> options;
         device->callMethod("RequestScan").onInterface(kNmDeviceWirelessInterface).withArguments(options);
         anyRequested = true;

--- a/src/dbus/network/wpa_supplicant_service.cpp
+++ b/src/dbus/network/wpa_supplicant_service.cpp
@@ -143,7 +143,7 @@ WpaSupplicantService::~WpaSupplicantService() = default;
 void WpaSupplicantService::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
 void WpaSupplicantService::subscribeInterface(const std::string& ifacePath) {
-  if (m_interfaces.count(ifacePath))
+  if (m_interfaces.contains(ifacePath))
     return;
   try {
     auto proxy = sdbus::createProxy(m_bus.connection(), kWpaBusName, sdbus::ObjectPath{ifacePath});
@@ -161,7 +161,7 @@ void WpaSupplicantService::subscribeInterface(const std::string& ifacePath) {
         .onInterface(kWpaIfaceInterface)
         .call([this](const sdbus::ObjectPath& bssPath, const std::map<std::string, sdbus::Variant>&) {
           const std::string key{bssPath};
-          if (!m_bssProxies.count(key)) {
+          if (!m_bssProxies.contains(key)) {
             try {
               m_bssProxies.emplace(key, sdbus::createProxy(m_bus.connection(), kWpaBusName, bssPath));
             } catch (const sdbus::Error&) {
@@ -181,7 +181,7 @@ void WpaSupplicantService::subscribeInterface(const std::string& ifacePath) {
           proxy->getProperty("BSSs").onInterface(kWpaIfaceInterface).get<std::vector<sdbus::ObjectPath>>();
       for (const auto& bssPath : bssPaths) {
         const std::string key{bssPath};
-        if (!m_bssProxies.count(key)) {
+        if (!m_bssProxies.contains(key)) {
           try {
             m_bssProxies.emplace(key, sdbus::createProxy(m_bus.connection(), kWpaBusName, bssPath));
           } catch (const sdbus::Error&) {
@@ -244,7 +244,7 @@ sdbus::IProxy* WpaSupplicantService::firstInterface() const {
   return m_interfaces.empty() ? nullptr : m_interfaces.begin()->second.get();
 }
 
-bool WpaSupplicantService::hasSavedConnection(const std::string& ssid) const { return m_savedNetworks.count(ssid) > 0; }
+bool WpaSupplicantService::hasSavedConnection(const std::string& ssid) const { return m_savedNetworks.contains(ssid); }
 
 bool WpaSupplicantService::activateAccessPoint(const AccessPointInfo& ap) {
   auto* iface = firstInterface();
@@ -452,8 +452,7 @@ void WpaSupplicantService::rebuildState() {
         auto existing =
             std::find_if(aps.begin(), aps.end(), [&](const AccessPointInfo& a) { return a.ssid == info->ssid; });
         if (existing != aps.end()) {
-          if (pct > existing->strength)
-            existing->strength = pct;
+          existing->strength = std::max(pct, existing->strength);
           if (active)
             existing->active = true;
         } else {

--- a/src/notification/notification_history_store.cpp
+++ b/src/notification/notification_history_store.cpp
@@ -551,7 +551,7 @@ namespace {
       if (!legacyPerId && !contentAddressed) {
         continue;
       }
-      if (keepFiles.find(name) == keepFiles.end()) {
+      if (!keepFiles.contains(name)) {
         std::filesystem::remove(ent.path(), ec);
       }
     }

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -339,9 +339,7 @@ namespace {
         for (std::uint32_t i = 0; i < n; ++i) {
           const float cubic = samples[i];
           const float linear = std::cbrt(std::max(0.0f, cubic));
-          if (linear > maxVol) {
-            maxVol = linear;
-          }
+          maxVol = std::max(linear, maxVol);
         }
         outVolume = maxVol;
         if (outChannelCount != nullptr) {

--- a/src/pipewire/pipewire_spectrum.cpp
+++ b/src/pipewire/pipewire_spectrum.cpp
@@ -629,12 +629,8 @@ void PipeWireSpectrum::computeAnalysisBandBins() {
 
     if (i > 0 && binLow <= m_analysisBandBinHigh[i - 1]) {
       binLow = m_analysisBandBinHigh[i - 1] + 1;
-      if (binLow > fftBins) {
-        binLow = fftBins;
-      }
-      if (binHigh < binLow) {
-        binHigh = binLow;
-      }
+      binLow = std::min(binLow, fftBins);
+      binHigh = std::max(binHigh, binLow);
     }
 
     m_analysisBandBinLow[i] = binLow;
@@ -659,9 +655,7 @@ bool PipeWireSpectrum::processListenerView(ListenerState& state, float nrFactor,
           static_cast<double>(state.peak[i])
           * (1.0 - static_cast<double>(state.fall[i]) * static_cast<double>(state.fall[i]) * gravityMod)
       );
-      if (bands[i] < 0.0f) {
-        bands[i] = 0.0f;
-      }
+      bands[i] = std::max(bands[i], 0.0f);
       state.fall[i] += 0.028f;
     } else {
       state.peak[i] = bands[i];

--- a/src/render/core/async_texture_cache.cpp
+++ b/src/render/core/async_texture_cache.cpp
@@ -414,7 +414,7 @@ void AsyncTextureCache::notifyReady(const RequestKey& key, TextureHandle handle)
   }
 
   for (auto& [id, callback] : callbacks) {
-    if (m_readyListeners.find(id) != m_readyListeners.end()) {
+    if (m_readyListeners.contains(id)) {
       callback(handle);
     }
   }

--- a/src/scripting/luau_host.cpp
+++ b/src/scripting/luau_host.cpp
@@ -502,11 +502,11 @@ bool LuauHost::startAsyncProcessMatch(std::vector<std::string> needles, int call
 }
 
 bool LuauHost::hasAsyncCommandCallback(int callbackRef) const {
-  return m_asyncCommandCallbackRefs.find(callbackRef) != m_asyncCommandCallbackRefs.end();
+  return m_asyncCommandCallbackRefs.contains(callbackRef);
 }
 
 bool LuauHost::hasAsyncProcessMatchCallback(int callbackRef) const {
-  return m_asyncProcessMatchCallbackRefs.find(callbackRef) != m_asyncProcessMatchCallbackRefs.end();
+  return m_asyncProcessMatchCallbackRefs.contains(callbackRef);
 }
 
 bool LuauHost::callAsyncCommandCallback(

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2759,7 +2759,7 @@ namespace {
     }
     barName = std::nullopt;
     monitorSelector = std::nullopt;
-    if (parts.size() >= 1) {
+    if (!parts.empty()) {
       barName = parts[0];
     }
     if (parts.size() >= 2) {

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -625,12 +625,8 @@ double SysmonWidget::normalizedFromStats(SysmonStat stat, const SystemStats& sta
   case SysmonStat::CpuTemp:
     if (stats.cpuTempC.has_value()) {
       const double temp = *stats.cpuTempC;
-      if (temp < tempMin) {
-        tempMin = temp;
-      }
-      if (temp > tempMax) {
-        tempMax = temp;
-      }
+      tempMin = std::min(tempMin, temp);
+      tempMax = std::max(tempMax, temp);
       const double range = tempMax - tempMin;
       if (range <= 0.0) {
         return 0.5;
@@ -642,12 +638,8 @@ double SysmonWidget::normalizedFromStats(SysmonStat stat, const SystemStats& sta
   case SysmonStat::GpuTemp:
     if (stats.gpuTempC.has_value()) {
       const double temp = *stats.gpuTempC;
-      if (temp < tempMin) {
-        tempMin = temp;
-      }
-      if (temp > tempMax) {
-        tempMax = temp;
-      }
+      tempMin = std::min(tempMin, temp);
+      tempMax = std::max(tempMax, temp);
       const double range = tempMax - tempMin;
       if (range <= 0.0) {
         return 0.5;
@@ -684,14 +676,12 @@ double SysmonWidget::normalizedFromStats(SysmonStat stat, const SystemStats& sta
     return 0.0;
 
   case SysmonStat::NetRx: {
-    if (stats.netRxBytesPerSec > tempMax)
-      tempMax = stats.netRxBytesPerSec;
+    tempMax = std::max(tempMax, stats.netRxBytesPerSec);
     return tempMax > 0.0 ? std::clamp(stats.netRxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
   }
 
   case SysmonStat::NetTx: {
-    if (stats.netTxBytesPerSec > tempMax)
-      tempMax = stats.netTxBytesPerSec;
+    tempMax = std::max(tempMax, stats.netTxBytesPerSec);
     return tempMax > 0.0 ? std::clamp(stats.netTxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
   }
 

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1658,7 +1658,7 @@ void TaskbarWidget::updateModels() {
           std::remove_if(
               nextTasks.begin(), nextTasks.end(),
               [&activeKeys](const TaskModel& t) {
-                return !t.workspaceKey.empty() && activeKeys.find(t.workspaceKey) == activeKeys.end();
+                return !t.workspaceKey.empty() && !activeKeys.contains(t.workspaceKey);
               }
           ),
           nextTasks.end()

--- a/src/shell/control_center/calendar_tab.cpp
+++ b/src/shell/control_center/calendar_tab.cpp
@@ -112,9 +112,7 @@ namespace {
       endTp = event.end - std::chrono::hours{24};
     }
     int endKey = localDateKey(endTp);
-    if (endKey < startKey) {
-      endKey = startKey;
-    }
+    endKey = std::max(endKey, startKey);
     return {startKey, endKey};
   }
 

--- a/src/shell/control_center/system_tab.cpp
+++ b/src/shell/control_center/system_tab.cpp
@@ -536,10 +536,8 @@ void SystemTab::updateGraphs(Renderer& renderer) {
 
       if (s.cpuTempC.has_value()) {
         const double t = *s.cpuTempC;
-        if (t < m_cpuTempMin)
-          m_cpuTempMin = t;
-        if (t > m_cpuTempMax)
-          m_cpuTempMax = t;
+        m_cpuTempMin = std::min(m_cpuTempMin, t);
+        m_cpuTempMax = std::max(m_cpuTempMax, t);
         const double range = m_cpuTempMax - m_cpuTempMin;
         cpuTemp[i] = range > 0.0 ? static_cast<float>(std::clamp((t - m_cpuTempMin) / range, 0.0, 1.0)) : 0.5f;
       }
@@ -585,10 +583,8 @@ void SystemTab::updateGraphs(Renderer& renderer) {
       if (s.gpuTempC.has_value()) {
         hasGpuTemp = true;
         const double t = *s.gpuTempC;
-        if (t < m_gpuTempMin)
-          m_gpuTempMin = t;
-        if (t > m_gpuTempMax)
-          m_gpuTempMax = t;
+        m_gpuTempMin = std::min(m_gpuTempMin, t);
+        m_gpuTempMax = std::max(m_gpuTempMax, t);
         const double range = m_gpuTempMax - m_gpuTempMin;
         gpuTemp[i] = range > 0.0 ? static_cast<float>(std::clamp((t - m_gpuTempMin) / range, 0.0, 1.0)) : 0.5f;
       }

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -258,10 +258,8 @@ double DesktopSysmonWidget::normalizedFromStats(
   case DesktopSysmonStat::CpuTemp:
     if (stats.cpuTempC.has_value()) {
       const double temp = *stats.cpuTempC;
-      if (temp < tempMin)
-        tempMin = temp;
-      if (temp > tempMax)
-        tempMax = temp;
+      tempMin = std::min(tempMin, temp);
+      tempMax = std::max(tempMax, temp);
       const double range = tempMax - tempMin;
       if (range <= 0.0)
         return 0.5;
@@ -272,10 +270,8 @@ double DesktopSysmonWidget::normalizedFromStats(
   case DesktopSysmonStat::GpuTemp:
     if (stats.gpuTempC.has_value()) {
       const double temp = *stats.gpuTempC;
-      if (temp < tempMin)
-        tempMin = temp;
-      if (temp > tempMax)
-        tempMax = temp;
+      tempMin = std::min(tempMin, temp);
+      tempMax = std::max(tempMax, temp);
       const double range = tempMax - tempMin;
       if (range <= 0.0)
         return 0.5;
@@ -305,13 +301,11 @@ double DesktopSysmonWidget::normalizedFromStats(
     return 0.0;
 
   case DesktopSysmonStat::NetRx:
-    if (stats.netRxBytesPerSec > tempMax)
-      tempMax = stats.netRxBytesPerSec;
+    tempMax = std::max(tempMax, stats.netRxBytesPerSec);
     return tempMax > 0.0 ? std::clamp(stats.netRxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
 
   case DesktopSysmonStat::NetTx:
-    if (stats.netTxBytesPerSec > tempMax)
-      tempMax = stats.netTxBytesPerSec;
+    tempMax = std::max(tempMax, stats.netTxBytesPerSec);
     return tempMax > 0.0 ? std::clamp(stats.netTxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
   }
 

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -559,7 +559,7 @@ void LockScreen::tryAuthenticate() {
 }
 
 void LockScreen::clearSensitiveString(std::string& value) {
-  volatile char* ptr = value.empty() ? nullptr : &value[0];
+  volatile char* ptr = value.empty() ? nullptr : value.data();
   for (std::size_t i = 0; i < value.size(); ++i) {
     ptr[i] = '\0';
   }

--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -1349,7 +1349,7 @@ void NotificationToast::resumeCountdowns(uint32_t notificationId) {
 
     state->progressBar->setOpacity(1.0f);
     state->progressBar->setProgress(remaining);
-    const bool isDriver = (m_instances.size() > 0 && m_instances[0].get() == inst.get());
+    const bool isDriver = (!m_instances.empty() && m_instances[0].get() == inst.get());
     state->countdownAnimId = inst->animations.animateTimer(
         remaining, 0.0f, static_cast<float>(entry->displayDurationMs) * remaining, Easing::Linear,
         [this, progressBar = state->progressBar, notificationId](float v) {
@@ -2782,7 +2782,7 @@ std::string NotificationToast::resolveNotificationIconPath(const PopupEntry& ent
       m_remoteIconCache.erase(it);
     }
 
-    if (m_failedRemoteIconDownloads.find(iconValue) != m_failedRemoteIconDownloads.end()) {
+    if (m_failedRemoteIconDownloads.contains(iconValue)) {
       kLog.warn("notification toast: #{} remote icon URL marked failed url='{}'", entry.notificationId, iconValue);
       return {};
     }
@@ -2795,7 +2795,7 @@ std::string NotificationToast::resolveNotificationIconPath(const PopupEntry& ent
       return cachedPath;
     }
 
-    if (m_httpClient != nullptr && m_pendingRemoteIconDownloads.find(iconValue) == m_pendingRemoteIconDownloads.end()) {
+    if (m_httpClient != nullptr && !m_pendingRemoteIconDownloads.contains(iconValue)) {
       std::filesystem::create_directories(cached.parent_path(), ec);
       if (ec) {
         kLog.warn(

--- a/src/shell/panel/panel_click_shield.cpp
+++ b/src/shell/panel/panel_click_shield.cpp
@@ -118,7 +118,7 @@ void PanelClickShield::activate(
   }
 
   for (wl_output* output : outputs) {
-    if (output == nullptr || m_shields.find(output) != m_shields.end()) {
+    if (output == nullptr || m_shields.contains(output)) {
       continue;
     }
     std::vector<InputRect> excludeRects;

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -296,7 +296,7 @@ namespace {
             inherits.emplace_back(std::move(name));
           }
         }
-      } else if (!currentSection.empty() && dirMap.count(currentSection)) {
+      } else if (!currentSection.empty() && dirMap.contains(currentSection)) {
         auto& entry = dirMap[currentSection];
         if (key == "Size") {
           try {
@@ -340,7 +340,7 @@ namespace {
       const std::string& themeName, const std::vector<std::string>& baseDirs, std::set<std::string>& visited,
       std::vector<IconSearchDir>& searchDirs
   ) {
-    if (visited.count(themeName)) {
+    if (visited.contains(themeName)) {
       return;
     }
     visited.insert(themeName);

--- a/src/theme/color.cpp
+++ b/src/theme/color.cpp
@@ -24,10 +24,8 @@ namespace noctalia::theme {
 
     int roundClamp255(double v) {
       long r = std::lround(v * 255.0);
-      if (r < 0)
-        r = 0;
-      if (r > 255)
-        r = 255;
+      r = std::max<long>(r, 0);
+      r = std::min<long>(r, 255);
       return static_cast<int>(r);
     }
 

--- a/src/theme/custom_schemes.cpp
+++ b/src/theme/custom_schemes.cpp
@@ -56,10 +56,8 @@ namespace noctalia::theme {
       else
         n = 1.055 * std::pow(v, 1.0 / 2.4) - 0.055;
       long r = std::lround(n * 255.0);
-      if (r < 0)
-        r = 0;
-      if (r > 255)
-        r = 255;
+      r = std::max<long>(r, 0);
+      r = std::min<long>(r, 255);
       return static_cast<int>(r);
     }
 

--- a/src/theme/fixed_palette.cpp
+++ b/src/theme/fixed_palette.cpp
@@ -39,9 +39,7 @@ namespace noctalia::theme {
       dst[std::string(key)] = colorToArgb(color);
     }
 
-    bool hasToken(const TokenMap& tokens, std::string_view key) {
-      return tokens.find(std::string(key)) != tokens.end();
-    }
+    bool hasToken(const TokenMap& tokens, std::string_view key) { return tokens.contains(std::string(key)); }
 
     std::uint32_t tokenOr(const TokenMap& tokens, std::string_view key, std::uint32_t fallback) {
       auto it = tokens.find(std::string(key));

--- a/src/theme/image_loader.cpp
+++ b/src/theme/image_loader.cpp
@@ -99,10 +99,8 @@ namespace noctalia::theme {
       scale = 1.0 / scale;
 
       auto toU8 = [](float v) -> uint8_t {
-        if (v < 0.0f)
-          v = 0.0f;
-        if (v > 255.0f)
-          v = 255.0f;
+        v = std::max(v, 0.0f);
+        v = std::min(v, 255.0f);
         float r = v < 0.0f ? std::ceil(v - 0.5f) : std::floor(v + 0.5f);
         return static_cast<uint8_t>(r);
       };
@@ -147,14 +145,10 @@ namespace noctalia::theme {
         const float inputyOrig = (static_cast<float>(outy) + 0.5f) * ratio;
         int left = static_cast<int>(std::floor(inputyOrig - srcSupport));
         int right = static_cast<int>(std::ceil(inputyOrig + srcSupport));
-        if (left < 0)
-          left = 0;
-        if (left > srcH - 1)
-          left = srcH - 1;
-        if (right < left + 1)
-          right = left + 1;
-        if (right > srcH)
-          right = srcH;
+        left = std::max(left, 0);
+        left = std::min(left, srcH - 1);
+        right = std::max(right, left + 1);
+        right = std::min(right, srcH);
         const float inputy = inputyOrig - 0.5f;
 
         ws.clear();
@@ -200,14 +194,10 @@ namespace noctalia::theme {
         const float inputxOrig = (static_cast<float>(outx) + 0.5f) * ratio;
         int left = static_cast<int>(std::floor(inputxOrig - srcSupport));
         int right = static_cast<int>(std::ceil(inputxOrig + srcSupport));
-        if (left < 0)
-          left = 0;
-        if (left > srcW - 1)
-          left = srcW - 1;
-        if (right < left + 1)
-          right = left + 1;
-        if (right > srcW)
-          right = srcW;
+        left = std::max(left, 0);
+        left = std::min(left, srcW - 1);
+        right = std::max(right, left + 1);
+        right = std::min(right, srcW);
         const float inputx = inputxOrig - 0.5f;
 
         ws.clear();
@@ -234,10 +224,8 @@ namespace noctalia::theme {
           // FloatNearest(clamp(t, 0, 255)) → u8. Rust's f32::round is
           // round-half-away-from-zero.
           auto toU8 = [](float v) -> uint8_t {
-            if (v < 0)
-              v = 0;
-            if (v > 255)
-              v = 255;
+            v = std::max(v, 0.0f);
+            v = std::min(v, 255.0f);
             float r = v < 0.0f ? std::ceil(v - 0.5f) : std::floor(v + 0.5f);
             return static_cast<uint8_t>(r);
           };

--- a/src/theme/m3_schemes.cpp
+++ b/src/theme/m3_schemes.cpp
@@ -84,8 +84,7 @@ namespace noctalia::theme {
     ) {
       if (max_colors == 0 || input_pixels.empty())
         return {};
-      if (max_colors > 256)
-        max_colors = 256;
+      max_colors = std::min<uint16_t>(max_colors, 256);
 
       // Dedupe input pixels in insertion order, building parallel
       // pixels/points/counts arrays. Matches matugen's IndexMap loop.

--- a/src/time/time_format.cpp
+++ b/src/time/time_format.cpp
@@ -18,9 +18,7 @@ namespace {
   std::string
   formatAgeSeconds(std::int64_t secs, std::optional<std::chrono::system_clock::time_point> calendarAfterSixDays) {
     using namespace std::chrono;
-    if (secs < 0) {
-      secs = 0;
-    }
+    secs = std::max<std::int64_t>(secs, 0);
     if (secs < 60) {
       return i18n::tr("time.relative.just-now");
     }

--- a/src/ui/controls/flex.cpp
+++ b/src/ui/controls/flex.cpp
@@ -460,7 +460,7 @@ LayoutSize Flex::runLayout(Renderer& renderer, const LayoutConstraints& constrai
     }
     auto& item = items.emplace_back();
     item.node = child.get();
-    item.gapExcluded = m_gapExcludedChildren.count(child.get()) > 0;
+    item.gapExcluded = m_gapExcludedChildren.contains(child.get());
     if (child->flexGrow() > 0.0f) {
       totalGrow += child->flexGrow();
     }

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -950,7 +950,7 @@ void Input::doLayout(Renderer& renderer) {
 
   std::size_t charCount = 0;
   if (showPasswordGlyphs) {
-    charCount = m_stopByte.size() > 0 ? m_stopByte.size() - 1 : 0;
+    charCount = !m_stopByte.empty() ? m_stopByte.size() - 1 : 0;
   }
   float passwordGlyphSize = 0.0f;
   const float passwordCellSize = showPasswordGlyphs ? std::round(m_fontSize * kPasswordGlyphScale) : 0.0f;

--- a/src/wayland/surface.cpp
+++ b/src/wayland/surface.cpp
@@ -536,9 +536,7 @@ std::vector<InputRect> Surface::tessellateRoundedRect(
     return out;
   }
 
-  if (stripPx < 1) {
-    stripPx = 1;
-  }
+  stripPx = std::max(stripPx, 1);
 
   const float halfW = static_cast<float>(w) * 0.5f;
   const float halfH = static_cast<float>(h) * 0.5f;
@@ -615,9 +613,7 @@ std::vector<InputRect> Surface::tessellateShape(
   if (w <= 0 || h <= 0) {
     return out;
   }
-  if (stripPx < 1) {
-    stripPx = 1;
-  }
+  stripPx = std::max(stripPx, 1);
 
   // (x, y, w, h) is the body rect. Expand outward by logicalInset to obtain the
   // visual rect that hosts concave-corner bulges; the body sits inside it offset


### PR DESCRIPTION
This commit fixes some obvious cases where more appropriate C++ syntax is available for the same thing. The second (optional) commit also adds clang-tidy rules for noticing and autofixing these cases.

## Type of Change
- [x] Refactoring

## Testing
- [x] Tested on Hyprland

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors