### PR TITLE
feat(launcher): added seassion search option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1658,6 +1658,10 @@
           "description": "Use smaller icons and tighter result rows",
           "label": "Compact Rows"
         },
+        "launcher-session-search": {
+          "description": "Include session actions (lock, suspend, reboot, shutdown, logout) in general launcher searches, not only behind the /session prefix",
+          "label": "Enable Session Search"
+        },
         "launcher-show-icons": {
           "description": "Show application icons in launcher results",
           "label": "Show App Icons"

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -746,6 +746,7 @@ struct ShellConfig {
     bool launcherCategories = true;
     bool launcherShowIcons = true;
     bool launcherCompact = false;
+    bool launcherSessionSearch = false;
 
     bool operator==(const PanelConfig&) const = default;
   };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -979,6 +979,7 @@ namespace noctalia::config::schema {
           field(&ShellConfig::PanelConfig::launcherCategories, "launcher_categories"),
           field(&ShellConfig::PanelConfig::launcherShowIcons, "launcher_show_icons"),
           field(&ShellConfig::PanelConfig::launcherCompact, "launcher_compact"),
+          field(&ShellConfig::PanelConfig::launcherSessionSearch, "launcher_session_search"),
       };
       return s;
     }

--- a/src/launcher/launcher_provider.h
+++ b/src/launcher/launcher_provider.h
@@ -42,6 +42,10 @@ public:
   // record each activation and surface frequently used entries higher.
   [[nodiscard]] virtual bool trackUsage() const { return false; }
 
+  // Prefixed providers (non-empty prefix()) normally only respond when their prefix is typed.
+  // Return true to also contribute results to the general (non-prefixed) search.
+  [[nodiscard]] virtual bool includeInGlobalSearch() const { return false; }
+
   [[nodiscard]] virtual std::vector<LauncherCategory> categories() const { return {}; }
 
   virtual void initialize() {}

--- a/src/launcher/session_provider.cpp
+++ b/src/launcher/session_provider.cpp
@@ -126,6 +126,10 @@ SessionProvider::SessionProvider(ConfigService* config, SessionActionRunner* act
 
 std::string SessionProvider::displayName() const { return i18n::tr("launcher.providers.session.title"); }
 
+bool SessionProvider::includeInGlobalSearch() const {
+  return m_config != nullptr && m_config->config().shell.panel.launcherSessionSearch;
+}
+
 std::vector<LauncherResult> SessionProvider::query(std::string_view text) const {
   auto entries = collectActions(m_config);
   if (entries.empty()) {

--- a/src/launcher/session_provider.h
+++ b/src/launcher/session_provider.h
@@ -14,6 +14,8 @@ public:
   [[nodiscard]] std::string displayName() const override;
   [[nodiscard]] std::string_view defaultGlyphName() const override { return "power"; }
 
+  [[nodiscard]] bool includeInGlobalSearch() const override;
+
   [[nodiscard]] std::vector<LauncherResult> query(std::string_view text) const override;
 
   bool activate(const LauncherResult& result) override;

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -716,9 +716,18 @@ void LauncherPanel::onInputChanged(const std::string& text) {
   } else if (startsWithSlash(text)) {
     m_allResults = providerOverviewResults(text);
   } else {
-    // Query default providers (empty prefix)
+    // Query default providers (empty prefix), plus prefixed providers that opt into global search.
+    // Prefixed opt-in providers (e.g. Session) only contribute once the query is at least 2 chars,
+    // so opening the launcher with no/short input does not flood it with their entries.
+    const bool allowGlobalOptIn = queryText.size() >= 2;
     for (auto& provider : m_providers) {
-      if (provider->prefix().empty()) {
+      const bool isDefault = provider->prefix().empty();
+      if (!isDefault) {
+        if (!provider->includeInGlobalSearch() || !allowGlobalOptIn) {
+          continue;
+        }
+      }
+      {
         auto results = provider->query(queryText);
         if (provider->trackUsage()) {
           applyUsageBoost(results, *provider);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -997,6 +997,12 @@ namespace settings {
         ToggleSetting{cfg.shell.panel.launcherCompact}, "launcher compact rows dense"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Panels, "launcher", tr("settings.schema.panels.launcher-session-search.label"),
+        tr("settings.schema.panels.launcher-session-search.description"), {"shell", "panel", "launcher_session_search"},
+        ToggleSetting{cfg.shell.panel.launcherSessionSearch},
+        "launcher session search power menu lock suspend reboot shutdown logout"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Panels, "clipboard", tr("settings.schema.panels.placement-clipboard.label"),
         tr("settings.schema.panels.placement-clipboard.description"), {"shell", "panel", "clipboard_placement"},
         asSegmented(enumSelect(kPanelPlacements, cfg.shell.panel.clipboardPlacement)),


### PR DESCRIPTION
## Motivation

This change adds session search to the launcher. The same way as it is done in the legacy v4.  
Session items appear when the user types 2 or more characters that contain the session option name.   
The option defaults to "disabled".  

## Type of Change

Mark the relevant option with an "x".
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Related Issue
- N/A

## Testing

- [x] Tested on niri
- [x] Tested on Hyprland
- [ ] Tested on sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors (if applicable)

## Screenshots / Videos

https://github.com/user-attachments/assets/3740b0aa-948c-4cff-ab9b-af241860b4e2

### User settings

<img width="2552" height="2806" alt="image" src="https://github.com/user-attachments/assets/af72f573-8225-4bf2-8d6f-5a9cb3524a7d" />

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed my code
- [x] No new warnings or errors
- [x] Documentation or comments updated (if relevant)