### PR TITLE
Remove redundant syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: >-
   -clang-diagnostic-*,
+  performance-move-const-arg,
   readability-container-contains,
   readability-container-data-pointer,
   readability-container-size-empty,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,4 +3,5 @@ Checks: >-
   readability-container-contains,
   readability-container-data-pointer,
   readability-container-size-empty,
+  readability-static-definition-in-anonymous-namespace,
   readability-use-std-min-max,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,5 +3,6 @@ Checks: >-
   readability-container-contains,
   readability-container-data-pointer,
   readability-container-size-empty,
+  readability-redundant-casting,
   readability-static-definition-in-anonymous-namespace,
   readability-use-std-min-max,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,5 +4,6 @@ Checks: >-
   readability-container-data-pointer,
   readability-container-size-empty,
   readability-redundant-casting,
+  readability-redundant-member-init,
   readability-static-definition-in-anonymous-namespace,
   readability-use-std-min-max,

--- a/src/capture/screenshot_service.cpp
+++ b/src/capture/screenshot_service.cpp
@@ -909,7 +909,7 @@ void ScreenshotService::deliverFrozenGlobalRegion(LogicalRect globalRegion, cons
 
   const std::optional<std::filesystem::path> destPath =
       options.saveToFile ? std::optional(makeScreenshotPath(options, "region")) : std::nullopt;
-  deliverCaptureResult(std::move(*composed), options, std::move(destPath));
+  deliverCaptureResult(std::move(*composed), options, destPath);
 }
 
 void ScreenshotService::captureGlobalRegion(LogicalRect globalRegion, const OutputOptions& options) {
@@ -1068,7 +1068,7 @@ void ScreenshotService::deliverFrozenRegion(LogicalRect region, wl_output* outpu
 
   const std::optional<std::filesystem::path> destPath =
       options.saveToFile ? std::optional(makeScreenshotPath(options, "region")) : std::nullopt;
-  deliverCaptureResult(std::move(*cropped), options, std::move(destPath));
+  deliverCaptureResult(std::move(*cropped), options, destPath);
 }
 
 void ScreenshotService::completeFullscreenSelection(wl_output* output, const OutputOptions& options) {
@@ -1122,7 +1122,7 @@ void ScreenshotService::captureOutput(
       pending.output, pending.region, false,
       [this, options = pending.outputOptions, destPath = pending.destPath,
        output = pending.output](std::optional<ScreencopyImage> image, const std::string& error) {
-        onCaptureComplete(std::move(image), error, std::move(options), std::move(destPath), output);
+        onCaptureComplete(std::move(image), error, options, destPath, output);
       }
   );
 }
@@ -1141,7 +1141,7 @@ void ScreenshotService::startNextQueuedCapture() {
         pending.output, pending.region, false,
         [this, options = pending.outputOptions, destPath = pending.destPath,
          output = pending.output](std::optional<ScreencopyImage> image, const std::string& error) {
-          onCaptureComplete(std::move(image), error, std::move(options), std::move(destPath), output);
+          onCaptureComplete(std::move(image), error, options, destPath, output);
         }
     );
   });

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -926,7 +926,7 @@ std::vector<std::string> CompositorPlatform::keyboardLayoutNames() const {
         return state->names;
       }
       auto waylandNames = m_wayland.keyboardLayoutNames();
-      return waylandNames.size() > state->names.size() ? std::move(waylandNames) : state->names;
+      return waylandNames.size() > state->names.size() ? waylandNames : state->names;
     }
   }
   return m_wayland.keyboardLayoutNames();

--- a/src/compositors/hyprland/hyprland_toplevel_mapping.cpp
+++ b/src/compositors/hyprland/hyprland_toplevel_mapping.cpp
@@ -201,7 +201,7 @@ namespace compositors::hyprland {
         .wlrToplevel = handle,
     };
     hyprland_toplevel_window_mapping_handle_v1_add_listener(requestHandle, &kMappingListener, this);
-    m_pending.emplace(requestHandle, std::move(request));
+    m_pending.emplace(requestHandle, request);
   }
 
   void HyprlandToplevelMapping::requestExtMapping(ext_foreign_toplevel_handle_v1* handle) {
@@ -227,7 +227,7 @@ namespace compositors::hyprland {
         .extToplevel = handle,
     };
     hyprland_toplevel_window_mapping_handle_v1_add_listener(requestHandle, &kMappingListener, this);
-    m_pending.emplace(requestHandle, std::move(request));
+    m_pending.emplace(requestHandle, request);
   }
 
   void HyprlandToplevelMapping::clearRequest(MappingRequest& request) {
@@ -290,7 +290,7 @@ namespace compositors::hyprland {
     }
 
     const std::uint64_t address = (static_cast<std::uint64_t>(addressHi) << 32) | static_cast<std::uint64_t>(addressLo);
-    MappingRequest request = std::move(it->second);
+    MappingRequest request = it->second;
     self->m_pending.erase(it);
     const auto kind = request.kind;
     auto* wlrToplevel = request.wlrToplevel;

--- a/src/compositors/sway/sway_keyboard_backend.cpp
+++ b/src/compositors/sway/sway_keyboard_backend.cpp
@@ -15,7 +15,7 @@ namespace {
 
   struct CurrentLayoutCache {
     std::optional<std::string> value;
-    std::chrono::steady_clock::time_point fetchedAt{};
+    std::chrono::steady_clock::time_point fetchedAt;
     bool valid = false;
   };
 

--- a/src/core/files/directory_scanner.cpp
+++ b/src/core/files/directory_scanner.cpp
@@ -56,7 +56,7 @@ std::vector<FileEntry> DirectoryScanner::scan(
     }
 
     FileEntry entry;
-    entry.name = std::move(name);
+    entry.name = name;
     entry.absPath = std::filesystem::absolute(item.path(), ec);
     if (ec) {
       entry.absPath = item.path();

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -912,7 +912,7 @@ namespace process {
       return;
     }
     if (systemdAvailable()) {
-      (void)startSystemdService(args, activationToken, workingDir, appName);
+      startSystemdService(args, activationToken, workingDir, appName);
       return;
     }
 #endif

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -184,7 +184,7 @@ namespace {
   }
 
   struct ProcessCommandLineCache {
-    std::chrono::steady_clock::time_point capturedAt{};
+    std::chrono::steady_clock::time_point capturedAt;
     std::vector<std::string> commandLines;
   };
 

--- a/src/core/timer_manager.cpp
+++ b/src/core/timer_manager.cpp
@@ -21,7 +21,7 @@ namespace {
 
   struct TimerEntry {
     TimerManager::TimerId id = 0;
-    std::chrono::steady_clock::time_point dueAt{};
+    std::chrono::steady_clock::time_point dueAt;
     std::chrono::milliseconds interval{0};
     std::function<void()> callback;
     bool repeating = false;

--- a/src/dbus/logind/logind_service.cpp
+++ b/src/dbus/logind/logind_service.cpp
@@ -7,9 +7,9 @@
 #include <utility>
 
 namespace {
-  static const sdbus::ServiceName kLogindBusName{"org.freedesktop.login1"};
-  static const sdbus::ObjectPath kLogindObjectPath{"/org/freedesktop/login1"};
-  static constexpr auto kLogindManagerInterface = "org.freedesktop.login1.Manager";
+  const sdbus::ServiceName kLogindBusName{"org.freedesktop.login1"};
+  const sdbus::ObjectPath kLogindObjectPath{"/org/freedesktop/login1"};
+  constexpr auto kLogindManagerInterface = "org.freedesktop.login1.Manager";
 } // namespace
 
 LogindService::LogindService(SystemBus& bus) : m_bus(bus) {

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -35,18 +35,18 @@ std::string joinedArtists(const std::vector<std::string>& artists) {
 
 namespace {
 
-  static constexpr auto kDbusInterface = "org.freedesktop.DBus";
-  static constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
-  static constexpr auto kMprisRootInterface = "org.mpris.MediaPlayer2";
-  static constexpr auto kMprisPlayerInterface = "org.mpris.MediaPlayer2.Player";
-  static constexpr auto kNoctaliaMprisInterface = "dev.noctalia.Mpris";
-  static constexpr auto kPropertiesDebounceWindow = std::chrono::milliseconds{120};
-  static constexpr auto kMetadataStabilizeWindow = std::chrono::milliseconds{900};
-  static const sdbus::ServiceName kDbusName{"org.freedesktop.DBus"};
-  static const sdbus::ObjectPath kDbusPath{"/org/freedesktop/DBus"};
-  static const sdbus::ObjectPath kMprisPath{"/org/mpris/MediaPlayer2"};
-  static const sdbus::ServiceName kNoctaliaMprisBusName{"dev.noctalia.Mpris"};
-  static const sdbus::ObjectPath kNoctaliaMprisObjectPath{"/dev/noctalia/Mpris"};
+  constexpr auto kDbusInterface = "org.freedesktop.DBus";
+  constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
+  constexpr auto kMprisRootInterface = "org.mpris.MediaPlayer2";
+  constexpr auto kMprisPlayerInterface = "org.mpris.MediaPlayer2.Player";
+  constexpr auto kNoctaliaMprisInterface = "dev.noctalia.Mpris";
+  constexpr auto kPropertiesDebounceWindow = std::chrono::milliseconds{120};
+  constexpr auto kMetadataStabilizeWindow = std::chrono::milliseconds{900};
+  const sdbus::ServiceName kDbusName{"org.freedesktop.DBus"};
+  const sdbus::ObjectPath kDbusPath{"/org/freedesktop/DBus"};
+  const sdbus::ObjectPath kMprisPath{"/org/mpris/MediaPlayer2"};
+  const sdbus::ServiceName kNoctaliaMprisBusName{"dev.noctalia.Mpris"};
+  const sdbus::ObjectPath kNoctaliaMprisObjectPath{"/dev/noctalia/Mpris"};
 
   bool is_mpris_bus_name(std::string_view name) { return name.starts_with("org.mpris.MediaPlayer2."); }
 

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -1008,9 +1008,7 @@ bool MprisService::setLoopStatus(const std::string& busName, std::string loopSta
   try {
     proxyIt->second->callMethodAsync("Set")
         .onInterface(kPropertiesInterface)
-        .withArguments(
-            std::string{kMprisPlayerInterface}, std::string{"LoopStatus"}, sdbus::Variant{std::move(loopStatus)}
-        )
+        .withArguments(std::string{kMprisPlayerInterface}, std::string{"LoopStatus"}, sdbus::Variant{loopStatus})
         .uponReplyInvoke(makeAsyncReplyHandler("set-loop-status", busName));
     return true;
   } catch (const sdbus::Error& e) {

--- a/src/dbus/power/power_profiles_service.cpp
+++ b/src/dbus/power/power_profiles_service.cpp
@@ -28,10 +28,10 @@ namespace {
 
   constexpr Logger kLog("power");
 
-  static const sdbus::ServiceName kPowerProfilesBusName{"org.freedesktop.UPower.PowerProfiles"};
-  static const sdbus::ObjectPath kPowerProfilesObjectPath{"/org/freedesktop/UPower/PowerProfiles"};
-  static constexpr auto kPowerProfilesInterface = "org.freedesktop.UPower.PowerProfiles";
-  static constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
+  const sdbus::ServiceName kPowerProfilesBusName{"org.freedesktop.UPower.PowerProfiles"};
+  const sdbus::ObjectPath kPowerProfilesObjectPath{"/org/freedesktop/UPower/PowerProfiles"};
+  constexpr auto kPowerProfilesInterface = "org.freedesktop.UPower.PowerProfiles";
+  constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
 
   template <typename T> T getPropertyOr(sdbus::IProxy& proxy, std::string_view propertyName, T fallback) {
     try {

--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -16,17 +16,17 @@
 
 namespace {
 
-  static const sdbus::ServiceName kWatcherBusName{"org.kde.StatusNotifierWatcher"};
-  static const sdbus::ObjectPath kWatcherObjectPath{"/StatusNotifierWatcher"};
-  static constexpr auto kWatcherInterface = "org.kde.StatusNotifierWatcher";
+  const sdbus::ServiceName kWatcherBusName{"org.kde.StatusNotifierWatcher"};
+  const sdbus::ObjectPath kWatcherObjectPath{"/StatusNotifierWatcher"};
+  constexpr auto kWatcherInterface = "org.kde.StatusNotifierWatcher";
 
-  static const sdbus::ServiceName kDbusName{"org.freedesktop.DBus"};
-  static const sdbus::ObjectPath kDbusPath{"/org/freedesktop/DBus"};
-  static constexpr auto kDbusInterface = "org.freedesktop.DBus";
-  static constexpr auto kItemInterface = "org.kde.StatusNotifierItem";
-  static constexpr auto kMenuInterface = "com.canonical.dbusmenu";
-  static constexpr auto kDefaultItemPath = "/StatusNotifierItem";
-  static constexpr auto kAyatanaItemPath = "/org/ayatana/NotificationItem";
+  const sdbus::ServiceName kDbusName{"org.freedesktop.DBus"};
+  const sdbus::ObjectPath kDbusPath{"/org/freedesktop/DBus"};
+  constexpr auto kDbusInterface = "org.freedesktop.DBus";
+  constexpr auto kItemInterface = "org.kde.StatusNotifierItem";
+  constexpr auto kMenuInterface = "com.canonical.dbusmenu";
+  constexpr auto kDefaultItemPath = "/StatusNotifierItem";
+  constexpr auto kAyatanaItemPath = "/org/ayatana/NotificationItem";
   constexpr auto kItemPropertyTimeout = std::chrono::milliseconds(200);
 
   bool isStatusNotifierItemBusName(std::string_view value) {

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -16,11 +16,11 @@
 
 namespace {
 
-  static const sdbus::ServiceName kUpowerBusName{"org.freedesktop.UPower"};
-  static const sdbus::ObjectPath kUpowerObjectPath{"/org/freedesktop/UPower"};
-  static constexpr auto kUpowerInterface = "org.freedesktop.UPower";
-  static constexpr auto kDeviceInterface = "org.freedesktop.UPower.Device";
-  static constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
+  const sdbus::ServiceName kUpowerBusName{"org.freedesktop.UPower"};
+  const sdbus::ObjectPath kUpowerObjectPath{"/org/freedesktop/UPower"};
+  constexpr auto kUpowerInterface = "org.freedesktop.UPower";
+  constexpr auto kDeviceInterface = "org.freedesktop.UPower.Device";
+  constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
 
 } // namespace
 

--- a/src/debug/debug_service.cpp
+++ b/src/debug/debug_service.cpp
@@ -7,9 +7,9 @@ namespace {
 
   constexpr Logger kLog("debug");
 
-  static const sdbus::ServiceName kDebugBusName{"dev.noctalia.Debug"};
-  static const sdbus::ObjectPath kDebugObjectPath{"/dev/noctalia/Debug"};
-  static constexpr auto kDebugInterface = "dev.noctalia.Debug";
+  const sdbus::ServiceName kDebugBusName{"dev.noctalia.Debug"};
+  const sdbus::ObjectPath kDebugObjectPath{"/dev/noctalia/Debug"};
+  constexpr auto kDebugInterface = "dev.noctalia.Debug";
 
   Urgency clamp_urgency(uint8_t urgency) {
     if (urgency > static_cast<uint8_t>(Urgency::Critical)) {

--- a/src/notification/notification_filter.cpp
+++ b/src/notification/notification_filter.cpp
@@ -21,7 +21,7 @@ std::vector<std::string> normalizeNotificationBlacklist(std::vector<std::string>
       continue;
     }
     if (seen.insert(token).second) {
-      normalized.push_back(std::move(token));
+      normalized.push_back(token);
     }
   }
 

--- a/src/render/text/cairo_glyph_renderer.cpp
+++ b/src/render/text/cairo_glyph_renderer.cpp
@@ -308,7 +308,7 @@ CairoGlyphRenderer::CacheEntry* CairoGlyphRenderer::lookupOrRasterize(char32_t c
   const float invScale = 1.0f / m_contentScale;
   entry.metrics = metrics_from_extents(extents, invScale);
 
-  auto [ins, inserted] = m_cache.emplace(std::move(key), std::move(entry));
+  auto [ins, inserted] = m_cache.emplace(key, entry);
   m_lru.push_front(ins->first);
   ins->second.lruIt = m_lru.begin();
   m_cacheBytes += ins->second.bytes;

--- a/src/scripting/script_runtime.cpp
+++ b/src/scripting/script_runtime.cpp
@@ -189,7 +189,7 @@ namespace scripting {
     SubscriberId nextSubscriberId = 1;
     std::uint64_t generation = 0;
     std::chrono::milliseconds updateInterval{250};
-    std::chrono::steady_clock::time_point lastUpdateAccepted{};
+    std::chrono::steady_clock::time_point lastUpdateAccepted;
     std::vector<std::chrono::steady_clock::time_point> timeoutHistory;
     ScriptWidgetResult replayState;
     bool replayStateReady = false;

--- a/src/scripting/scripted_widget_bindings.cpp
+++ b/src/scripting/scripted_widget_bindings.cpp
@@ -120,7 +120,7 @@ namespace {
       if (!singleRow.key.empty() || !singleRow.value.empty()) {
         patch.rows.push_back(std::move(singleRow));
       } else {
-        const int rowCount = static_cast<int>(lua_objlen(L, 1));
+        const int rowCount = lua_objlen(L, 1);
         patch.rows.reserve(static_cast<std::size_t>(std::max(0, rowCount)));
         for (int i = 1; i <= rowCount; ++i) {
           lua_rawgeti(L, 1, i);
@@ -324,7 +324,7 @@ namespace {
     lua_getfield(L, fieldIndex, "options");
     if (lua_istable(L, -1)) {
       const int optionsIndex = lua_gettop(L);
-      const int count = static_cast<int>(lua_objlen(L, optionsIndex));
+      const int count = lua_objlen(L, optionsIndex);
       for (int i = 1; i <= count; ++i) {
         lua_rawgeti(L, optionsIndex, i);
         if (lua_istable(L, -1)) {
@@ -349,7 +349,7 @@ namespace {
     lua_getfield(L, fieldIndex, "extensions");
     if (lua_istable(L, -1)) {
       const int extensionsIndex = lua_gettop(L);
-      const int count = static_cast<int>(lua_objlen(L, extensionsIndex));
+      const int count = lua_objlen(L, extensionsIndex);
       for (int i = 1; i <= count; ++i) {
         lua_rawgeti(L, extensionsIndex, i);
         if (lua_isstring(L, -1)) {
@@ -370,7 +370,7 @@ namespace {
       lua_getfield(L, visIndex, "values");
       if (lua_istable(L, -1)) {
         const int valuesIndex = lua_gettop(L);
-        const int count = static_cast<int>(lua_objlen(L, valuesIndex));
+        const int count = lua_objlen(L, valuesIndex);
         for (int i = 1; i <= count; ++i) {
           lua_rawgeti(L, valuesIndex, i);
           if (lua_isstring(L, -1)) {
@@ -399,7 +399,7 @@ namespace {
     lua_getfield(L, tableIndex, "settings");
     if (lua_istable(L, -1)) {
       const int settingsIndex = lua_gettop(L);
-      const int count = static_cast<int>(lua_objlen(L, settingsIndex));
+      const int count = lua_objlen(L, settingsIndex);
       for (int i = 1; i <= count; ++i) {
         lua_rawgeti(L, settingsIndex, i);
         if (lua_istable(L, -1)) {

--- a/src/scripting/scripted_widget_manifest.cpp
+++ b/src/scripting/scripted_widget_manifest.cpp
@@ -27,7 +27,7 @@ namespace scripting {
     }
 
     struct CacheEntry {
-      std::filesystem::file_time_type mtime{};
+      std::filesystem::file_time_type mtime;
       std::uintmax_t size = 0;
       std::optional<ScriptWidgetManifest> manifest;
     };

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -71,7 +71,7 @@ BatteryWidget::BatteryWidget(
     BatteryDisplayMode displayMode, bool showLabel, bool hideWhenPlugged, bool hideWhenFull
 )
     : m_upower(upower), m_deviceSelector(std::move(deviceSelector)), m_warningThreshold(warningThreshold),
-      m_warningColor(std::move(warningColor)), m_displayMode(displayMode), m_showLabel(showLabel),
+      m_warningColor(warningColor), m_displayMode(displayMode), m_showLabel(showLabel),
       m_hideWhenPlugged(hideWhenPlugged), m_hideWhenFull(hideWhenFull) {}
 
 void BatteryWidget::create() {

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -111,8 +111,8 @@ SysmonWidget::SysmonWidget(
     SysmonDisplayMode displayMode, ColorSpec gaugeColor, ColorSpec highlightColor, ConfigService& configService,
     bool showLabel, float labelMinWidth
 )
-    : m_monitor(monitor), m_stat(stat), m_displayMode(displayMode), m_gaugeColor(std::move(gaugeColor)),
-      m_highlightColor(std::move(highlightColor)), m_configService(configService), m_showLabel(showLabel),
+    : m_monitor(monitor), m_stat(stat), m_displayMode(displayMode), m_gaugeColor(gaugeColor),
+      m_highlightColor(highlightColor), m_configService(configService), m_showLabel(showLabel),
       m_labelMinWidth(labelMinWidth), m_diskPath(std::move(diskPath)) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat)) {

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -157,11 +157,10 @@ TaskbarWidget::TaskbarWidget(
       m_showWorkspaceLabel(showWorkspaceLabel), m_workspaceLabelPlacement(workspaceLabelPlacement),
       m_hideEmptyWorkspaces(hideEmptyWorkspaces), m_workspaceGroupCapsule(workspaceGroupCapsule),
       m_groupSingleIconPerApp(groupSingleIconPerApp), m_showActiveIndicator(showActiveIndicator),
-      m_activeOpacity(activeOpacity), m_inactiveOpacity(inactiveOpacity), m_focusedColor(std::move(focusedColor)),
-      m_occupiedColor(std::move(occupiedColor)), m_emptyColor(std::move(emptyColor)),
-      m_showWindowTitle(showWindowTitle), m_windowTitleMaxWidth(windowTitleMaxWidth),
-      m_taskbarMaxWidth(taskbarMaxWidth), m_barPosition(std::move(barPosition)),
-      m_shadowConfig(std::move(shadowConfig)) {
+      m_activeOpacity(activeOpacity), m_inactiveOpacity(inactiveOpacity), m_focusedColor(focusedColor),
+      m_occupiedColor(occupiedColor), m_emptyColor(emptyColor), m_showWindowTitle(showWindowTitle),
+      m_windowTitleMaxWidth(windowTitleMaxWidth), m_taskbarMaxWidth(taskbarMaxWidth),
+      m_barPosition(std::move(barPosition)), m_shadowConfig(shadowConfig) {
   // Window title not implemented for vertical bars or workspace grouping.
   if (m_barPosition == "left" || m_barPosition == "right" || m_groupByWorkspace) {
     m_showWindowTitle = false;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -45,8 +45,7 @@ WorkspacesWidget::WorkspacesWidget(
 )
     : m_platform(platform), m_output(output), m_displayMode(displayMode), m_maxLabelChars(maxLabelChars),
       m_labelsOnlyWhenOccupied(labelsOnlyWhenOccupied), m_hideWhenEmpty(hideWhenEmpty), m_pillScale(pillScale),
-      m_minimal(minimal), m_focusedColor(std::move(focusedColor)), m_occupiedColor(std::move(occupiedColor)),
-      m_emptyColor(std::move(emptyColor)) {}
+      m_minimal(minimal), m_focusedColor(focusedColor), m_occupiedColor(occupiedColor), m_emptyColor(emptyColor) {}
 
 WorkspacesWidget::DisplayMode WorkspacesWidget::effectiveDisplayMode() const noexcept {
   if (m_minimal && m_displayMode == DisplayMode::None) {

--- a/src/shell/desktop/desktop_widgets_controller.cpp
+++ b/src/shell/desktop/desktop_widgets_controller.cpp
@@ -41,7 +41,7 @@ namespace {
     if (widget.type == "sticker") {
       const auto opacityIt = widget.settings.find("opacity");
       if (opacityIt == widget.settings.end()) {
-        widget.settings.insert_or_assign("opacity", static_cast<double>(1.0));
+        widget.settings.insert_or_assign("opacity", 1.0);
         return;
       }
       if (const auto* doubleValue = std::get_if<double>(&opacityIt->second)) {
@@ -53,7 +53,7 @@ namespace {
         widget.settings.insert_or_assign("opacity", clamped);
         return;
       }
-      widget.settings.insert_or_assign("opacity", static_cast<double>(1.0));
+      widget.settings.insert_or_assign("opacity", 1.0);
       return;
     }
 

--- a/src/shell/desktop/widgets/desktop_clock_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_clock_widget.cpp
@@ -29,8 +29,7 @@ namespace {
 } // namespace
 
 DesktopClockWidget::DesktopClockWidget(std::string format, ColorSpec color, bool shadow)
-    : m_format(std::move(format)), m_color(std::move(color)), m_shadow(shadow),
-      m_showsSeconds(formatShowsSeconds(m_format)) {}
+    : m_format(std::move(format)), m_color(color), m_shadow(shadow), m_showsSeconds(formatShowsSeconds(m_format)) {}
 
 void DesktopClockWidget::create() {
   auto rootNode = std::make_unique<Node>();

--- a/src/shell/desktop/widgets/desktop_label_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_label_widget.cpp
@@ -21,7 +21,7 @@ namespace {
 } // namespace
 
 DesktopLabelWidget::DesktopLabelWidget(std::string title, std::string description, ColorSpec color, bool shadow)
-    : m_title(std::move(title)), m_description(std::move(description)), m_color(std::move(color)), m_shadow(shadow) {}
+    : m_title(std::move(title)), m_description(std::move(description)), m_color(color), m_shadow(shadow) {}
 
 void DesktopLabelWidget::create() {
   auto rootNode = std::make_unique<Node>();

--- a/src/shell/desktop/widgets/desktop_media_player_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_media_player_widget.cpp
@@ -34,7 +34,7 @@ namespace {
 DesktopMediaPlayerWidget::DesktopMediaPlayerWidget(
     MprisService* mpris, HttpClient* httpClient, bool vertical, ColorSpec color, bool shadow, bool hideWhenNoMedia
 )
-    : m_mpris(mpris), m_httpClient(httpClient), m_vertical(vertical), m_color(std::move(color)), m_shadow(shadow),
+    : m_mpris(mpris), m_httpClient(httpClient), m_vertical(vertical), m_color(color), m_shadow(shadow),
       m_hideWhenNoMedia(hideWhenNoMedia) {}
 
 DesktopMediaPlayerWidget::~DesktopMediaPlayerWidget() { cancelVisibilityAnimation(); }

--- a/src/shell/desktop/widgets/desktop_weather_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_weather_widget.cpp
@@ -35,7 +35,7 @@ namespace {
 } // namespace
 
 DesktopWeatherWidget::DesktopWeatherWidget(const WeatherService* weather, ColorSpec color, bool shadow)
-    : m_weather(weather), m_color(std::move(color)), m_shadow(shadow) {}
+    : m_weather(weather), m_color(color), m_shadow(shadow) {}
 
 void DesktopWeatherWidget::create() {
   auto rootNode = std::make_unique<Node>();

--- a/src/shell/lockscreen/lockscreen_widgets_controller.cpp
+++ b/src/shell/lockscreen/lockscreen_widgets_controller.cpp
@@ -46,7 +46,7 @@ namespace {
     if (widget.type == "sticker") {
       const auto opacityIt = widget.settings.find("opacity");
       if (opacityIt == widget.settings.end()) {
-        widget.settings.insert_or_assign("opacity", static_cast<double>(1.0));
+        widget.settings.insert_or_assign("opacity", 1.0);
         return;
       }
       if (const auto* doubleValue = std::get_if<double>(&opacityIt->second)) {
@@ -58,7 +58,7 @@ namespace {
         widget.settings.insert_or_assign("opacity", clamped);
         return;
       }
-      widget.settings.insert_or_assign("opacity", static_cast<double>(1.0));
+      widget.settings.insert_or_assign("opacity", 1.0);
       return;
     }
 

--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -1501,7 +1501,7 @@ namespace settings {
               defaultString != nullptr) {
             selectSetting.clearOnEmpty = defaultString->empty();
           }
-          ctx.makeRow(*panel, entry, ctx.makeSelect(std::move(selectSetting), path));
+          ctx.makeRow(*panel, entry, ctx.makeSelect(selectSetting, path));
           break;
         }
         case WidgetControlKind::ColorSpec: {
@@ -1509,7 +1509,7 @@ namespace settings {
           pickerSetting.selectedValue = settingValueAsString(value);
           pickerSetting.allowNone = spec.advanced;
           pickerSetting.allowCustomColor = spec.allowCustomColor;
-          ctx.makeRow(*panel, entry, ctx.makeColorSpecPicker(std::move(pickerSetting), path));
+          ctx.makeRow(*panel, entry, ctx.makeColorSpecPicker(pickerSetting, path));
           break;
         }
         }

--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -1878,7 +1878,7 @@ namespace settings {
             valueInputPtr->setValue(formatSliderValue(next, integerValue));
           },
       });
-      slider->setOnDragEnd([sliderPtr, onCommit]() { onCommit(static_cast<double>(sliderPtr->value())); });
+      slider->setOnDragEnd([sliderPtr, onCommit]() { onCommit(sliderPtr->value()); });
 
       const auto commitInputText = [sliderPtr, valueInputPtr, minV, maxV, integerValue,
                                     onCommit](const std::string& text) {
@@ -1890,7 +1890,7 @@ namespace settings {
         valueInputPtr->setInvalid(false);
         sliderPtr->setValue(*parsed);
         valueInputPtr->setValue(formatSliderValue(sliderPtr->value(), integerValue));
-        onCommit(static_cast<double>(sliderPtr->value()));
+        onCommit(sliderPtr->value());
       };
       valueInput->setOnChange([valueInputPtr](const std::string& /*text*/) { valueInputPtr->setInvalid(false); });
       valueInput->setOnSubmit([commitInputText](const std::string& text) { commitInputText(text); });

--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -310,7 +310,7 @@ namespace settings {
       setOverride(path, std::move(primary));
     };
 
-    slider->setOnDragEnd([commit, sliderPtr]() { commit(static_cast<double>(sliderPtr->value())); });
+    slider->setOnDragEnd([commit, sliderPtr]() { commit(sliderPtr->value()); });
 
     const auto commitInputText = [commit, sliderPtr, valueInputPtr, minValue, maxValue,
                                   integerValue](const std::string& text) {

--- a/src/shell/widgets_editor/background_widgets_editor.cpp
+++ b/src/shell/widgets_editor/background_widgets_editor.cpp
@@ -1103,7 +1103,7 @@ void BackgroundWidgetsEditor::addWidget(const std::string& outputName, const std
   }
 
   if (widget.type == "sticker") {
-    widget.settings.emplace("opacity", static_cast<double>(1.0));
+    widget.settings.emplace("opacity", 1.0);
     auto widgetId = widget.id;
     m_snapshot.widgets.push_back(std::move(widget));
 

--- a/src/shell/widgets_editor/background_widgets_editor_settings.cpp
+++ b/src/shell/widgets_editor/background_widgets_editor_settings.cpp
@@ -171,7 +171,7 @@ namespace {
   ) {
     settings::ColorSpecSelectOptions options{
         .roles = {},
-        .selectedValue = getStr(s, key, std::move(fallbackValue)),
+        .selectedValue = getStr(s, key, fallbackValue),
         .allowNone = false,
         .allowCustomColor = true,
         .noneLabel = {},

--- a/src/shell/widgets_editor/background_widgets_editor_settings.cpp
+++ b/src/shell/widgets_editor/background_widgets_editor_settings.cpp
@@ -58,7 +58,7 @@ namespace {
     return fallback;
   }
 
-  static std::string settingValueAsString(
+  std::string settingValueAsString(
       const Settings& s, const std::string& key, const std::vector<settings::WidgetSettingSpec>& allSpecs
   ) {
     const auto it = s.find(key);
@@ -84,7 +84,7 @@ namespace {
     return {};
   }
 
-  static bool isSpecVisible(
+  bool isSpecVisible(
       const settings::WidgetSettingSpec& spec, const Settings& s,
       const std::vector<settings::WidgetSettingSpec>& allSpecs
   ) {

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -118,9 +118,9 @@ namespace {
     std::vector<DdcCandidate> candidates;
   };
 
-  static const sdbus::ServiceName kLogindBusName{"org.freedesktop.login1"};
-  static constexpr auto kLogindManagerInterface = "org.freedesktop.login1.Manager";
-  static constexpr auto kLogindSessionInterface = "org.freedesktop.login1.Session";
+  const sdbus::ServiceName kLogindBusName{"org.freedesktop.login1"};
+  constexpr auto kLogindManagerInterface = "org.freedesktop.login1.Manager";
+  constexpr auto kLogindSessionInterface = "org.freedesktop.login1.Session";
 
   std::string joinBrightnessDisplayIds(const BrightnessService& service) {
     std::string out;

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -72,7 +72,7 @@ namespace {
     std::uint64_t ddcWriteEpoch = 0;
     int failureCount = 0;
     bool quarantined = false;
-    std::chrono::steady_clock::time_point cooldownUntil{};
+    std::chrono::steady_clock::time_point cooldownUntil;
   };
 
   struct DdcCandidate {

--- a/src/ui/builders.cpp
+++ b/src/ui/builders.cpp
@@ -208,7 +208,7 @@ namespace ui {
       control->setVariant(*props.variant);
     }
     if (props.customPalette.has_value()) {
-      control->setCustomPalette(std::move(*props.customPalette));
+      control->setCustomPalette(*props.customPalette);
     }
     if (props.surfaceOpacity.has_value()) {
       control->setSurfaceOpacity(*props.surfaceOpacity);
@@ -762,9 +762,7 @@ namespace ui {
       control->setScale(*props.scale);
     }
     if (props.checkedFill.has_value() || props.checkedBorder.has_value() || props.checkedGlyph.has_value()) {
-      control->setCheckedColors(
-          std::move(props.checkedFill), std::move(props.checkedBorder), std::move(props.checkedGlyph)
-      );
+      control->setCheckedColors(props.checkedFill, props.checkedBorder, props.checkedGlyph);
     }
     if (props.onChange) {
       control->setOnChange(std::move(props.onChange));

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -14,9 +14,9 @@ namespace {
 
   Button::ButtonStateColors makeState(ColorSpec bg, ColorSpec border, ColorSpec label) {
     return Button::ButtonStateColors{
-        .bg = std::move(bg),
-        .border = std::move(border),
-        .label = std::move(label),
+        .bg = bg,
+        .border = border,
+        .label = label,
     };
   }
 
@@ -410,7 +410,7 @@ void Button::setVariant(ButtonVariant variant) {
 }
 
 void Button::setCustomPalette(ButtonPalette customPalette) {
-  m_customPalette = std::move(customPalette);
+  m_customPalette = customPalette;
   applyVariant();
 }
 

--- a/src/ui/controls/checkbox.cpp
+++ b/src/ui/controls/checkbox.cpp
@@ -69,9 +69,9 @@ void Checkbox::setScale(float scale) {
 void Checkbox::setCheckedColors(
     std::optional<ColorSpec> fill, std::optional<ColorSpec> border, std::optional<ColorSpec> glyph
 ) {
-  m_checkedFill = std::move(fill);
-  m_checkedBorder = std::move(border);
-  m_checkedGlyph = std::move(glyph);
+  m_checkedFill = fill;
+  m_checkedBorder = border;
+  m_checkedGlyph = glyph;
   applyState();
 }
 

--- a/src/ui/controls/keybind_recorder.cpp
+++ b/src/ui/controls/keybind_recorder.cpp
@@ -76,7 +76,7 @@ KeybindRecorder::KeybindRecorder() {
 KeybindRecorder::~KeybindRecorder() = default;
 
 void KeybindRecorder::setChord(std::optional<KeyChord> chord) {
-  m_chord = std::move(chord);
+  m_chord = chord;
   refreshLabel();
 }
 

--- a/src/ui/controls/label.cpp
+++ b/src/ui/controls/label.cpp
@@ -17,7 +17,7 @@ namespace {
 
 } // namespace
 
-Label::Label() : InputArea() {
+Label::Label() {
   auto textNode = std::make_unique<TextNode>();
   m_textNode = static_cast<TextNode*>(addChild(std::move(textNode)));
   m_textNode->setFontSize(Style::fontSizeBody);


### PR DESCRIPTION
These commits remove C++ syntax that doesn't do anything at all (in these places). The commit messages explain each type of redudant syntax that was removed.

## Type of Change
- [x] Refactoring

## Testing
- [x] Tested on Hyprland


## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
