### PR TITLE
fix(desktop-clock): stop digital clock jitter on second changes

### DIFF
--- a/src/shell/desktop/widgets/desktop_clock_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_clock_widget.cpp
@@ -197,7 +197,10 @@ void DesktopClockWidget::create() {
       .fontSize = clockFontSize(contentScale()),
       .color = m_color,
       .fontWeight = FontWeight::Bold,
-      .textAlign = TextAlign::Center,
+      // Left-aligned inside the widest-digit reserved width (see updateStableDigitalWidth):
+      // the box stays put AND the leading glyphs (the first colon) don't drift as digits
+      // change advance width — only the trailing edge breathes into the reserved space.
+      .textAlign = TextAlign::Start,
   });
   m_digitalRoot->addChild(std::move(label));
   rootNode->addChild(std::move(digitalRoot));
@@ -521,6 +524,55 @@ void DesktopClockWidget::doLayout(Renderer& renderer) {
   layoutDigital(renderer);
 }
 
+void DesktopClockWidget::updateStableDigitalWidth(Renderer& renderer, const std::string& text) {
+  if (m_label == nullptr) {
+    return;
+  }
+
+  const float fontSize = clockFontSize(contentScale());
+
+  // Re-pick the widest digit only when the font identity (size or family) changes.
+  if (fontSize != m_metricsFontSize || m_fontFamily != m_metricsFontFamily) {
+    m_metricsFontSize = fontSize;
+    m_metricsFontFamily = m_fontFamily;
+    float widest = -1.0f;
+    for (char digit = '0'; digit <= '9'; ++digit) {
+      const std::string glyph(1, digit);
+      const float advance =
+          renderer.measureText(glyph, fontSize, FontWeight::Bold, 0.0f, 0, TextAlign::Start, m_fontFamily).width;
+      if (advance > widest) {
+        widest = advance;
+        m_widestDigit = digit;
+      }
+    }
+    m_stableSample.clear(); // force a width recompute below
+  }
+
+  // Normalize digits to the widest glyph: the result's width is invariant across
+  // seconds (and minutes), so the box keeps a constant size and never reflows.
+  std::string sample = text;
+  for (char& ch : sample) {
+    if (ch >= '0' && ch <= '9') {
+      ch = m_widestDigit;
+    }
+  }
+  if (sample == m_stableSample) {
+    return;
+  }
+  m_stableSample = sample;
+
+  const float width =
+      renderer.measureText(sample, fontSize, FontWeight::Bold, 0.0f, 0, TextAlign::Start, m_fontFamily).width;
+  if (std::abs(width - m_stableWidth) > 0.5f) {
+    m_stableWidth = width;
+    m_label->setMinWidth(m_stableWidth);
+    m_label->setMaxWidth(m_stableWidth);
+    // The reserved width changed (font, or a non-digit field like the date/AM-PM);
+    // this fires at most a couple of times a day, never on the per-second path.
+    requestLayout();
+  }
+}
+
 void DesktopClockWidget::doUpdate(Renderer& renderer) {
   if (m_style == Style::Analog) {
     updateAnalogHands();
@@ -533,6 +585,7 @@ void DesktopClockWidget::doUpdate(Renderer& renderer) {
 
   m_label->setFontSize(clockFontSize(contentScale()));
   const std::string text = formatText();
+  updateStableDigitalWidth(renderer, text);
   if (text == m_lastText) {
     return;
   }

--- a/src/shell/desktop/widgets/desktop_clock_widget.h
+++ b/src/shell/desktop/widgets/desktop_clock_widget.h
@@ -37,6 +37,9 @@ private:
   void syncAnalogColors();
   void layoutAnalog(Renderer& renderer, float size);
   void layoutDigital(Renderer& renderer);
+  // Pin the digital label to the width of its widest-digit rendering so the box
+  // stops reflowing every second as proportional digits change advance width.
+  void updateStableDigitalWidth(Renderer& renderer, const std::string& text);
   void updateAnalogHands();
   [[nodiscard]] static Style styleFromSetting(std::string_view value);
 
@@ -59,4 +62,13 @@ private:
   int m_lastHour = -1;
   int m_lastMinute = -1;
   int m_lastSecond = -1;
+
+  // Stable-width state for the digital label. m_stableSample is the current text
+  // with every digit replaced by the widest digit glyph; its measured width is
+  // constant across seconds, so we only re-measure when it actually changes.
+  float m_stableWidth = 0.0f;
+  std::string m_stableSample;
+  char m_widestDigit = '0';
+  float m_metricsFontSize = -1.0f;
+  std::string m_metricsFontFamily;
 };


### PR DESCRIPTION
## Problem

The digital desktop clock visibly shifts every second. With a seconds format (e.g. `{:%H:%M:%S}`) and a proportional font, the digits and the colon jump left/right on each tick.

## Root cause

`DesktopClockWidget::doUpdate()` re-measures the label every second, so the content width changes as digit advance widths change. That reflows the widget:

- **Boxed** widget: `intrinsicWidth()` returns the fixed box width, but the content is re-centered *inside* the box using the live width (`DesktopWidget` content centering), so the glyphs drift within the tile.
- **Unboxed** widget: the intrinsic width itself changes, so the whole widget re-centers at its anchor.

## Fix

Pin the digital label to the width of its **widest-digit** rendering (`setMinWidth == setMaxWidth`) and **left-align** it:

- The reserved width is constant for a given format/font, so the box never reflows on a digit change.
- Left alignment keeps the leading glyphs (e.g. the first colon) anchored; only the trailing edge breathes into the reserved slack.
- The stable width is measured off-label via `Renderer::measureText` (so it never clobbers the live label) and is recomputed only when the font identity or the non-digit text changes — never on the per-second path.

Analog style is unaffected.

## Testing

Built with `just build` and run live on niri with a multi-monitor desktop. Verified with a proportional font (Lobster) and `{:%H:%M:%S}`: the clock no longer jitters as the seconds advance, on both boxed and unboxed widgets.

## Note

For a proportional font the text now sits anchored within the widest-digit box rather than perfectly optically centered (the slack sits on the trailing side). This is stable and, for a clock, reads better than the previous per-second jitter. Fully centered + stable would additionally require tabular figures, which depends on the font.