### PR TITLE
fix(script): Appy change of glyph without having to restart on shared scope

### DIFF
--- a/src/scripting/script_runtime.cpp
+++ b/src/scripting/script_runtime.cpp
@@ -11,8 +11,12 @@
 
 #include <algorithm>
 #include <deque>
+#include <iomanip>
 #include <mutex>
+#include <sstream>
+#include <type_traits>
 #include <unordered_map>
+#include <vector>
 
 namespace scripting {
   namespace {
@@ -87,6 +91,82 @@ namespace scripting {
           break;
         }
       }
+    }
+
+    std::string escapeRuntimeKeyToken(std::string_view token) {
+      std::string out;
+      out.reserve(token.size());
+      for (char ch : token) {
+        if (ch == '\\' || ch == '|' || ch == '=' || ch == ',' || ch == ':') {
+          out.push_back('\\');
+        }
+        out.push_back(ch);
+      }
+      return out;
+    }
+
+    std::string encodeRuntimeSettingValue(const WidgetSettingValue& value) {
+      return std::visit(
+          [](const auto& concrete) -> std::string {
+            using T = std::decay_t<decltype(concrete)>;
+            if constexpr (std::is_same_v<T, bool>) {
+              return std::string("b:") + (concrete ? "1" : "0");
+            } else if constexpr (std::is_same_v<T, std::int64_t>) {
+              return std::string("i:") + std::to_string(concrete);
+            } else if constexpr (std::is_same_v<T, double>) {
+              std::ostringstream out;
+              out << "d:" << std::setprecision(17) << concrete;
+              return out.str();
+            } else if constexpr (std::is_same_v<T, std::string>) {
+              return std::string("s:") + escapeRuntimeKeyToken(concrete);
+            } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+              std::ostringstream out;
+              out << "v:" << concrete.size() << ':';
+              for (std::size_t i = 0; i < concrete.size(); ++i) {
+                if (i != 0) {
+                  out << ',';
+                }
+                out << escapeRuntimeKeyToken(concrete[i]);
+              }
+              return out.str();
+            } else {
+              return std::string{};
+            }
+          },
+          value
+      );
+    }
+
+    std::string buildSharedScriptRuntimeKey(
+        std::string_view baseKey, std::string_view scriptPath, const ScriptWidgetSettings& settings
+    ) {
+      std::vector<std::string> settingKeys;
+      settingKeys.reserve(settings.size());
+      for (const auto& [key, value] : settings) {
+        (void)value;
+        settingKeys.push_back(key);
+      }
+      std::sort(settingKeys.begin(), settingKeys.end());
+
+      std::ostringstream out;
+      out
+          << "base="
+          << escapeRuntimeKeyToken(baseKey)
+          << "|script="
+          << escapeRuntimeKeyToken(scriptPath)
+          << "|settings=";
+      for (std::size_t i = 0; i < settingKeys.size(); ++i) {
+        if (i != 0) {
+          out << '|';
+        }
+        const auto& key = settingKeys[i];
+        const auto it = settings.find(key);
+        if (it == settings.end()) {
+          continue;
+        }
+        out << escapeRuntimeKeyToken(key) << '=' << encodeRuntimeSettingValue(it->second);
+      }
+      return out.str();
     }
   } // namespace
 
@@ -631,16 +711,20 @@ namespace scripting {
   }
 
   SharedScriptRuntimeAcquireResult SharedScriptRuntimeRegistry::acquire(
-      const std::string& key, ScriptWidgetSettings settings, ScriptApiContext& api, ClipboardService* clipboard
+      std::string_view baseKey, std::string_view scriptPath, ScriptWidgetSettings settings, ScriptApiContext& api,
+      ClipboardService* clipboard
   ) {
     static std::mutex mutex;
     static std::unordered_map<std::string, std::weak_ptr<ScriptRuntime>> runtimes;
+
+    const std::string key = buildSharedScriptRuntimeKey(baseKey, scriptPath, settings);
 
     std::lock_guard lock(mutex);
     if (auto it = runtimes.find(key); it != runtimes.end()) {
       if (auto runtime = it->second.lock()) {
         return {.runtime = std::move(runtime), .created = false};
       }
+      runtimes.erase(it);
     }
 
     auto runtime = std::make_shared<ScriptRuntime>(key, std::move(settings), api, clipboard);

--- a/src/scripting/script_runtime.h
+++ b/src/scripting/script_runtime.h
@@ -57,7 +57,7 @@ namespace scripting {
   class SharedScriptRuntimeRegistry {
   public:
     static SharedScriptRuntimeAcquireResult acquire(
-        const std::string& key, ScriptWidgetSettings settings, ScriptApiContext& api,
+        std::string_view baseKey, std::string_view scriptPath, ScriptWidgetSettings settings, ScriptApiContext& api,
         ClipboardService* clipboard = nullptr
     );
   };

--- a/src/shell/bar/widgets/scripted_widget.cpp
+++ b/src/shell/bar/widgets/scripted_widget.cpp
@@ -179,8 +179,7 @@ namespace {
     std::sort(settingKeys.begin(), settingKeys.end());
 
     std::ostringstream out;
-    out << "base=" << escapeRuntimeKeyToken(baseKey) << "|script=" << escapeRuntimeKeyToken(scriptPath)
-        << "|settings=";
+    out << "base=" << escapeRuntimeKeyToken(baseKey) << "|script=" << escapeRuntimeKeyToken(scriptPath) << "|settings=";
     for (std::size_t i = 0; i < settingKeys.size(); ++i) {
       if (i != 0) {
         out << '|';
@@ -311,9 +310,9 @@ void ScriptedWidget::create() {
   bool createdRuntime = true;
   if (m_sharedScope) {
     const std::string sharedRuntimeKey =
-      buildSharedScriptRuntimeKey(m_widgetConfigName, m_resolvedPath.string(), m_settings);
+        buildSharedScriptRuntimeKey(m_widgetConfigName, m_resolvedPath.string(), m_settings);
     auto acquired =
-      scripting::SharedScriptRuntimeRegistry::acquire(sharedRuntimeKey, m_settings, m_scriptApi, m_clipboard);
+        scripting::SharedScriptRuntimeRegistry::acquire(sharedRuntimeKey, m_settings, m_scriptApi, m_clipboard);
     m_runtime = std::move(acquired.runtime);
     createdRuntime = acquired.created;
   } else {

--- a/src/shell/bar/widgets/scripted_widget.cpp
+++ b/src/shell/bar/widgets/scripted_widget.cpp
@@ -27,9 +27,7 @@
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <sstream>
-#include <type_traits>
 #include <unordered_set>
-#include <variant>
 #include <vector>
 
 namespace {
@@ -121,77 +119,6 @@ namespace {
     std::stringstream ss;
     ss << f.rdbuf();
     return ss.str();
-  }
-
-  std::string escapeRuntimeKeyToken(std::string_view token) {
-    std::string out;
-    out.reserve(token.size());
-    for (char ch : token) {
-      if (ch == '\\' || ch == '|' || ch == '=' || ch == ',' || ch == ':') {
-        out.push_back('\\');
-      }
-      out.push_back(ch);
-    }
-    return out;
-  }
-
-  std::string encodeRuntimeSettingValue(const WidgetSettingValue& value) {
-    return std::visit(
-        [](const auto& concrete) -> std::string {
-          using T = std::decay_t<decltype(concrete)>;
-          if constexpr (std::is_same_v<T, bool>) {
-            return std::string("b:") + (concrete ? "1" : "0");
-          } else if constexpr (std::is_same_v<T, std::int64_t>) {
-            return std::string("i:") + std::to_string(concrete);
-          } else if constexpr (std::is_same_v<T, double>) {
-            std::ostringstream out;
-            out << "d:" << std::setprecision(17) << concrete;
-            return out.str();
-          } else if constexpr (std::is_same_v<T, std::string>) {
-            return std::string("s:") + escapeRuntimeKeyToken(concrete);
-          } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
-            std::ostringstream out;
-            out << "v:" << concrete.size() << ':';
-            for (std::size_t i = 0; i < concrete.size(); ++i) {
-              if (i != 0) {
-                out << ',';
-              }
-              out << escapeRuntimeKeyToken(concrete[i]);
-            }
-            return out.str();
-          } else {
-            return std::string{};
-          }
-        },
-        value
-    );
-  }
-
-  std::string buildSharedScriptRuntimeKey(
-      std::string_view baseKey, std::string_view scriptPath, const scripting::ScriptWidgetSettings& settings
-  ) {
-    std::vector<std::string> settingKeys;
-    settingKeys.reserve(settings.size());
-    for (const auto& [key, value] : settings) {
-      (void)value;
-      settingKeys.push_back(key);
-    }
-    std::sort(settingKeys.begin(), settingKeys.end());
-
-    std::ostringstream out;
-    out << "base=" << escapeRuntimeKeyToken(baseKey) << "|script=" << escapeRuntimeKeyToken(scriptPath) << "|settings=";
-    for (std::size_t i = 0; i < settingKeys.size(); ++i) {
-      if (i != 0) {
-        out << '|';
-      }
-      const auto& key = settingKeys[i];
-      const auto it = settings.find(key);
-      if (it == settings.end()) {
-        continue;
-      }
-      out << escapeRuntimeKeyToken(key) << '=' << encodeRuntimeSettingValue(it->second);
-    }
-    return out.str();
   }
 
 } // namespace
@@ -309,10 +236,9 @@ void ScriptedWidget::create() {
 
   bool createdRuntime = true;
   if (m_sharedScope) {
-    const std::string sharedRuntimeKey =
-        buildSharedScriptRuntimeKey(m_widgetConfigName, m_resolvedPath.string(), m_settings);
-    auto acquired =
-        scripting::SharedScriptRuntimeRegistry::acquire(sharedRuntimeKey, m_settings, m_scriptApi, m_clipboard);
+    auto acquired = scripting::SharedScriptRuntimeRegistry::acquire(
+        m_widgetConfigName, m_resolvedPath.string(), m_settings, m_scriptApi, m_clipboard
+    );
     m_runtime = std::move(acquired.runtime);
     createdRuntime = acquired.created;
   } else {

--- a/src/shell/bar/widgets/scripted_widget.cpp
+++ b/src/shell/bar/widgets/scripted_widget.cpp
@@ -27,7 +27,9 @@
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <sstream>
+#include <type_traits>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace {
@@ -119,6 +121,78 @@ namespace {
     std::stringstream ss;
     ss << f.rdbuf();
     return ss.str();
+  }
+
+  std::string escapeRuntimeKeyToken(std::string_view token) {
+    std::string out;
+    out.reserve(token.size());
+    for (char ch : token) {
+      if (ch == '\\' || ch == '|' || ch == '=' || ch == ',' || ch == ':') {
+        out.push_back('\\');
+      }
+      out.push_back(ch);
+    }
+    return out;
+  }
+
+  std::string encodeRuntimeSettingValue(const WidgetSettingValue& value) {
+    return std::visit(
+        [](const auto& concrete) -> std::string {
+          using T = std::decay_t<decltype(concrete)>;
+          if constexpr (std::is_same_v<T, bool>) {
+            return std::string("b:") + (concrete ? "1" : "0");
+          } else if constexpr (std::is_same_v<T, std::int64_t>) {
+            return std::string("i:") + std::to_string(concrete);
+          } else if constexpr (std::is_same_v<T, double>) {
+            std::ostringstream out;
+            out << "d:" << std::setprecision(17) << concrete;
+            return out.str();
+          } else if constexpr (std::is_same_v<T, std::string>) {
+            return std::string("s:") + escapeRuntimeKeyToken(concrete);
+          } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+            std::ostringstream out;
+            out << "v:" << concrete.size() << ':';
+            for (std::size_t i = 0; i < concrete.size(); ++i) {
+              if (i != 0) {
+                out << ',';
+              }
+              out << escapeRuntimeKeyToken(concrete[i]);
+            }
+            return out.str();
+          } else {
+            return std::string{};
+          }
+        },
+        value
+    );
+  }
+
+  std::string buildSharedScriptRuntimeKey(
+      std::string_view baseKey, std::string_view scriptPath, const scripting::ScriptWidgetSettings& settings
+  ) {
+    std::vector<std::string> settingKeys;
+    settingKeys.reserve(settings.size());
+    for (const auto& [key, value] : settings) {
+      (void)value;
+      settingKeys.push_back(key);
+    }
+    std::sort(settingKeys.begin(), settingKeys.end());
+
+    std::ostringstream out;
+    out << "base=" << escapeRuntimeKeyToken(baseKey) << "|script=" << escapeRuntimeKeyToken(scriptPath)
+        << "|settings=";
+    for (std::size_t i = 0; i < settingKeys.size(); ++i) {
+      if (i != 0) {
+        out << '|';
+      }
+      const auto& key = settingKeys[i];
+      const auto it = settings.find(key);
+      if (it == settings.end()) {
+        continue;
+      }
+      out << escapeRuntimeKeyToken(key) << '=' << encodeRuntimeSettingValue(it->second);
+    }
+    return out.str();
   }
 
 } // namespace
@@ -236,8 +310,10 @@ void ScriptedWidget::create() {
 
   bool createdRuntime = true;
   if (m_sharedScope) {
+    const std::string sharedRuntimeKey =
+      buildSharedScriptRuntimeKey(m_widgetConfigName, m_resolvedPath.string(), m_settings);
     auto acquired =
-        scripting::SharedScriptRuntimeRegistry::acquire(m_widgetConfigName, m_settings, m_scriptApi, m_clipboard);
+      scripting::SharedScriptRuntimeRegistry::acquire(sharedRuntimeKey, m_settings, m_scriptApi, m_clipboard);
     m_runtime = std::move(acquired.runtime);
     createdRuntime = acquired.created;
   } else {


### PR DESCRIPTION
# Pull Request

## Motivation
Script Widget shared scope changing glyph gets applied without having to restart

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- Closes #(issue number) (if any)

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [X] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)

## Additional Notes
Add any additional context or follow-up notes for reviewers.
