### PR TITLE
fix(tray): resolve IconThemePath before clearing generic icon name

### DIFF
--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -827,13 +827,13 @@ std::string TrayWidget::resolveIconPath(const TrayItemInfo& item) {
   } else {
     preferred = item.iconName;
   }
-  if (tray::looksGenericStatusItemName(preferred)) {
-    preferred.clear();
-  }
-
   if (const auto themed = resolveFromTrayThemePath(item.iconThemePath, preferred); !themed.empty()) {
     m_preferredIconPaths[item.id] = themed;
     return themed;
+  }
+
+  if (tray::looksGenericStatusItemName(preferred)) {
+    preferred.clear();
   }
 
   // Match the on-screen request size used when the icon is loaded (see rebuild).


### PR DESCRIPTION
## Summary

Resolve a tray item's `IconThemePath` icon before `looksGenericStatusItemName()` clears the icon name, so Electron/Chromium apps render their real tray icon instead of the generic fallback.

## Motivation

Electron/Chromium apps (Vesktop, Discord, Slack, VS Code, ...) do not send an `IconPixmap` over the StatusNotifierItem interface. They write the tray PNG into a private temp directory and advertise it by name:

```
IconName      = "status_icon_1"
IconThemePath = "/tmp/org.chromium.Chromium.XXXXXX"   (contains status_icon_1.png)
IconPixmap    = (not provided)
```

In `TrayWidget::resolveIconPath()` the name goes into `preferred`, then:

```cpp
if (tray::looksGenericStatusItemName(preferred)) {
    preferred.clear();
}
if (const auto themed = resolveFromTrayThemePath(item.iconThemePath, preferred); !themed.empty()) {
    ...
}
```

`looksGenericStatusItemName()` matches the `status_icon` substring, so `preferred` is cleared to `""`. `resolveFromTrayThemePath()` then hits its empty-name guard and returns nothing, and with no `IconPixmap` to fall back on the item renders the generic placeholder.

Clearing the name is correct for app-identity / pin matching, where `status_icon_1` carries no meaning. But `IconThemePath` is the app's own icon directory and the icon name is the literal file name inside it, so that file lookup should still use the original name. This patch moves the theme-path resolution ahead of the clear. The generic-name filter still applies to the desktop-icon and name matching that follows.

## Type of Change

- [x] Bug fix

## Related Issue

Same class of bug as #2599 (reported on v4, closed as deferred to v5). It still reproduces on current v5.

## Testing

Verified the root cause against the live StatusNotifierItem exported by Vesktop (Electron, v1.6.5) on Niri / NixOS:

1. Read the item's D-Bus properties and confirmed `IconName=status_icon_1`, `IconThemePath=/tmp/org.chromium.Chromium.*`, and no `IconPixmap`.
2. Confirmed `status_icon_1.png` exists in the advertised `IconThemePath`.
3. Confirmed `looksGenericStatusItemName("status_icon_1")` is true, which is what blanks the name before the theme-path lookup.

I was not able to run a full meson build of the shell in my environment, so the patched binary has not been run. The change is a straight reorder of two existing calls with no new logic.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested with multiple monitors

Left unchecked: root cause was verified from source and live D-Bus, but the patched binary was not built/run.
