### PR TITLE
feat(nix): add config validation to hjem module

### DIFF
--- a/nix/hjem-module.nix
+++ b/nix/hjem-module.nix
@@ -14,7 +14,19 @@ let
   toml = pkgs.formats.toml { };
   json = pkgs.formats.json { };
 
-  configToml = toml.generate "config.toml" cfg.settings;
+  configToml =
+    let
+      rawConfig = toml.generate "config.toml" cfg.settings;
+    in
+    if cfg.package != null && cfg.validateConfig then
+      pkgs.runCommand "noctalia-config" { } ''
+        cp ${rawConfig} config.toml
+        ${lib.getExe cfg.package} config validate .
+        cp config.toml $out
+      ''
+    else
+      rawConfig;
+
   paletteFiles = mapAttrs (
     name: palette: json.generate "${name}-palette.json" palette
   ) cfg.customPalettes;
@@ -37,6 +49,12 @@ in
     package = mkOption {
       type = lib.types.nullOr lib.types.package;
       description = "The noctalia package to use.";
+    };
+
+    validateConfig = mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Validate the configuration file at build time.";
     };
 
     settings = mkOption {


### PR DESCRIPTION
Since there is an cli option to validate the noctalia config, I added it as an option to the hjem module to validate the config.toml at build time.

While testing I could not yet make it error out, but it did provide warnings for wrong config options, which you can see in the build log.

The same can probably be added to the home-manager module, but I can't test that.

@linusammon

An example of the build output with a wrong section (misspelled theme):
```
noctalia-config> WARN  theAsme: unknown section
noctalia-config>
noctalia-config> ✓ Config is valid (1 warning(s))
```