### PR TITLE
audio: add easyeffects profiles support

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -113,6 +113,8 @@
   "control-center": {
     "audio": {
       "application-volumes": "Application Volumes",
+      "choose-effects-profile": "Choose a profile",
+      "effects-profile": "Effects:",
       "input-volume": "Input Volume",
       "no-application-audio": "No application audio",
       "no-application-audio-body": "No application playback streams are currently available.",
@@ -596,6 +598,10 @@
     "dnd": {
       "off": "DND Off",
       "on": "DND On"
+    },
+    "effects": {
+      "input": "Input Effects",
+      "output": "Output Effects"
     },
     "lock-keys": {
       "caps-off": "Caps Lock Off",

--- a/meson.build
+++ b/meson.build
@@ -670,6 +670,7 @@ _noctalia_sources = files(
   'src/system/hardware_info.cpp',
   'src/system/icon_resolver.cpp',
   'src/system/internal_app_metadata.cpp',
+  'src/system/easyeffects_service.cpp',
   'src/system/day_night_schedule.cpp',
   'src/system/gamma_service.cpp',
   'src/system/location_service.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -106,6 +106,15 @@ namespace {
     };
   }
 
+  OsdContent effectsProfileOsdContent(AudioEffectsProfileKind kind, std::string_view profile) {
+    const char* labelKey = kind == AudioEffectsProfileKind::Input ? "osd.effects.input" : "osd.effects.output";
+    return OsdContent{
+        .icon = "adjustments",
+        .value = i18n::tr(labelKey) + ": " + std::string(profile),
+        .showProgress = false,
+    };
+  }
+
   OsdContent caffeineOsdContent(bool enabled) {
     return OsdContent{
         .kind = OsdKind::Caffeine,
@@ -991,6 +1000,9 @@ void Application::initServices() {
 
   try {
     m_pipewireService = std::make_unique<PipeWireService>();
+    m_easyEffectsService = std::make_unique<EasyEffectsService>();
+    m_easyEffectsService->refreshProfiles();
+    m_easyEffectsService->refreshActiveEffectsProfiles();
     m_pipewireSpectrum = std::make_unique<PipeWireSpectrum>(*m_pipewireService);
     m_soundPlayer = std::make_unique<SoundPlayer>(m_pipewireService->loop());
 
@@ -1046,6 +1058,7 @@ void Application::initServices() {
     kLog.warn("pipewire disabled: {}", e.what());
     m_soundPlayer.reset();
     m_pipewireSpectrum.reset();
+    m_easyEffectsService.reset();
     m_pipewireService.reset();
   }
 
@@ -1448,12 +1461,13 @@ void Application::initUi() {
   m_panelManager.registerPanel(
       "control-center",
       std::make_unique<ControlCenterPanel>(
-          &m_notificationManager, m_pipewireService.get(), m_mprisService.get(), &m_configService, &m_httpClient,
-          &m_weatherService, m_pipewireSpectrum.get(), m_upowerService.get(), m_powerProfilesService.get(),
-          m_networkService.get(), m_networkSecretAgent.get(), m_bluetoothService.get(), m_bluetoothAgent.get(),
-          m_brightnessService.get(), m_systemMonitor.get(), &m_screenTimeService, &m_gammaService, &m_themeService,
-          &m_idleInhibitor, &m_dependencyService, &m_compositorPlatform, &m_ipcService, &m_wallpaper,
-          &m_calendarService, &m_scriptApi, &m_clipboardService, m_accountsService.get(), &m_thumbnailService
+          &m_notificationManager, m_pipewireService.get(), m_easyEffectsService.get(), m_mprisService.get(),
+          &m_configService, &m_httpClient, &m_weatherService, m_pipewireSpectrum.get(), m_upowerService.get(),
+          m_powerProfilesService.get(), m_networkService.get(), m_networkSecretAgent.get(), m_bluetoothService.get(),
+          m_bluetoothAgent.get(), m_brightnessService.get(), m_systemMonitor.get(), &m_screenTimeService,
+          &m_gammaService, &m_themeService, &m_idleInhibitor, &m_dependencyService, &m_compositorPlatform,
+          &m_ipcService, &m_wallpaper, &m_calendarService, &m_scriptApi, &m_clipboardService, m_accountsService.get(),
+          &m_thumbnailService
       )
   );
   {
@@ -1629,11 +1643,11 @@ void Application::initUi() {
 
   m_bar.initialize(
       m_compositorPlatform, &m_configService, &m_timeService, &m_notificationManager, m_trayService.get(),
-      m_pipewireService.get(), m_upowerService.get(), m_systemMonitor.get(), m_powerProfilesService.get(),
-      m_networkService.get(), &m_idleInhibitor, m_mprisService.get(), m_pipewireSpectrum.get(), &m_httpClient,
-      &m_weatherService, &m_renderContext, &m_gammaService, &m_themeService, m_bluetoothService.get(),
-      m_brightnessService.get(), kLockKeysEnabled ? &m_lockKeysService : nullptr, &m_clipboardService, &m_fileWatcher,
-      &m_screenshotService, &m_scriptApi
+      m_pipewireService.get(), m_easyEffectsService.get(), m_upowerService.get(), m_systemMonitor.get(),
+      m_powerProfilesService.get(), m_networkService.get(), &m_idleInhibitor, m_mprisService.get(),
+      m_pipewireSpectrum.get(), &m_httpClient, &m_weatherService, &m_renderContext, &m_gammaService, &m_themeService,
+      m_bluetoothService.get(), m_brightnessService.get(), kLockKeysEnabled ? &m_lockKeysService : nullptr,
+      &m_clipboardService, &m_fileWatcher, &m_screenshotService, &m_scriptApi
   );
   m_bar.setOpenWidgetSettingsCallback([this](std::string barName, std::string widgetName) {
     if (m_panelManager.isOpen()) {
@@ -1796,6 +1810,14 @@ void Application::initUi() {
         m_audioOsd.showInput(id, volume, muted);
       } else {
         m_audioOsd.showOutput(id, volume, muted);
+      }
+    });
+  }
+  if (m_easyEffectsService != nullptr) {
+    m_easyEffectsService->setChangeCallback([this, shouldRefreshControlCenter]() {
+      m_bar.refresh();
+      if (shouldRefreshControlCenter()) {
+        m_panelManager.refresh();
       }
     });
   }
@@ -2129,6 +2151,13 @@ void Application::initIpc() {
   }
   if (m_pipewireService) {
     m_pipewireService->registerIpc(m_ipcService, m_configService);
+  }
+  if (m_easyEffectsService) {
+    m_easyEffectsService->registerIpc(
+        m_ipcService, m_configService, [this](AudioEffectsProfileKind kind, std::string_view profile) {
+          m_osdOverlay.show(effectsProfileOsdContent(kind, profile));
+        }
+    );
   }
   m_screenshotService.registerIpc(m_ipcService, m_configService);
   m_windowSwitcher.registerIpc(m_ipcService);

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -84,6 +84,7 @@
 #include "system/brightness_service.h"
 #include "system/dependency_service.h"
 #include "system/desktop_entry_poll_source.h"
+#include "system/easyeffects_service.h"
 #include "system/gamma_service.h"
 #include "system/icon_theme_poll_source.h"
 #include "system/location_poll_source.h"
@@ -210,6 +211,7 @@ private:
   std::unique_ptr<TrayService> m_trayService;
   std::unique_ptr<NotificationService> m_notificationDbus;
   std::unique_ptr<PipeWireService> m_pipewireService;
+  std::unique_ptr<EasyEffectsService> m_easyEffectsService;
   std::unique_ptr<PipeWireSpectrum> m_pipewireSpectrum;
   std::unique_ptr<SoundPlayer> m_soundPlayer;
 

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -16,6 +16,7 @@
 #include "shell/panel/panel_manager.h"
 #include "shell/surface/shadow.h"
 #include "shell/tooltip/tooltip_manager.h"
+#include "system/easyeffects_service.h"
 #include "system/gamma_service.h"
 #include "system/system_monitor_service.h"
 #include "system/weather_service.h"
@@ -849,18 +850,20 @@ Bar::Bar() = default;
 
 bool Bar::initialize(
     CompositorPlatform& platform, ConfigService* config, TimeService* timeService, NotificationManager* notifications,
-    TrayService* tray, PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon,
-    PowerProfilesService* powerProfiles, INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris,
-    PipeWireSpectrum* audioSpectrum, HttpClient* httpClient, WeatherService* weatherService,
-    RenderContext* renderContext, GammaService* nightLight, noctalia::theme::ThemeService* themeService,
-    BluetoothService* bluetooth, BrightnessService* brightness, LockKeysService* lockKeys, ClipboardService* clipboard,
-    FileWatcher* fileWatcher, ScreenshotService* screenshots, scripting::ScriptApiContext* scriptApi
+    TrayService* tray, PipeWireService* audio, EasyEffectsService* easyEffects, UPowerService* upower,
+    SystemMonitorService* sysmon, PowerProfilesService* powerProfiles, INetworkService* network,
+    IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum, HttpClient* httpClient,
+    WeatherService* weatherService, RenderContext* renderContext, GammaService* nightLight,
+    noctalia::theme::ThemeService* themeService, BluetoothService* bluetooth, BrightnessService* brightness,
+    LockKeysService* lockKeys, ClipboardService* clipboard, FileWatcher* fileWatcher, ScreenshotService* screenshots,
+    scripting::ScriptApiContext* scriptApi
 ) {
   m_platform = &platform;
   m_config = config;
   m_notifications = notifications;
   m_tray = tray;
   m_audio = audio;
+  m_easyEffects = easyEffects;
   m_upower = upower;
   m_sysmon = sysmon;
   m_powerProfiles = powerProfiles;
@@ -882,9 +885,10 @@ bool Bar::initialize(
   m_scriptApi = scriptApi;
 
   m_widgetFactory = std::make_unique<WidgetFactory>(
-      *m_platform, *m_config, m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
-      m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight, m_themeService,
-      m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher, m_screenshots, m_renderContext, m_scriptApi
+      *m_platform, *m_config, m_notifications, m_tray, m_audio, easyEffects, m_upower, m_sysmon, m_powerProfiles,
+      m_network, m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight,
+      m_themeService, m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher, m_screenshots, m_renderContext,
+      m_scriptApi
   );
 
   (void)timeService;
@@ -930,9 +934,10 @@ void Bar::reload() {
   m_lastShadow = m_config->config().shell.shadow;
   m_lastPlugins = m_config->config().plugins;
   m_widgetFactory = std::make_unique<WidgetFactory>(
-      *m_platform, *m_config, m_notifications, m_tray, m_audio, m_upower, m_sysmon, m_powerProfiles, m_network,
-      m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight, m_themeService,
-      m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher, m_screenshots, m_renderContext, m_scriptApi
+      *m_platform, *m_config, m_notifications, m_tray, m_audio, m_easyEffects, m_upower, m_sysmon, m_powerProfiles,
+      m_network, m_idleInhibitor, m_mpris, m_audioSpectrum, m_httpClient, m_weatherService, m_nightLight,
+      m_themeService, m_bluetooth, m_brightness, m_lockKeys, m_clipboard, m_fileWatcher, m_screenshots, m_renderContext,
+      m_scriptApi
   );
 
   if (recreateForOrder) {

--- a/src/shell/bar/bar.h
+++ b/src/shell/bar/bar.h
@@ -24,6 +24,7 @@ class MprisService;
 class BluetoothService;
 class BrightnessService;
 class ClipboardService;
+class EasyEffectsService;
 class ScreenshotService;
 class INetworkService;
 class NotificationManager;
@@ -52,13 +53,13 @@ public:
 
   bool initialize(
       CompositorPlatform& platform, ConfigService* config, TimeService* timeService, NotificationManager* notifications,
-      TrayService* tray, PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon,
-      PowerProfilesService* powerProfiles, INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris,
-      PipeWireSpectrum* audioSpectrum, HttpClient* httpClient, WeatherService* weatherService,
-      RenderContext* renderContext, GammaService* nightLight, noctalia::theme::ThemeService* themeService,
-      BluetoothService* bluetooth, BrightnessService* brightness, LockKeysService* lockKeys,
-      ClipboardService* clipboard, FileWatcher* fileWatcher = nullptr, ScreenshotService* screenshots = nullptr,
-      scripting::ScriptApiContext* scriptApi = nullptr
+      TrayService* tray, PipeWireService* audio, EasyEffectsService* easyEffects, UPowerService* upower,
+      SystemMonitorService* sysmon, PowerProfilesService* powerProfiles, INetworkService* network,
+      IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum, HttpClient* httpClient,
+      WeatherService* weatherService, RenderContext* renderContext, GammaService* nightLight,
+      noctalia::theme::ThemeService* themeService, BluetoothService* bluetooth, BrightnessService* brightness,
+      LockKeysService* lockKeys, ClipboardService* clipboard, FileWatcher* fileWatcher = nullptr,
+      ScreenshotService* screenshots = nullptr, scripting::ScriptApiContext* scriptApi = nullptr
   );
   void reload();
   void closeAllInstances();
@@ -152,6 +153,7 @@ private:
   NotificationManager* m_notifications = nullptr;
   TrayService* m_tray = nullptr;
   PipeWireService* m_audio = nullptr;
+  EasyEffectsService* m_easyEffects = nullptr;
   UPowerService* m_upower = nullptr;
   SystemMonitorService* m_sysmon = nullptr;
   PowerProfilesService* m_powerProfiles = nullptr;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -51,6 +51,7 @@
 #include "shell/bar/widgets/wallpaper_widget.h"
 #include "shell/bar/widgets/weather_widget.h"
 #include "shell/bar/widgets/workspaces_widget.h"
+#include "system/easyeffects_service.h"
 #include "system/lock_keys_service.h"
 #include "system/system_monitor_service.h"
 #include "system/weather_service.h"
@@ -103,19 +104,20 @@ namespace {
 
 WidgetFactory::WidgetFactory(
     CompositorPlatform& platform, ConfigService& config, NotificationManager* notifications, TrayService* tray,
-    PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon, PowerProfilesService* powerProfiles,
-    INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum,
-    HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
+    PipeWireService* audio, EasyEffectsService* easyEffects, UPowerService* upower, SystemMonitorService* sysmon,
+    PowerProfilesService* powerProfiles, INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris,
+    PipeWireSpectrum* audioSpectrum, HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
     noctalia::theme::ThemeService* themeService, BluetoothService* bluetooth, BrightnessService* brightness,
     LockKeysService* lockKeys, ClipboardService* clipboard, FileWatcher* fileWatcher, ScreenshotService* screenshots,
     RenderContext* renderContext, scripting::ScriptApiContext* scriptApi
 )
     : m_platform(platform), m_configService(config), m_config(config.config()), m_notifications(notifications),
-      m_tray(tray), m_audio(audio), m_upower(upower), m_sysmon(sysmon), m_powerProfiles(powerProfiles),
-      m_network(network), m_idleInhibitor(idleInhibitor), m_mpris(mpris), m_audioSpectrum(audioSpectrum),
-      m_httpClient(httpClient), m_weather(weather), m_nightLight(nightLight), m_themeService(themeService),
-      m_bluetooth(bluetooth), m_brightness(brightness), m_lockKeys(lockKeys), m_clipboard(clipboard),
-      m_fileWatcher(fileWatcher), m_screenshots(screenshots), m_renderContext(renderContext), m_scriptApi(scriptApi) {
+      m_tray(tray), m_audio(audio), m_easyEffects(easyEffects), m_upower(upower), m_sysmon(sysmon),
+      m_powerProfiles(powerProfiles), m_network(network), m_idleInhibitor(idleInhibitor), m_mpris(mpris),
+      m_audioSpectrum(audioSpectrum), m_httpClient(httpClient), m_weather(weather), m_nightLight(nightLight),
+      m_themeService(themeService), m_bluetooth(bluetooth), m_brightness(brightness), m_lockKeys(lockKeys),
+      m_clipboard(clipboard), m_fileWatcher(fileWatcher), m_screenshots(screenshots), m_renderContext(renderContext),
+      m_scriptApi(scriptApi) {
   scripting::PluginRegistry::instance().ensureScanned();
 }
 
@@ -554,7 +556,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
         static_cast<int>(std::clamp<std::int64_t>(wc != nullptr ? wc->getInt("scroll_step", 5) : 5, 1, 25));
     const std::string target = wc != nullptr ? wc->getString("device", "output") : std::string("output");
     const auto volumeTarget = target == "input" ? VolumeWidgetTarget::Input : VolumeWidgetTarget::Output;
-    auto widget = std::make_unique<VolumeWidget>(m_audio, &m_config, output, showLabel, volumeTarget, scrollStep);
+    auto widget =
+        std::make_unique<VolumeWidget>(m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep);
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widget_factory.h
+++ b/src/shell/bar/widget_factory.h
@@ -17,6 +17,7 @@ class MprisService;
 class BluetoothService;
 class BrightnessService;
 class ClipboardService;
+class EasyEffectsService;
 class RenderContext;
 class ScreenshotService;
 class INetworkService;
@@ -40,9 +41,9 @@ class WidgetFactory {
 public:
   WidgetFactory(
       CompositorPlatform& platform, ConfigService& config, NotificationManager* notifications, TrayService* tray,
-      PipeWireService* audio, UPowerService* upower, SystemMonitorService* sysmon, PowerProfilesService* powerProfiles,
-      INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris, PipeWireSpectrum* audioSpectrum,
-      HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
+      PipeWireService* audio, EasyEffectsService* easyEffects, UPowerService* upower, SystemMonitorService* sysmon,
+      PowerProfilesService* powerProfiles, INetworkService* network, IdleInhibitor* idleInhibitor, MprisService* mpris,
+      PipeWireSpectrum* audioSpectrum, HttpClient* httpClient, WeatherService* weather, GammaService* nightLight,
       noctalia::theme::ThemeService* themeService, BluetoothService* bluetooth, BrightnessService* brightness,
       LockKeysService* lockKeys, ClipboardService* clipboard, FileWatcher* fileWatcher = nullptr,
       ScreenshotService* screenshots = nullptr, RenderContext* renderContext = nullptr,
@@ -62,6 +63,7 @@ private:
   NotificationManager* m_notifications;
   TrayService* m_tray;
   PipeWireService* m_audio;
+  EasyEffectsService* m_easyEffects;
   UPowerService* m_upower;
   SystemMonitorService* m_sysmon;
   PowerProfilesService* m_powerProfiles;

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -1,10 +1,12 @@
 #include "shell/bar/widgets/volume_widget.h"
 
 #include "config/config_types.h"
+#include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "system/easyeffects_service.h"
 #include "ui/builders.h"
 #include "ui/palette.h"
 #include "ui/style.h"
@@ -32,10 +34,10 @@ namespace {
 } // namespace
 
 VolumeWidget::VolumeWidget(
-    PipeWireService* audio, const Config* config, wl_output* /*output*/, bool showLabel, VolumeWidgetTarget target,
-    int scrollStepPercent
+    PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* /*output*/,
+    bool showLabel, VolumeWidgetTarget target, int scrollStepPercent
 )
-    : m_audio(audio), m_config(config), m_showLabel(showLabel),
+    : m_audio(audio), m_easyEffects(easyEffects), m_config(config), m_showLabel(showLabel),
       m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target) {}
 
 void VolumeWidget::create() {
@@ -140,14 +142,22 @@ void VolumeWidget::syncState(Renderer& renderer) {
   const auto* node = m_target == VolumeWidgetTarget::Input ? m_audio->defaultSource() : m_audio->defaultSink();
   float volume = node != nullptr ? node->volume : 0.0f;
   bool muted = node != nullptr ? node->muted : false;
+  const auto kind =
+      m_target == VolumeWidgetTarget::Input ? AudioEffectsProfileKind::Input : AudioEffectsProfileKind::Output;
+  const std::string effectsProfile =
+      m_easyEffects != nullptr ? m_easyEffects->activeEffectsProfile(kind) : std::string{};
 
-  if (volume == m_lastVolume && muted == m_lastMuted && m_isVertical == m_lastVertical) {
+  if (volume == m_lastVolume
+      && muted == m_lastMuted
+      && m_isVertical == m_lastVertical
+      && effectsProfile == m_lastEffectsProfile) {
     return;
   }
 
   m_lastVolume = volume;
   m_lastMuted = muted;
   m_lastVertical = m_isVertical;
+  m_lastEffectsProfile = effectsProfile;
 
   m_glyph->setGlyph(volumeGlyphName(volume, muted, m_target));
   m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
@@ -177,6 +187,9 @@ void VolumeWidget::syncState(Renderer& renderer) {
       rows.push_back({m_target == VolumeWidgetTarget::Input ? "Mic" : "Volume", std::to_string(pct) + "%"});
       if (!node->description.empty()) {
         rows.push_back({"Device", node->description});
+      }
+      if (!effectsProfile.empty()) {
+        rows.push_back({i18n::tr("control-center.audio.effects-profile"), effectsProfile});
       }
       area->setTooltip(std::move(rows));
     } else {

--- a/src/shell/bar/widgets/volume_widget.h
+++ b/src/shell/bar/widgets/volume_widget.h
@@ -3,8 +3,10 @@
 #include "shell/bar/widget.h"
 
 #include <cstdint>
+#include <string>
 
 struct Config;
+class EasyEffectsService;
 class Glyph;
 class Label;
 class PipeWireService;
@@ -18,8 +20,8 @@ enum class VolumeWidgetTarget {
 class VolumeWidget : public Widget {
 public:
   VolumeWidget(
-      PipeWireService* audio, const Config* config, wl_output* output, bool showLabel, VolumeWidgetTarget target,
-      int scrollStepPercent
+      PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* output, bool showLabel,
+      VolumeWidgetTarget target, int scrollStepPercent
   );
 
   void create() override;
@@ -30,6 +32,7 @@ private:
   void syncState(Renderer& renderer);
 
   PipeWireService* m_audio = nullptr;
+  EasyEffectsService* m_easyEffects = nullptr;
   const Config* m_config = nullptr;
   bool m_showLabel = true;
   float m_scrollStep = 0.05f;
@@ -37,6 +40,7 @@ private:
   Glyph* m_glyph = nullptr;
   Label* m_label = nullptr;
   float m_lastVolume = -1.0f;
+  std::string m_lastEffectsProfile;
   bool m_lastMuted = false;
   bool m_isVertical = false;
   bool m_lastVertical = false;

--- a/src/shell/control_center/audio_tab.cpp
+++ b/src/shell/control_center/audio_tab.cpp
@@ -12,6 +12,7 @@
 #include "shell/control_center/tab.h"
 #include "shell/panel/panel_manager.h"
 #include "system/desktop_entry.h"
+#include "system/easyeffects_service.h"
 #include "system/icon_resolver.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu.h"
@@ -1274,10 +1275,11 @@ namespace {
 } // namespace
 
 AudioTab::AudioTab(
-    PipeWireService* audio, MprisService* mpris, ConfigService* config, WaylandConnection* wayland,
-    RenderContext* renderContext
+    PipeWireService* audio, EasyEffectsService* easyEffects, MprisService* mpris, ConfigService* config,
+    WaylandConnection* wayland, RenderContext* renderContext
 )
-    : m_audio(audio), m_mpris(mpris), m_config(config), m_wayland(wayland), m_renderContext(renderContext) {}
+    : m_audio(audio), m_easyEffects(easyEffects), m_mpris(mpris), m_config(config), m_wayland(wayland),
+      m_renderContext(renderContext) {}
 
 AudioTab::~AudioTab() = default;
 
@@ -1408,6 +1410,36 @@ std::unique_ptr<Flex> AudioTab::create() {
     });
   };
 
+  auto makeEffectsProfileRow = [this, scale](Flex** rowOut, Select** selectOut) {
+    return ui::row(
+        {
+            .out = rowOut,
+            .align = FlexAlign::Center,
+            .gap = Style::spaceSm * scale,
+            .visible = false,
+            .participatesInLayout = false,
+        },
+        ui::label({
+            .text = i18n::tr("control-center.audio.effects-profile"),
+            .fontSize = Style::fontSizeCaption * scale,
+            .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+        }),
+        ui::select({
+            .out = selectOut,
+            .placeholder = i18n::tr("control-center.audio.choose-effects-profile"),
+            .fontSize = Style::fontSizeCaption * scale,
+            .controlHeight = Style::controlHeightSm * scale,
+            .horizontalPadding = Style::spaceSm * scale,
+            .glyphSize = Style::fontSizeBody * scale,
+            .notifyOnReselect = true,
+            .enabled = false,
+            .surfaceOpacity = panelCardOpacity(),
+            .height = Style::controlHeightSm * scale,
+            .flexGrow = 1.0f,
+        })
+    );
+  };
+
   auto volumeRow = ui::row({
       .out = &m_volumeColumn,
       .align = FlexAlign::Stretch,
@@ -1499,6 +1531,7 @@ std::unique_ptr<Flex> AudioTab::create() {
       })
   );
   outputVolumeCard->addChild(std::move(outputRow));
+  outputVolumeCard->addChild(makeEffectsProfileRow(&m_outputEffectsProfileRow, &m_outputEffectsProfileSelect));
   volumeRow->addChild(std::move(outputVolumeCard));
 
   auto inputVolumeCard = ui::column({
@@ -1584,6 +1617,7 @@ std::unique_ptr<Flex> AudioTab::create() {
       })
   );
   inputVolumeCard->addChild(std::move(inputRow));
+  inputVolumeCard->addChild(makeEffectsProfileRow(&m_inputEffectsProfileRow, &m_inputEffectsProfileSelect));
   volumeRow->addChild(std::move(inputVolumeCard));
 
   tab->addChild(std::move(volumeRow));
@@ -1632,6 +1666,11 @@ std::unique_ptr<Flex> AudioTab::create() {
     });
   }
 
+  if (m_easyEffects != nullptr) {
+    m_easyEffects->refreshProfiles();
+    m_easyEffects->refreshActiveEffectsProfiles();
+  }
+
   return tab;
 }
 
@@ -1664,6 +1703,7 @@ void AudioTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight
 void AudioTab::doUpdate(Renderer& renderer) {
   rebuildProgramVolumes(renderer);
   syncValueLabelWidths(renderer);
+  syncEffectsProfileControls(renderer);
 
   if (m_audio != nullptr) {
     const AudioState& state = m_audio->state();
@@ -1791,6 +1831,11 @@ void AudioTab::onClose() {
   m_volumeColumn = nullptr;
   m_outputVolumeCard = nullptr;
   m_inputVolumeCard = nullptr;
+  m_outputEffectsProfileRow = nullptr;
+  m_inputEffectsProfileRow = nullptr;
+  m_outputEffectsProfileSelect = nullptr;
+  m_inputEffectsProfileSelect = nullptr;
+  m_lastEffectsProfileListKey.clear();
   m_outputDeviceLabel = nullptr;
   m_inputDeviceLabel = nullptr;
   m_outputSlider = nullptr;
@@ -1833,6 +1878,82 @@ void AudioTab::onClose() {
   m_lastSourceCommitAt = {};
   m_ignoreSinkStateUntil = {};
   m_ignoreSourceStateUntil = {};
+}
+
+void AudioTab::syncEffectsProfileControls(Renderer& /*renderer*/) {
+  const auto outputProfiles = m_easyEffects != nullptr ? m_easyEffects->effectsProfiles(AudioEffectsProfileKind::Output)
+                                                       : std::vector<std::string>{};
+  const auto inputProfiles = m_easyEffects != nullptr ? m_easyEffects->effectsProfiles(AudioEffectsProfileKind::Input)
+                                                      : std::vector<std::string>{};
+  const std::string activeOutput =
+      m_easyEffects != nullptr ? m_easyEffects->activeEffectsProfile(AudioEffectsProfileKind::Output) : std::string{};
+  const std::string activeInput =
+      m_easyEffects != nullptr ? m_easyEffects->activeEffectsProfile(AudioEffectsProfileKind::Input) : std::string{};
+
+  std::string key = activeOutput;
+  key.push_back('\n');
+  for (const auto& profile : outputProfiles) {
+    key += profile;
+    key.push_back('\n');
+  }
+  key += "---input---\n";
+  key += activeInput;
+  key.push_back('\n');
+  for (const auto& profile : inputProfiles) {
+    key += profile;
+    key.push_back('\n');
+  }
+
+  if (key == m_lastEffectsProfileListKey) {
+    return;
+  }
+
+  m_lastEffectsProfileListKey = std::move(key);
+
+  auto syncDirection = [this](
+                           const std::vector<std::string>& profiles, const std::string& active, Flex* row,
+                           Select* select, AudioEffectsProfileKind kind
+                       ) {
+    if (row == nullptr || select == nullptr) {
+      return;
+    }
+    const bool hasProfiles = !profiles.empty();
+    row->setVisible(hasProfiles);
+    row->setParticipatesInLayout(hasProfiles);
+    select->setEnabled(hasProfiles);
+    select->setOnSelectionChanged(nullptr);
+    select->setOptions(profiles);
+    if (!hasProfiles) {
+      select->clearSelection();
+      select->setOnSelectionChanged(nullptr);
+      return;
+    }
+
+    const auto selected = std::ranges::find(profiles, active);
+    if (selected != profiles.end()) {
+      select->setSelectedIndex(static_cast<std::size_t>(std::distance(profiles.begin(), selected)));
+    } else {
+      select->clearSelection();
+    }
+
+    select->setOnSelectionChanged([this, kind](std::size_t /*index*/, std::string_view profile) {
+      if (m_easyEffects == nullptr || profile.empty()) {
+        return;
+      }
+      if (!m_easyEffects->loadEffectsProfile(kind, profile)) {
+        m_lastEffectsProfileListKey.clear();
+      }
+      PanelManager::instance().refresh();
+    });
+  };
+
+  syncDirection(
+      outputProfiles, activeOutput, m_outputEffectsProfileRow, m_outputEffectsProfileSelect,
+      AudioEffectsProfileKind::Output
+  );
+  syncDirection(
+      inputProfiles, activeInput, m_inputEffectsProfileRow, m_inputEffectsProfileSelect, AudioEffectsProfileKind::Input
+  );
 }
 
 void AudioTab::rebuildProgramVolumes(Renderer& renderer) {

--- a/src/shell/control_center/audio_tab.h
+++ b/src/shell/control_center/audio_tab.h
@@ -12,6 +12,7 @@
 class ConfigService;
 class Button;
 class ContextMenuPopup;
+class EasyEffectsService;
 class Flex;
 class Label;
 class MprisService;
@@ -19,14 +20,15 @@ class PipeWireService;
 class RenderContext;
 class Renderer;
 class ScrollView;
+class Select;
 class Slider;
 class WaylandConnection;
 
 class AudioTab : public Tab {
 public:
   AudioTab(
-      PipeWireService* audio, MprisService* mpris, ConfigService* config, WaylandConnection* wayland,
-      RenderContext* renderContext
+      PipeWireService* audio, EasyEffectsService* easyEffects, MprisService* mpris, ConfigService* config,
+      WaylandConnection* wayland, RenderContext* renderContext
   );
   ~AudioTab() override;
 
@@ -50,8 +52,10 @@ private:
   void flushPendingVolumes(bool force = false);
 
   void openDeviceMenu(bool isOutput);
+  void syncEffectsProfileControls(Renderer& renderer);
 
   PipeWireService* m_audio = nullptr;
+  EasyEffectsService* m_easyEffects = nullptr;
   MprisService* m_mpris = nullptr;
   ConfigService* m_config = nullptr;
   WaylandConnection* m_wayland = nullptr;
@@ -74,14 +78,19 @@ private:
   std::vector<Flex*> m_programRows;
   std::string m_lastProgramListKey;
   float m_lastProgramSliderMax = -1.0f;
+  std::string m_lastEffectsProfileListKey;
   float m_syncedPercentLabelMinWidth = -1.0f;
   float m_lastSyncedPercentLabelSliderMax = -1.0f;
   Label* m_outputDeviceLabel = nullptr;
   Label* m_inputDeviceLabel = nullptr;
+  Flex* m_outputEffectsProfileRow = nullptr;
+  Flex* m_inputEffectsProfileRow = nullptr;
   Flex* m_outputDeviceMenuAnchor = nullptr;
   Flex* m_inputDeviceMenuAnchor = nullptr;
   Button* m_outputDeviceMenuButton = nullptr;
   Button* m_inputDeviceMenuButton = nullptr;
+  Select* m_outputEffectsProfileSelect = nullptr;
+  Select* m_inputEffectsProfileSelect = nullptr;
   std::unique_ptr<ContextMenuPopup> m_deviceMenuPopup;
   bool m_deviceMenuIsOutput = true;
   Slider* m_outputSlider = nullptr;

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -14,6 +14,7 @@
 #include "shell/panel/panel_button_style.h"
 #include "shell/panel/panel_manager.h"
 #include "system/dependency_service.h"
+#include "system/easyeffects_service.h"
 #include "system/screen_time_service.h"
 #include "ui/builders.h"
 
@@ -40,15 +41,15 @@ namespace {
 } // namespace
 
 ControlCenterPanel::ControlCenterPanel(
-    NotificationManager* notifications, PipeWireService* audio, MprisService* mpris, ConfigService* config,
-    HttpClient* httpClient, WeatherService* weather, PipeWireSpectrum* spectrum, UPowerService* upower,
-    PowerProfilesService* powerProfiles, INetworkService* network, NetworkSecretAgent* networkSecrets,
-    BluetoothService* bluetooth, BluetoothAgent* bluetoothAgent, BrightnessService* brightness,
-    SystemMonitorService* sysmon, ScreenTimeService* screenTime, GammaService* nightLight,
-    noctalia::theme::ThemeService* theme, IdleInhibitor* idleInhibitor, DependencyService* dependencies,
-    CompositorPlatform* platform, IpcService* ipc, Wallpaper* wallpaper, CalendarService* calendar,
-    scripting::ScriptApiContext* scriptApi, ClipboardService* clipboard, AccountsService* accounts,
-    ThumbnailService* thumbnails
+    NotificationManager* notifications, PipeWireService* audio, EasyEffectsService* easyEffects, MprisService* mpris,
+    ConfigService* config, HttpClient* httpClient, WeatherService* weather, PipeWireSpectrum* spectrum,
+    UPowerService* upower, PowerProfilesService* powerProfiles, INetworkService* network,
+    NetworkSecretAgent* networkSecrets, BluetoothService* bluetooth, BluetoothAgent* bluetoothAgent,
+    BrightnessService* brightness, SystemMonitorService* sysmon, ScreenTimeService* screenTime,
+    GammaService* nightLight, noctalia::theme::ThemeService* theme, IdleInhibitor* idleInhibitor,
+    DependencyService* dependencies, CompositorPlatform* platform, IpcService* ipc, Wallpaper* wallpaper,
+    CalendarService* calendar, scripting::ScriptApiContext* scriptApi, ClipboardService* clipboard,
+    AccountsService* accounts, ThumbnailService* thumbnails
 ) {
   (void)upower;
   WaylandConnection* wayland = platform != nullptr ? &platform->wayland() : nullptr;
@@ -64,7 +65,7 @@ ControlCenterPanel::ControlCenterPanel(
       mpris, httpClient, spectrum, config, wayland, PanelManager::instance().renderContext()
   );
   m_tabs[tabIndex(TabId::Audio)] =
-      std::make_unique<AudioTab>(audio, mpris, config, wayland, PanelManager::instance().renderContext());
+      std::make_unique<AudioTab>(audio, easyEffects, mpris, config, wayland, PanelManager::instance().renderContext());
   m_tabs[tabIndex(TabId::Weather)] = std::make_unique<WeatherTab>(weather, config);
   m_tabs[tabIndex(TabId::Calendar)] = std::make_unique<CalendarTab>(config, calendar);
   m_tabs[tabIndex(TabId::Notifications)] = std::make_unique<NotificationsTab>(notifications);

--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -27,6 +27,7 @@ class Button;
 class CompositorPlatform;
 class ConfigService;
 class DependencyService;
+class EasyEffectsService;
 class Flex;
 class HttpClient;
 class IdleInhibitor;
@@ -62,18 +63,18 @@ class ThumbnailService;
 class ControlCenterPanel : public Panel {
 public:
   ControlCenterPanel(
-      NotificationManager* notifications, PipeWireService* audio, MprisService* mpris, ConfigService* config = nullptr,
-      HttpClient* httpClient = nullptr, WeatherService* weather = nullptr, PipeWireSpectrum* spectrum = nullptr,
-      UPowerService* upower = nullptr, PowerProfilesService* powerProfiles = nullptr,
-      INetworkService* network = nullptr, NetworkSecretAgent* networkSecrets = nullptr,
-      BluetoothService* bluetooth = nullptr, BluetoothAgent* bluetoothAgent = nullptr,
-      BrightnessService* brightness = nullptr, SystemMonitorService* sysmon = nullptr,
-      ScreenTimeService* screenTime = nullptr, GammaService* nightLight = nullptr,
-      noctalia::theme::ThemeService* theme = nullptr, IdleInhibitor* idleInhibitor = nullptr,
-      DependencyService* dependencies = nullptr, CompositorPlatform* platform = nullptr, IpcService* ipc = nullptr,
-      Wallpaper* wallpaper = nullptr, CalendarService* calendar = nullptr,
-      scripting::ScriptApiContext* scriptApi = nullptr, ClipboardService* clipboard = nullptr,
-      AccountsService* accounts = nullptr, ThumbnailService* thumbnails = nullptr
+      NotificationManager* notifications, PipeWireService* audio, EasyEffectsService* easyEffects, MprisService* mpris,
+      ConfigService* config = nullptr, HttpClient* httpClient = nullptr, WeatherService* weather = nullptr,
+      PipeWireSpectrum* spectrum = nullptr, UPowerService* upower = nullptr,
+      PowerProfilesService* powerProfiles = nullptr, INetworkService* network = nullptr,
+      NetworkSecretAgent* networkSecrets = nullptr, BluetoothService* bluetooth = nullptr,
+      BluetoothAgent* bluetoothAgent = nullptr, BrightnessService* brightness = nullptr,
+      SystemMonitorService* sysmon = nullptr, ScreenTimeService* screenTime = nullptr,
+      GammaService* nightLight = nullptr, noctalia::theme::ThemeService* theme = nullptr,
+      IdleInhibitor* idleInhibitor = nullptr, DependencyService* dependencies = nullptr,
+      CompositorPlatform* platform = nullptr, IpcService* ipc = nullptr, Wallpaper* wallpaper = nullptr,
+      CalendarService* calendar = nullptr, scripting::ScriptApiContext* scriptApi = nullptr,
+      ClipboardService* clipboard = nullptr, AccountsService* accounts = nullptr, ThumbnailService* thumbnails = nullptr
   );
 
   void create() override;

--- a/src/system/easyeffects_service.cpp
+++ b/src/system/easyeffects_service.cpp
@@ -1,0 +1,543 @@
+#include "system/easyeffects_service.h"
+
+#include "config/config_service.h"
+#include "core/log.h"
+#include "core/process.h"
+#include "ipc/ipc_arg_parse.h"
+#include "ipc/ipc_service.h"
+#include "util/string_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <optional>
+#include <poll.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <unordered_set>
+
+namespace {
+
+  bool isProtocolSafePresetName(std::string_view name) {
+    return !name.contains(':') && !name.contains('\r') && !name.contains('\n');
+  }
+
+  void pushUniqueProfile(std::vector<std::string>& profiles, std::unordered_set<std::string>& seen, std::string name) {
+    name = StringUtils::trim(name);
+    if (name.empty() || !isProtocolSafePresetName(name) || !seen.insert(name).second) {
+      return;
+    }
+    profiles.push_back(std::move(name));
+  }
+
+  std::string presetNameFromUsageEntry(std::string_view entry) {
+    const auto colon = entry.find(':');
+    if (colon != std::string_view::npos) {
+      entry = entry.substr(0, colon);
+    }
+    return StringUtils::trim(entry);
+  }
+
+  void appendCommaSeparatedPresetNames(
+      std::vector<std::string>& profiles, std::unordered_set<std::string>& seen, std::string_view value,
+      bool stripUsageCount
+  ) {
+    std::size_t start = 0;
+    while (start <= value.size()) {
+      const std::size_t end = value.find(',', start);
+      std::string_view item(value.data() + start, (end == std::string_view::npos ? value.size() : end) - start);
+      std::string name = stripUsageCount ? presetNameFromUsageEntry(item) : StringUtils::trim(item);
+      pushUniqueProfile(profiles, seen, std::move(name));
+      if (end == std::string_view::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+  }
+
+  struct EasyEffectsPresetConfig {
+    std::vector<std::string> outputProfiles;
+    std::vector<std::string> inputProfiles;
+    std::string lastLoadedOutputPreset;
+    std::string lastLoadedInputPreset;
+  };
+
+  EasyEffectsPresetConfig readEasyEffectsPresetConfig(const std::filesystem::path& file) {
+    EasyEffectsPresetConfig result;
+    std::unordered_set<std::string> seenOutputs;
+    std::unordered_set<std::string> seenInputs;
+    std::ifstream in(file);
+    if (!in) {
+      return result;
+    }
+
+    std::string section;
+    std::string line;
+    while (std::getline(in, line)) {
+      line = StringUtils::trim(line);
+      if (line.empty() || line.front() == '#' || line.front() == ';') {
+        continue;
+      }
+      if (line.size() >= 2 && line.front() == '[' && line.back() == ']') {
+        section = line.substr(1, line.size() - 2);
+        continue;
+      }
+
+      const auto eq = line.find('=');
+      if (eq == std::string::npos) {
+        continue;
+      }
+      const std::string key = StringUtils::trim(std::string_view(line.data(), eq));
+      const std::string value = StringUtils::trim(std::string_view(line.data() + eq + 1, line.size() - eq - 1));
+
+      if (key == "lastLoadedOutputPreset") {
+        result.lastLoadedOutputPreset = value;
+        pushUniqueProfile(result.outputProfiles, seenOutputs, value);
+      } else if (key == "lastLoadedInputPreset") {
+        result.lastLoadedInputPreset = value;
+        pushUniqueProfile(result.inputProfiles, seenInputs, value);
+      } else if (section == "StreamOutputs") {
+        if (key == "usedPresets") {
+          appendCommaSeparatedPresetNames(result.outputProfiles, seenOutputs, value, true);
+        } else if (key == "mostUsedPresets") {
+          appendCommaSeparatedPresetNames(result.outputProfiles, seenOutputs, value, false);
+        }
+      } else if (section == "StreamInputs") {
+        if (key == "usedPresets") {
+          appendCommaSeparatedPresetNames(result.inputProfiles, seenInputs, value, true);
+        } else if (key == "mostUsedPresets") {
+          appendCommaSeparatedPresetNames(result.inputProfiles, seenInputs, value, false);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  void appendPresetFilesFromDir(
+      std::vector<std::string>& profiles, std::unordered_set<std::string>& seen, const std::filesystem::path& dir
+  ) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(dir, ec) || ec) {
+      return;
+    }
+
+    for (const auto& entry :
+         std::filesystem::directory_iterator(dir, std::filesystem::directory_options::skip_permission_denied, ec)) {
+      if (ec) {
+        ec.clear();
+        continue;
+      }
+      if (!entry.is_regular_file(ec) || ec) {
+        ec.clear();
+        continue;
+      }
+      const auto& path = entry.path();
+      if (path.extension() != ".json") {
+        continue;
+      }
+      pushUniqueProfile(profiles, seen, path.stem().string());
+    }
+  }
+
+  std::filesystem::path homePath() {
+    const char* home = std::getenv("HOME");
+    return home != nullptr && home[0] != '\0' ? std::filesystem::path(home) : std::filesystem::path{};
+  }
+
+  void
+  appendColonSeparatedRoots(std::vector<std::filesystem::path>& roots, std::string_view dirs, std::string_view appDir) {
+    std::size_t start = 0;
+    while (start <= dirs.size()) {
+      const std::size_t end = dirs.find(':', start);
+      const std::string_view item(dirs.data() + start, (end == std::string::npos ? dirs.size() : end) - start);
+      if (!item.empty()) {
+        roots.emplace_back(std::filesystem::path(item) / appDir);
+      }
+      if (end == std::string::npos) {
+        break;
+      }
+      start = end + 1;
+    }
+  }
+
+  std::vector<std::filesystem::path> easyeffectsConfigRoots() {
+    std::vector<std::filesystem::path> roots;
+
+    const char* xdgConfigHome = std::getenv("XDG_CONFIG_HOME");
+    if (xdgConfigHome != nullptr && xdgConfigHome[0] != '\0') {
+      roots.emplace_back(std::filesystem::path(xdgConfigHome) / "easyeffects");
+    } else if (const auto home = homePath(); !home.empty()) {
+      roots.emplace_back(home / ".config/easyeffects");
+    }
+
+    const char* xdgConfigDirs = std::getenv("XDG_CONFIG_DIRS");
+    const std::string dirs =
+        (xdgConfigDirs != nullptr && xdgConfigDirs[0] != '\0') ? xdgConfigDirs : std::string{"/etc/xdg"};
+    appendColonSeparatedRoots(roots, dirs, "easyeffects");
+
+    if (const auto home = homePath(); !home.empty()) {
+      roots.emplace_back(home / ".var/app/com.github.wwmm.easyeffects/config/easyeffects");
+    }
+
+    return roots;
+  }
+
+  std::vector<std::filesystem::path> easyeffectsDataRoots() {
+    std::vector<std::filesystem::path> roots;
+
+    const char* xdgDataHome = std::getenv("XDG_DATA_HOME");
+    if (xdgDataHome != nullptr && xdgDataHome[0] != '\0') {
+      roots.emplace_back(std::filesystem::path(xdgDataHome) / "easyeffects");
+    } else if (const auto home = homePath(); !home.empty()) {
+      roots.emplace_back(home / ".local/share/easyeffects");
+    }
+
+    const char* xdgDataDirs = std::getenv("XDG_DATA_DIRS");
+    const std::string dirs =
+        (xdgDataDirs != nullptr && xdgDataDirs[0] != '\0') ? xdgDataDirs : std::string{"/usr/local/share:/usr/share"};
+    appendColonSeparatedRoots(roots, dirs, "easyeffects");
+
+    if (const auto home = homePath(); !home.empty()) {
+      roots.emplace_back(home / ".var/app/com.github.wwmm.easyeffects/data/easyeffects");
+    }
+
+    return roots;
+  }
+
+  std::optional<AudioEffectsProfileKind> parseEffectsProfileKind(std::string_view value) {
+    const std::string trimmed = StringUtils::trim(value);
+    if (trimmed == "output" || trimmed == "out" || trimmed == "sink") {
+      return AudioEffectsProfileKind::Output;
+    }
+    if (trimmed == "input" || trimmed == "in" || trimmed == "source" || trimmed == "mic") {
+      return AudioEffectsProfileKind::Input;
+    }
+    return std::nullopt;
+  }
+
+  std::string effectsProfileKindName(AudioEffectsProfileKind kind) {
+    return kind == AudioEffectsProfileKind::Input ? "input" : "output";
+  }
+
+  std::string availableEffectsProfilesSuffix(const std::vector<std::string>& profiles) {
+    if (profiles.empty()) {
+      return "\n";
+    }
+    std::string suffix = "; available:";
+    for (const auto& profile : profiles) {
+      suffix += std::format(" {}", profile);
+    }
+    suffix.push_back('\n');
+    return suffix;
+  }
+
+  std::filesystem::path easyEffectsServerPath() {
+    if (const char* runtimeDir = std::getenv("XDG_RUNTIME_DIR"); runtimeDir != nullptr && runtimeDir[0] != '\0') {
+      return std::filesystem::path(runtimeDir) / "EasyEffectsServer";
+    }
+    return std::filesystem::path("/run/user") / std::to_string(::getuid()) / "EasyEffectsServer";
+  }
+
+  bool easyeffectsRunning() {
+    std::error_code ec;
+    return std::filesystem::exists(easyEffectsServerPath(), ec) && !ec;
+  }
+
+  std::vector<std::string> discoverEffectsProfiles(AudioEffectsProfileKind kind) {
+    std::vector<std::string> profiles;
+    std::unordered_set<std::string> seen;
+
+    if (!easyeffectsRunning()) {
+      return profiles;
+    }
+
+    const auto profileDir = kind == AudioEffectsProfileKind::Input ? "input" : "output";
+    for (const auto& root : easyeffectsDataRoots()) {
+      appendPresetFilesFromDir(profiles, seen, root / profileDir);
+    }
+
+    const bool foundDataProfiles = !profiles.empty();
+    for (const auto& root : easyeffectsConfigRoots()) {
+      if (!foundDataProfiles) {
+        appendPresetFilesFromDir(profiles, seen, root / profileDir);
+        const auto config = readEasyEffectsPresetConfig(root / "db/easyeffectsrc");
+        const auto& discovered = kind == AudioEffectsProfileKind::Input ? config.inputProfiles : config.outputProfiles;
+        for (const auto& profile : discovered) {
+          pushUniqueProfile(profiles, seen, profile);
+        }
+      }
+    }
+
+    std::ranges::sort(profiles, [](const std::string& a, const std::string& b) {
+      return StringUtils::toLower(a) < StringUtils::toLower(b);
+    });
+    return profiles;
+  }
+
+  std::string discoverActiveEffectsProfile(AudioEffectsProfileKind kind) {
+    if (!easyeffectsRunning()) {
+      return {};
+    }
+    for (const auto& root : easyeffectsConfigRoots()) {
+      const auto config = readEasyEffectsPresetConfig(root / "db/easyeffectsrc");
+      if (kind == AudioEffectsProfileKind::Output && !config.lastLoadedOutputPreset.empty()) {
+        return config.lastLoadedOutputPreset;
+      }
+      if (kind == AudioEffectsProfileKind::Input && !config.lastLoadedInputPreset.empty()) {
+        return config.lastLoadedInputPreset;
+      }
+    }
+    return {};
+  }
+
+  std::optional<std::string> exchangeEasyEffectsServerCommand(std::string_view command, bool readResponse) {
+    const std::filesystem::path path = easyEffectsServerPath();
+    const std::string nativePath = path.string();
+    if (nativePath.empty() || nativePath.size() >= sizeof(sockaddr_un::sun_path)) {
+      return std::nullopt;
+    }
+
+    const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+      return std::nullopt;
+    }
+
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, nativePath.c_str(), sizeof(addr.sun_path) - 1);
+
+    bool ok = false;
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+      std::string payload(command);
+      payload.push_back('\n');
+      const char* data = payload.data();
+      std::size_t remaining = payload.size();
+      ok = true;
+      while (remaining > 0) {
+        const ssize_t n = ::send(fd, data, remaining, MSG_NOSIGNAL);
+        if (n > 0) {
+          const auto written = static_cast<std::size_t>(n);
+          data += written;
+          remaining -= written;
+          continue;
+        }
+        if (n < 0 && errno == EINTR) {
+          continue;
+        }
+        ok = false;
+        break;
+      }
+    }
+
+    std::string response;
+    bool receivedResponse = false;
+    if (ok && readResponse) {
+      (void)::shutdown(fd, SHUT_WR);
+      std::array<char, 512> buffer{};
+      while (true) {
+        pollfd pfd{.fd = fd, .events = POLLIN | POLLHUP, .revents = 0};
+        const int pollRc = ::poll(&pfd, 1, 250);
+        if (pollRc < 0 && errno == EINTR) {
+          continue;
+        }
+        if (pollRc <= 0) {
+          break;
+        }
+
+        const ssize_t n = ::recv(fd, buffer.data(), buffer.size(), 0);
+        if (n > 0) {
+          receivedResponse = true;
+          response.append(buffer.data(), static_cast<std::size_t>(n));
+          continue;
+        }
+        if (n < 0 && errno == EINTR) {
+          continue;
+        }
+        break;
+      }
+    }
+
+    ::close(fd);
+    if (!ok) {
+      return std::nullopt;
+    }
+    if (readResponse && !receivedResponse) {
+      return std::nullopt;
+    }
+    return response;
+  }
+
+  bool sendEasyEffectsServerCommand(std::string_view command) {
+    return exchangeEasyEffectsServerCommand(command, false).has_value();
+  }
+
+  std::string easyEffectsLoadPresetCommand(AudioEffectsProfileKind kind, std::string_view profile) {
+    return std::format("load_preset:{}:{}", effectsProfileKindName(kind), profile);
+  }
+
+  std::string easyEffectsGetLastLoadedPresetCommand(AudioEffectsProfileKind kind) {
+    return std::format("get_last_loaded_preset:{}", effectsProfileKindName(kind));
+  }
+
+  std::optional<std::string> queryEasyEffectsActivePreset(AudioEffectsProfileKind kind) {
+    const auto response = exchangeEasyEffectsServerCommand(easyEffectsGetLastLoadedPresetCommand(kind), true);
+    if (!response.has_value()) {
+      return std::nullopt;
+    }
+    return StringUtils::trim(*response);
+  }
+
+} // namespace
+
+const std::vector<std::string>& EasyEffectsService::effectsProfiles(AudioEffectsProfileKind kind) const {
+  return kind == AudioEffectsProfileKind::Input ? m_inputEffectsProfiles : m_outputEffectsProfiles;
+}
+
+std::string EasyEffectsService::activeEffectsProfile(AudioEffectsProfileKind kind) const {
+  const std::optional<std::string>& active =
+      kind == AudioEffectsProfileKind::Input ? m_activeInputEffectsProfile : m_activeOutputEffectsProfile;
+  return active.value_or(std::string{});
+}
+
+void EasyEffectsService::emitChanged() {
+  if (m_changeCallback) {
+    m_changeCallback();
+  }
+}
+
+void EasyEffectsService::refreshProfiles() {
+  const auto nextOutput = discoverEffectsProfiles(AudioEffectsProfileKind::Output);
+  const auto nextInput = discoverEffectsProfiles(AudioEffectsProfileKind::Input);
+  if (nextOutput == m_outputEffectsProfiles && nextInput == m_inputEffectsProfiles) {
+    return;
+  }
+  m_outputEffectsProfiles = nextOutput;
+  m_inputEffectsProfiles = nextInput;
+  emitChanged();
+}
+
+void EasyEffectsService::refreshActiveEffectsProfiles() {
+  bool changed = false;
+  auto refreshKind = [this, &changed](AudioEffectsProfileKind kind) {
+    auto active = queryEasyEffectsActivePreset(kind);
+    if (!active.has_value()) {
+      const std::string discovered = discoverActiveEffectsProfile(kind);
+      if (discovered.empty()) {
+        return;
+      }
+      active = discovered;
+    }
+
+    std::optional<std::string>& cached =
+        kind == AudioEffectsProfileKind::Input ? m_activeInputEffectsProfile : m_activeOutputEffectsProfile;
+    if (!cached.has_value() || *cached != *active) {
+      cached = *active;
+      changed = true;
+    }
+  };
+
+  refreshKind(AudioEffectsProfileKind::Output);
+  refreshKind(AudioEffectsProfileKind::Input);
+  if (changed) {
+    emitChanged();
+  }
+}
+
+bool EasyEffectsService::loadEffectsProfile(AudioEffectsProfileKind kind, std::string_view profile) {
+  static const Logger kLog("easyeffects");
+  const std::string trimmed = StringUtils::trim(profile);
+  if (trimmed.empty()) {
+    return false;
+  }
+  if (!isProtocolSafePresetName(trimmed)) {
+    kLog.warn(
+        "refusing to load EasyEffects {} profile with protocol-unsafe name \"{}\"", effectsProfileKindName(kind),
+        trimmed
+    );
+    return false;
+  }
+
+  if (!sendEasyEffectsServerCommand(easyEffectsLoadPresetCommand(kind, trimmed))) {
+    kLog.warn(
+        "failed to load EasyEffects {} profile \"{}\" - local server unavailable", effectsProfileKindName(kind), trimmed
+    );
+    return false;
+  }
+
+  const auto activePreset = queryEasyEffectsActivePreset(kind);
+  if (!activePreset.has_value()) {
+    kLog.warn(
+        "failed to confirm EasyEffects {} profile \"{}\" after load command", effectsProfileKindName(kind), trimmed
+    );
+    return false;
+  }
+  if (*activePreset != trimmed) {
+    kLog.warn(
+        "EasyEffects {} profile load mismatch requested=\"{}\" active=\"{}\"", effectsProfileKindName(kind), trimmed,
+        *activePreset
+    );
+    return false;
+  }
+
+  std::optional<std::string>& cached =
+      kind == AudioEffectsProfileKind::Input ? m_activeInputEffectsProfile : m_activeOutputEffectsProfile;
+  const bool changed = !cached.has_value() || *cached != *activePreset;
+  cached = *activePreset;
+  if (changed) {
+    emitChanged();
+  }
+  return true;
+}
+
+void EasyEffectsService::registerIpc(
+    IpcService& ipc, const ConfigService&, EffectsProfileFeedbackCallback effectsProfileFeedback
+) {
+  ipc.registerHandler(
+      "effects-profile-set",
+      [this, effectsProfileFeedback](const std::string& args) -> std::string {
+        const auto trimmedView = std::string_view(args);
+        const auto split = trimmedView.find(' ');
+        if (split == std::string_view::npos) {
+          return "error: effects-profile-set requires <output|input> <profile>\n";
+        }
+        const std::string kindArg = StringUtils::trim(trimmedView.substr(0, split));
+        const auto kind = parseEffectsProfileKind(kindArg);
+        if (!kind.has_value()) {
+          return "error: effects-profile-set requires <output|input> <profile>\n";
+        }
+        const std::string profile = StringUtils::trim(trimmedView.substr(split));
+        if (profile.empty()) {
+          return "error: profile required\n";
+        }
+
+        refreshProfiles();
+        const auto profiles = effectsProfiles(*kind);
+        if (profiles.empty()) {
+          return std::format("error: no EasyEffects {} profiles found\n", effectsProfileKindName(*kind));
+        }
+        if (std::ranges::find(profiles, profile) == profiles.end()) {
+          return std::format(
+              "error: unknown EasyEffects {} profile \"{}\"{}", effectsProfileKindName(*kind), profile,
+              availableEffectsProfilesSuffix(profiles)
+          );
+        }
+        if (!loadEffectsProfile(*kind, profile)) {
+          return std::format(
+              "error: failed to set EasyEffects {} profile (is EasyEffects running?)\n", effectsProfileKindName(*kind)
+          );
+        }
+        if (effectsProfileFeedback) {
+          effectsProfileFeedback(*kind, profile);
+        }
+        return "ok\n";
+      },
+      "effects-profile-set <output|input> <profile>", "Set the EasyEffects output or input profile"
+  );
+}

--- a/src/system/easyeffects_service.h
+++ b/src/system/easyeffects_service.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class ConfigService;
+class IpcService;
+
+enum class AudioEffectsProfileKind : std::uint8_t {
+  Output,
+  Input,
+};
+
+class EasyEffectsService {
+public:
+  using ChangeCallback = std::function<void()>;
+  using EffectsProfileFeedbackCallback = std::function<void(AudioEffectsProfileKind kind, std::string_view profile)>;
+
+  void setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
+  [[nodiscard]] const std::vector<std::string>& effectsProfiles(AudioEffectsProfileKind kind) const;
+  [[nodiscard]] std::string activeEffectsProfile(AudioEffectsProfileKind kind) const;
+  void refreshProfiles();
+  void refreshActiveEffectsProfiles();
+  bool loadEffectsProfile(AudioEffectsProfileKind kind, std::string_view profile);
+  void
+  registerIpc(IpcService& ipc, const ConfigService& config, EffectsProfileFeedbackCallback effectsProfileFeedback = {});
+
+private:
+  void emitChanged();
+
+  std::vector<std::string> m_outputEffectsProfiles;
+  std::vector<std::string> m_inputEffectsProfiles;
+  std::optional<std::string> m_activeOutputEffectsProfile;
+  std::optional<std::string> m_activeInputEffectsProfile;
+  ChangeCallback m_changeCallback;
+};


### PR DESCRIPTION
This commit adds support for switching between easyeffects profiles (output and input audio) if available.

## Type of Change
- [x] New feature

## Testing
- [x] Tested on Hyprland

## Screenshots
<img width="669" height="513" alt="image" src="https://github.com/user-attachments/assets/16f84467-9b58-4e38-822b-d5456957d17a" />
<img width="463" height="171" alt="image" src="https://github.com/user-attachments/assets/d2092a68-b144-44c9-bdd0-29d693867c0b" />

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors