### PR TITLE
feat: add workspace alert IPC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -737,6 +737,7 @@ _noctalia_sources = files(
   'src/wayland/text_input_service.cpp',
   'src/wayland/virtual_keyboard_service.cpp',
   'src/compositors/compositor_platform.cpp',
+  'src/compositors/workspace_alert_service.cpp',
   'src/compositors/compositor_detect.cpp',
   'src/compositors/compositor_runtime.cpp',
   'src/compositors/dwl/dwl_workspace_backend.cpp',
@@ -908,6 +909,16 @@ notification_filter_test = executable('notification_filter_test',
 )
 
 test('notification_filter', notification_filter_test)
+
+workspace_alert_service_test = executable('workspace_alert_service_test',
+  sources: files(
+    'tests/workspace_alert_service_test.cpp',
+    'src/compositors/workspace_alert_service.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('workspace_alert_service', workspace_alert_service_test)
 
 animation_manager_test = executable('animation_manager_test',
   sources: files(

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -47,6 +47,7 @@
 #include "ui/dialogs/glyph_picker_dialog.h"
 #include "ui/style.h"
 #include "util/file_utils.h"
+#include "util/string_utils.h"
 
 #include <algorithm>
 #include <chrono>
@@ -1965,13 +1966,12 @@ void Application::initIpc() {
   m_ipcService.registerHandler(
       "workspace-alert-add",
       [this](const std::string& args) -> std::string {
-        const auto parts = noctalia::ipc::splitWords(args);
-        if (parts.size() != 1) {
+        const std::string workspaceKey = StringUtils::trim(args);
+        if (workspaceKey.empty()) {
           return "error: workspace-alert-add requires <workspace-key>\n";
         }
-        const std::string& workspaceKey = parts[0];
         if (!m_compositorPlatform.isKnownWorkspaceAlertKey(workspaceKey)) {
-          return "error: unknown workspace key '" + parts[0] + "'\n";
+          return "error: unknown workspace key '" + workspaceKey + "'\n";
         }
         (void)m_workspaceAlertService.add(workspaceKey);
         m_bar.refresh();
@@ -1999,11 +1999,11 @@ void Application::initIpc() {
   m_ipcService.registerHandler(
       "workspace-alert-clear",
       [this](const std::string& args) -> std::string {
-        const auto parts = noctalia::ipc::splitWords(args);
-        if (parts.size() != 1) {
+        const std::string workspaceKey = StringUtils::trim(args);
+        if (workspaceKey.empty()) {
           return "error: workspace-alert-clear requires <workspace-key>\n";
         }
-        (void)m_workspaceAlertService.clear(parts[0]);
+        (void)m_workspaceAlertService.clear(workspaceKey);
         m_bar.refresh();
         return "ok\n";
       },

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -634,7 +634,11 @@ void Application::initServices() {
     }
   });
   m_compositorPlatform.setWorkspaceChangeCallback([this]() {
-    (void)m_compositorPlatform.clearActiveWorkspaceAlerts();
+    if (wl_output* output = m_compositorPlatform.preferredInteractiveOutput(); output != nullptr) {
+      (void)m_compositorPlatform.clearActiveWorkspaceAlerts(output);
+    } else {
+      (void)m_compositorPlatform.clearActiveWorkspaceAlerts();
+    }
     m_bar.refresh();
     m_windowSwitcher.onToplevelChange();
   });
@@ -1955,12 +1959,7 @@ void Application::initIpc() {
     if (keys.empty()) {
       return std::string{"(no workspace alerts)\n"};
     }
-    std::string out;
-    for (const auto& key : keys) {
-      out += key;
-      out += '\n';
-    }
-    return out;
+    return StringUtils::join(keys, "\n") + "\n";
   };
 
   m_ipcService.registerHandler(
@@ -1972,6 +1971,9 @@ void Application::initIpc() {
         }
         if (!m_compositorPlatform.isKnownWorkspaceAlertKey(workspaceKey)) {
           return "error: unknown workspace key '" + workspaceKey + "'\n";
+        }
+        if (m_compositorPlatform.isActiveWorkspaceAlertKey(workspaceKey)) {
+          return "ok\n";
         }
         (void)m_workspaceAlertService.add(workspaceKey);
         m_bar.refresh();
@@ -1989,6 +1991,9 @@ void Application::initIpc() {
         const auto workspaceKey = m_compositorPlatform.workspaceAlertKeyForWindow(parts[0]);
         if (!workspaceKey.has_value()) {
           return "error: could not resolve workspace for window id '" + parts[0] + "'\n";
+        }
+        if (m_compositorPlatform.isActiveWorkspaceAlertKey(*workspaceKey)) {
+          return "ok\n";
         }
         (void)m_workspaceAlertService.add(*workspaceKey);
         m_bar.refresh();

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -572,6 +572,7 @@ void Application::initServices() {
     throw std::runtime_error("failed to connect to Wayland display");
   }
   m_compositorPlatform.initialize();
+  m_compositorPlatform.setWorkspaceAlertService(&m_workspaceAlertService);
   m_screenTimeService.initialize(&m_wayland);
   syncScreenTimeService();
   m_screenTimeService.setChangeCallback([this]() {
@@ -632,6 +633,7 @@ void Application::initServices() {
     }
   });
   m_compositorPlatform.setWorkspaceChangeCallback([this]() {
+    (void)m_compositorPlatform.clearActiveWorkspaceAlerts();
     m_bar.refresh();
     m_windowSwitcher.onToplevelChange();
   });
@@ -1945,6 +1947,89 @@ void Application::initIpc() {
         return "ok\n";
       },
       "dpms-off", "Turn monitors off"
+  );
+
+  auto workspaceAlertStatus = [this]() {
+    const auto keys = m_workspaceAlertService.keys();
+    if (keys.empty()) {
+      return std::string{"(no workspace alerts)\n"};
+    }
+    std::string out;
+    for (const auto& key : keys) {
+      out += key;
+      out += '\n';
+    }
+    return out;
+  };
+
+  m_ipcService.registerHandler(
+      "workspace-alert-add",
+      [this](const std::string& args) -> std::string {
+        const auto parts = noctalia::ipc::splitWords(args);
+        if (parts.size() != 1) {
+          return "error: workspace-alert-add requires <workspace-key>\n";
+        }
+        const std::string& workspaceKey = parts[0];
+        if (!m_compositorPlatform.isKnownWorkspaceAlertKey(workspaceKey)) {
+          return "error: unknown workspace key '" + parts[0] + "'\n";
+        }
+        (void)m_workspaceAlertService.add(workspaceKey);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-add <workspace-key>", "Add a workspace alert"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-add-window",
+      [this](const std::string& args) -> std::string {
+        const auto parts = noctalia::ipc::splitWords(args);
+        if (parts.size() != 1) {
+          return "error: workspace-alert-add-window requires <window-id>\n";
+        }
+        const auto workspaceKey = m_compositorPlatform.workspaceAlertKeyForWindow(parts[0]);
+        if (!workspaceKey.has_value()) {
+          return "error: could not resolve workspace for window id '" + parts[0] + "'\n";
+        }
+        (void)m_workspaceAlertService.add(*workspaceKey);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-add-window <window-id>", "Add a workspace alert for a window"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-clear",
+      [this](const std::string& args) -> std::string {
+        const auto parts = noctalia::ipc::splitWords(args);
+        if (parts.size() != 1) {
+          return "error: workspace-alert-clear requires <workspace-key>\n";
+        }
+        (void)m_workspaceAlertService.clear(parts[0]);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-clear <workspace-key>", "Clear a workspace alert"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-clear-all",
+      [this](const std::string& args) -> std::string {
+        if (!noctalia::ipc::splitWords(args).empty()) {
+          return "error: workspace-alert-clear-all takes no arguments\n";
+        }
+        m_workspaceAlertService.clearAll();
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-clear-all", "Clear all workspace alerts"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-status",
+      [workspaceAlertStatus](const std::string& args) -> std::string {
+        if (!noctalia::ipc::splitWords(args).empty()) {
+          return "error: workspace-alert-status takes no arguments\n";
+        }
+        return workspaceAlertStatus();
+      },
+      "workspace-alert-status", "Print workspace alerts"
   );
 
   registerSessionIpc(m_ipcService, m_sessionActionRunner, m_lockScreen, m_configService);

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -7,6 +7,7 @@
 #include "calendar/calendar_service.h"
 #include "capture/screenshot_service.h"
 #include "compositors/compositor_platform.h"
+#include "compositors/workspace_alert_service.h"
 #include "config/config_poll_source.h"
 #include "config/config_service.h"
 #include "core/file_watcher.h"
@@ -157,6 +158,7 @@ private:
   [[nodiscard]] std::vector<PollSource*> buildPollSources();
 
   WaylandConnection m_wayland;
+  WorkspaceAlertService m_workspaceAlertService;
   CompositorPlatform m_compositorPlatform{m_wayland};
   ClipboardService m_clipboardService;
   TextInputService m_textInputService;

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -1116,6 +1116,7 @@ bool CompositorPlatform::sameWorkspaceModelSnapshot(
   auto sameWorkspace = [](const Workspace& a, const Workspace& b) {
     return a.id == b.id
         && a.name == b.name
+        && a.key == b.key
         && a.coordinates == b.coordinates
         && a.active == b.active
         && a.urgent == b.urgent

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -21,6 +21,7 @@
 #include "compositors/triad/triad_output_backend.h"
 #include "compositors/triad/triad_runtime.h"
 #include "compositors/triad/triad_workspace_backend.h"
+#include "compositors/workspace_alert_service.h"
 #include "core/log.h"
 #include "core/process.h"
 #include "wayland/wayland_connection.h"
@@ -814,6 +815,9 @@ std::vector<Workspace> CompositorPlatform::workspaces() const {
   if (m_workspaceMetadataBackend != nullptr) {
     m_workspaceMetadataBackend->apply(current);
   }
+  if (m_workspaceAlertService != nullptr) {
+    m_workspaceAlertService->applyOverlay(current);
+  }
   return current;
 }
 
@@ -822,7 +826,52 @@ std::vector<Workspace> CompositorPlatform::workspaces(wl_output* output) const {
   if (m_workspaceMetadataBackend != nullptr) {
     m_workspaceMetadataBackend->apply(current, connectorNameForOutput(output));
   }
+  if (m_workspaceAlertService != nullptr) {
+    m_workspaceAlertService->applyOverlay(current);
+  }
   return current;
+}
+
+void CompositorPlatform::setWorkspaceAlertService(WorkspaceAlertService* service) noexcept {
+  m_workspaceAlertService = service;
+}
+
+bool CompositorPlatform::isKnownWorkspaceAlertKey(std::string_view workspaceKey) const {
+  if (workspaceKey.empty()) {
+    return false;
+  }
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return WorkspaceAlertService::isKnownWorkspaceKey(workspaceKey, workspaces());
+  }
+  for (const auto& output : outputs) {
+    if (WorkspaceAlertService::isKnownWorkspaceKey(workspaceKey, workspaces(output.output))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<std::string> CompositorPlatform::workspaceAlertKeyForWindow(std::string_view windowId) const {
+  if (windowId.empty()) {
+    return std::nullopt;
+  }
+  return WorkspaceAlertService::workspaceKeyForWindow(windowId, workspaceWindowAssignments());
+}
+
+std::size_t CompositorPlatform::clearActiveWorkspaceAlerts() {
+  if (m_workspaceAlertService == nullptr) {
+    return 0;
+  }
+  std::size_t cleared = 0;
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return m_workspaceAlertService->clearActive(workspaces());
+  }
+  for (const auto& output : outputs) {
+    cleared += m_workspaceAlertService->clearActive(workspaces(output.output));
+  }
+  return cleared;
 }
 
 std::unordered_map<std::string, std::vector<std::string>>

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -852,15 +852,71 @@ bool CompositorPlatform::isKnownWorkspaceAlertKey(std::string_view workspaceKey)
   return false;
 }
 
+bool CompositorPlatform::isActiveWorkspaceAlertKey(std::string_view workspaceKey) const {
+  if (workspaceKey.empty()) {
+    return false;
+  }
+  const auto containsActive = [workspaceKey](const std::vector<Workspace>& workspaces) {
+    return std::any_of(workspaces.begin(), workspaces.end(), [workspaceKey](const Workspace& workspace) {
+      return workspace.active && workspace.key == workspaceKey;
+    });
+  };
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return containsActive(workspaces());
+  }
+  for (const auto& output : outputs) {
+    if (containsActive(workspaces(output.output))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::optional<std::string> CompositorPlatform::workspaceAlertKeyForWindow(std::string_view windowId) const {
   if (windowId.empty()) {
     return std::nullopt;
   }
-  return WorkspaceAlertService::workspaceKeyForWindow(windowId, workspaceWindowAssignments());
+  const auto resolveForOutput = [this, windowId](wl_output* output) -> std::optional<std::string> {
+    const auto assignmentKey =
+        WorkspaceAlertService::workspaceKeyForWindow(windowId, workspaceWindowAssignments(output));
+    if (!assignmentKey.has_value()) {
+      return std::nullopt;
+    }
+
+    const auto current = workspaces(output);
+    if (WorkspaceAlertService::isKnownWorkspaceKey(*assignmentKey, current)) {
+      return assignmentKey;
+    }
+    for (const auto& workspace : current) {
+      if (!workspace.key.empty() && (workspace.id == *assignmentKey || workspace.name == *assignmentKey)) {
+        return workspace.key;
+      }
+    }
+    return std::nullopt;
+  };
+
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return resolveForOutput(nullptr);
+  }
+  for (const auto& output : outputs) {
+    if (auto workspaceKey = resolveForOutput(output.output); workspaceKey.has_value()) {
+      return workspaceKey;
+    }
+  }
+  return std::nullopt;
+}
+
+std::size_t CompositorPlatform::clearActiveWorkspaceAlerts(wl_output* output) {
+  if (m_workspaceAlertService == nullptr || m_workspaceAlertService->empty()) {
+    return 0;
+  }
+  return m_workspaceAlertService->clearActive(workspaces(output));
 }
 
 std::size_t CompositorPlatform::clearActiveWorkspaceAlerts() {
-  if (m_workspaceAlertService == nullptr) {
+  if (m_workspaceAlertService == nullptr || m_workspaceAlertService->empty()) {
     return 0;
   }
   std::size_t cleared = 0;

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <poll.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -22,6 +23,7 @@ struct hyprland_toplevel_mapping_manager_v1;
 struct zwlr_foreign_toplevel_handle_v1;
 struct ext_foreign_toplevel_handle_v1;
 class WaylandWorkspaces;
+class WorkspaceAlertService;
 
 namespace compositors::hyprland {
   class HyprlandToplevelMapping;
@@ -102,6 +104,10 @@ public:
   void dispatchWorkspacePoll(const std::vector<pollfd>& fds, std::size_t startIdx);
   [[nodiscard]] std::vector<Workspace> workspaces() const;
   [[nodiscard]] std::vector<Workspace> workspaces(wl_output* output) const;
+  void setWorkspaceAlertService(WorkspaceAlertService* service) noexcept;
+  [[nodiscard]] bool isKnownWorkspaceAlertKey(std::string_view workspaceKey) const;
+  [[nodiscard]] std::optional<std::string> workspaceAlertKeyForWindow(std::string_view windowId) const;
+  [[nodiscard]] std::size_t clearActiveWorkspaceAlerts();
   [[nodiscard]] std::unordered_map<std::string, std::vector<std::string>>
   appIdsByWorkspace(wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<std::string> workspaceDisplayKeys(wl_output* outputFilter = nullptr) const;
@@ -155,6 +161,7 @@ private:
   std::unique_ptr<compositors::CompositorRuntimeRegistry> m_runtimeRegistry;
   std::unique_ptr<WaylandWorkspaces> m_workspaces;
   std::unique_ptr<compositors::WorkspaceMetadataBackend> m_workspaceMetadataBackend;
+  WorkspaceAlertService* m_workspaceAlertService = nullptr;
   std::vector<std::unique_ptr<compositors::FocusedOutputBackend>> m_focusedOutputBackends;
   std::unique_ptr<compositors::OutputPowerBackend> m_outputPowerBackend;
   mutable std::optional<bool> m_lastRequestedOutputPowerState;

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -106,7 +106,9 @@ public:
   [[nodiscard]] std::vector<Workspace> workspaces(wl_output* output) const;
   void setWorkspaceAlertService(WorkspaceAlertService* service) noexcept;
   [[nodiscard]] bool isKnownWorkspaceAlertKey(std::string_view workspaceKey) const;
+  [[nodiscard]] bool isActiveWorkspaceAlertKey(std::string_view workspaceKey) const;
   [[nodiscard]] std::optional<std::string> workspaceAlertKeyForWindow(std::string_view windowId) const;
+  [[nodiscard]] std::size_t clearActiveWorkspaceAlerts(wl_output* output);
   [[nodiscard]] std::size_t clearActiveWorkspaceAlerts();
   [[nodiscard]] std::unordered_map<std::string, std::vector<std::string>>
   appIdsByWorkspace(wl_output* outputFilter = nullptr) const;

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -36,15 +36,6 @@ namespace compositors {
   }
 } // namespace compositors
 
-struct WorkspaceWindowAssignment {
-  std::string windowId;
-  std::string workspaceKey;
-  std::string appId;
-  std::string title;
-  std::int32_t x = 0;
-  std::int32_t y = 0;
-};
-
 class CompositorPlatform {
 public:
   using ChangeCallback = std::function<void()>;

--- a/src/compositors/dwl/dwl_workspace_backend.cpp
+++ b/src/compositors/dwl/dwl_workspace_backend.cpp
@@ -370,9 +370,11 @@ std::optional<std::size_t> DwlWorkspaceBackend::parseTagIndex(const std::string&
 std::size_t DwlWorkspaceBackend::protocolIndexForDisplay(std::size_t displayIndex) const { return displayIndex; }
 
 Workspace DwlWorkspaceBackend::makeWorkspace(std::size_t index, const TagInfo& tag) {
+  const std::string key = std::to_string(index + 1);
   return Workspace{
-      .id = std::to_string(index + 1),
-      .name = std::to_string(index + 1),
+      .id = key,
+      .name = key,
+      .key = key,
       .coordinates = {static_cast<std::uint32_t>(index)},
       .index = static_cast<std::uint32_t>(index + 1),
       .active = tag.active,

--- a/src/compositors/dwl/dwl_workspace_backend.cpp
+++ b/src/compositors/dwl/dwl_workspace_backend.cpp
@@ -103,6 +103,10 @@ void DwlWorkspaceBackend::bindDwlIpcWorkspace(zdwl_ipc_manager_v2* manager) {
 
 void DwlWorkspaceBackend::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
+void DwlWorkspaceBackend::setOutputNameResolver(WorkspaceOutputNameResolver::Resolver resolver) {
+  m_outputNameResolver = std::move(resolver);
+}
+
 void DwlWorkspaceBackend::activate(const std::string& id) {
   auto* state = activeOutputState();
   if (state == nullptr) {
@@ -151,7 +155,7 @@ std::vector<Workspace> DwlWorkspaceBackend::forOutput(wl_output* output) const {
   result.reserve(state->tags.size());
   for (std::size_t displayIndex = 0; displayIndex < state->tags.size(); ++displayIndex) {
     const std::size_t protocolIndex = protocolIndexForDisplay(displayIndex);
-    result.push_back(makeWorkspace(displayIndex, state->tags[protocolIndex]));
+    result.push_back(makeWorkspace(outputName(state->output), displayIndex, state->tags[protocolIndex]));
   }
   return result;
 }
@@ -345,6 +349,10 @@ const DwlWorkspaceBackend::OutputState* DwlWorkspaceBackend::outputStateFor(wl_o
   return it != m_outputs.end() ? &it->second : nullptr;
 }
 
+std::string DwlWorkspaceBackend::outputName(wl_output* output) const {
+  return m_outputNameResolver ? m_outputNameResolver(output) : std::string{};
+}
+
 std::optional<std::size_t> DwlWorkspaceBackend::parseTagIndex(const Workspace& workspace) {
   if (!workspace.coordinates.empty()) {
     return static_cast<std::size_t>(workspace.coordinates[0]);
@@ -369,12 +377,20 @@ std::optional<std::size_t> DwlWorkspaceBackend::parseTagIndex(const std::string&
 
 std::size_t DwlWorkspaceBackend::protocolIndexForDisplay(std::size_t displayIndex) const { return displayIndex; }
 
-Workspace DwlWorkspaceBackend::makeWorkspace(std::size_t index, const TagInfo& tag) {
+std::string DwlWorkspaceBackend::workspaceKey(std::string_view outputName, std::size_t index) {
+  const std::string key = std::to_string(index + 1);
+  if (outputName.empty()) {
+    return key;
+  }
+  return std::string(outputName) + ":" + key;
+}
+
+Workspace DwlWorkspaceBackend::makeWorkspace(std::string_view outputName, std::size_t index, const TagInfo& tag) {
   const std::string key = std::to_string(index + 1);
   return Workspace{
       .id = key,
       .name = key,
-      .key = key,
+      .key = workspaceKey(outputName, index),
       .coordinates = {static_cast<std::uint32_t>(index)},
       .index = static_cast<std::uint32_t>(index + 1),
       .active = tag.active,

--- a/src/compositors/dwl/dwl_workspace_backend.h
+++ b/src/compositors/dwl/dwl_workspace_backend.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -15,6 +16,7 @@ struct zdwl_ipc_output_v2;
 
 class DwlWorkspaceBackend final : public WorkspaceBackend,
                                   public OutputLifecycleObserver,
+                                  public WorkspaceOutputNameResolver,
                                   public DwlIpcWorkspaceProtocolBinder {
 public:
   void bindDwlIpcWorkspace(zdwl_ipc_manager_v2* manager) override;
@@ -22,6 +24,7 @@ public:
   [[nodiscard]] const char* backendName() const override { return "dwl-ipc"; }
   [[nodiscard]] bool isAvailable() const noexcept override { return m_manager != nullptr; }
   void setChangeCallback(ChangeCallback callback) override;
+  void setOutputNameResolver(WorkspaceOutputNameResolver::Resolver resolver) override;
   void activate(const std::string& id) override;
   void activateForOutput(wl_output* output, const std::string& id) override;
   void activateForOutput(wl_output* output, const Workspace& workspace) override;
@@ -71,15 +74,18 @@ private:
   [[nodiscard]] OutputState* activeOutputState();
   [[nodiscard]] const OutputState* preferredOutputState() const;
   [[nodiscard]] const OutputState* outputStateFor(wl_output* output) const;
+  [[nodiscard]] std::string outputName(wl_output* output) const;
   [[nodiscard]] static std::optional<std::size_t> parseTagIndex(const Workspace& workspace);
   [[nodiscard]] static std::optional<std::size_t> parseTagIndex(const std::string& id);
   [[nodiscard]] std::size_t protocolIndexForDisplay(std::size_t displayIndex) const;
-  [[nodiscard]] static Workspace makeWorkspace(std::size_t index, const TagInfo& tag);
+  [[nodiscard]] static std::string workspaceKey(std::string_view outputName, std::size_t index);
+  [[nodiscard]] static Workspace makeWorkspace(std::string_view outputName, std::size_t index, const TagInfo& tag);
   void notifyChanged();
 
   zdwl_ipc_manager_v2* m_manager = nullptr;
   std::uint32_t m_tagCount = 0;
   std::vector<std::string> m_layouts;
+  WorkspaceOutputNameResolver::Resolver m_outputNameResolver;
   std::unordered_map<wl_output*, OutputState> m_outputs;
   std::unordered_map<zdwl_ipc_output_v2*, wl_output*> m_outputByHandle;
   ChangeCallback m_changeCallback;

--- a/src/compositors/ext_workspace/ext_workspace_backend.cpp
+++ b/src/compositors/ext_workspace/ext_workspace_backend.cpp
@@ -356,7 +356,9 @@ void ExtWorkspaceBackend::onWorkspaceCreated(ext_workspace_handle_v1* workspace)
 void ExtWorkspaceBackend::onWorkspaceIdChanged(ext_workspace_handle_v1* workspace, const char* id) {
   const auto it = m_workspaces.find(workspace);
   if (it != m_workspaces.end()) {
-    it->second.id = id != nullptr ? id : "";
+    const std::string value = id != nullptr ? id : "";
+    it->second.id = value;
+    it->second.key = value;
   }
 }
 

--- a/src/compositors/ext_workspace/ext_workspace_backend.cpp
+++ b/src/compositors/ext_workspace/ext_workspace_backend.cpp
@@ -358,7 +358,7 @@ void ExtWorkspaceBackend::onWorkspaceIdChanged(ext_workspace_handle_v1* workspac
   if (it != m_workspaces.end()) {
     const std::string value = id != nullptr ? id : "";
     it->second.id = value;
-    it->second.key = value;
+    it->second.key = !value.empty() ? value : it->second.name;
   }
 }
 
@@ -366,6 +366,9 @@ void ExtWorkspaceBackend::onWorkspaceNameChanged(ext_workspace_handle_v1* worksp
   const auto it = m_workspaces.find(workspace);
   if (it != m_workspaces.end()) {
     it->second.name = name != nullptr ? name : "";
+    if (it->second.id.empty()) {
+      it->second.key = it->second.name;
+    }
   }
 }
 

--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -762,9 +762,11 @@ bool HyprlandWorkspaceBackend::workspaceOrderLess(const WorkspaceState* a, const
 Workspace HyprlandWorkspaceBackend::toWorkspace(const WorkspaceState& state) {
   const std::uint32_t coord =
       state.id >= 0 ? static_cast<std::uint32_t>(state.id - 1) : static_cast<std::uint32_t>(state.ordinal);
+  const std::string key = std::to_string(state.id);
   return Workspace{
-      .id = std::to_string(state.id),
+      .id = key,
       .name = state.name,
+      .key = key,
       .coordinates = {coord},
       .active = state.active,
       .urgent = state.urgent,

--- a/src/compositors/mango/mango_workspace_backend.cpp
+++ b/src/compositors/mango/mango_workspace_backend.cpp
@@ -543,9 +543,11 @@ std::optional<std::size_t> MangoWorkspaceBackend::shellActiveTagIndex(const std:
 }
 
 Workspace MangoWorkspaceBackend::makeWorkspace(const TagInfo& tag, bool shellActive) {
+  const std::string key = std::to_string(tag.index);
   return Workspace{
-      .id = std::to_string(tag.index),
-      .name = std::to_string(tag.index),
+      .id = key,
+      .name = key,
+      .key = key,
       .coordinates = {tag.index > 0 ? tag.index - 1 : 0},
       .index = tag.index,
       .active = shellActive,

--- a/src/compositors/mango/mango_workspace_backend.cpp
+++ b/src/compositors/mango/mango_workspace_backend.cpp
@@ -161,7 +161,7 @@ std::vector<Workspace> MangoWorkspaceBackend::forOutput(wl_output* output) const
   std::vector<Workspace> result;
   result.reserve(state->tags.size());
   for (std::size_t i = 0; i < state->tags.size(); ++i) {
-    result.push_back(makeWorkspace(state->tags[i], shellActive.has_value() && i == *shellActive));
+    result.push_back(makeWorkspace(state->name, state->tags[i], shellActive.has_value() && i == *shellActive));
   }
   return result;
 }
@@ -542,12 +542,20 @@ std::optional<std::size_t> MangoWorkspaceBackend::shellActiveTagIndex(const std:
   return activeTags.front();
 }
 
-Workspace MangoWorkspaceBackend::makeWorkspace(const TagInfo& tag, bool shellActive) {
+std::string MangoWorkspaceBackend::workspaceKey(std::string_view outputName, std::uint32_t tag) {
+  const std::string key = std::to_string(tag);
+  if (outputName.empty()) {
+    return key;
+  }
+  return std::string(outputName) + ":" + key;
+}
+
+Workspace MangoWorkspaceBackend::makeWorkspace(const std::string& outputName, const TagInfo& tag, bool shellActive) {
   const std::string key = std::to_string(tag.index);
   return Workspace{
       .id = key,
       .name = key,
-      .key = key,
+      .key = workspaceKey(outputName, tag.index),
       .coordinates = {tag.index > 0 ? tag.index - 1 : 0},
       .index = tag.index,
       .active = shellActive,

--- a/src/compositors/mango/mango_workspace_backend.h
+++ b/src/compositors/mango/mango_workspace_backend.h
@@ -94,7 +94,8 @@ private:
   [[nodiscard]] static std::optional<std::size_t> parseTagIndex(const Workspace& workspace);
   [[nodiscard]] static std::optional<std::size_t> parseTagIndex(const std::string& id);
   [[nodiscard]] std::optional<std::size_t> shellActiveTagIndex(const std::vector<TagInfo>& tags) const;
-  [[nodiscard]] static Workspace makeWorkspace(const TagInfo& tag, bool shellActive);
+  [[nodiscard]] static std::string workspaceKey(std::string_view outputName, std::uint32_t tag);
+  [[nodiscard]] static Workspace makeWorkspace(const std::string& outputName, const TagInfo& tag, bool shellActive);
   [[nodiscard]] static std::optional<OutputState> parseMonitor(const nlohmann::json& json);
   [[nodiscard]] static std::optional<ClientState> parseClient(const nlohmann::json& json);
 

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -191,11 +191,13 @@ void NiriWorkspaceBackend::apply(std::vector<Workspace>& workspaces, const std::
 
   for (std::size_t i = 0; i < workspaces.size(); ++i) {
     if (matches[i] != nullptr) {
+      workspaces[i].key = workspaceKey(*matches[i]);
       if (matches[i]->idx > 0) {
         workspaces[i].index = matches[i]->idx;
       }
       workspaces[i].occupied = m_occupancy.contains(matches[i]->id) && m_occupancy.at(matches[i]->id) > 0;
     } else {
+      workspaces[i].key = {};
       workspaces[i].index = 0;
       workspaces[i].occupied = false;
     }

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -191,7 +191,9 @@ void NiriWorkspaceBackend::apply(std::vector<Workspace>& workspaces, const std::
 
   for (std::size_t i = 0; i < workspaces.size(); ++i) {
     if (matches[i] != nullptr) {
-      workspaces[i].key = workspaceKey(*matches[i]);
+      if (const std::string key = workspaceKey(*matches[i]); !key.empty()) {
+        workspaces[i].key = key;
+      }
       if (matches[i]->idx > 0) {
         workspaces[i].index = matches[i]->idx;
       }

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -197,7 +197,6 @@ void NiriWorkspaceBackend::apply(std::vector<Workspace>& workspaces, const std::
       }
       workspaces[i].occupied = m_occupancy.contains(matches[i]->id) && m_occupancy.at(matches[i]->id) > 0;
     } else {
-      workspaces[i].key = {};
       workspaces[i].index = 0;
       workspaces[i].occupied = false;
     }

--- a/src/compositors/sway/sway_workspace_backend.cpp
+++ b/src/compositors/sway/sway_workspace_backend.cpp
@@ -34,6 +34,10 @@ namespace {
     return it->get<std::string>();
   }
 
+  std::string swayWorkspaceKey(int num, std::string_view name) {
+    return num > 0 ? std::to_string(num) : std::string{name};
+  }
+
   void tallyWorkspaceWindows(
       const nlohmann::json& node, const std::string& currentWorkspace,
       std::unordered_map<std::string, std::size_t>& counts
@@ -148,8 +152,7 @@ namespace {
           workspaceName = name;
         }
         if (const auto numIt = node.find("num"); numIt != node.end() && numIt->is_number_integer()) {
-          const int num = numIt->get<int>();
-          workspaceKey = num > 0 ? std::to_string(num) : workspaceName;
+          workspaceKey = swayWorkspaceKey(numIt->get<int>(), workspaceName);
         } else {
           workspaceKey = workspaceName;
         }
@@ -417,10 +420,8 @@ std::vector<WorkspaceWindow> SwayWorkspaceBackend::workspaceWindows(wl_output* o
     if (workspace.output != outputName) {
       continue;
     }
-    if (workspace.num > 0) {
-      workspaceKeys.insert(std::to_string(workspace.num));
-    } else if (!workspace.name.empty()) {
-      workspaceKeys.insert(workspace.name);
+    if (const std::string key = swayWorkspaceKey(workspace.num, workspace.name); !key.empty()) {
+      workspaceKeys.insert(key);
     }
   }
 
@@ -664,11 +665,10 @@ void SwayWorkspaceBackend::refreshFromWorkspaceEvent() { requestSnapshot(); }
 Workspace SwayWorkspaceBackend::toWorkspace(const SwayWorkspace& workspace) {
   const std::uint32_t coord = workspace.num >= 0 ? static_cast<std::uint32_t>(workspace.num - 1)
                                                  : static_cast<std::uint32_t>(workspace.ordinal);
-  const std::string key = workspace.num > 0 ? std::to_string(workspace.num) : workspace.name;
   return Workspace{
       .id = workspace.name,
       .name = workspace.name,
-      .key = key,
+      .key = swayWorkspaceKey(workspace.num, workspace.name),
       .coordinates = {coord},
       .active = workspace.visible,
       .urgent = workspace.urgent,

--- a/src/compositors/sway/sway_workspace_backend.cpp
+++ b/src/compositors/sway/sway_workspace_backend.cpp
@@ -664,9 +664,11 @@ void SwayWorkspaceBackend::refreshFromWorkspaceEvent() { requestSnapshot(); }
 Workspace SwayWorkspaceBackend::toWorkspace(const SwayWorkspace& workspace) {
   const std::uint32_t coord = workspace.num >= 0 ? static_cast<std::uint32_t>(workspace.num - 1)
                                                  : static_cast<std::uint32_t>(workspace.ordinal);
+  const std::string key = workspace.num > 0 ? std::to_string(workspace.num) : workspace.name;
   return Workspace{
       .id = workspace.name,
       .name = workspace.name,
+      .key = key,
       .coordinates = {coord},
       .active = workspace.visible,
       .urgent = workspace.urgent,

--- a/src/compositors/triad/triad_workspace_backend.cpp
+++ b/src/compositors/triad/triad_workspace_backend.cpp
@@ -184,10 +184,12 @@ std::vector<Workspace> TriadWorkspaceBackend::all() const {
   const auto workspaces = sortedWorkspaces();
   result.reserve(workspaces.size());
   for (const auto* workspace : workspaces) {
+    const std::string key = workspaceKey(*workspace);
     result.push_back(
         Workspace{
-            .id = workspaceKey(*workspace),
-            .name = workspace->name.empty() ? workspaceKey(*workspace) : workspace->name,
+            .id = key,
+            .name = workspace->name.empty() ? key : workspace->name,
+            .key = key,
             .coordinates = {workspace->index},
             .index = workspace->index,
             .active = workspace->active,
@@ -204,10 +206,12 @@ std::vector<Workspace> TriadWorkspaceBackend::forOutput(wl_output* output) const
   const auto workspaces = sortedWorkspaces(outputNameFor(output));
   result.reserve(workspaces.size());
   for (const auto* workspace : workspaces) {
+    const std::string key = workspaceKey(*workspace);
     result.push_back(
         Workspace{
-            .id = workspaceKey(*workspace),
-            .name = workspace->name.empty() ? workspaceKey(*workspace) : workspace->name,
+            .id = key,
+            .name = workspace->name.empty() ? key : workspace->name,
+            .key = key,
             .coordinates = {workspace->index},
             .index = workspace->index,
             .active = workspace->active,

--- a/src/compositors/triad/triad_workspace_backend.cpp
+++ b/src/compositors/triad/triad_workspace_backend.cpp
@@ -361,6 +361,9 @@ void TriadWorkspaceBackend::apply(std::vector<Workspace>& workspaces, const std:
       workspace.occupied = false;
       continue;
     }
+    if (const std::string key = workspaceKey(**found); !key.empty()) {
+      workspace.key = key;
+    }
     workspace.index = (*found)->index;
     workspace.occupied = (*found)->occupied;
     workspace.urgent = (*found)->urgent;

--- a/src/compositors/workspace_alert_service.cpp
+++ b/src/compositors/workspace_alert_service.cpp
@@ -45,6 +45,9 @@ void WorkspaceAlertService::applyOverlay(std::vector<Workspace>& workspaces) con
 }
 
 std::size_t WorkspaceAlertService::clearActive(const std::vector<Workspace>& workspaces) {
+  if (m_alerts.empty()) {
+    return 0;
+  }
   std::size_t cleared = 0;
   for (const auto& workspace : workspaces) {
     if (!workspace.active || workspace.key.empty()) {

--- a/src/compositors/workspace_alert_service.cpp
+++ b/src/compositors/workspace_alert_service.cpp
@@ -1,0 +1,83 @@
+#include "compositors/workspace_alert_service.h"
+
+#include <algorithm>
+
+bool WorkspaceAlertService::add(std::string_view workspaceKey) {
+  if (workspaceKey.empty()) {
+    return false;
+  }
+  return m_alerts.emplace(std::string{workspaceKey}).second;
+}
+
+bool WorkspaceAlertService::clear(std::string_view workspaceKey) {
+  if (workspaceKey.empty()) {
+    return false;
+  }
+  const auto it = m_alerts.find(workspaceKey);
+  if (it == m_alerts.end()) {
+    return false;
+  }
+  m_alerts.erase(it);
+  return true;
+}
+
+void WorkspaceAlertService::clearAll() { m_alerts.clear(); }
+
+bool WorkspaceAlertService::contains(std::string_view workspaceKey) const {
+  return !workspaceKey.empty() && m_alerts.contains(workspaceKey);
+}
+
+bool WorkspaceAlertService::empty() const noexcept { return m_alerts.empty(); }
+
+std::vector<std::string> WorkspaceAlertService::keys() const {
+  return {m_alerts.begin(), m_alerts.end()};
+}
+
+void WorkspaceAlertService::applyOverlay(std::vector<Workspace>& workspaces) const {
+  if (m_alerts.empty()) {
+    return;
+  }
+  for (auto& workspace : workspaces) {
+    if (!workspace.active && contains(workspace.key)) {
+      workspace.urgent = true;
+    }
+  }
+}
+
+std::size_t WorkspaceAlertService::clearActive(const std::vector<Workspace>& workspaces) {
+  std::size_t cleared = 0;
+  for (const auto& workspace : workspaces) {
+    if (!workspace.active || workspace.key.empty()) {
+      continue;
+    }
+    if (clear(workspace.key)) {
+      ++cleared;
+    }
+  }
+  return cleared;
+}
+
+bool WorkspaceAlertService::isKnownWorkspaceKey(
+    std::string_view workspaceKey, const std::vector<Workspace>& workspaces
+) {
+  if (workspaceKey.empty()) {
+    return false;
+  }
+  return std::any_of(workspaces.begin(), workspaces.end(), [&](const Workspace& workspace) {
+    return workspace.key == workspaceKey;
+  });
+}
+
+std::optional<std::string> WorkspaceAlertService::workspaceKeyForWindow(
+    std::string_view windowId, const std::vector<WorkspaceWindowAssignment>& assignments
+) {
+  if (windowId.empty()) {
+    return std::nullopt;
+  }
+  for (const auto& assignment : assignments) {
+    if (assignment.windowId == windowId && !assignment.workspaceKey.empty()) {
+      return assignment.workspaceKey;
+    }
+  }
+  return std::nullopt;
+}

--- a/src/compositors/workspace_alert_service.h
+++ b/src/compositors/workspace_alert_service.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "compositors/workspace_backend.h"
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class WorkspaceAlertService {
+public:
+  [[nodiscard]] bool add(std::string_view workspaceKey);
+  [[nodiscard]] bool clear(std::string_view workspaceKey);
+  void clearAll();
+
+  [[nodiscard]] bool contains(std::string_view workspaceKey) const;
+  [[nodiscard]] bool empty() const noexcept;
+  [[nodiscard]] std::vector<std::string> keys() const;
+
+  void applyOverlay(std::vector<Workspace>& workspaces) const;
+  [[nodiscard]] std::size_t clearActive(const std::vector<Workspace>& workspaces);
+
+  [[nodiscard]] static bool isKnownWorkspaceKey(
+      std::string_view workspaceKey, const std::vector<Workspace>& workspaces
+  );
+  [[nodiscard]] static std::optional<std::string> workspaceKeyForWindow(
+      std::string_view windowId, const std::vector<WorkspaceWindowAssignment>& assignments
+  );
+
+private:
+  std::set<std::string, std::less<>> m_alerts;
+};

--- a/src/compositors/workspace_backend.h
+++ b/src/compositors/workspace_backend.h
@@ -14,6 +14,7 @@ struct zdwl_ipc_manager_v2;
 struct Workspace {
   std::string id;
   std::string name;
+  std::string key;
   std::vector<std::uint32_t> coordinates;
   std::uint32_t index = 0;
   bool active = false;
@@ -22,6 +23,15 @@ struct Workspace {
 };
 
 struct WorkspaceWindow {
+  std::string windowId;
+  std::string workspaceKey;
+  std::string appId;
+  std::string title;
+  std::int32_t x = 0;
+  std::int32_t y = 0;
+};
+
+struct WorkspaceWindowAssignment {
   std::string windowId;
   std::string workspaceKey;
   std::string appId;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -172,6 +172,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
         Workspace{
             .id = ws.id,
             .name = ws.name,
+            .key = ws.key,
             .coordinates = ws.coordinates,
             .index = ws.index,
             .active = ws.active,

--- a/src/wayland/wayland_workspaces.cpp
+++ b/src/wayland/wayland_workspaces.cpp
@@ -36,6 +36,7 @@ WaylandWorkspaces::WaylandWorkspaces(compositors::CompositorRuntimeRegistry& run
   auto dwlIpcBackend = std::make_unique<DwlWorkspaceBackend>();
   m_dwlIpcWorkspaceBinder = dwlIpcBackend.get();
   m_dwlIpcBackend = dwlIpcBackend.get();
+  m_outputNameResolvers.push_back(dwlIpcBackend.get());
   m_outputObservers.push_back(dwlIpcBackend.get());
   m_backends.push_back(std::move(dwlIpcBackend));
 

--- a/tests/workspace_alert_service_test.cpp
+++ b/tests/workspace_alert_service_test.cpp
@@ -30,6 +30,7 @@ int main() {
 
   WorkspaceAlertService service;
   ok &= check(service.empty(), "new service is empty");
+  ok &= check(service.clearActive(sampleWorkspaces()) == 0, "empty service clearActive is a no-op");
   ok &= check(service.add("2"), "add returns true for new key");
   ok &= check(!service.add("2"), "duplicate add returns false");
   ok &= check(!service.add(""), "empty add is rejected");

--- a/tests/workspace_alert_service_test.cpp
+++ b/tests/workspace_alert_service_test.cpp
@@ -1,0 +1,140 @@
+#include "compositors/workspace_alert_service.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+  bool check(bool cond, const char* msg) {
+    if (!cond) {
+      std::cerr << "FAIL: " << msg << '\n';
+    }
+    return cond;
+  }
+
+  std::vector<Workspace> sampleWorkspaces() {
+    return {
+        Workspace{.id = "1", .name = "1", .key = "1", .index = 1, .active = false, .urgent = false, .occupied = true},
+        Workspace{.id = "2", .name = "2", .key = "2", .index = 2, .active = false, .urgent = false, .occupied = true},
+        Workspace{.id = "3", .name = "3", .key = "3", .index = 3, .active = true, .urgent = false, .occupied = true},
+        Workspace{.id = "4", .name = "4", .key = "4", .index = 4, .active = false, .urgent = true, .occupied = true},
+        Workspace{.id = "5", .name = "5", .key = "", .index = 5, .active = false, .urgent = false, .occupied = false},
+    };
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  WorkspaceAlertService service;
+  ok &= check(service.empty(), "new service is empty");
+  ok &= check(service.add("2"), "add returns true for new key");
+  ok &= check(!service.add("2"), "duplicate add returns false");
+  ok &= check(!service.add(""), "empty add is rejected");
+  ok &= check(service.contains("2"), "contains added key");
+
+  auto overlaid = sampleWorkspaces();
+  service.applyOverlay(overlaid);
+  ok &= check(overlaid[1].urgent, "overlay marks non-active alerted workspace urgent");
+  ok &= check(!overlaid[2].urgent, "overlay does not mark active workspace urgent");
+  ok &= check(overlaid[3].urgent, "overlay preserves compositor urgent state");
+  ok &= check(!overlaid[4].urgent, "overlay ignores empty workspace keys");
+  ok &= check(service.contains("2"), "overlay is pure read and keeps alert");
+
+  WorkspaceAlertService keyOnlyService;
+  ok &= check(keyOnlyService.add("external-id"), "id-like key add succeeds");
+  ok &= check(keyOnlyService.add("display-name"), "name-like key add succeeds");
+  std::vector<Workspace> keyOnlyRows{
+      Workspace{
+          .id = "external-id",
+          .name = "display-name",
+          .key = "canonical-key",
+          .index = 6,
+          .active = false,
+          .urgent = false,
+          .occupied = true,
+      },
+  };
+  keyOnlyService.applyOverlay(keyOnlyRows);
+  ok &= check(!keyOnlyRows[0].urgent, "overlay ignores id and name when key differs");
+  ok &= check(keyOnlyService.add("canonical-key"), "canonical key add succeeds");
+  keyOnlyService.applyOverlay(keyOnlyRows);
+  ok &= check(keyOnlyRows[0].urgent, "overlay matches canonical workspace key");
+
+  ok &= check(service.add("3"), "active key add succeeds");
+  auto activeRows = sampleWorkspaces();
+  const std::size_t cleared = service.clearActive(activeRows);
+  ok &= check(cleared == 1, "clearActive clears active alert");
+  ok &= check(!service.contains("3"), "active key removed");
+  ok &= check(service.contains("2"), "inactive key remains");
+
+  std::vector<WorkspaceWindowAssignment> assignments{
+      WorkspaceWindowAssignment{.windowId = "10", .workspaceKey = "1", .appId = "kitty", .title = "shell"},
+      WorkspaceWindowAssignment{.windowId = "20", .workspaceKey = "2", .appId = "code", .title = "editor"},
+      WorkspaceWindowAssignment{.windowId = "30", .workspaceKey = "", .appId = "empty", .title = "empty"},
+  };
+  ok &= check(WorkspaceAlertService::workspaceKeyForWindow("20", assignments) == "2", "resolves window id");
+  ok &= check(!WorkspaceAlertService::workspaceKeyForWindow("30", assignments).has_value(), "rejects empty assignment key");
+  ok &= check(!WorkspaceAlertService::workspaceKeyForWindow("99", assignments).has_value(), "rejects unknown window id");
+
+  ok &= check(WorkspaceAlertService::isKnownWorkspaceKey("1", sampleWorkspaces()), "known key validates");
+  ok &= check(!WorkspaceAlertService::isKnownWorkspaceKey("9", sampleWorkspaces()), "unknown key rejects");
+  ok &= check(!WorkspaceAlertService::isKnownWorkspaceKey("", sampleWorkspaces()), "empty key rejects");
+  ok &= check(
+      WorkspaceAlertService::isKnownWorkspaceKey(
+          "canonical-key",
+          {Workspace{
+              .id = "external-id",
+              .name = "display-name",
+              .key = "canonical-key",
+              .index = 6,
+              .active = false,
+              .urgent = false,
+              .occupied = true,
+          }}
+      ),
+      "known workspace validation uses canonical key"
+  );
+  ok &= check(
+      !WorkspaceAlertService::isKnownWorkspaceKey(
+          "external-id",
+          {Workspace{
+              .id = "external-id",
+              .name = "display-name",
+              .key = "canonical-key",
+              .index = 6,
+              .active = false,
+              .urgent = false,
+              .occupied = true,
+          }}
+      ),
+      "known workspace validation ignores id when key differs"
+  );
+  ok &= check(
+      !WorkspaceAlertService::isKnownWorkspaceKey(
+          "display-name",
+          {Workspace{
+              .id = "external-id",
+              .name = "display-name",
+              .key = "canonical-key",
+              .index = 6,
+              .active = false,
+              .urgent = false,
+              .occupied = true,
+          }}
+      ),
+      "known workspace validation ignores name when key differs"
+  );
+
+  ok &= check(service.add("1"), "sort key add succeeds");
+  const auto keys = service.keys();
+  ok &= check(keys.size() == 2 && keys[0] == "1" && keys[1] == "2", "keys are sorted");
+  ok &= check(service.clear("1"), "clear returns true for present key");
+  ok &= check(!service.contains("1"), "clear removes key");
+  service.clearAll();
+  ok &= check(service.empty(), "clearAll empties service");
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add a generic `workspace-alert` IPC surface for marking and clearing workspace attention state.
- Thread canonical workspace keys through compositor workspace models and overlay alerts through the shared workspace read path.
- Resolve window-origin alerts through compositor window assignments, scope keys correctly across outputs, and clear alerts when the user visits the alerted workspace.

## Example Usage

```
noctalia msg workspace-alert-status
noctalia msg workspace-alert-add 4
noctalia msg workspace-alert-status
noctalia msg workspace-alert-clear 4
```

## Test Plan
- `just test workspace_alert_service`
- `just build`
- `git diff --check upstream/main..HEAD`

## Notes
- Alerts reuse the existing urgent/error workspace styling for the initial implementation.
- Direct `workspace-alert-add` expects the canonical key shown by `workspace-alert-status`; `workspace-alert-add-window` resolves window assignments automatically.