### PR TITLE
lock: enable parallel fprintd unlocks

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1,5 +1,17 @@
 {
   "auth": {
+    "fingerprint": {
+      "disconnected": "Fingerprint reader disconnected",
+      "error": "Fingerprint authentication error",
+      "no-match": "Fingerprint did not match",
+      "not-centered": "Center your finger and try again",
+      "present": "Reading fingerprint...",
+      "ready": "Place your finger on the reader",
+      "remove-and-retry": "Remove your finger and try again",
+      "retry": "Please scan your fingerprint again",
+      "swipe-too-short": "Swipe was too short, try again",
+      "too-many-attempts": "Fingerprint disabled (too many attempts)"
+    },
     "pam": {
       "authentication-failed": "Authentication failed",
       "start-failed": "PAM start failed",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1593,6 +1593,10 @@
           "description": "Enable session lock, logind integration, and lock actions",
           "label": "Lock Screen"
         },
+        "fingerprint": {
+          "description": "Unlock with a fingerprint reader via fprintd, alongside password entry",
+          "label": "Fingerprint Unlock"
+        },
         "monitors": {
           "description": "Choose which monitors show the lock screen; leave empty to show on all monitors",
           "label": "Monitors"

--- a/meson.build
+++ b/meson.build
@@ -366,6 +366,7 @@ _noctalia_sources = files(
   'src/app/application.cpp',
   'src/app/main_loop.cpp',
   'src/app/single_instance_lock.cpp',
+  'src/auth/fingerprint_authenticator.cpp',
   'src/auth/pam_authenticator.cpp',
   'src/calendar/caldav_client.cpp',
   'src/calendar/caldav_discovery.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1241,7 +1241,7 @@ void Application::initUi() {
         i18n::tr("notifications.internal.wallpaper-palette-export-success", "name", paletteName)
     );
   });
-  m_lockScreen.initialize(m_wayland, &m_renderContext, &m_configService, &m_sharedTextureCache);
+  m_lockScreen.initialize(m_wayland, &m_renderContext, &m_configService, &m_sharedTextureCache, m_systemBus.get());
   m_wallpaper.setAutomationGate([this]() { return !m_lockScreen.isActive(); });
   m_configService.addReloadCallback([this]() {
     if (m_logindService != nullptr) {

--- a/src/auth/fingerprint_authenticator.cpp
+++ b/src/auth/fingerprint_authenticator.cpp
@@ -1,0 +1,328 @@
+#include "auth/fingerprint_authenticator.h"
+
+#include "core/log.h"
+#include "dbus/system_bus.h"
+#include "i18n/i18n.h"
+
+#include <chrono>
+#include <map>
+#include <optional>
+#include <sdbus-c++/Error.h>
+#include <sdbus-c++/IConnection.h>
+#include <sdbus-c++/IProxy.h>
+#include <sdbus-c++/Types.h>
+#include <string>
+#include <utility>
+
+namespace {
+  constexpr Logger kLog("fingerprint");
+
+  const sdbus::ServiceName kFprintBusName{"net.reactivated.Fprint"};
+  const sdbus::ObjectPath kManagerPath{"/net/reactivated/Fprint/Manager"};
+  constexpr auto kManagerInterface = "net.reactivated.Fprint.Manager";
+  constexpr auto kDeviceInterface = "net.reactivated.Fprint.Device";
+  constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
+
+  const sdbus::ServiceName kLoginBusName{"org.freedesktop.login1"};
+  const sdbus::ObjectPath kLoginPath{"/org/freedesktop/login1"};
+  constexpr auto kLoginManagerInterface = "org.freedesktop.login1.Manager";
+
+  constexpr int kMaxRetries = 3;
+  constexpr auto kRetryDelay = std::chrono::milliseconds(250);
+
+  enum class MatchResult {
+    Invalid,
+    NoMatch,
+    Matched,
+    Retry,
+    SwipeTooShort,
+    FingerNotCentered,
+    RemoveAndRetry,
+    Disconnected,
+    UnknownError,
+  };
+
+  MatchResult parseVerifyResult(const std::string& result) {
+    static const std::map<std::string, MatchResult> kResults = {
+        {"verify-no-match", MatchResult::NoMatch},
+        {"verify-match", MatchResult::Matched},
+        {"verify-retry-scan", MatchResult::Retry},
+        {"verify-swipe-too-short", MatchResult::SwipeTooShort},
+        {"verify-finger-not-centered", MatchResult::FingerNotCentered},
+        {"verify-remove-and-retry", MatchResult::RemoveAndRetry},
+        {"verify-disconnected", MatchResult::Disconnected},
+        {"verify-unknown-error", MatchResult::UnknownError},
+    };
+    const auto it = kResults.find(result);
+    return it == kResults.end() ? MatchResult::Invalid : it->second;
+  }
+} // namespace
+
+FingerprintAuthenticator::FingerprintAuthenticator(SystemBus& bus) : m_bus(bus) {
+  try {
+    m_loginManager = sdbus::createProxy(m_bus.connection(), kLoginBusName, kLoginPath);
+    // on sleep, stop verification; on resume, restart if active and not aborted
+    m_loginManager->uponSignal("PrepareForSleep").onInterface(kLoginManagerInterface).call([this](bool sleeping) {
+      m_sleeping = sleeping;
+      if (sleeping) {
+        stopVerify();
+      } else if (m_active && !m_abort) {
+        startVerify(false);
+      }
+    });
+  } catch (const sdbus::Error& e) {
+    kLog.debug("could not monitor PrepareForSleep: {}", e.what());
+    m_loginManager.reset();
+  }
+}
+
+FingerprintAuthenticator::~FingerprintAuthenticator() { stop(); }
+
+void FingerprintAuthenticator::setAuthenticatedCallback(AuthenticatedCallback callback) {
+  m_onAuthenticated = std::move(callback);
+}
+
+void FingerprintAuthenticator::setStatusCallback(StatusCallback callback) { m_onStatus = std::move(callback); }
+
+void FingerprintAuthenticator::start() {
+  if (m_active) {
+    return;
+  }
+  if (!m_bus.nameHasOwner("net.reactivated.Fprint")) {
+    kLog.debug("fprintd not available on system bus; fingerprint disabled");
+    return;
+  }
+  m_active = true;
+  m_abort = false;
+  m_retries = 0;
+  if (m_sleeping) {
+    return;
+  }
+  startVerify(false);
+}
+
+void FingerprintAuthenticator::stop() {
+  m_retryTimer.stop();
+  m_active = false;
+  m_verifying = false;
+  m_claiming = false;
+  if (!m_abort) {
+    releaseDevice();
+  } else {
+    m_device.reset();
+  }
+}
+
+bool FingerprintAuthenticator::createDeviceProxy() {
+  sdbus::ObjectPath path;
+  try {
+    auto manager = sdbus::createProxy(m_bus.connection(), kFprintBusName, kManagerPath);
+    manager->callMethod("GetDefaultDevice").onInterface(kManagerInterface).storeResultsTo(path);
+  } catch (const sdbus::Error& e) {
+    kLog.info("no fprintd device available: {}", e.what());
+    return false;
+  }
+
+  kLog.info("using fingerprint device {}", path.c_str());
+  try {
+    m_device = sdbus::createProxy(m_bus.connection(), kFprintBusName, path);
+  } catch (const sdbus::Error& e) {
+    kLog.warn("could not create device proxy: {}", e.what());
+    m_device.reset();
+    return false;
+  }
+
+  m_device->uponSignal("VerifyStatus").onInterface(kDeviceInterface).call([this](const std::string& result, bool done) {
+    handleVerifyStatus(result, done);
+  });
+
+  m_device->uponSignal("PropertiesChanged")
+      .onInterface(kPropertiesInterface)
+      .call([this](
+                const std::string& interfaceName, const std::map<std::string, sdbus::Variant>& changed,
+                const std::vector<std::string>& /*invalidated*/
+            ) {
+        if (interfaceName != kDeviceInterface) {
+          return;
+        }
+        const auto it = changed.find("finger-present");
+        if (it == changed.end()) {
+          return;
+        }
+        try {
+          if (it->second.get<bool>()) {
+            emitStatus(i18n::tr("auth.fingerprint.present"), false);
+          }
+        } catch (const sdbus::Error&) {
+        }
+      });
+
+  return true;
+}
+
+void FingerprintAuthenticator::claimDevice() {
+  if (m_device == nullptr || m_claiming) {
+    return;
+  }
+  m_claiming = true;
+
+  m_device->callMethodAsync("Claim")
+      .onInterface(kDeviceInterface)
+      .withArguments(std::string{})
+      .uponReplyInvoke([this](std::optional<sdbus::Error> e) {
+        m_claiming = false;
+        if (e.has_value()) {
+          kLog.info("could not claim fingerprint device: {}", e->what());
+          m_verifying = false;
+          return;
+        }
+        kLog.info("claimed fingerprint device");
+        if (m_active && !m_sleeping) {
+          startVerify(false);
+        }
+      });
+}
+
+void FingerprintAuthenticator::startVerify(bool isRetry) {
+  if (!m_active || m_sleeping || m_abort) {
+    return;
+  }
+  m_verifying = true;
+
+  if (m_device == nullptr) {
+    if (!createDeviceProxy()) {
+      m_verifying = false;
+      return;
+    }
+
+    emitStatus(i18n::tr("auth.fingerprint.ready"), false);
+    claimDevice();
+    return;
+  }
+  if (m_claiming) {
+    return;
+  }
+
+  m_device->callMethodAsync("VerifyStart")
+      .onInterface(kDeviceInterface)
+      .withArguments(std::string{"any"})
+      .uponReplyInvoke([this, isRetry](std::optional<sdbus::Error> e) {
+        if (e.has_value()) {
+          kLog.info("could not start fingerprint verification: {}", e->what());
+          m_verifying = false;
+          emitStatus({}, false); // issue loading: drop the status message
+          return;
+        }
+        kLog.debug("fingerprint verification started");
+        if (isRetry) {
+          m_retries++;
+        }
+        emitStatus(i18n::tr("auth.fingerprint.ready"), false);
+      });
+}
+
+void FingerprintAuthenticator::stopVerify() {
+  m_retryTimer.stop();
+  m_verifying = false;
+  if (m_device == nullptr) {
+    return;
+  }
+  try {
+    m_device->callMethod("VerifyStop").onInterface(kDeviceInterface);
+    kLog.debug("fingerprint verification stopped");
+  } catch (const sdbus::Error& e) {
+    kLog.debug("could not stop fingerprint verification: {}", e.what());
+  }
+}
+
+void FingerprintAuthenticator::releaseDevice() {
+  if (m_device == nullptr) {
+    return;
+  }
+  try {
+    m_device->callMethod("Release").onInterface(kDeviceInterface);
+    kLog.info("released fingerprint device");
+  } catch (const sdbus::Error& e) {
+    kLog.debug("could not release fingerprint device: {}", e.what());
+  }
+  m_device.reset();
+}
+
+void FingerprintAuthenticator::handleVerifyStatus(const std::string& result, bool done) {
+  if (!m_active) {
+    return;
+  }
+  if (m_sleeping) {
+    stopVerify();
+    return;
+  }
+
+  kLog.debug("verify status: {} (done={})", result, done);
+  const MatchResult match = parseVerifyResult(result);
+
+  bool authenticated = false;
+  bool retryInPlace = false;
+
+  switch (match) {
+  case MatchResult::Invalid:
+    kLog.warn("unknown fingerprint verify status: {}", result);
+    break;
+  case MatchResult::Matched:
+    stopVerify();
+    authenticated = true;
+    break;
+  case MatchResult::NoMatch:
+    stopVerify();
+    if (m_retries >= kMaxRetries) {
+      emitStatus(i18n::tr("auth.fingerprint.too-many-attempts"), true);
+    } else {
+      emitStatus(i18n::tr("auth.fingerprint.no-match"), true);
+      // XXX: rearm after a short delay
+      m_retryTimer.start(kRetryDelay, [this]() { startVerify(true); });
+    }
+    break;
+  case MatchResult::Retry:
+    retryInPlace = true;
+    emitStatus(i18n::tr("auth.fingerprint.retry"), false);
+    break;
+  case MatchResult::SwipeTooShort:
+    retryInPlace = true;
+    emitStatus(i18n::tr("auth.fingerprint.swipe-too-short"), false);
+    break;
+  case MatchResult::FingerNotCentered:
+    retryInPlace = true;
+    emitStatus(i18n::tr("auth.fingerprint.not-centered"), false);
+    break;
+  case MatchResult::RemoveAndRetry:
+    retryInPlace = true;
+    emitStatus(i18n::tr("auth.fingerprint.remove-and-retry"), false);
+    break;
+  case MatchResult::Disconnected:
+    stopVerify();
+    m_abort = true;
+    emitStatus(i18n::tr("auth.fingerprint.disconnected"), true);
+    break;
+  case MatchResult::UnknownError:
+    stopVerify();
+    emitStatus(i18n::tr("auth.fingerprint.error"), true);
+    break;
+  }
+
+  if (authenticated) {
+    if (m_onAuthenticated) {
+      m_onAuthenticated();
+    }
+    return;
+  }
+
+  // In-place retries keep verifying; otherwise restart only when fprintd reports done.
+  if (!retryInPlace && done && !m_abort && match != MatchResult::NoMatch && m_active && !m_sleeping) {
+    startVerify(true);
+  }
+}
+
+void FingerprintAuthenticator::emitStatus(const std::string& message, bool isError) {
+  if (m_onStatus) {
+    m_onStatus(message, isError);
+  }
+}

--- a/src/auth/fingerprint_authenticator.h
+++ b/src/auth/fingerprint_authenticator.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "core/timer_manager.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+class SystemBus;
+
+namespace sdbus {
+  class IProxy;
+}
+
+class FingerprintAuthenticator {
+public:
+  using AuthenticatedCallback = std::function<void()>;
+  using StatusCallback = std::function<void(const std::string& message, bool isError)>;
+
+  explicit FingerprintAuthenticator(SystemBus& bus);
+  ~FingerprintAuthenticator();
+
+  FingerprintAuthenticator(const FingerprintAuthenticator&) = delete;
+  FingerprintAuthenticator& operator=(const FingerprintAuthenticator&) = delete;
+
+  void setAuthenticatedCallback(AuthenticatedCallback callback);
+  void setStatusCallback(StatusCallback callback);
+
+  void start();
+  void stop();
+
+private:
+  bool createDeviceProxy();
+  void claimDevice();
+  void startVerify(bool isRetry);
+  void stopVerify();
+  void releaseDevice();
+  void handleVerifyStatus(const std::string& result, bool done);
+  void emitStatus(const std::string& message, bool isError);
+
+  SystemBus& m_bus;
+  std::unique_ptr<sdbus::IProxy> m_loginManager;
+  std::unique_ptr<sdbus::IProxy> m_device;
+
+  AuthenticatedCallback m_onAuthenticated;
+  StatusCallback m_onStatus;
+
+  Timer m_retryTimer;
+
+  bool m_active = false;
+  bool m_verifying = false;
+  bool m_claiming = false;
+  bool m_sleeping = false;
+  bool m_abort = false;
+  int m_retries = 0;
+};

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -391,6 +391,7 @@ struct BackdropConfig {
 
 struct LockscreenConfig {
   bool enabled = true;
+  bool fingerprint = true;
   bool blurredDesktop = false;
   float blurIntensity = 0.5f;
   float tintIntensity = 0.3f;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -77,6 +77,7 @@ namespace noctalia::config::schema {
   const Schema<LockscreenConfig>& lockscreenSchema() {
     static const Schema<LockscreenConfig> s = {
         field(&LockscreenConfig::enabled, "enabled"),
+        field(&LockscreenConfig::fingerprint, "fingerprint"),
         field(&LockscreenConfig::blurredDesktop, "blurred_desktop"),
         field(&LockscreenConfig::blurIntensity, "blur_intensity", kUnitRange),
         field(&LockscreenConfig::tintIntensity, "tint_intensity", kUnitRange),

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -1,5 +1,6 @@
 #include "shell/lockscreen/lock_screen.h"
 
+#include "auth/fingerprint_authenticator.h"
 #include "capture/screencopy_util.h"
 #include "config/config_service.h"
 #include "config/config_types.h"
@@ -50,13 +51,27 @@ LockScreen::~LockScreen() {
 
 bool LockScreen::initialize(
     WaylandConnection& wayland, RenderContext* renderContext, ConfigService* configService,
-    SharedTextureCache* textureCache
+    SharedTextureCache* textureCache, SystemBus* systemBus
 ) {
   m_wayland = &wayland;
   m_renderContext = renderContext;
   m_configService = configService;
   m_textureCache = textureCache;
+  m_systemBus = systemBus;
   m_user = PamAuthenticator::currentUsername();
+
+  if (m_systemBus != nullptr) {
+    m_fingerprint = std::make_unique<FingerprintAuthenticator>(*m_systemBus);
+    m_fingerprint->setAuthenticatedCallback([this]() {
+      m_status = i18n::tr("lockscreen.unlocked");
+      m_statusIsError = false;
+      updatePromptOnSurfaces();
+      unlock();
+    });
+    m_fingerprint->setStatusCallback([this](const std::string& message, bool isError) {
+      handleFingerprintStatus(message, isError);
+    });
+  }
   return true;
 }
 
@@ -135,6 +150,7 @@ void LockScreen::unlock() {
   }
 
   m_pendingAfterLocked = {};
+  stopFingerprint();
 
   const bool wasLockedInteractive = m_locked;
 
@@ -359,6 +375,7 @@ void LockScreen::handleLocked(void* data, ext_session_lock_v1* /*lock*/) {
     instance.surface->setOnLogin([self]() { self->tryAuthenticate(); });
   }
   self->updatePromptOnSurfaces();
+  self->startFingerprint();
   kLog.info("session is locked");
   if (self->m_onSessionLocked) {
     self->m_onSessionLocked();
@@ -374,6 +391,7 @@ void LockScreen::handleFinished(void* data, ext_session_lock_v1* /*lock*/) {
   auto* self = static_cast<LockScreen*>(data);
   kLog.info("session lock finished by compositor");
   self->m_pendingAfterLocked = {};
+  self->stopFingerprint();
 
   if (self->m_lock != nullptr) {
     if (self->m_locked) {
@@ -661,6 +679,36 @@ void LockScreen::tryAuthenticate() {
 
   m_status = result.message.empty() ? i18n::tr("lockscreen.authentication-failed") : result.message;
   m_statusIsError = true;
+  updatePromptOnSurfaces();
+}
+
+void LockScreen::startFingerprint() {
+  if (m_fingerprint == nullptr) {
+    return;
+  }
+  if (m_configService != nullptr && !m_configService->config().lockscreen.fingerprint) {
+    return;
+  }
+  m_fingerprint->start();
+}
+
+void LockScreen::stopFingerprint() {
+  if (m_fingerprint != nullptr) {
+    m_fingerprint->stop();
+  }
+}
+
+void LockScreen::handleFingerprintStatus(const std::string& message, bool isError) {
+  if (!isActive()) {
+    return;
+  }
+  // Don't clobber a password the user is typing.
+  if (!m_password.empty()) {
+    return;
+  }
+  // Empty message means verification disarmed; fall back to the default prompt.
+  m_status = message.empty() ? i18n::tr("lockscreen.ready") : message;
+  m_statusIsError = isError;
   updatePromptOnSurfaces();
 }
 

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -21,9 +21,11 @@ struct wl_surface;
 struct wl_output;
 class ConfigService;
 
+class FingerprintAuthenticator;
 class LockSurface;
 class RenderContext;
 class SharedTextureCache;
+class SystemBus;
 class WaylandConnection;
 
 class LockScreen {
@@ -33,7 +35,7 @@ public:
 
   bool initialize(
       WaylandConnection& wayland, RenderContext* renderContext, ConfigService* configService,
-      SharedTextureCache* textureCache
+      SharedTextureCache* textureCache, SystemBus* systemBus
   );
   void setSessionHooks(std::function<void()> onLocked, std::function<void()> onUnlocked);
   void setLockEngagedCallback(std::function<void()> callback);
@@ -90,16 +92,21 @@ private:
   void updatePromptOnSurfaces();
   void handlePasswordEdited(const std::string& value);
   void tryAuthenticate();
+  void startFingerprint();
+  void stopFingerprint();
+  void handleFingerprintStatus(const std::string& message, bool isError);
   static void clearSensitiveString(std::string& value);
 
   WaylandConnection* m_wayland = nullptr;
   RenderContext* m_renderContext = nullptr;
   ConfigService* m_configService = nullptr;
   SharedTextureCache* m_textureCache = nullptr;
+  SystemBus* m_systemBus = nullptr;
   ext_session_lock_v1* m_lock = nullptr;
   std::vector<Instance> m_instances;
   std::unordered_map<wl_output*, ScreencopyImage> m_desktopCaptures;
   PamAuthenticator m_authenticator;
+  std::unique_ptr<FingerprintAuthenticator> m_fingerprint;
   std::string m_user;
   std::string m_password;
   std::string m_status;

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -12,6 +12,7 @@
 #include "shell/lockscreen/lockscreen_login_box.h"
 #include "shell/lockscreen/lockscreen_widgets_host.h"
 #include "ui/builders.h"
+#include "ui/controls/label.h"
 #include "ui/palette.h"
 #include "ui/style.h"
 #include "wayland/wayland_connection.h"
@@ -113,6 +114,17 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
                 }
               },
           .configure = [](Button& button) { button.setZIndex(2); },
+      })
+  );
+
+  m_root.addChild(
+      ui::label({
+          .out = &m_statusLabel,
+          .fontSize = Style::fontSizeCaption,
+          .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+          .textAlign = TextAlign::Center,
+          .visible = false,
+          .configure = [](Label& label) { label.setZIndex(2); },
       })
   );
 
@@ -442,6 +454,9 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     m_loginPanel->setVisible(false);
     m_passwordField->setVisible(false);
     m_loginButton->setVisible(false);
+    if (m_statusLabel != nullptr) {
+      m_statusLabel->setVisible(false);
+    }
     return;
   }
 
@@ -547,9 +562,29 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     m_loginButton->setPosition(contentLeft + inputWidth + gap, contentTop);
     m_loginButton->layout(*renderer);
   }
+
+  // Status line, centered above the login panel.
+  if (m_statusLabel != nullptr && m_locked && !m_status.empty()) {
+    m_statusLabel->setMaxWidth(contentWidth);
+    m_statusLabel->layout(*renderer);
+    const float labelX = panelX + std::round((panelWidth - m_statusLabel->width()) * 0.5f);
+    const float labelY = panelY - m_statusLabel->height() - Style::spaceSm;
+    m_statusLabel->setPosition(labelX, labelY);
+  }
 }
 
-void LockSurface::updateCopy() { m_passwordField->setValue(m_password); }
+void LockSurface::updateCopy() {
+  m_passwordField->setValue(m_password);
+
+  if (m_statusLabel != nullptr) {
+    const bool show = m_locked && !m_blackout && !m_status.empty();
+    m_statusLabel->setVisible(show);
+    if (show) {
+      m_statusLabel->setText(m_status);
+      m_statusLabel->setColor(colorSpecFromRole(m_error ? ColorRole::Error : ColorRole::OnSurfaceVariant));
+    }
+  }
+}
 
 void LockSurface::releaseWallpaperTextureRef(const std::string& path) {
   if (m_wallpaperTexture.id == 0) {

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -22,6 +22,7 @@ struct wl_output;
 class Button;
 class Box;
 class Input;
+class Label;
 class SharedTextureCache;
 class WallpaperNode;
 struct KeyboardEvent;
@@ -89,6 +90,7 @@ private:
   Box* m_loginPanel = nullptr;
   Input* m_passwordField = nullptr;
   Button* m_loginButton = nullptr;
+  Label* m_statusLabel = nullptr;
   SharedTextureCache* m_textureCache = nullptr;
   TextureHandle m_wallpaperTexture{};
   TextureHandle m_blurredWallpaperTexture{};

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1116,6 +1116,15 @@ namespace settings {
       );
       entries.push_back(std::move(e));
     }
+    {
+      auto e = makeEntry(
+          SettingsSection::Security, "lock-screen", tr("settings.schema.lockscreen.fingerprint.label"),
+          tr("settings.schema.lockscreen.fingerprint.description"), {"lockscreen", "fingerprint"},
+          ToggleSetting{cfg.lockscreen.fingerprint}, "lock screen fingerprint fprintd biometric"
+      );
+      e.visibleWhen = lockscreenOn;
+      entries.push_back(std::move(e));
+    }
     if (env.screencopySupported) {
       auto e = makeEntry(
           SettingsSection::Security, "lock-screen", tr("settings.schema.lockscreen.blurred-desktop.label"),


### PR DESCRIPTION
## Summary

lockscreen: parallel fingerprint and password input

## Motivation

Discussion on discord. User (and I) had to press enter to unlock the session with a fingerprint reader.
Took example on hyprlock for the implementation.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue


## Testing



## Manual Coverage

- [X] Tested on Niri
- [] Tested on Hyprland
- [] Tested on Sway
- [] Tested on another compositor:
- [] Tested with different bar positions and density settings
- [] Tested at different interface scaling values
- [X] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Just need to test it on a non fingerprint system to make sure it doesn't break anything.

