### PR TITLE
pipewire: show QEMU audio streams in Application Volumes

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -8,6 +8,7 @@
 #include "util/string_utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <charconv>
 #include <chrono>
 #include <cmath>
@@ -481,12 +482,15 @@ namespace {
   bool isProgramStreamClass(std::string_view mediaClass) { return mediaClass == "Stream/Output/Audio"; }
 
   [[nodiscard]] bool isProgramOutputNode(const PipeWireService::NodeData& nd) {
-    // Match wpctl "Streams": Stream/Output/Audio without node.link-group. Loopback/filter endpoints also
-    // expose target.object or node.passive and must not appear as application volumes.
+    // Match wpctl "Streams": Stream/Output/Audio without node.link-group. Loopback/filter endpoints
+    // also expose node.passive and must not appear as application volumes. (target.object is NOT
+    // excluded here: virtual streams that feed another endpoint — e.g. QEMU relaying host audio
+    // into a VM's HDA codec — set target.object to identify the target, but they are still
+    // user-controllable application volumes the way pavucontrol/wpctl show them.)
     if (!isProgramStreamClass(nd.mediaClass) || !nd.streamClassificationReady) {
       return false;
     }
-    if (!nd.linkGroup.empty() || !nd.targetObject.empty() || nd.nodePassive) {
+    if (!nd.linkGroup.empty() || nd.nodePassive) {
       return false;
     }
     return true;
@@ -1256,6 +1260,43 @@ void PipeWireService::refreshNodeIdentity(NodeData& nd) {
   }
   if (nd.iconName.empty() && !client.iconName.empty()) {
     nd.iconName = client.iconName;
+  }
+
+  // QEMU audio (libvirt <audio type="pipewire">) sets target.object from the
+  // <input>/<output> name but never sets application.name. Surface that name
+  // (falling back to "QEMU" when absent) as the application identity. The block
+  // runs unconditionally because refreshNodeIdentity is invoked from onClientInfo
+  // (no target.object yet) and onNodeInfo (target.object populated later); without
+  // this the earlier call would pin applicationName to "QEMU" for the stream's
+  // lifetime. Matches every qemu-system-<arch> binary.
+  if (isProgramStreamClass(nd.mediaClass) && nd.name.starts_with("qemu-system-")) {
+    const std::string renameTo = nd.targetObject.empty() ? std::string{"QEMU"} : nd.targetObject;
+    nd.applicationName = renameTo;
+    // Sanitize target.object into a reverse-DNS-friendly applicationId suffix: the
+    // libvirt <input>/<output> name is free-form and may contain spaces or uppercase
+    // (e.g. "Windows 11"), which produces an awkward id like "org.qemu.vm.Windows 11"
+    // and breaks tools that expect a lowercase-hyphenated reverse-DNS identifier.
+    std::string idSuffix;
+    idSuffix.reserve(renameTo.size());
+    bool prevDash = false;
+    for (const char ch : renameTo) {
+      const unsigned char u = static_cast<unsigned char>(ch);
+      const bool alphanumeric = (u >= 'a' && u <= 'z') || (u >= 'A' && u <= 'Z') || (u >= '0' && u <= '9');
+      if (alphanumeric) {
+        idSuffix.push_back(static_cast<char>(std::tolower(u)));
+        prevDash = false;
+      } else if (!prevDash) {
+        idSuffix.push_back('-');
+        prevDash = true;
+      }
+    }
+    while (!idSuffix.empty() && idSuffix.back() == '-') {
+      idSuffix.pop_back();
+    }
+    if (idSuffix.empty()) {
+      idSuffix = "qemu";
+    }
+    nd.applicationId = "org.qemu.vm." + idSuffix;
   }
 }
 


### PR DESCRIPTION
## Disclaimer
I know that this is a very edge cases and is intended for people who uses QEMU VMs and want the audio to appear on the "Application Volumes" widget. This will solve the below issues for me and I'll be really grateful if this is merged.

1. `!nd.targetObject.empty()` causes the QEMU VMs to be filtered out from the list
2. Show proper VM name instead of generic QEMU process name

** This change was made with the help of Claude Fable 5. **

## Summary

QEMU's PipeWire audio stream (libvirt `<audio type="pipewire">`) is a `Stream/Output/Audio` node with `target.object` set to the libvirt `<input>/<output>` name (e.g. "Windows 11"). Noctalia's `isProgramOutputNode` filter deliberately excluded any node with a non-empty `target.object` as a "loopback/filter endpoint", so QEMU streams were hidden from Application Volumes even though `pavucontrol` and `wpctl` show them. This makes the QEMU volume uncontrollable from the panel while the VM is playing audio.

Two changes:

1. **Drop the `!nd.targetObject.empty()` exclusion** in `isProgramOutputNode`. `node.link-group` and `node.passive` remain excluded (those still correctly hide Wine/Proton link-grouped stubs and real loopback/filter endpoints). Only `target.object` is relaxed. The comment is updated to match the new behaviour and to explain why virtual streams that feed another endpoint (QEMU → VM HDA) are user-controllable application volumes.

2. **Promote `target.object` to `applicationName`** in `refreshNodeIdentity` for any `Stream/Output/Audio` node whose `node.name` starts with `qemu-system-` (covering every QEMU system emulator binary: `qemu-system-x86_64`, `qemu-system-aarch64`, `qemu-system-riscv64`, `qemu-system-arm`, `qemu-system-ppc64`, ...). QEMU's PipeWire backend does not expose `application.name` / `application.id` from process metadata, so without this the stream would show as the bare process name. When the libvirt `<input>/<output>` has a `name` attribute, that name is used; when it does not, the stream falls back to the generic label `"QEMU"`. The block synthesises a stable `applicationId` of `org.qemu.vm.<name>` so the stream doesn't collide with any other process's identity.

The block runs **unconditionally** for any matching node — not gated on whether `applicationName` is already set — because `refreshNodeIdentity` is called from both `onClientInfo` (which fires before the node's `target.object` is populated, and would otherwise pin `applicationName` to `"QEMU"` for the lifetime of the stream) and `onNodeInfo` (which fills in `target.object` later). QEMU's PipeWire backend never sets `application.name` on its own, so there is no other source of application identity for this stream that we could be clobbering.

## Reproduction

On a libvirt-managed QEMU VM with `<audio type="pipewire">` and a `<sound>` device, open the audio panel's "Application Volumes". The QEMU stream is missing. The same stream is visible in `pavucontrol` and listed in `wpctl status` as a Stream.

`pw-cli info <id>` on the QEMU `Stream/Output/Audio` node confirms:
- `node.name = "qemu-system-<arch>"`
- `target.object = "<libvirt <input>/<output> name>"`
- `application.name` and `application.id` not set

## Verification

- `meson setup build && ninja -C build` — 688/688 targets compile and link cleanly.
- `meson test -C build` — 22/22 pass.
- The change is contained to one file (`src/pipewire/pipewire_service.cpp`, +31 / −3).

## Result

<img width="652" height="519" alt="image" src="https://github.com/user-attachments/assets/a3a1610e-cf94-4601-9a8d-d1eaa60b9a53" />

based on QEMU config:

```
<domain>
  ...
  <devices>
    ...
    <audio id="1" type="pipewire" runtimeDir="/run/user/1000">
        <input mixingEngine="no" name="Windows 11"/>
        <output mixingEngine="no" name="Windows 11"/>
    </audio>
    ...
  </devices>
  ...
</domain>
```

## Risk

With this change, any PipeWire node with `target.object` set (e.g. a virtual sink feeding another virtual sink) will now appear in Application Volumes. On the reporter's system there are zero such nodes besides QEMU; if a future use case needs to keep hiding a particular category of `target.object` streams, that should be added as a follow-up with a more specific predicate.