### PR TITLE
feat(hyprland): add color exports to the template

### DIFF
--- a/assets/templates/hyprland/apply.sh
+++ b/assets/templates/hyprland/apply.sh
@@ -44,7 +44,7 @@ detect_mode() {
 
 apply_lua() {
   local include_line='-- For Noctalia Color templates
-require("noctalia")'
+require("noctalia").apply_theme()'
 
   mkdir -p "$config_dir"
 

--- a/assets/templates/hyprland/apply.sh
+++ b/assets/templates/hyprland/apply.sh
@@ -53,7 +53,12 @@ require("noctalia").apply_theme()'
     return
   fi
 
-  # Avoid appending duplicate Noctalia includes
+  # Migrate the legacy bare include to the apply_theme() form.
+  # Only matches a line that is *exactly* require("noctalia"), so user code
+  # like require("noctalia").colors.primary is left untouched.
+  sed -i 's/^[[:space:]]*require("noctalia")[[:space:]]*$/require("noctalia").apply_theme()/' "$lua_config_file"
+
+  # Append only if there is no Noctalia include at all
   if ! grep -qF 'require("noctalia")' "$lua_config_file"; then
     printf '\n%s\n' "$include_line" >>"$lua_config_file"
   fi

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -5,29 +5,41 @@ local surface = "rgb({{colors.surface.default.hex_stripped}})"
 local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
 
-hl.config({
-	general = {
-		col = {
-			active_border = primary,
-			inactive_border = surface,
-		},
-	},
+local function apply_theme()
+    hl.config({
+        general = {
+            col = {
+                active_border = primary,
+                inactive_border = surface,
+            },
+        },
 
-	group = {
-		col = {
-			border_active = secondary,
-			border_inactive = surface,
-			border_locked_active = error,
-			border_locked_inactive = surface,
-		},
+        group = {
+            col = {
+                border_active = secondary,
+                border_inactive = surface,
+                border_locked_active = error,
+                border_locked_inactive = surface,
+            },
 
-		groupbar = {
-			col = {
-				active = secondary,
-				inactive = surface,
-				locked_active = error,
-				locked_inactive = surface,
-			},
-		},
-	},
-})
+            groupbar = {
+                col = {
+                    active = secondary,
+                    inactive = surface,
+                    locked_active = error,
+                    locked_inactive = surface,
+                },
+            },
+        },
+    })
+end
+
+return {
+    colors = {
+        primary = primary,
+        surface = surface,
+        secondary = secondary,
+        error = error,
+    },
+    apply_theme = apply_theme
+}


### PR DESCRIPTION
https://github.com/noctalia-dev/noctalia/issues/2927

This PR allows to customize what noctalia does to hyprland. With these changes importing will change to the following: `require("noctalia").apply_theme()` where `apply_theme` can be omitted if you only need the colors.