### PR TITLE
[v5] fix: file dialog path handling in settings_content

### DIFF
--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -282,13 +282,11 @@ namespace settings {
               }
             }
             (void)FileDialog::open(
-                std::move(options), [setOverride, path, inputPtr](std::optional<std::filesystem::path> picked) {
+                std::move(options), [setOverride, path](std::optional<std::filesystem::path> picked) {
                   if (!picked.has_value()) {
                     return;
                   }
-                  const std::string s = picked->string();
-                  inputPtr->setValue(s);
-                  setOverride(path, s);
+                  setOverride(path, picked->string());
                 }
             );
           },


### PR DESCRIPTION
# Pull Request

<!-- If this is a color scheme PR, please create it in https://github.com/noctalia-dev/noctalia-colorschemes instead -->

## Motivation
This PR fixes crash when picking out an directory in noctalia settings , for example changing wallpaper or screenshot directory

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring


## Testing
Describe how you tested your changes and mark the relevant items.

- [x] Tested on niri
- [x] Tested on Hyprland
- [x] Tested on mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
Video showing noctalia crash when changing directories


https://github.com/user-attachments/assets/5baa50c3-434b-4ec0-a786-d7bcbbc075c6



## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

