### PR TITLE
refactor(dock): extract shiftAlongEdge helper to deduplicate DockEdge switch

### DIFF
--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -37,6 +37,23 @@ namespace shell::dock {
 
   bool isVerticalEdge(DockEdge edge) { return edge == DockEdge::Left || edge == DockEdge::Right; }
 
+  void shiftAlongEdge(DockEdge edge, float& x, float& y, float amount) {
+    switch (edge) {
+    case DockEdge::Bottom:
+      y += amount;
+      break;
+    case DockEdge::Top:
+      y -= amount;
+      break;
+    case DockEdge::Left:
+      x -= amount;
+      break;
+    case DockEdge::Right:
+      x += amount;
+      break;
+    }
+  }
+
   std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount) {
     const auto n = static_cast<std::int32_t>(itemCount);
     const std::int32_t cellSize = cfg.iconSize + kCellPad * 2;

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -31,6 +31,7 @@ namespace shell::dock {
 
   [[nodiscard]] std::uint32_t positionToAnchor(DockEdge edge);
   [[nodiscard]] bool isVerticalEdge(DockEdge edge);
+  void shiftAlongEdge(DockEdge edge, float& x, float& y, float amount);
   [[nodiscard]] std::int32_t dockContentSize(const DockConfig& cfg, std::size_t itemCount);
   [[nodiscard]] std::int32_t dockThickness(const DockConfig& cfg);
   [[nodiscard]] std::int32_t dockHoverZoomCrossPad(const DockConfig& cfg);

--- a/src/shell/dock/dock_items.cpp
+++ b/src/shell/dock/dock_items.cpp
@@ -54,20 +54,7 @@ namespace {
     const float shift = scale > 1.0f ? iconSize * (1.0f - scale) * 0.5f : 0.0f;
     float x = baseX;
     float y = baseY;
-    switch (edge) {
-    case DockEdge::Bottom:
-      y += shift;
-      break;
-    case DockEdge::Top:
-      y -= shift;
-      break;
-    case DockEdge::Left:
-      x -= shift;
-      break;
-    case DockEdge::Right:
-      x += shift;
-      break;
-    }
+    shell::dock::shiftAlongEdge(edge, x, y, shift);
     iconNode->setPosition(x, y);
   }
 
@@ -81,20 +68,7 @@ namespace {
     const float shift = iconScale > 1.0f ? iconSize * (1.0f - iconScale) * 0.5f : 0.0f;
     float iconX = iconBaseX;
     float iconY = iconBaseY;
-    switch (edge) {
-    case DockEdge::Bottom:
-      iconY += shift;
-      break;
-    case DockEdge::Top:
-      iconY -= shift;
-      break;
-    case DockEdge::Left:
-      iconX -= shift;
-      break;
-    case DockEdge::Right:
-      iconX += shift;
-      break;
-    }
+    shell::dock::shiftAlongEdge(edge, iconX, iconY, shift);
     const float iconRight = iconX + iconSize * (1.0f + iconScale) * 0.5f;
     const float iconTop = iconY + iconSize * (1.0f - iconScale) * 0.5f;
     const float badgeCenterAdjust = badgeSize * (1.0f - iconScale) * 0.5f;
@@ -226,20 +200,7 @@ namespace {
     float iconX = iconBase;
     float iconY = iconBase;
     const float shift = iconSize * (1.0f - scale) * 0.5f;
-    switch (edge) {
-    case DockEdge::Bottom:
-      iconY += shift;
-      break;
-    case DockEdge::Top:
-      iconY -= shift;
-      break;
-    case DockEdge::Left:
-      iconX -= shift;
-      break;
-    case DockEdge::Right:
-      iconX += shift;
-      break;
-    }
+    shell::dock::shiftAlongEdge(edge, iconX, iconY, shift);
     const float left = iconX + centerAdjust;
     const float top = iconY + centerAdjust;
     const float visualSize = iconSize * scale;


### PR DESCRIPTION
## Summary

Extract a common `shiftAlongEdge` helper into `dock_geometry` to replace three identical DockEdge switch blocks in `dock_items.cpp`.

## Motivation

The same switch-on-`DockEdge` pattern (add/subtract shift to x/y based on edge direction) was duplicated in `applyHoverIconVisual`, `applyHoverBadgeVisual`, and `scaledIconTooltipAnchor`. This creates maintenance overhead — adding or changing behavior requires modifying three separate switch blocks.

## Type of Change

- [x] Refactoring

## Testing

- Compiled all dock object files (`dock_geometry.o`, `dock_items.o`, `dock.o`) successfully with `ninja -C build`
- Ran the full `noctalia` binary — dock renders correctly on the right edge
- Visual: dock icons, magnification hover, and badge positioning behave identically to before

## Checklist

- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.