### PR TITLE
system_monitor_service: add Tctl to the list of valid CPU temp labels

### DIFF
--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -215,7 +215,10 @@ namespace {
   }
 
   bool isPrimaryCpuSensorLabel(const std::string& label) {
-    return label.starts_with("Package id") || label.starts_with("Tdie") || label.starts_with("SoC Temperature");
+    return label.starts_with("Package id")
+        || label.starts_with("Tdie")
+        || label.starts_with("Tctl")
+        || label.starts_with("SoC Temperature");
   }
 
   bool isCoreCpuSensorLabel(const std::string& label) { return label.starts_with("Core") || label.starts_with("Tccd"); }


### PR DESCRIPTION
## Summary

Adds Tctl to the list of valid CPU temp labels

## Motivation

On my system, I have no Tdie sensor. The fallback to any "CPU" label that exists  can poll the wrong sensor resulting in 0C or invalid readings overall

```
❯ grep "" /sys/class/hwmon/hwmon*/temp*_label
/sys/class/hwmon/hwmon0/temp1_label:Composite
/sys/class/hwmon/hwmon1/temp1_label:Composite
/sys/class/hwmon/hwmon2/temp1_label:CPU
/sys/class/hwmon/hwmon2/temp2_label:System
/sys/class/hwmon/hwmon2/temp3_label:VRM MOS
/sys/class/hwmon/hwmon2/temp4_label:PCH
/sys/class/hwmon/hwmon2/temp5_label:CPU Socket
/sys/class/hwmon/hwmon2/temp6_label:PCIe x1
/sys/class/hwmon/hwmon2/temp7_label:M2_1
/sys/class/hwmon/hwmon3/temp1_label:edge
/sys/class/hwmon/hwmon3/temp2_label:junction
/sys/class/hwmon/hwmon3/temp3_label:mem
/sys/class/hwmon/hwmon4/temp1_label:edge
/sys/class/hwmon/hwmon5/temp1_label:Tctl
/sys/class/hwmon/hwmon5/temp3_label:Tccd1
/sys/class/hwmon/hwmon5/temp4_label:Tccd2
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x]  this PR has no code changes.
- [ ] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] this PR does not change user-facing configuration or behavior.
- [x] or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

