### PR TITLE
docs() remove repeated package typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ sudo xbps-install meson ninja pkg-config git \
   pango-devel fontconfig-devel freetype-devel \
   harfbuzz-devel libxkbcommon-devel pipewire-devel \
   libcurl-devel pam-devel libwebp-devel \
-  basu-devel libcurl-devel sdbus-c++-devel \
+  basu-devel sdbus-c++-devel \
   polkit-devel librsvg-devel libqalculate-devel libxml2-devel jemalloc-devel
 ```
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Just a small typo in the README, lists libcurl-devel twice in the Void `xbps-install` command.