### PR TITLE
fix(widget): prevent infinite image reload loop on missing file

### DIFF
--- a/Widgets/NImageRounded.qml
+++ b/Widgets/NImageRounded.qml
@@ -15,9 +15,15 @@ Item {
   property color borderColor: "transparent"
   property int imageFillMode: Image.PreserveAspectCrop
 
-  readonly property bool _isAnimated: imagePath.toLowerCase().endsWith(".gif")
+  property string _loadedImagePath: ""
+
+  onImagePathChanged: {
+    _loadedImagePath = imagePath;
+  }
+
+  readonly property bool _isAnimated: _loadedImagePath.toLowerCase().endsWith(".gif")
   readonly property Item imageSource: imageSourceLoader.item
-  readonly property bool showFallback: fallbackIcon !== "" && (imagePath === "" || (imageSource && imageSource.status === Image.Error))
+  readonly property bool showFallback: fallbackIcon !== "" && (imagePath === "" || _loadedImagePath === "" || (imageSource && imageSource.status === Image.Error))
   readonly property int status: imageSource ? imageSource.status : Image.Null
 
   Rectangle {
@@ -31,7 +37,7 @@ Item {
       id: imageSourceLoader
       anchors.fill: parent
       anchors.margins: root.borderWidth
-      active: root.imagePath !== ""
+      active: root._loadedImagePath !== ""
       sourceComponent: root._isAnimated ? animatedComponent : staticComponent
     }
 
@@ -39,12 +45,16 @@ Item {
       id: staticComponent
       Image {
         visible: false
-        source: root.imagePath
+        source: root._loadedImagePath
         mipmap: true
         smooth: true
         asynchronous: true
         antialiasing: true
         fillMode: root.imageFillMode
+        onStatusChanged: {
+          if (status === Image.Error)
+            root._loadedImagePath = "";
+        }
       }
     }
 
@@ -52,13 +62,17 @@ Item {
       id: animatedComponent
       AnimatedImage {
         visible: false
-        source: root.imagePath
+        source: root._loadedImagePath
         mipmap: true
         smooth: true
         asynchronous: true
         antialiasing: true
         fillMode: root.imageFillMode
         playing: true
+        onStatusChanged: {
+          if (status === Image.Error)
+            root._loadedImagePath = "";
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

Fix NImageRounded entering an infinite image reload loop when `imagePath` points to a non-existent file (e.g., a notification cache image that was cleaned up from disk while the notification history still references it).

## Motivation

<!-- What problem does this solve? -->

On a machine that has been running noctalia-shell continuously for 3+ days, the notification progress timer (50ms interval) re-evaluates delegate bindings on each tick. When a cached notification image has been deleted from disk but its `cachedImage` path persists in the history model, the Image component fails with `Error` on every re-evaluation cycle. Each failed attempt generates binary qslog entries, accumulating 500+ MB of logs and burning ~90% CPU on the main QML engine thread (~30 hours of accumulated CPU time over 70 hours of uptime).

The existing `showFallback` / NIcon fallback mechanism only responds to the current `Image.Error` state, but does not prevent the Loader and Image from being re-created on the next binding re-evaluation. The `_loadedImagePath` guard makes the "failed → fallback" transition permanent and stable.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

1. Start noctalia after applying the patch
2. Monitor CPU usage when a cached notification image is missing
3. Monitor binary qslog growth
4. Confirm NIcon fallback (bell icon) displays correctly for notifications whose cached images are missing

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
