### PR TITLE
idle: suppress behaviors while caffeine is enabled

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -386,6 +386,12 @@ void Application::syncClipboardService() {
   }
 }
 
+void Application::syncIdleInhibitLocks() {
+  const std::int64_t screenSaverLocks = m_screenSaverService ? m_screenSaverService->inhibitLocks() : 0;
+  const std::int64_t keepAwakeLocks = m_idleInhibitor.enabled() ? 1 : 0;
+  m_idleManager.setScreenSaverInhibitLocks(screenSaverLocks + keepAwakeLocks);
+}
+
 void Application::run(std::function<void()> startupReadyCallback) {
   initLogFile();
   kLog.info("noctalia {}", noctalia::build_info::displayVersion());
@@ -671,6 +677,7 @@ void Application::initServices() {
   }
   m_idleInhibitor.initialize(m_wayland, &m_renderContext);
   m_idleInhibitor.setChangeCallback([this, shouldRefreshControlCenter]() {
+    syncIdleInhibitLocks();
     m_bar.refresh();
     if (shouldRefreshControlCenter()) {
       m_panelManager.refresh();
@@ -1546,16 +1553,16 @@ void Application::initUi() {
   try {
     m_screenSaverService = std::make_unique<ScreenSaverService>(m_systemBus.get());
     if (m_screenSaverService->active()) {
-      m_screenSaverService->setChangeCallback([this](std::int64_t locks) {
-        m_idleManager.setScreenSaverInhibitLocks(locks);
-      });
-      m_idleManager.setScreenSaverInhibitLocks(m_screenSaverService->inhibitLocks());
+      m_screenSaverService->setChangeCallback([this](std::int64_t /*locks*/) { syncIdleInhibitLocks(); });
+      syncIdleInhibitLocks();
     } else {
       m_screenSaverService.reset();
+      syncIdleInhibitLocks();
     }
   } catch (const std::exception& e) {
     kLog.warn("idle inhibit service disabled: {}", e.what());
     m_screenSaverService.reset();
+    syncIdleInhibitLocks();
   }
   m_configService.addReloadCallback(
       [this]() {

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -142,6 +142,7 @@ private:
   void syncPolkitAgent();
   void syncClipboardService();
   void syncScreenTimeService();
+  void syncIdleInhibitLocks();
   bool runUserCommand(const std::string& command);
   bool runUserCommandBlocking(const std::string& command);
   bool runIdleAction(const IdleActionRequest& action);


### PR DESCRIPTION
 ## Summary

  Manual Keep Awake ("caffeine") was not included in the inhibit lock count used by
  `IdleManager`.

  That meant idle behaviors like screen off / lock / suspend could still trigger even while
  Keep Awake was enabled from the bar or control center.

  ## Fix

  Include `m_idleInhibitor.enabled()` in the inhibit lock calculation and resync it when:
  - Keep Awake changes
  - ScreenSaverService lock count changes
  - ScreenSaverService becomes unavailable

  ## Result

  With Keep Awake enabled, Noctalia now suppresses idle behaviors consistently instead of only
  registering the Wayland idle inhibitor.

  ## Notes

  I could not fully build locally because `sdbus-c++` is missing in my environment, so this was
  verified by code-path inspection and runtime behavior on the current shell.