### PR TITLE
settings: add an "force en translation" toggle on top

### DIFF
--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -239,6 +239,7 @@ private:
   std::string m_selectedSection;
   std::string m_statusMessage;
   std::string m_pendingResetPageScope;
+  bool m_forceEnTranslation = false;
   bool m_showAdvanced = false;
   bool m_showOverriddenOnly = false;
   bool m_statusIsError = false;

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -24,6 +24,7 @@
 #include "ui/palette.h"
 #include "ui/style.h"
 #include "util/string_utils.h"
+#include "util/sys_utils.h"
 #include "wayland/toplevel_surface.h"
 #include "wayland/wayland_connection.h"
 
@@ -636,6 +637,28 @@ std::unique_ptr<Flex> SettingsWindow::buildFilterRow(
       })
   );
   filters->addChild(ui::spacer());
+
+  static const bool translatorMode = SysUtils::isEnvFlagOn("NOCTALIA_TRANSLATOR");
+  if (translatorMode) {
+    auto enLabel =
+        makeLabel("en", Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::Error), FontWeight::Normal);
+    filters->addChild(std::move(enLabel));
+
+    filters->addChild(
+        ui::toggle({
+            .checked = m_forceEnTranslation,
+            .scale = scale,
+            .onChange = [this, requestRebuild](bool value) {
+              m_forceEnTranslation = value;
+              if (value)
+                i18n::Service::instance().setLanguage("en");
+              else if (m_config != nullptr)
+                i18n::Service::instance().setLanguage(m_config->config().shell.lang);
+              requestRebuild();
+            },
+        })
+    );
+  }
 
   auto advancedLabel = makeLabel(
       i18n::tr("settings.badges.advanced"), Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant),

--- a/src/util/sys_utils.h
+++ b/src/util/sys_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdlib>
+#include <string_view>
+
+namespace SysUtils {
+
+  [[nodiscard]] inline bool isEnvFlagOn(std::string_view name) {
+    const char* s = std::getenv(name.data());
+    if (s == nullptr) {
+      return false;
+    }
+    std::string_view sv(s);
+    return !sv.empty() && sv != "0" && sv != "false" && sv != "no" && sv != "off";
+  }
+
+} // namespace SysUtils

--- a/src/wayland/surface.cpp
+++ b/src/wayland/surface.cpp
@@ -7,6 +7,7 @@
 #include "render/animation/animation_manager.h"
 #include "render/render_context.h"
 #include "render/scene/node.h"
+#include "util/sys_utils.h"
 #include "viewporter-client-protocol.h"
 #include "wayland/wayland_connection.h"
 
@@ -75,13 +76,7 @@ namespace {
   }
 
   bool idleProfileEnabled() {
-    static const bool enabled = [] {
-      const char* value = std::getenv("NOCTALIA_IDLE_PROFILE");
-      return value != nullptr
-          && value[0] != '\0'
-          && std::string_view(value) != "0"
-          && std::string_view(value) != "false";
-    }();
+    static const bool enabled = SysUtils::isEnvFlagOn("NOCTALIA_IDLE_PROFILE");
     return enabled;
   }
 


### PR DESCRIPTION
This should be convenient for translators when proofreading translations.
When you find something in doubt, just turn on this toggle to check the
original English text, without needing to go to the translation website
and search.

To enable it, set the environment variable NOCTALIA_TRANSLATOR=1 before
launching Noctalia. E.g.:

    NOCTALIA_TRANSLATOR=1 noctalia