### PR TITLE
feat(niri): add layer-rule for noctalia-backdrop namespace

### DIFF
--- a/assets/templates/niri/niri.kdl
+++ b/assets/templates/niri/niri.kdl
@@ -33,3 +33,8 @@ recent-windows {
         urgent-color "{{colors.error.default.hex}}"
     }
 }
+
+layer-rule {
+    match namespace="^noctalia-backdrop$"
+    place-within-backdrop true
+}


### PR DESCRIPTION
Added the missing layer rule that will allow the niri backdrop to be set to current noctalia-wallpaper