### PR TITLE
feat(nixos/hm): add config validation to home-manager module

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -32,6 +32,12 @@ in
       description = "The noctalia package to use.";
     };
 
+    validateConfig = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Validate the configuration file at build time.";
+    };
+
     settings = lib.mkOption {
       type =
         with lib.types;
@@ -109,7 +115,18 @@ in
     xdg = {
       configFile = lib.mkMerge [
         (lib.mkIf (cfg.settings != { }) {
-          "noctalia/config.toml".source = generateToml "config.toml" cfg.settings;
+          "noctalia/config.toml".source =
+            let
+              rawConfig = generateToml "config.toml" cfg.settings;
+            in
+            if cfg.validateConfig && cfg.package != null then
+              pkgs.runCommand "noctalia-config" { } ''
+                cp ${rawConfig} config.toml
+                ${lib.getExe cfg.package} config validate .
+                cp config.toml $out
+              ''
+            else
+              rawConfig;
         })
         (lib.mapAttrs' (
           name: palette:


### PR DESCRIPTION
## Summary

Adds `programs.noctalia.validateConfig` (default `true`) option to the home-manager module. Same as in the hjem module.

## Motivation

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Same code as hjem module, works on nixos-rebuild

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.