### PR TITLE
feat(session menu): change default session menu to use lock_and_suspend

### DIFF
--- a/src/config/config_types.cpp
+++ b/src/config/config_types.cpp
@@ -66,7 +66,7 @@ std::vector<SessionPanelActionConfig> defaultSessionPanelActions() {
           KeyChord{XKB_KEY_2, 0}
       },
       SessionPanelActionConfig{
-          "suspend", true, std::nullopt, std::nullopt, std::nullopt, SessionActionButtonVariant::Default,
+          "lock_and_suspend", true, std::nullopt, std::nullopt, std::nullopt, SessionActionButtonVariant::Default,
           KeyChord{XKB_KEY_3, 0}
       },
       SessionPanelActionConfig{

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -67,7 +67,7 @@ namespace {
       return "suspend";
     }
     if (action == "lock_and_suspend") {
-      return "lock";
+      return "suspend";
     }
     if (action == "reboot") {
       return "reboot";


### PR DESCRIPTION
# Pull Request

## Motivation
Just my 2c...feel free to ignore this PR if you disagree. The default session menu item to suspend does not lock, which I think is a less common choice than `lock-and-suspend`. I changed the default option to `lock-and-suspend` while users with a custom session config would not be affected. I also changed the glyph for `lock-and-suspend` to use the suspend symbol (pause).

Ideally, I think `suspend` and `lock-and-suspend` would make more sense as `suspend` (defaults to lock) and `suspend-no-lock` if a user wants it for some reason (seems a less common choice). But that would be a breaking change that needs IPC changes, doc updates, i18n, etc., so I'd want buy-in from you guys before doing anything.

## Type of Change
Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
Describe how you tested your changes and mark the relevant items.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
