### PR TITLE
feat: add lock screen login scale setting

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1518,6 +1518,10 @@
           "description": "Choose which monitors show the lock screen; leave empty to show on all monitors",
           "label": "Monitors"
         },
+        "login-scale": {
+          "description": "Size multiplier for the lock screen login and password field",
+          "label": "Login Scale"
+        },
         "tint-intensity": {
           "description": "Surface-color tint over the lock screen background",
           "label": "Tint Intensity"

--- a/example.toml
+++ b/example.toml
@@ -158,6 +158,7 @@ keyboard_layout = true              # input keyboard layout changes
 blurred_desktop         = false       # use a desktop snapshot as the lock screen background (requires wlr-screencopy)
 blur_intensity          = 0.5         # lock screen background blur (0.0 = none, 1.0 = maximum)
 tint_intensity          = 0.3         # surface-color tint over the lock screen background
+login_scale             = 1.0         # lock screen login/password box size multiplier
 # wallpaper             = ""          # optional image path for the lock screen; empty uses the desktop wallpaper
 # monitors              = ["DP-1"]    # connectors that show the lock screen; empty shows all monitors, others stay black
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -389,6 +389,7 @@ struct LockscreenConfig {
   float blurIntensity = 0.5f;
   float tintIntensity = 0.3f;
   std::string wallpaper;
+  float loginScale = 1.0f;
   std::vector<std::string> monitors;
 
   bool operator==(const LockscreenConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -79,6 +79,7 @@ namespace noctalia::config::schema {
         field(&LockscreenConfig::blurIntensity, "blur_intensity", kUnitRange),
         field(&LockscreenConfig::tintIntensity, "tint_intensity", kUnitRange),
         field(&LockscreenConfig::wallpaper, "wallpaper"),
+        field(&LockscreenConfig::loginScale, "login_scale", kLockscreenLoginScaleRange),
         field(&LockscreenConfig::monitors, "monitors"),
     };
     return s;

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -11,6 +11,7 @@ namespace noctalia::config::schema {
   // Shared ranges for concepts that recur verbatim across many settings.
   inline constexpr Range<float> kUnitRange{0.0f, 1.0f, 0.01f};          // opacities, intensities, 0..1 factors
   inline constexpr Range<float> kScaleRange{0.5f, 2.5f, 0.05f};         // ui_scale, notification/osd scale
+  inline constexpr Range<float> kLockscreenLoginScaleRange{0.5f, 2.5f, 0.05f}; // lockscreen login box scale
   inline constexpr Range<std::int64_t> kRefreshMinutesRange{5, 240, 5}; // calendar/weather refresh interval
 
   // Shell.

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -450,6 +450,7 @@ void LockScreen::applyLockscreenStyle(LockSurface& surface) const {
   }
   const auto& lockscreen = m_configService->config().lockscreen;
   surface.setBackgroundStyle(lockscreen.blurIntensity, lockscreen.tintIntensity);
+  surface.requestLayout();
 }
 
 bool LockScreen::isInteractiveOutput(const WaylandOutput& output) const {

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -452,15 +452,18 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   m_loginPanel->setVisible(true);
   m_passwordField->setVisible(true);
   m_loginButton->setVisible(true);
-  const float panelHeight = lockscreen_login_box::panelHeight();
-  float panelWidth = lockscreen_login_box::panelWidth(sw);
+  const float loginScale = m_config != nullptr ? m_config->config().lockscreen.loginScale : 1.0f;
+  const float panelHeight = lockscreen_login_box::panelHeight(loginScale);
+  float panelWidth = lockscreen_login_box::panelWidth(sw, loginScale);
   float panelX = std::round((sw - panelWidth) * 0.5f);
-  float panelY = std::max(Style::spaceLg, sh - panelHeight - 84.0f);
+  float panelY = std::max(Style::spaceLg * loginScale, sh - panelHeight - 84.0f * loginScale);
   if (m_config != nullptr) {
     if (const DesktopWidgetState* loginBox =
             lockscreen_login_box::findForOutput(m_config->config().lockscreenWidgets.widgets, m_outputKey);
         loginBox != nullptr) {
-      lockscreen_login_box::panelOriginFromCenter(loginBox->cx, loginBox->cy, sw, panelX, panelY, panelWidth);
+      lockscreen_login_box::panelOriginFromCenter(
+          loginBox->cx, loginBox->cy, sw, loginScale, panelX, panelY, panelWidth
+      );
     }
   }
 
@@ -507,25 +510,29 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
           .fill = colorForRole(ColorRole::SurfaceVariant, 0.88f),
           .border = colorForRole(ColorRole::Outline, 0.95f),
           .fillMode = FillMode::Solid,
-          .radius = Style::scaledRadiusXl(),
+          .radius = Style::scaledRadiusXl(loginScale),
           .softness = 1.0f,
-          .borderWidth = Style::borderWidth,
+          .borderWidth = Style::borderWidth * loginScale,
       }
   );
 
-  const float contentLeft = panelX + Style::spaceLg;
-  const float contentTop = panelY + 22.0f;
-  const float rightInset = Style::spaceLg + Style::spaceSm;
-  const float contentWidth = panelWidth - Style::spaceLg - rightInset;
-  const float buttonWidth = Style::controlHeight;
-  const float gap = Style::spaceSm;
-  const float inputWidth = std::max(120.0f, contentWidth - buttonWidth - gap);
+  const float contentLeft = panelX + Style::spaceLg * loginScale;
+  const float contentTop = panelY + 22.0f * loginScale;
+  const float rightInset = (Style::spaceLg + Style::spaceSm) * loginScale;
+  const float contentWidth = panelWidth - Style::spaceLg * loginScale - rightInset;
+  const float buttonWidth = Style::controlHeight * loginScale;
+  const float gap = Style::spaceSm * loginScale;
+  const float inputWidth = std::max(120.0f * loginScale, contentWidth - buttonWidth - gap);
 
+  m_passwordField->setFontSize(Style::fontSizeBody * loginScale);
+  m_passwordField->setControlHeight(Style::controlHeight * loginScale);
+  m_passwordField->setHorizontalPadding(Style::spaceMd * loginScale);
   m_passwordField->setSize(inputWidth, 0.0f);
   m_passwordField->setPosition(contentLeft, contentTop);
   m_passwordField->layout(*renderer);
 
-  m_loginButton->setSize(buttonWidth, Style::controlHeight);
+  m_loginButton->setGlyphSize(16.0f * loginScale);
+  m_loginButton->setSize(buttonWidth, Style::controlHeight * loginScale);
   m_loginButton->setPosition(contentLeft + inputWidth + gap, contentTop);
   m_loginButton->layout(*renderer);
 }

--- a/src/shell/lockscreen/lockscreen_login_box.cpp
+++ b/src/shell/lockscreen/lockscreen_login_box.cpp
@@ -8,6 +8,17 @@
 #include <format>
 #include <unordered_set>
 
+namespace {
+
+  [[nodiscard]] float clampedLoginScale(float loginScale) noexcept {
+    if (!std::isfinite(loginScale)) {
+      return 1.0f;
+    }
+    return std::clamp(loginScale, 0.5f, 2.5f);
+  }
+
+} // namespace
+
 namespace lockscreen_login_box {
 
   bool isLoginBoxWidget(const DesktopWidgetState& state) { return state.type == kWidgetType; }
@@ -18,23 +29,29 @@ namespace lockscreen_login_box {
 
   std::string widgetIdForOutput(std::string_view outputKey) { return std::format("{}{}", kWidgetIdPrefix, outputKey); }
 
-  float panelWidth(float screenWidth) { return std::min(screenWidth - Style::spaceLg * 2.0f, 520.0f); }
+  float panelWidth(float screenWidth, float loginScale) {
+    const float scale = clampedLoginScale(loginScale);
+    return std::min(screenWidth - Style::spaceLg * 2.0f * scale, 520.0f * scale);
+  }
 
-  float panelHeight() { return 78.0f; }
+  float panelHeight(float loginScale) { return 78.0f * clampedLoginScale(loginScale); }
 
-  void defaultPanelCenter(float screenWidth, float screenHeight, float& cx, float& cy) {
-    const float width = panelWidth(screenWidth);
-    const float height = panelHeight();
+  void defaultPanelCenter(float screenWidth, float screenHeight, float& cx, float& cy, float loginScale) {
+    const float scale = clampedLoginScale(loginScale);
+    const float width = panelWidth(screenWidth, scale);
+    const float height = panelHeight(scale);
     const float panelX = std::round((screenWidth - width) * 0.5f);
-    const float panelY = std::max(Style::spaceLg, screenHeight - height - 84.0f);
+    const float panelY = std::max(Style::spaceLg * scale, screenHeight - height - 84.0f * scale);
     cx = panelX + width * 0.5f;
     cy = panelY + height * 0.5f;
   }
 
-  void
-  panelOriginFromCenter(float cx, float cy, float screenWidth, float& panelX, float& panelY, float& panelWidthOut) {
-    panelWidthOut = panelWidth(screenWidth);
-    const float height = panelHeight();
+  void panelOriginFromCenter(
+      float cx, float cy, float screenWidth, float loginScale, float& panelX, float& panelY, float& panelWidthOut
+  ) {
+    const float scale = clampedLoginScale(loginScale);
+    panelWidthOut = panelWidth(screenWidth, scale);
+    const float height = panelHeight(scale);
     panelX = cx - panelWidthOut * 0.5f;
     panelY = cy - height * 0.5f;
   }

--- a/src/shell/lockscreen/lockscreen_login_box.h
+++ b/src/shell/lockscreen/lockscreen_login_box.h
@@ -17,10 +17,12 @@ namespace lockscreen_login_box {
   [[nodiscard]] bool isLoginBoxWidgetId(std::string_view id);
   [[nodiscard]] std::string widgetIdForOutput(std::string_view outputKey);
 
-  [[nodiscard]] float panelWidth(float screenWidth);
-  [[nodiscard]] float panelHeight();
-  void defaultPanelCenter(float screenWidth, float screenHeight, float& cx, float& cy);
-  void panelOriginFromCenter(float cx, float cy, float screenWidth, float& panelX, float& panelY, float& panelWidthOut);
+  [[nodiscard]] float panelWidth(float screenWidth, float loginScale = 1.0f);
+  [[nodiscard]] float panelHeight(float loginScale = 1.0f);
+  void defaultPanelCenter(float screenWidth, float screenHeight, float& cx, float& cy, float loginScale = 1.0f);
+  void panelOriginFromCenter(
+      float cx, float cy, float screenWidth, float loginScale, float& panelX, float& panelY, float& panelWidthOut
+  );
 
   [[nodiscard]] const DesktopWidgetState*
   findForOutput(const std::vector<DesktopWidgetState>& widgets, std::string_view outputKey);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1119,6 +1119,12 @@ namespace settings {
         sliderFor(cfg.lockscreen.tintIntensity, noctalia::config::schema::kUnitRange, false), "lock screen tint"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Security, "lock-screen", tr("settings.schema.lockscreen.login-scale.label"),
+        tr("settings.schema.lockscreen.login-scale.description"), {"lockscreen", "login_scale"},
+        sliderFor(cfg.lockscreen.loginScale, noctalia::config::schema::kLockscreenLoginScaleRange, false),
+        "lock screen login password input size scale"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Security, "lock-screen", tr("settings.schema.lockscreen.monitors.label"),
         tr("settings.schema.lockscreen.monitors.description"), {"lockscreen", "monitors"},
         ListSetting{.items = cfg.lockscreen.monitors, .suggestedOptions = env.availableOutputs},

--- a/tests/config_path_resolution_test.cpp
+++ b/tests/config_path_resolution_test.cpp
@@ -51,6 +51,7 @@ int main() {
   expectKnown({"theme", "templates", "enable_builtin_templates"});
   expectKnown({"wallpaper", "automation", "interval_seconds"});
   expectKnown({"wallpaper", "fill_color"});
+  expectKnown({"lockscreen", "login_scale"});
   expectKnown({"dock", "icon_size"});
   expectKnown({"dock", "radius_top_left"});
   expectKnown({"desktop_widgets", "enabled"});

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -182,7 +182,11 @@ namespace {
     c.osd.kinds.keyboardLayout = false;
     c.backdrop = BackdropConfig{true, 0.8f, 0.2f};
     c.lockscreen = LockscreenConfig{
-        .blurredDesktop = true, .blurIntensity = 0.6f, .tintIntensity = 0.25f, .monitors = {"DP-1"}
+        .blurredDesktop = true,
+        .blurIntensity = 0.6f,
+        .tintIntensity = 0.25f,
+        .loginScale = 1.35f,
+        .monitors = {"DP-1"},
     };
     c.system.monitor.enabled = false;
     c.system.monitor.cpuPollSeconds = 5.0f;
@@ -344,6 +348,16 @@ namespace {
       readInto(t, o, osdSchema(), "osd", d);
       if (o.scale != 0.5f) {
         fail("osd.scale clamp: expected 0.5");
+      }
+    }
+    // lockscreen.login_scale above the max clamps to 2.5.
+    {
+      auto t = toml::parse("login_scale = 9.0");
+      LockscreenConfig lockscreen{};
+      Diagnostics d;
+      readInto(t, lockscreen, lockscreenSchema(), "lockscreen", d);
+      if (lockscreen.loginScale != 2.5f) {
+        fail("lockscreen.login_scale clamp: expected 2.5");
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `[lockscreen].login_scale` with schema validation and example config
- scale the real lock screen login panel, password field, padding, button, glyph, and panel radius
- expose the setting in Settings > Security > Lock screen
- cover the new config path and clamp behavior in existing config tests

## Tests
- `nix build --impure --expr 'let flake = builtins.getFlake (toString ./.); pkg = flake.packages.x86_64-linux.default; in pkg.overrideAttrs (old: { doCheck = true; checkPhase = "meson test --print-errorlogs config_schema_roundtrip config_path_resolution"; })' --extra-experimental-features 'nix-command flakes'`