### PR TITLE
fix(nightlight): smoother transition on/off with easing

### DIFF
--- a/src/system/gamma_service.cpp
+++ b/src/system/gamma_service.cpp
@@ -2,6 +2,7 @@
 
 #include "core/log.h"
 #include "ipc/ipc_service.h"
+#include "render/animation/animation.h"
 #include "system/day_night_schedule.h"
 #include "wayland/wayland_connection.h"
 #include "wlr-gamma-control-unstable-v1-client-protocol.h"
@@ -19,7 +20,8 @@ namespace {
   constexpr Logger kLog("gamma");
 
   constexpr float kTransitionDurationMs = 1500.0f;
-  constexpr int kTransitionIntervalMs = 100;
+  constexpr int kTransitionIntervalMs = 20;
+
   constexpr auto kScheduleRecheckInterval = std::chrono::minutes(1);
 
   const zwlr_gamma_control_v1_listener kGammaControlListener = {
@@ -362,8 +364,9 @@ void GammaService::tickTransition() {
   m_transitionProgress = std::min(
       1.0f, static_cast<float>(std::chrono::duration<double, std::milli>(elapsed).count()) / kTransitionDurationMs
   );
+  const auto easeProgress = applyEasing(Easing::EaseInOutCubic, m_transitionProgress);
   const int interpolated = static_cast<int>(
-      std::lerp(static_cast<float>(m_transitionFromKelvin), static_cast<float>(m_targetKelvin), m_transitionProgress)
+      std::lerp(static_cast<float>(m_transitionFromKelvin), static_cast<float>(m_targetKelvin), easeProgress)
   );
   if (interpolated != m_currentKelvin) {
     applyGammaToAll(interpolated);


### PR DESCRIPTION
# Pull Request

## Motivation
When nightlight is enabled/disabled, the gamma update happens at discrete 100ms ticks. Visually, the discrete steps are very obvious which is jarring. I reduced the time between animation ticks to 20ms (which is still greater than 16ms frame interval at 60Hz) and added easing at both ends. Visually, the transition looks very smooth now.

## Type of Change
Mark the relevant option with an "x".
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring

## Testing
I tested on both 60Hz and 240Hz monitors with Niri. The transitions on both appear visually smooth, and I can't distinguish the discrete steps anymore.

- [X] Tested on niri
- [ ] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos
If applicable, include screenshots or videos to help illustrate your changes.

## Checklist
- [X] Code follows project style guidelines
- [X] Self-reviewed my code
- [X] No new warnings or errors
- [ ] Documentation or comments updated (if relevant)
