### PR TITLE
fix(avatar): change avatar config schema to expand path

### DIFF
--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -885,7 +885,7 @@ namespace noctalia::config::schema {
   }
 
   namespace {
-    // Plain string, but emitted only when non-empty (shell.lang, shell.avatar_path).
+    // Plain string, but emitted only when non-empty (shell.lang).
     template <typename Struct> Field<Struct> stringIfNonEmptyField(std::string Struct::* member, std::string_view key) {
       return custom<Struct>(
           key,
@@ -1080,7 +1080,7 @@ namespace noctalia::config::schema {
         field(&ShellConfig::disableMipmaps, "disable_mipmaps"),
         enumField(&ShellConfig::clipboardAutoPaste, "clipboard_auto_paste", kClipboardAutoPasteModes),
         field(&ShellConfig::clipboardImageActionCommand, "clipboard_image_action_command"),
-        stringIfNonEmptyField(&ShellConfig::avatarPath, "avatar_path"),
+        pathStringField(&ShellConfig::avatarPath, "avatar_path"),
         subTable(&ShellConfig::animation, "animation", shellAnimationSchema()),
         subTable(&ShellConfig::shadow, "shadow", shellShadowSchema()),
         subTable(&ShellConfig::panel, "panel", shellPanelSchema()),


### PR DESCRIPTION
# Pull Request

## Motivation
The avatar path in TOML config does not expand home dir ~ so user must write full path: /home/*/... This PR expands the path on read using `pathStringField`.

## Type of Change
Mark the relevant option with an "x".
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
