### PR TITLE
fix(lock): deferred lock when no monitor is connected blocks suspend

### DIFF
--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -85,6 +85,8 @@ bool LockScreen::lock() {
   if (m_wayland->outputs().empty()) {
     m_lockDeferred = true;
     kLog.warn("no outputs available for lock screen; lock deferred until an output is connected");
+    // Run any pending post-lock action (e.g. suspend) immediately rather than holding it until a monitor connects.
+    dispatchPendingAfterLocked();
     return true;
   }
 
@@ -363,11 +365,7 @@ void LockScreen::handleLocked(void* data, ext_session_lock_v1* /*lock*/) {
   if (self->m_onSessionLocked) {
     self->m_onSessionLocked();
   }
-  if (self->m_pendingAfterLocked) {
-    auto pending = std::move(self->m_pendingAfterLocked);
-    self->m_pendingAfterLocked = {};
-    DeferredCall::callLater(std::move(pending));
-  }
+  self->dispatchPendingAfterLocked();
 }
 
 void LockScreen::handleFinished(void* data, ext_session_lock_v1* /*lock*/) {
@@ -607,6 +605,14 @@ void LockScreen::createInstance(const WaylandOutput& output) {
           .surface = std::move(surface),
       }
   );
+}
+
+void LockScreen::dispatchPendingAfterLocked() {
+  if (m_pendingAfterLocked) {
+    auto pending = std::move(m_pendingAfterLocked);
+    m_pendingAfterLocked = {};
+    DeferredCall::callLater(std::move(pending));
+  }
 }
 
 void LockScreen::resetLockState() {

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -76,6 +76,7 @@ private:
     std::unique_ptr<LockSurface> surface;
   };
 
+  void dispatchPendingAfterLocked();
   void syncInstances();
   void captureDesktopSnapshots();
   [[nodiscard]] bool shouldUseBlurredDesktop() const;


### PR DESCRIPTION
## Summary

When a suspend with `lock_before_suspend=true` behavior is triggered but no monitor is connected, the computer never suspends.

Steps to reproduce:

1) Configure suspend behavior

```
[idle.behavior.suspend]
enabled = true
timeout = 10 # Just 10 seconds to make it happen quickly
lock_before_suspend = true
command = "noctalia:session suspend"
```

2) Unplug monitor and wait 10 seconds (suspend never happens)
3) Re-plug monitor and computer immediately suspends

## Motivation

Commit 7e013e80 fixed an issue where idle lock behavior triggered when no monitor is connected would cause a lock screen crash (Niri red screen). The fix deferred lock until a monitor reconnects. As as a side effect, the suspend is also deferred, so unplugging a monitor will cause the computer never to suspend. On reconnecting the monitor, the computer immediately suspends.

As a side note, `[idle.behavior.suspend].lock_before_suspend` isn't documented. Not sure if there's a reason to keep it if the user can just set `command = "noctalia:session lock-and-suspend"` as the suspend command? This fix applies to both cases.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

I tested the following cases both with/without unplugging monitor before idle triggers, and it fixes both.

1. `lock-and-suspend` with `lock_before_suspend = false`

```
[idle.behavior.suspend]
enabled = true
timeout = 10
lock_before_suspend = false
command = "noctalia:session lock-and-suspend"
```

2. `suspend` with `lock_before_suspend = true`

```
[idle.behavior.suspend]
enabled = true
timeout = 10
lock_before_suspend = true
command = "noctalia:session suspend"
```

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
