### PR TITLE
Add rotate_hue filter to template engine

### DIFF
--- a/src/theme/template_engine.cpp
+++ b/src/theme/template_engine.cpp
@@ -122,7 +122,7 @@ namespace noctalia::theme {
     const std::unordered_map<std::string, int> kSupportedFilters = {
         {"grayscale", 0},      {"invert", 0},   {"set_alpha", 1},  {"set_lightness", 1},  {"set_hue", 1},
         {"set_saturation", 1}, {"set_red", 1},  {"set_green", 1},  {"set_blue", 1},       {"lighten", 1},
-        {"darken", 1},         {"saturate", 1}, {"desaturate", 1}, {"auto_lightness", 1},
+        {"darken", 1},         {"saturate", 1}, {"desaturate", 1}, {"auto_lightness", 1}, {"rotate_hue", 1},
     };
 
     const std::unordered_set<std::string> kColorArgFilters = {"blend", "harmonize"};
@@ -566,6 +566,8 @@ namespace noctalia::theme {
         color.color = Color::fromHsl(h, s, std::clamp(numArg / 100.0, 0.0, 1.0));
       } else if (name == "set_hue") {
         color.color = Color::fromHsl(std::fmod(numArg + 360.0, 360.0), s, l);
+      } else if (name == "rotate_hue") {
+        color.color = Color::fromHsl(std::fmod(h + numArg + 360.0, 360.0), s, l);
       } else if (name == "set_saturation") {
         color.color = Color::fromHsl(h, std::clamp(numArg / 100.0, 0.0, 1.0), l);
       } else if (name == "lighten") {


### PR DESCRIPTION
## Summary

Add a `rotate_hue` filter to the templating engine that rotates a color in HSL space

## Motivation

I would like to have my niri borders be gradients relative to the wallpaper-derived scheme

## Type of Change


- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Ran it locally and it generated the expected gradients.

## Manual Coverage

- [X] Tested on Niri

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
