### PR TITLE
fix(lockscreen): run PAM on background thread to avoid blocking UI

### DIFF
--- a/src/auth/pam_authenticator.cpp
+++ b/src/auth/pam_authenticator.cpp
@@ -96,7 +96,8 @@ namespace {
 
 } // namespace
 
-PamAuthenticator::Result PamAuthenticator::authenticateCurrentUser(std::string_view password) const {
+// Potentially not called from the main thread so should not mutate shared state (class method).
+PamAuthenticator::Result PamAuthenticator::authenticateCurrentUser(std::string_view password) {
   std::string user = currentUsername();
   if (user.empty()) {
     return Result{.success = false, .message = i18n::tr("auth.pam.user-unavailable")};

--- a/src/auth/pam_authenticator.h
+++ b/src/auth/pam_authenticator.h
@@ -10,6 +10,6 @@ public:
     std::string message;
   };
 
-  [[nodiscard]] Result authenticateCurrentUser(std::string_view password) const;
+  [[nodiscard]] static Result authenticateCurrentUser(std::string_view password);
   [[nodiscard]] static std::string currentUsername();
 };

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <string>
+#include <thread>
 #include <wayland-client.h>
 
 namespace {
@@ -609,6 +610,7 @@ void LockScreen::createInstance(const WaylandOutput& output) {
   surface->setOnLogin([this]() { tryAuthenticate(); });
   surface->setOnPasswordChanged([this](const std::string& value) { handlePasswordEdited(value); });
   surface->setPromptState(m_user, m_password, m_status, m_statusIsError);
+  surface->setInputEnabled(!m_pamAuthInFlight);
 
   surface->setBlackout(!isInteractiveOutput(output));
 
@@ -651,6 +653,15 @@ void LockScreen::updatePromptOnSurfaces() {
   }
 }
 
+// Freeze the password field UI for visual indication request is in-flight
+void LockScreen::updateInputEnabledOnSurfaces() {
+  for (auto& instance : m_instances) {
+    if (instance.surface != nullptr) {
+      instance.surface->setInputEnabled(!m_pamAuthInFlight);
+    }
+  }
+}
+
 void LockScreen::handlePasswordEdited(const std::string& value) {
   if (m_password == value && m_status.empty() && !m_statusIsError) {
     return;
@@ -662,13 +673,38 @@ void LockScreen::handlePasswordEdited(const std::string& value) {
 }
 
 void LockScreen::tryAuthenticate() {
+  if (m_pamAuthInFlight) {
+    return;
+  }
+  m_pamAuthInFlight = true;
   m_status = i18n::tr("lockscreen.authenticating");
   m_statusIsError = false;
   updatePromptOnSurfaces();
+  // Important to call this after we set m_pamAuthInFlight
+  updateInputEnabledOnSurfaces();
 
-  const auto result = m_authenticator.authenticateCurrentUser(m_password);
-  clearSensitiveString(m_password);
+  std::string pw = std::move(m_password);
+  m_password.clear();
 
+  // PAM can stall the main thread long enough to freeze the UI, so run it on a
+  // background thread and schedule a callback on the main thread.
+  //
+  // Many distros rate limit PAM with pam_faildelay which causes a UI hang when the password is wrong.
+  std::thread([this, pw = std::move(pw)]() mutable {
+    auto result = PamAuthenticator::authenticateCurrentUser(pw);
+    clearSensitiveString(pw);
+    // Callback is scheduled on the main thread, so shared state is safe
+    DeferredCall::callLater([this, result = std::move(result)]() mutable { onAuthResult(std::move(result)); });
+  }).detach();
+}
+
+void LockScreen::onAuthResult(PamAuthenticator::Result result) {
+  m_pamAuthInFlight = false;
+  updateInputEnabledOnSurfaces();
+
+  if (!isActive()) {
+    return;
+  }
   if (result.success) {
     m_status = i18n::tr("lockscreen.unlocked");
     m_statusIsError = false;
@@ -676,7 +712,6 @@ void LockScreen::tryAuthenticate() {
     unlock();
     return;
   }
-
   m_status = result.message.empty() ? i18n::tr("lockscreen.authentication-failed") : result.message;
   m_statusIsError = true;
   updatePromptOnSurfaces();

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -90,11 +90,13 @@ private:
   void resetLockState();
   void clearInstances();
   void updatePromptOnSurfaces();
+  void updateInputEnabledOnSurfaces();
   void handlePasswordEdited(const std::string& value);
   void tryAuthenticate();
   void startFingerprint();
   void stopFingerprint();
   void handleFingerprintStatus(const std::string& message, bool isError);
+  void onAuthResult(PamAuthenticator::Result result);
   static void clearSensitiveString(std::string& value);
 
   WaylandConnection* m_wayland = nullptr;
@@ -105,13 +107,14 @@ private:
   ext_session_lock_v1* m_lock = nullptr;
   std::vector<Instance> m_instances;
   std::unordered_map<wl_output*, ScreencopyImage> m_desktopCaptures;
-  PamAuthenticator m_authenticator;
   std::unique_ptr<FingerprintAuthenticator> m_fingerprint;
   std::string m_user;
   std::string m_password;
   std::string m_status;
   wl_surface* m_pointerSurface = nullptr;
   bool m_statusIsError = false;
+  // Track whether async PAM request is in-flight
+  bool m_pamAuthInFlight = false;
   bool m_lockPending = false;
   bool m_locked = false;
   bool m_desktopCapturesPrimed = false;

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -200,7 +200,8 @@ bool LockSurface::passwordFieldContainsPoint(float sceneX, float sceneY) const {
 }
 
 void LockSurface::focusPasswordField() {
-  if (!m_locked || m_blackout || m_passwordField == nullptr) {
+  if (!m_locked || m_blackout || m_passwordField == nullptr || !m_passwordField->enabled()) {
+    // Password field is disabled while PAM auth is in-flight, so block focus
     return;
   }
   m_inputDispatcher.setFocus(m_passwordField->inputArea());
@@ -306,6 +307,21 @@ void LockSurface::setOnPasswordChanged(std::function<void(const std::string&)> o
   m_onPasswordChanged = std::move(onPasswordChanged);
 }
 
+void LockSurface::setInputEnabled(bool enabled) {
+  if (m_passwordField != nullptr) {
+    m_passwordField->setEnabled(enabled);
+  }
+  if (m_loginButton != nullptr) {
+    m_loginButton->setEnabled(enabled);
+  }
+  if (!enabled) {
+    // Drop focus so keyboard events aren't delivered while auth is in flight.
+    m_inputDispatcher.setFocus(nullptr);
+  } else {
+    focusPasswordField();
+  }
+}
+
 void LockSurface::selectAllPassword() {
   if (m_passwordField == nullptr) {
     return;
@@ -378,9 +394,11 @@ void LockSurface::onKeyboardEvent(const KeyboardEvent& event) {
     return;
   }
 
+  // Don't steal focus back to the password field while it's disabled (PAM auth in flight).
   if (m_locked
       && event.pressed
       && m_passwordField != nullptr
+      && m_passwordField->enabled()
       && m_inputDispatcher.focusedArea() != m_passwordField->inputArea()) {
     focusPasswordField();
   }

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -50,6 +50,7 @@ public:
   [[nodiscard]] bool isBlackout() const noexcept { return m_blackout; }
   void setOnLogin(std::function<void()> onLogin);
   void setOnPasswordChanged(std::function<void(const std::string&)> onPasswordChanged);
+  void setInputEnabled(bool enabled);
   void selectAllPassword();
   void clearPasswordSelection();
   void onThemeChanged();


### PR DESCRIPTION
## Summary

The PAM call on the lock screen is blocking and when a distro has `pam_faildelay` configured, typing a wrong password will cause Noctalia's main thread to block for a couple seconds. Before, blocking the UI thread naturally made the UI freeze to give a visual indication a failed auth attempt is in-progress. Now that it runs async, I updated the lockscreen UI to unfocus and disable the lock text box and button to visually indicate the lock request is in-flight (this only applies if password was wrong and there's a `faildelay`).

I think this may have also fixed a difficult to reproduce issue where the lock screen would very rarely freeze indefinitely because PAM call never returns. I think it might be related to some circular dependence (maybe D-Bus?) where forward progress of the PAM call is blocked because the main Noctalia thread can't sink D-Bus messages. (Uncertain because it happens to me so rarely)

## Motivation

Stalling the main thread for seconds is not good and may be the cause of intermittent deadlock I was seeing.

The UI changes are just for the case where password is incorrect and user should wait a couple seconds before trying again. Without these changes, the password box can be focused, changed, etc without visual indication user can't resubmit yet. The code does guard against re-submission if the async PAM thread hasn't finished yet.

The PAM thread shares no mutable state with the main thread. The PAM thread schedules the auth result handling back on the main thread which runs out of the regular event queue.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

I tested repeated unlock attempts (both success and failure). I did not test with multiple monitors attached (might be relevant to the UI changes). I also didn't test with fingerprint reader (is that supported on V5 and would there be UI issues?).

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
