### PR TITLE
fix(lock screen): idle: desktop capture before fade out

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1427,15 +1427,26 @@ void Application::initUi() {
   m_wayland.setIdleCapabilitiesReadyCallback([this]() { m_idleManager.reload(m_configService.config().idle); });
   m_idleManager.initialize(
       m_wayland,
-      [this](const std::string& behaviorName, std::chrono::milliseconds fadeIn, std::function<void()> onFadeComplete) {
+      [this](
+          const std::string& behaviorName, std::chrono::milliseconds fadeIn, bool willLockSession,
+          std::function<void()> onFadeComplete
+      ) {
         (void)behaviorName;
+        // Snapshot the clean desktop before the overlay fades in
+        if (willLockSession) {
+          m_lockScreen.primeDesktopCaptures();
+        }
         DeferredCall::callLater([this, fadeIn, done = std::move(onFadeComplete)]() mutable {
           m_idleGraceOverlay.show(fadeIn, std::move(done));
         });
       },
       [this](bool userCancelled) {
-        (void)userCancelled;
-        DeferredCall::callLater([this]() { m_idleGraceOverlay.hide(); });
+        DeferredCall::callLater([this, userCancelled]() {
+          m_idleGraceOverlay.hide();
+          if (userCancelled) {
+            m_lockScreen.clearPrimedDesktopCaptures();
+          }
+        });
       }
   );
   m_idleManager.setActionRunner(

--- a/src/idle/idle_manager.cpp
+++ b/src/idle/idle_manager.cpp
@@ -310,6 +310,8 @@ void IdleManager::handleIdled(void* data, ext_idle_notification_v1* /*notificati
     const int fadeMs = static_cast<int>(std::lround(static_cast<double>(fadeSec) * 1000.0));
     const auto fade = std::chrono::milliseconds(std::clamp(fadeMs, 1, 600000));
     kLog.info("idle behavior '{}' pre-action fade {}ms", behavior->config.name, fade.count());
+    const IdleActionKind idleKind = resolveIdleBehaviorActions(behavior->config).idleAction.kind;
+    const bool willLockSession = idleKind == IdleActionKind::Lock || idleKind == IdleActionKind::LockAndSuspend;
     self.joinActiveGrace(*behavior);
     const std::uint64_t generation = ++self.m_graceGeneration;
     self.m_graceFallbackTimer.start(fade + std::chrono::milliseconds(250), [&self, generation]() {
@@ -319,7 +321,7 @@ void IdleManager::handleIdled(void* data, ext_idle_notification_v1* /*notificati
       kLog.debug("idle pre-action fade fallback completed");
       self.graceFadeComplete();
     });
-    self.m_onGraceBegin(behavior->config.name, fade, [ptr = &self, generation]() {
+    self.m_onGraceBegin(behavior->config.name, fade, willLockSession, [ptr = &self, generation]() {
       DeferredCall::callLater([ptr, generation]() {
         if (ptr->m_graceGeneration != generation || !ptr->hasActiveGrace()) {
           return;

--- a/src/idle/idle_manager.h
+++ b/src/idle/idle_manager.h
@@ -19,8 +19,11 @@ public:
   /// Runs the resolved idle or resume action for this behavior.
   using ActionRunner = std::function<bool(const IdleBehaviorConfig& behavior, const IdleActionRequest& action)>;
   /// Starts the pre-action fade overlay; call `onFadeComplete` once every output has finished fading.
+  /// `willLockSession` is true when the idle action locks the session, so the caller can capture
+  /// a clean desktop snapshot before the overlay fades in.
   using GraceBeginCallback = std::function<void(
-      const std::string& behaviorName, std::chrono::milliseconds fadeDuration, std::function<void()> onFadeComplete
+      const std::string& behaviorName, std::chrono::milliseconds fadeDuration, bool willLockSession,
+      std::function<void()> onFadeComplete
   )>;
   /// `userCancelled` is true when input resumed during the fade before the idle action ran.
   using GraceEndCallback = std::function<void(bool userCancelled)>;

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -84,9 +84,13 @@ bool LockScreen::lock() {
     return true;
   }
 
-  m_desktopCaptures.clear();
-  if (shouldUseBlurredDesktop()) {
-    captureDesktopSnapshots();
+  if (m_desktopCapturesPrimed) {
+    m_desktopCapturesPrimed = false;
+  } else {
+    m_desktopCaptures.clear();
+    if (shouldUseBlurredDesktop()) {
+      captureDesktopSnapshots();
+    }
   }
 
   m_lock = ext_session_lock_manager_v1_lock(m_wayland->sessionLockManager());
@@ -148,6 +152,7 @@ void LockScreen::unlock() {
   m_statusIsError = false;
   m_wayland->stopKeyRepeat();
   m_desktopCaptures.clear();
+  m_desktopCapturesPrimed = false;
 
   // Tear down widgets while lock surfaces still exist. Session hooks run only after
   // isActive() is false so LockscreenWidgetsController::applyVisibility() hides first.
@@ -371,6 +376,7 @@ void LockScreen::handleFinished(void* data, ext_session_lock_v1* /*lock*/) {
   self->m_status.clear();
   self->m_statusIsError = false;
   self->m_desktopCaptures.clear();
+  self->m_desktopCapturesPrimed = false;
   if (self->m_onSessionUnlocked) {
     self->m_onSessionUnlocked();
   }
@@ -412,6 +418,27 @@ bool LockScreen::shouldUseBlurredDesktop() const {
       && m_configService->config().lockscreen.blurredDesktop
       && m_wayland != nullptr
       && m_wayland->hasScreencopy();
+}
+
+void LockScreen::primeDesktopCaptures() {
+  if (isActive()) {
+    return;
+  }
+  m_desktopCaptures.clear();
+  m_desktopCapturesPrimed = false;
+  if (!shouldUseBlurredDesktop()) {
+    return;
+  }
+  captureDesktopSnapshots();
+  m_desktopCapturesPrimed = true;
+}
+
+void LockScreen::clearPrimedDesktopCaptures() {
+  if (!m_desktopCapturesPrimed) {
+    return;
+  }
+  m_desktopCapturesPrimed = false;
+  m_desktopCaptures.clear();
 }
 
 void LockScreen::captureDesktopSnapshots() {

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -38,6 +38,8 @@ public:
   void setSessionHooks(std::function<void()> onLocked, std::function<void()> onUnlocked);
   void setLockEngagedCallback(std::function<void()> callback);
   bool lock();
+  void primeDesktopCaptures();
+  void clearPrimedDesktopCaptures();
   void unlock();
   void onOutputChange();
   void onFontChanged();
@@ -105,6 +107,7 @@ private:
   bool m_statusIsError = false;
   bool m_lockPending = false;
   bool m_locked = false;
+  bool m_desktopCapturesPrimed = false;
   bool m_lockDeferred = false;
   std::function<void()> m_pendingAfterLocked;
   std::function<void()> m_onSessionLocked;


### PR DESCRIPTION
Small QOL: idle lock did not trigger the desktip capture before the fade out screen, rendering jsut a gray background on the lock screen.

Fixed by taking the screenshot befor the fadeout screen when idle locking