### PR TITLE
feat(brightness): add minimum brightness configuration and clamp cont…

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1818,7 +1818,7 @@
           "label": "Longitude"
         },
         "minimum-brightness": {
-          "description": "Prevent screen from going completely dark",
+          "description": "Prevent the screen from going completely dark",
           "label": "Minimum Brightness"
         },
         "mpris-blacklist": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1817,6 +1817,10 @@
           "description": "Manual longitude for the sunrise/sunset schedule, used when auto-locate and address are off",
           "label": "Longitude"
         },
+        "minimum-brightness": {
+          "description": "Prevent screen from going completely dark",
+          "label": "Minimum Brightness"
+        },
         "mpris-blacklist": {
           "description": "Players to ignore for media controls and Now Playing",
           "label": "MPRIS Player Blacklist"

--- a/example.toml
+++ b/example.toml
@@ -195,7 +195,7 @@ notification_sound = ""             # empty = bundled sounds/notification.wav
 [brightness]
 enable_ddcutil = false
 # ignore_mmids = []                 # skip these monitors from ddcutil; run: ddcutil --verbose detect
-# minimum_brightness = 0.0          # clamp brightness to at least this value (0.0 to 1.0)
+# minimum_brightness = 0.2          # clamp brightness to at least this value (0.0 to 1.0)
 
 # Per-monitor backend override:
 # [brightness.monitor.eDP-1]

--- a/example.toml
+++ b/example.toml
@@ -195,6 +195,7 @@ notification_sound = ""             # empty = bundled sounds/notification.wav
 [brightness]
 enable_ddcutil = false
 # ignore_mmids = []                 # skip these monitors from ddcutil; run: ddcutil --verbose detect
+# minimum_brightness = 0.0          # clamp brightness to at least this value (0.0 to 1.0)
 
 # Per-monitor backend override:
 # [brightness.monitor.eDP-1]

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -954,6 +954,7 @@ struct BrightnessConfig {
   bool enableDdcutil = false;
   std::vector<std::string> ddcutilIgnoreMmids;
   std::vector<BrightnessMonitorOverride> monitorOverrides;
+  float minimumBrightness = 0.0f;
 
   bool operator==(const BrightnessConfig&) const = default;
 };

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -954,7 +954,7 @@ struct BrightnessConfig {
   bool enableDdcutil = false;
   std::vector<std::string> ddcutilIgnoreMmids;
   std::vector<BrightnessMonitorOverride> monitorOverrides;
-  float minimumBrightness = 0.0f;
+  float minimumBrightness = 0.2f;
 
   bool operator==(const BrightnessConfig&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -294,6 +294,7 @@ namespace noctalia::config::schema {
     static const Schema<BrightnessConfig> s = {
         field(&BrightnessConfig::enableDdcutil, "enable_ddcutil"),
         field(&BrightnessConfig::ddcutilIgnoreMmids, "ignore_mmids"),
+        field(&BrightnessConfig::minimumBrightness, "minimum_brightness", kUnitRange),
         // Map key seeds `match`; an explicit `match` key inside overrides it.
         namedMap<BrightnessConfig, BrightnessMonitorOverride>(
             &BrightnessConfig::monitorOverrides, "monitor", brightnessMonitorSchema(),

--- a/src/shell/control_center/display_tab.cpp
+++ b/src/shell/control_center/display_tab.cpp
@@ -60,7 +60,8 @@ namespace {
 
 } // namespace
 
-DisplayTab::DisplayTab(BrightnessService* brightness, ConfigService* /*config*/) : m_brightness(brightness) {}
+DisplayTab::DisplayTab(BrightnessService* brightness, ConfigService* config)
+    : m_brightness(brightness), m_configService(config) {}
 
 std::unique_ptr<Flex> DisplayTab::create() {
   const float scale = contentScale();
@@ -183,8 +184,13 @@ void DisplayTab::doUpdate(Renderer& renderer) {
         && now < m_ignoreStateUntil
         && std::abs(display->brightness - m_lastSentBrightness) > 0.02f;
 
+    float minBrightness = 0.0f;
+    if (m_configService != nullptr) {
+      minBrightness = m_configService->config().brightness.minimumBrightness;
+    }
+
     const float displayedBrightness = std::clamp(
-        isPending ? m_pendingBrightness : (holdState ? m_lastSentBrightness : display->brightness), 0.0f, 1.0f
+        isPending ? m_pendingBrightness : (holdState ? m_lastSentBrightness : display->brightness), minBrightness, 1.0f
     );
 
     if (!isDragging
@@ -284,13 +290,17 @@ void DisplayTab::rebuildCards(Renderer& /*renderer*/) {
     );
 
     const std::string displayId = display.id;
+    float minBrightness = 0.0f;
+    if (m_configService != nullptr) {
+      minBrightness = m_configService->config().brightness.minimumBrightness;
+    }
     Slider* sliderPtr = nullptr;
     auto slider = ui::slider({
         .out = &sliderPtr,
-        .minValue = 0.0f,
+        .minValue = minBrightness,
         .maxValue = 1.0f,
         .step = 0.01f,
-        .value = display.brightness,
+        .value = std::max(display.brightness, minBrightness),
         .enabled = display.controllable,
         .trackHeight = Style::sliderTrackHeight * scale,
         .thumbSize = Style::sliderThumbSize * scale,

--- a/src/shell/control_center/display_tab.h
+++ b/src/shell/control_center/display_tab.h
@@ -32,6 +32,7 @@ private:
   void flushPendingBrightness(bool force = false);
 
   BrightnessService* m_brightness = nullptr;
+  ConfigService* m_configService = nullptr;
 
   struct DisplayCard {
     std::string displayId;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1949,6 +1949,11 @@ namespace settings {
         ToggleSetting{.checked = cfg.brightness.enableDdcutil, .enabled = env.ddcutilAvailable}, "monitor ddcutil"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Services, "brightness", tr("settings.schema.services.minimum-brightness.label"),
+        tr("settings.schema.services.minimum-brightness.description"), {"brightness", "minimum_brightness"},
+        sliderFor(cfg.brightness.minimumBrightness, noctalia::config::schema::kUnitRange, false), "floor clamp"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Services, "media", tr("settings.schema.services.mpris-blacklist.label"),
         tr("settings.schema.services.mpris-blacklist.description"), {"shell", "mpris", "blacklist"},
         ListSetting{.items = cfg.shell.mpris.blacklist}, "mpris media player dbus session blacklist"

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -1289,7 +1289,8 @@ struct BrightnessService::Impl {
       display.ddcBus = candidate.bus;
       display.maxRaw = candidate.maxRaw;
       display.pub.id = candidate.connectorName;
-      display.pub.brightness = std::max(normalizedBrightness(candidate.currentRaw, candidate.maxRaw), activeConfig.minimumBrightness);
+      display.pub.brightness =
+          std::max(normalizedBrightness(candidate.currentRaw, candidate.maxRaw), activeConfig.minimumBrightness);
       applyOutputMetadata(display.pub, *output);
       internals.push_back(std::move(display));
 
@@ -1324,7 +1325,8 @@ struct BrightnessService::Impl {
       display->quarantined = false;
       display->cooldownUntil = {};
       display->maxRaw = completion.maxRaw;
-      display->pub.brightness = std::max(normalizedBrightness(completion.currentRaw, completion.maxRaw), activeConfig.minimumBrightness);
+      display->pub.brightness =
+          std::max(normalizedBrightness(completion.currentRaw, completion.maxRaw), activeConfig.minimumBrightness);
       syncPublicDisplay(*display);
       return std::abs(display->pub.brightness - oldBrightness) > 0.001f;
     }
@@ -1372,7 +1374,8 @@ struct BrightnessService::Impl {
             continue;
           }
 
-          const float newBrightness = std::max(readBacklightBrightness(display.sysfsPath, display.maxRaw), activeConfig.minimumBrightness);
+          const float newBrightness =
+              std::max(readBacklightBrightness(display.sysfsPath, display.maxRaw), activeConfig.minimumBrightness);
           if (std::abs(newBrightness - display.pub.brightness) > 0.001f) {
             display.pub.brightness = newBrightness;
             syncPublicDisplay(display);

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -862,7 +862,7 @@ struct BrightnessService::Impl {
       display.sysfsPath = path;
       display.connectorName = connectorName;
       display.pub.id = !connectorName.empty() ? connectorName : name;
-      display.pub.brightness = readBacklightBrightness(path, maxBrightness);
+      display.pub.brightness = std::max(readBacklightBrightness(path, maxBrightness), activeConfig.minimumBrightness);
 
       if (output != nullptr) {
         applyOutputMetadata(display.pub, *output);
@@ -994,7 +994,7 @@ struct BrightnessService::Impl {
       return;
     }
 
-    value = std::clamp(value, 0.0f, 1.0f);
+    value = std::clamp(value, std::clamp(activeConfig.minimumBrightness, 0.0f, 1.0f), 1.0f);
     switch (display->backend) {
     case RuntimeBackend::Backlight:
       setBacklightBrightness(*display, value);
@@ -1289,7 +1289,7 @@ struct BrightnessService::Impl {
       display.ddcBus = candidate.bus;
       display.maxRaw = candidate.maxRaw;
       display.pub.id = candidate.connectorName;
-      display.pub.brightness = normalizedBrightness(candidate.currentRaw, candidate.maxRaw);
+      display.pub.brightness = std::max(normalizedBrightness(candidate.currentRaw, candidate.maxRaw), activeConfig.minimumBrightness);
       applyOutputMetadata(display.pub, *output);
       internals.push_back(std::move(display));
 
@@ -1324,7 +1324,7 @@ struct BrightnessService::Impl {
       display->quarantined = false;
       display->cooldownUntil = {};
       display->maxRaw = completion.maxRaw;
-      display->pub.brightness = normalizedBrightness(completion.currentRaw, completion.maxRaw);
+      display->pub.brightness = std::max(normalizedBrightness(completion.currentRaw, completion.maxRaw), activeConfig.minimumBrightness);
       syncPublicDisplay(*display);
       return std::abs(display->pub.brightness - oldBrightness) > 0.001f;
     }
@@ -1372,7 +1372,7 @@ struct BrightnessService::Impl {
             continue;
           }
 
-          const float newBrightness = readBacklightBrightness(display.sysfsPath, display.maxRaw);
+          const float newBrightness = std::max(readBacklightBrightness(display.sysfsPath, display.maxRaw), activeConfig.minimumBrightness);
           if (std::abs(newBrightness - display.pub.brightness) > 0.001f) {
             display.pub.brightness = newBrightness;
             syncPublicDisplay(display);


### PR DESCRIPTION
…rol center slider

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This pull request implements a new configuration option, `minimum_brightness`, allowing users to prevent their displays from going completely dark when brightness.

Key changes:                                                                        
    - Added a `minimum_brightness` option (range `0.0` to `1.0`, defaults to `0.2`) under the `[brightness]` section in example.toml and registered it in the       configuration schema config_schema.cpp.
    - Updated brightness_service.cpp to clamp display brightness to the configured minimum value when read, initialized, or set.                                                       
    - Modified the Control Center's display tab in display_tab.cpp to clamp the brightness slider's minimum value and displayed level to the configured floor.        
    - Added translation labels and descriptions under `settings.schema.services.minimum-brightness` in en.json and exposed it as a slider in settings_registry.cpp. 

## Motivation

Add minimum brightness configuration

## Type of Change

<!-- Mark all that apply. -->
- [x] New feature

## Related Issue

<!-- Example: Closes #123 -->
Closes #3009

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
The following automated and verification checks were successfully run:              
    - Build compilation: `just build` (completed successfully)                      
    - Unit testing: `just test` (26/26 tests passed)                                
    - Formatting: `just format` (verified code formatting complies with clang-      
  format)
    - Translation validation: `python3 tools/i18n-check.py` (0 warnings/errors, all 
  translation keys verified)

Test UI with `just run` and it worked

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="1078" height="911" alt="image" src="https://github.com/user-attachments/assets/35928bac-f468-4871-8ce7-591c1633b6a4" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
