### PR TITLE
Support for Non-GNU systems

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,16 @@ project('noctalia', ['c', 'cpp'],
 cc  = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
+
+# Clang requires an opt-in flag to properly use experimental C++ libraries.
+# GCC/libstdc++ doesn't need this since these libraries are unconditionally
+# exposed.
+is_libcxx = cpp.get_define('_LIBCPP_VERSION', prefix: '#include <version>' ) != ''
+if is_libcxx
+  add_project_arguments('-fexperimental-library', language: 'cpp')
+  add_project_link_arguments('-lc++experimental', language: 'cpp')
+endif
+
 # Sanitizers are enabled via meson's built-in -Db_sanitize=address,undefined.
 # pipewire_lsan.cpp is only needed when address sanitizer is active.
 sanitize = get_option('b_sanitize') != 'none'

--- a/meson.build
+++ b/meson.build
@@ -333,7 +333,7 @@ _wlr_ls_h = custom_target('wlr-layer-shell-unstable-v1-client-header',
   output:  'wlr-layer-shell-unstable-v1-client-protocol.h',
   command: [
     'sh', '-c',
-    '"$1" client-header "$2" "$3" && sed -i s/namespace/name_space/g "$3"',
+    '"$1" client-header "$2" "$3" && sed -i.bak s/namespace/name_space/g "$3"',
     '_', wayland_scanner.full_path(), '@INPUT@', '@OUTPUT@',
   ],
 )

--- a/src/render/core/thumbnail_service.cpp
+++ b/src/render/core/thumbnail_service.cpp
@@ -76,7 +76,7 @@ namespace {
         + '\n'
         + std::to_string(size)
         + '\n'
-        + std::to_string(ticks)
+        + std::to_string(static_cast<long long>(ticks))
         + '\n'
         + std::to_string(kThumbnailTargetPx)
         + '\n'

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 
-  const Logger log("desktop_entry_launch");
+  constexpr Logger kLog("desktop_entry_launch");
 
   std::string stripFieldCodes(std::string_view exec) {
     std::string result;
@@ -127,7 +127,7 @@ namespace desktop_entry_launch {
   bool launchEntry(const DesktopEntry& entry, const LaunchOptions& options) {
     auto prepared = prepareCommand(entry.exec, entry.terminal);
     if (!prepared.has_value()) {
-      log.warn("Failed to prepare launch command for desktop entry '{}'", entry.id.empty() ? entry.name : entry.id);
+      kLog.warn("Failed to prepare launch command for desktop entry '{}'", entry.id.empty() ? entry.name : entry.id);
       return false;
     }
 
@@ -145,7 +145,7 @@ namespace desktop_entry_launch {
   ) {
     auto prepared = prepareCommand(action.exec, terminal);
     if (!prepared.has_value()) {
-      log.warn("Failed to prepare launch command for desktop action '{}'", action.id.empty() ? action.name : action.id);
+      kLog.warn("Failed to prepare launch command for desktop action '{}'", action.id.empty() ? action.name : action.id);
       return false;
     }
 


### PR DESCRIPTION
I'm daily-driving Chimera Linux, which is a Non-GNU Linux distro with clang and BSD coreutils as main components. Noctalia fails to build on such Non-GNU systems as of now.

Currently, Noctalia depends on some GNU-specific extensions and assumptions to build, and this PR attempts to address those.

Currently, the following errors are identified (those with fixes are ticked):

- [x] GNU extension behavior of the `-i` option in `sed` (in-place replacement must provide backup file suffix in POSIX standard)
- [x] Clang requires a separate feature flag for ABI-unstable experimental features (like `<chrono>` and `<format>`)
- [x] libc++ declares filesystem timestamps to be `__int128_t`, requiring extra work to format using `std::to_string`
- [x] libc++ includes `<cmath>` in `<format>`, causing name clash of `log` in certain source files