### PR TITLE
launcher: don't fallback to double-forking if systemd-run fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -921,6 +921,7 @@ process_test = executable('process_test',
   sources: files(
     'tests/process_test.cpp',
     'src/core/process.cpp',
+    'src/core/log.cpp'
   ),
   include_directories: _noctalia_inc,
 )
@@ -1003,6 +1004,7 @@ plugin_git_export_test = executable('plugin_git_export_test',
     'tests/plugin_git_export_test.cpp',
     'src/scripting/plugin_git.cpp',
     'src/core/process.cpp',
+    'src/core/log.cpp',
   ),
   include_directories: _noctalia_inc,
 )

--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -1,5 +1,6 @@
 #include "core/process.h"
 
+#include "core/log.h"
 #include "util/string_utils.h"
 
 #include <algorithm>
@@ -25,6 +26,8 @@
 #include <unistd.h>
 
 namespace {
+
+  constexpr Logger kLog("process");
 
   constexpr std::chrono::milliseconds kProcessPollInterval{100};
   constexpr std::chrono::milliseconds kProcessCommandLineCacheTtl{250};
@@ -621,31 +624,10 @@ namespace {
     return res;
   }
 
-  void startSystemdService(
+  bool startSystemdService(
       const std::vector<std::string>& args, const std::string& activationToken, const std::string& workingDir,
       const std::string& appName
   ) {
-    const pid_t intermediate = ::fork();
-    if (intermediate < 0) {
-      return;
-    }
-
-    if (intermediate > 0) {
-      // Parent: wait for intermediate to exit (after it forks the grandchild).
-      while (::waitpid(intermediate, nullptr, 0) < 0 && errno == EINTR) {
-      }
-      return;
-    }
-
-    // Intermediate child: fork again and exit, so parent doesn't wait for systemd-run
-
-    const pid_t worker = ::fork();
-    if (worker != 0) {
-      ::_exit(0);
-    }
-
-    // Grandchild
-
     std::vector<std::string> systemdArgs;
     systemdArgs.push_back("systemd-run");
     systemdArgs.push_back("--user");
@@ -669,9 +651,15 @@ namespace {
       systemdArgs.push_back("--working-directory=" + workingDir);
     }
 
+    process::RunOptions runOptions;
+
     if (!activationToken.empty()) {
-      ::setenv("XDG_ACTIVATION_TOKEN", activationToken.c_str(), 1);
-      ::setenv("DESKTOP_STARTUP_ID", activationToken.c_str(), 1);
+      systemdArgs.push_back("-E");
+      systemdArgs.push_back("XDG_ACTIVATION_TOKEN");
+      systemdArgs.push_back("-E");
+      systemdArgs.push_back("DESKTOP_STARTUP_ID");
+      runOptions.env.push_back({"XDG_ACTIVATION_TOKEN", activationToken});
+      runOptions.env.push_back({"DESKTOP_STARTUP_ID", activationToken});
     }
 
     // App should inherit our environment.
@@ -688,21 +676,25 @@ namespace {
 
     systemdArgs.push_back("--");
     systemdArgs.insert(systemdArgs.end(), args.begin(), args.end());
-    process::RunResult result = runSyncProcess(systemdArgs, {});
-    if (result) {
-      ::_exit(0);
-    }
-
-    // If systemd-run failed, fall back to normal launch. E.g., if systemd-run is not available,
-    // or its version is too old for the switches we used, or the executable is not found.
-    // We'd unnecessarily fail again later in the last case, but seems OK to err on the safe side here.
-
-    // This would be two more unnecessary forks if systemd-run is missing, but seems acceptable for
-    // the fallback path.
-    (void)doubleForkExecDetached(args, nullptr, activationToken, workingDir);
-    ::_exit(0);
+    return process::runAsync(
+        systemdArgs,
+        process::RunCallbacks{
+            .stdOut = [](std::string_view) {},
+            .stdErr = [](std::string_view) {},
+            .onExit =
+                [](process::RunResult result) {
+                  if (result.exitCode != 0) {
+                    // We'd like to show a toast or notification here, but the callback is not on the UI thread, so
+                    // unclear how to
+                    kLog.error(
+                        "startSystemdService: systemd-run failed with exit code {}: {}", result.exitCode, result.err
+                    );
+                  }
+                }
+        },
+        runOptions
+    );
   }
-
 } // namespace
 
 namespace process {
@@ -936,22 +928,18 @@ namespace process {
 #endif
   }
 
-  // We don't have a return code, so we don't wait for the launch mechanism to complete (e.g., systemd-run),
-  // which might take more time than a double-fork-exec and block the UI thread for too long. Launcher/AppProvider
-  // doesn't check if the app launch succeeded, anyway.
-  void runAsyncAsSystemdService(
+  bool runAsyncAsSystemdService(
       const std::vector<std::string>& args, const std::string& appName, const std::string& activationToken,
       const std::string& workingDir
   ) {
 #ifdef __linux__
     if (args.empty() || args.front().empty()) {
-      return;
+      return false;
     }
     if (systemdAvailable()) {
-      startSystemdService(args, activationToken, workingDir, appName);
-      return;
+      return startSystemdService(args, activationToken, workingDir, appName);
     }
 #endif
-    (void)runAsync(args, activationToken, workingDir);
+    return runAsync(args, activationToken, workingDir);
   }
 } // namespace process

--- a/src/core/process.h
+++ b/src/core/process.h
@@ -90,9 +90,8 @@ namespace process {
 
   [[nodiscard]] bool launchFirstAvailable(std::initializer_list<std::initializer_list<const char*>> commandVariants);
 
-  bool systemdAvailable();
-  // Run an app as a systemd service
-  void runAsyncAsSystemdService(
+  [[nodiscard]] bool systemdAvailable();
+  [[nodiscard]] bool runAsyncAsSystemdService(
       const std::vector<std::string>& args, const std::string& appName, const std::string& activationToken = {},
       const std::string& workingDir = {}
   );

--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -133,8 +133,7 @@ namespace desktop_entry_launch {
 
     const std::string appName = !entry.id.empty() ? entry.id : appNameOrDefault(entry.name);
     if (options.runAsSystemdService) {
-      process::runAsyncAsSystemdService(prepared->args, appName, options.activationToken, entry.workingDir);
-      return true;
+      return process::runAsyncAsSystemdService(prepared->args, appName, options.activationToken, entry.workingDir);
     }
     return process::runAsync(prepared->args, options.activationToken, entry.workingDir);
   }
@@ -152,10 +151,9 @@ namespace desktop_entry_launch {
     }
 
     if (options.runAsSystemdService) {
-      process::runAsyncAsSystemdService(
+      return process::runAsyncAsSystemdService(
           prepared->args, appNameOrDefault(appName), options.activationToken, std::string(workingDir)
       );
-      return true;
     }
     return process::runAsync(prepared->args, options.activationToken, std::string(workingDir));
   }


### PR DESCRIPTION
Since the systemd-run path is only used on an option which has to be explicitly enabled by the user, if it fails, it's better to just fail the launch, so the user can be aware of the issue.

Still fallback to double-forking if systemd is not detected, in case there's a leftover in the config file enabling the systemd launcher on a non-systemd setup. In this case, there's no such option in settings UI, so the user won't even know that the option is enabled, anyway.