### PR TITLE
nix: rename nixos module attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,11 +63,15 @@
           programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
 
-      hjemModules.default =
-        { pkgs, lib, ... }:
-        {
-          imports = [ ./nix/hjem-module.nix ];
-          programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-        };
+      nixosModules = {
+        default = self.nixosModules.noctalia;
+
+        noctalia =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ./nix/hjem-module.nix ];
+            programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          };
+      };
     };
 }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Motivation and summary

<!-- What changed and why? -->

change the attribute name from 'hjemModules' to
'nixosModules' as this is the standard attribute
to place nixos modules under as per the flake schema spec. This ensure that the exported nixos module is more discoverable from nix tooling like `nix flake show`

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [x] Build / packaging

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Tested the change with `nix flake show .` locally, no need to invoke cpp tests and there are no code changes.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [ ] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
