### PR TITLE
feat(battery widget): add hide-when-idle option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2474,6 +2474,10 @@
           "description": "Hide the battery widget when fully charged",
           "label": "Hide When Full"
         },
+        "hide-when-idle": {
+          "description": "Hide the battery widget while plugged in but not charging (e.g. held at a BIOS charge limit)",
+          "label": "Hide When Idle"
+        },
         "hide-when-no-connected-device": {
           "description": "Hide the bluetooth widget when no device is connected",
           "label": "Hide When No Connected Device"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -182,6 +182,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const bool showLabel = wc != nullptr ? wc->getBool("show_label", true) : true;
     const bool hideWhenPlugged = wc != nullptr ? wc->getBool("hide_when_plugged", false) : false;
     const bool hideWhenFull = wc != nullptr ? wc->getBool("hide_when_full", false) : false;
+    const bool hideWhenIdle = wc != nullptr ? wc->getBool("hide_when_idle", false) : false;
     BatteryDisplayMode displayMode = BatteryDisplayMode::Glyph;
     if (displayModeStr == "graphic") {
       displayMode = BatteryDisplayMode::Graphic;
@@ -189,7 +190,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
       kLog.warn("invalid widget.{}.display_mode '{}'; expected glyph or graphic", name, displayModeStr);
     }
     auto widget = std::make_unique<BatteryWidget>(
-        m_upower, deviceSelector, warningThreshold, warningColor, displayMode, showLabel, hideWhenPlugged, hideWhenFull
+        m_upower, deviceSelector, warningThreshold, warningColor, displayMode, showLabel, hideWhenPlugged, hideWhenFull,
+        hideWhenIdle
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -68,11 +68,11 @@ namespace {
 
 BatteryWidget::BatteryWidget(
     UPowerService* upower, std::string deviceSelector, int warningThreshold, ColorSpec warningColor,
-    BatteryDisplayMode displayMode, bool showLabel, bool hideWhenPlugged, bool hideWhenFull
+    BatteryDisplayMode displayMode, bool showLabel, bool hideWhenPlugged, bool hideWhenFull, bool hideWhenIdle
 )
     : m_upower(upower), m_deviceSelector(std::move(deviceSelector)), m_warningThreshold(warningThreshold),
       m_warningColor(warningColor), m_displayMode(displayMode), m_showLabel(showLabel),
-      m_hideWhenPlugged(hideWhenPlugged), m_hideWhenFull(hideWhenFull) {}
+      m_hideWhenPlugged(hideWhenPlugged), m_hideWhenFull(hideWhenFull), m_hideWhenIdle(hideWhenIdle) {}
 
 void BatteryWidget::create() {
   auto container = std::make_unique<InputArea>();
@@ -356,9 +356,13 @@ void BatteryWidget::syncState(Renderer& renderer) {
       || s.state == BatteryState::FullyCharged
       || s.state == BatteryState::PendingCharge;
 
+  // The battery is not charging due to a charge limit, but still plugged in.
+  const bool isIdle = s.state == BatteryState::PendingCharge;
+
   const bool showWidget = s.isPresent
       && !(m_hideWhenPlugged && isPluggedIn)
-      && !(m_hideWhenFull && (s.state == BatteryState::FullyCharged || s.state == BatteryState::PendingCharge));
+      && !(m_hideWhenFull && s.state == BatteryState::FullyCharged)
+      && !(m_hideWhenIdle && isIdle);
 
   auto* rootNode = root();
   if (rootNode != nullptr) {

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -19,7 +19,7 @@ public:
   BatteryWidget(
       UPowerService* upower, std::string deviceSelector = "auto", int warningThreshold = 0, ColorSpec warningColor = {},
       BatteryDisplayMode displayMode = BatteryDisplayMode::Glyph, bool showLabel = true, bool hideWhenPlugged = false,
-      bool hideWhenFull = false
+      bool hideWhenFull = false, bool hideWhenIdle = false
   );
 
   void create() override;
@@ -45,6 +45,7 @@ private:
   bool m_showLabel = true;
   bool m_hideWhenPlugged = false;
   bool m_hideWhenFull = false;
+  bool m_hideWhenIdle = false;
 
   // Glyph mode nodes
   Glyph* m_glyph = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -639,6 +639,7 @@ namespace settings {
       add(boolSpec("show_label", true));
       add(boolSpec("hide_when_plugged", false));
       add(boolSpec("hide_when_full", false));
+      add(boolSpec("hide_when_idle", false));
       add(selectSpec("device", "auto", {{"auto", "common.states.auto"}}));
       {
         auto warn = colorSpec("warning_color", "error");


### PR DESCRIPTION
## Summary
Add a hide when idle option in the battery widget.
The battery is considered idle when upower reports it as Pending Charge.
This is useful for laptops with a charging limit enforced in BIOS, because the hide when full option will not work (as it will never reach 100%)

## Motivation


## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Task in the triage list on discord

## Testing


## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [X] Tested with different bar positions and density settings
- [X] Tested at different interface scaling values
- [X] Tested with multiple monitors

## Screenshots / Videos


## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes


