### PR TITLE
nix: add nixos module for noctalia

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,5 +27,10 @@ in
     programs.noctalia.package = mkDefault package;
   };
 
+  nixosModule = {
+    imports = [ ./nix/nixos-module.nix ];
+    programs.noctalia.package = mkDefault package;
+  };
+
   inherit package;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -69,5 +69,12 @@
           imports = [ ./nix/hjem-module.nix ];
           programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
+
+      nixosModules.default =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./nix/nixos-module.nix ];
+          programs.noctalia.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
     };
 }

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.noctalia;
+in
+{
+  options.programs.noctalia = {
+    enable = lib.mkEnableOption "Whether to enable noctalia, a lightweight Wayland shell and bar.";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "The noctalia package to install.";
+    };
+
+    systemd = {
+      enable = lib.mkEnableOption "Enables a systemd user service for noctalia.";
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "graphical-session.target";
+        example = "hyprland-session.target";
+        description = "The systemd user target for the noctalia service.";
+      };
+    };
+
+    recommendedServices.enable = lib.mkEnableOption ''
+      NixOS services used by Noctalia v5 integrations, including NetworkManager,
+      Bluetooth, UPower, and a power profile service.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      environment.systemPackages = lib.optional (cfg.package != null) cfg.package;
+
+      systemd.user.services.noctalia = lib.mkIf cfg.systemd.enable {
+        description = "Noctalia - A lightweight Wayland shell and bar";
+        documentation = [ "https://docs.noctalia.dev/v5/" ];
+        partOf = [ cfg.systemd.target ];
+        after = [ cfg.systemd.target ];
+        wantedBy = [ cfg.systemd.target ];
+
+        serviceConfig = {
+          ExecStart = lib.getExe cfg.package;
+          Restart = "on-failure";
+        };
+
+        path = config.environment.systemPackages;
+      };
+
+      assertions = [
+        {
+          assertion = !cfg.systemd.enable || cfg.package != null;
+          message = "programs.noctalia.package cannot be null when programs.noctalia.systemd.enable is true";
+        }
+      ];
+    }
+
+    (lib.mkIf cfg.recommendedServices.enable {
+      networking.networkmanager.enable = lib.mkDefault true;
+      hardware.bluetooth.enable = lib.mkDefault true;
+      services.upower.enable = lib.mkDefault true;
+      services.power-profiles-daemon.enable = lib.mkIf (!config.services.tuned.enable) (lib.mkDefault true);
+    })
+  ]);
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -44,12 +44,14 @@ in
         after = [ cfg.systemd.target ];
         wantedBy = [ cfg.systemd.target ];
 
+        enableDefaultPath = false;
+
         serviceConfig = {
           ExecStart = lib.getExe cfg.package;
+          # Expose user and global packages to noctalia, speficially for the app launcher
+          Environment = "PATH=/etc/profiles/per-user/%u/bin:/run/current-system/sw/bin";
           Restart = "on-failure";
         };
-
-        path = config.environment.systemPackages;
       };
 
       assertions = [

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -48,8 +48,6 @@ in
 
         serviceConfig = {
           ExecStart = lib.getExe cfg.package;
-          # Expose user and global packages to noctalia, speficially for the app launcher
-          # Environment = "PATH=/etc/profiles/per-user/%u/bin:/run/current-system/sw/bin";
           Restart = "on-failure";
         };
       };

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -49,7 +49,7 @@ in
         serviceConfig = {
           ExecStart = lib.getExe cfg.package;
           # Expose user and global packages to noctalia, speficially for the app launcher
-          Environment = "PATH=/etc/profiles/per-user/%u/bin:/run/current-system/sw/bin";
+          # Environment = "PATH=/etc/profiles/per-user/%u/bin:/run/current-system/sw/bin";
           Restart = "on-failure";
         };
       };


### PR DESCRIPTION
## Summary and Motivation

add a plain nixos module for noctalia
which doesn't rely on any home managing
frameworks

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Testing

I tested this manually by enabling the module in my machines nixos config and verifying that the systemd service and package worked as expected which it did.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
