### PR TITLE
sysmon: allow network widgets to target an interface

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -370,6 +370,7 @@
         "font-family-default": "System default",
         "forecast-days": "Forecast Days",
         "format": "Format",
+        "interface": "Interface",
         "hide-when-no-media": "Hide When No Media",
         "horizontal": "Horizontal",
         "image-path": "Image",
@@ -2608,6 +2609,10 @@
         "icon-size": {
           "description": "Icon size in pixels",
           "label": "Icon Size"
+        },
+        "interface": {
+          "description": "Network interface to monitor; leave empty to use the total across all interfaces",
+          "label": "Interface"
         },
         "inactive-opacity": {
           "description": "Opacity of icons for inactive (unfocused) windows.",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -456,6 +456,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
       stat = SysmonStat::NetTx;
     }
     const std::string display = wc != nullptr ? wc->getString("display", "gauge") : std::string("gauge");
+    const std::string networkInterface = wc != nullptr ? wc->getString("interface", "") : std::string();
     SysmonDisplayMode displayMode = SysmonDisplayMode::Gauge;
     if (display == "text")
       displayMode = SysmonDisplayMode::Text;
@@ -469,7 +470,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
           )
         : colorSpecFromRole(ColorRole::Error);
     auto widget = std::make_unique<SysmonWidget>(
-        m_sysmon, output, stat, std::move(path), displayMode, highlightColor, m_configService, showLabel, labelMinWidth
+        m_sysmon, output, stat, std::move(path), displayMode, highlightColor, m_configService, networkInterface,
+        showLabel, labelMinWidth
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -105,12 +105,12 @@ namespace {
 
 SysmonWidget::SysmonWidget(
     SystemMonitorService* monitor, wl_output* /*output*/, SysmonStat stat, std::string diskPath,
-    SysmonDisplayMode displayMode, ColorSpec highlightColor, ConfigService& configService, bool showLabel,
-    float labelMinWidth
+    SysmonDisplayMode displayMode, ColorSpec highlightColor, ConfigService& configService, std::string networkInterface,
+    bool showLabel, float labelMinWidth
 )
     : m_monitor(monitor), m_stat(stat), m_displayMode(displayMode), m_highlightColor(highlightColor),
       m_configService(configService), m_showLabel(showLabel), m_labelMinWidth(labelMinWidth),
-      m_diskPath(std::move(diskPath)) {
+      m_diskPath(std::move(diskPath)), m_networkInterface(std::move(networkInterface)) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat)) {
       m_monitor->retainCpuTemp();
@@ -311,9 +311,9 @@ double SysmonWidget::currentGradientValue() {
     }
     return 0.0;
   case SysmonStat::NetRx:
-    return std::max(stats.netRxBytesPerSec / kBytesPerMb, 0.0);
+    return std::max(m_monitor->netRxBytesPerSec(m_networkInterface) / kBytesPerMb, 0.0);
   case SysmonStat::NetTx:
-    return std::max(stats.netTxBytesPerSec / kBytesPerMb, 0.0);
+    return std::max(m_monitor->netTxBytesPerSec(m_networkInterface) / kBytesPerMb, 0.0);
   case SysmonStat::DiskPct:
     return 0.0;
   }
@@ -585,7 +585,9 @@ void SysmonWidget::updateGraph(Renderer& renderer) {
     }
     data.resize(hist.size());
     for (std::size_t i = 0; i < hist.size(); ++i) {
-      data[i] = static_cast<float>(std::clamp(normalizedFromStats(m_stat, hist[i], m_tempMin, m_tempMax), 0.0, 1.0));
+      data[i] = static_cast<float>(
+          std::clamp(normalizedFromStats(m_stat, hist[i], m_tempMin, m_tempMax, m_networkInterface), 0.0, 1.0)
+      );
     }
   }
 
@@ -613,7 +615,9 @@ float SysmonWidget::scrollProgressForSample(std::chrono::steady_clock::time_poin
   return std::chrono::duration<float>(clamped).count() / std::chrono::duration<float>(sampleInterval).count();
 }
 
-double SysmonWidget::normalizedFromStats(SysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax) {
+double SysmonWidget::normalizedFromStats(
+    SysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax, std::string_view networkInterface
+) {
   switch (stat) {
   case SysmonStat::CpuUsage:
     return stats.cpuUsagePercent / 100.0;
@@ -672,13 +676,27 @@ double SysmonWidget::normalizedFromStats(SysmonStat stat, const SystemStats& sta
     return 0.0;
 
   case SysmonStat::NetRx: {
-    tempMax = std::max(tempMax, stats.netRxBytesPerSec);
-    return tempMax > 0.0 ? std::clamp(stats.netRxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
+    const double value = networkInterface.empty() ? stats.netRxBytesPerSec : [&stats, networkInterface]() {
+      if (const auto it = stats.netThroughputByInterface.find(std::string(networkInterface));
+          it != stats.netThroughputByInterface.end()) {
+        return it->second.rxBytesPerSec;
+      }
+      return 0.0;
+    }();
+    tempMax = std::max(tempMax, value);
+    return tempMax > 0.0 ? std::clamp(value / tempMax, 0.0, 1.0) : 0.0;
   }
 
   case SysmonStat::NetTx: {
-    tempMax = std::max(tempMax, stats.netTxBytesPerSec);
-    return tempMax > 0.0 ? std::clamp(stats.netTxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
+    const double value = networkInterface.empty() ? stats.netTxBytesPerSec : [&stats, networkInterface]() {
+      if (const auto it = stats.netThroughputByInterface.find(std::string(networkInterface));
+          it != stats.netThroughputByInterface.end()) {
+        return it->second.txBytesPerSec;
+      }
+      return 0.0;
+    }();
+    tempMax = std::max(tempMax, value);
+    return tempMax > 0.0 ? std::clamp(value / tempMax, 0.0, 1.0) : 0.0;
   }
 
   case SysmonStat::DiskPct:
@@ -696,7 +714,9 @@ double SysmonWidget::currentNormalized() {
     return std::clamp(static_cast<double>(m_monitor->diskUsagePercent(m_diskPath)) / 100.0, 0.0, 1.0);
   }
 
-  return std::clamp(normalizedFromStats(m_stat, m_monitor->latest(), m_tempMin, m_tempMax), 0.0, 1.0);
+  return std::clamp(
+      normalizedFromStats(m_stat, m_monitor->latest(), m_tempMin, m_tempMax, m_networkInterface), 0.0, 1.0
+  );
 }
 
 std::string SysmonWidget::formatValue() const {
@@ -756,10 +776,10 @@ std::string SysmonWidget::formatValue() const {
     return "--";
 
   case SysmonStat::NetRx:
-    return FormatUnits::formatDecimalBytesPerSecond(stats.netRxBytesPerSec);
+    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netRxBytesPerSec(m_networkInterface));
 
   case SysmonStat::NetTx:
-    return FormatUnits::formatDecimalBytesPerSecond(stats.netTxBytesPerSec);
+    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netTxBytesPerSec(m_networkInterface));
 
   case SysmonStat::DiskPct:
     break; // handled above

--- a/src/shell/bar/widgets/sysmon_widget.h
+++ b/src/shell/bar/widgets/sysmon_widget.h
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <string>
+#include <string_view>
 #include <utility>
 
 class Box;
@@ -39,8 +40,8 @@ class SysmonWidget : public Widget {
 public:
   SysmonWidget(
       SystemMonitorService* monitor, wl_output* output, SysmonStat stat, std::string diskPath,
-      SysmonDisplayMode displayMode, ColorSpec highlightColor, ConfigService& configService, bool showLabel = true,
-      float labelMinWidth = 0.0f
+      SysmonDisplayMode displayMode, ColorSpec highlightColor, ConfigService& configService,
+      std::string networkInterface = {}, bool showLabel = true, float labelMinWidth = 0.0f
   );
   ~SysmonWidget() override;
 
@@ -65,8 +66,9 @@ private:
   [[nodiscard]] Color currentValueColor(ColorSpec baseColor);
   [[nodiscard]] double currentGradientValue();
   [[nodiscard]] std::pair<double, double> currentThresholds() const;
-  [[nodiscard]] static double
-  normalizedFromStats(SysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax);
+  [[nodiscard]] static double normalizedFromStats(
+      SysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax, std::string_view networkInterface
+  );
 
   SystemMonitorService* m_monitor;
   SysmonStat m_stat;
@@ -76,6 +78,7 @@ private:
   bool m_showLabel;
   float m_labelMinWidth = 0.0f;
   std::string m_diskPath;
+  std::string m_networkInterface;
   std::string m_lastRawValue;
   bool m_isVerticalBar = false;
   bool m_lastLabelVertical = false;

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -284,13 +284,14 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
     };
     const DesktopSysmonStat stat = parseStat(getStringSetting(settings, "stat", "cpu_usage"));
     const std::string stat2Str = getStringSetting(settings, "stat2");
+    const std::string networkInterface = getStringSetting(settings, "interface");
     std::optional<DesktopSysmonStat> stat2;
     if (!stat2Str.empty()) {
       stat2 = parseStat(stat2Str);
     }
     auto widget = std::make_unique<DesktopSysmonWidget>(
         m_sysmon, stat, stat2, getColorSpecSetting(settings, "color", colorSpecFromRole(ColorRole::Primary)),
-        getColorSpecSetting(settings, "color2", colorSpecFromRole(ColorRole::Secondary)),
+        getColorSpecSetting(settings, "color2", colorSpecFromRole(ColorRole::Secondary)), networkInterface,
         getBoolSetting(settings, "show_label", true), getBoolSetting(settings, "shadow", true)
     );
     applyCommonSettings(*widget, settings);

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -303,6 +303,12 @@ namespace desktop_settings {
     } else if (type == "sysmon") {
       add(selectSpec("stat", "cpu_usage", sysmonStats));
       add(selectSpec("stat2", "", sysmonStatsWithNone));
+      {
+        auto interface = stringSpec("interface");
+        interface.visibleWhen =
+            WidgetSettingVisibility{{{"stat", {"net_rx", "net_tx"}}, {"stat2", {"net_rx", "net_tx"}}}};
+        add(std::move(interface));
+      }
       add(colorSpec("color", "primary"));
       add(colorSpec("color2", "secondary"));
       add(fontFamilySpec());

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -27,10 +27,10 @@ namespace {
 
 DesktopSysmonWidget::DesktopSysmonWidget(
     SystemMonitorService* monitor, DesktopSysmonStat stat, std::optional<DesktopSysmonStat> stat2, ColorSpec lineColor,
-    ColorSpec lineColor2, bool showLabel, bool shadow
+    ColorSpec lineColor2, std::string networkInterface, bool showLabel, bool shadow
 )
     : m_monitor(monitor), m_stat(stat), m_stat2(stat2), m_lineColor(lineColor), m_lineColor2(lineColor2),
-      m_showLabel(showLabel), m_shadow(shadow) {
+      m_networkInterface(std::move(networkInterface)), m_showLabel(showLabel), m_shadow(shadow) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat))
       m_monitor->retainCpuTemp();
@@ -259,7 +259,8 @@ void DesktopSysmonWidget::syncLabel() {
 }
 
 double DesktopSysmonWidget::normalizedFromStats(
-    DesktopSysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax
+    DesktopSysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax,
+    std::string_view networkInterface
 ) {
   switch (stat) {
   case DesktopSysmonStat::CpuUsage:
@@ -310,13 +311,29 @@ double DesktopSysmonWidget::normalizedFromStats(
     }
     return 0.0;
 
-  case DesktopSysmonStat::NetRx:
-    tempMax = std::max(tempMax, stats.netRxBytesPerSec);
-    return tempMax > 0.0 ? std::clamp(stats.netRxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
+  case DesktopSysmonStat::NetRx: {
+    const double value = networkInterface.empty() ? stats.netRxBytesPerSec : [&stats, networkInterface]() {
+      if (const auto it = stats.netThroughputByInterface.find(std::string(networkInterface));
+          it != stats.netThroughputByInterface.end()) {
+        return it->second.rxBytesPerSec;
+      }
+      return 0.0;
+    }();
+    tempMax = std::max(tempMax, value);
+    return tempMax > 0.0 ? std::clamp(value / tempMax, 0.0, 1.0) : 0.0;
+  }
 
-  case DesktopSysmonStat::NetTx:
-    tempMax = std::max(tempMax, stats.netTxBytesPerSec);
-    return tempMax > 0.0 ? std::clamp(stats.netTxBytesPerSec / tempMax, 0.0, 1.0) : 0.0;
+  case DesktopSysmonStat::NetTx: {
+    const double value = networkInterface.empty() ? stats.netTxBytesPerSec : [&stats, networkInterface]() {
+      if (const auto it = stats.netThroughputByInterface.find(std::string(networkInterface));
+          it != stats.netThroughputByInterface.end()) {
+        return it->second.txBytesPerSec;
+      }
+      return 0.0;
+    }();
+    tempMax = std::max(tempMax, value);
+    return tempMax > 0.0 ? std::clamp(value / tempMax, 0.0, 1.0) : 0.0;
+  }
   }
 
   return 0.0;
@@ -372,10 +389,10 @@ std::string DesktopSysmonWidget::formatValueFor(DesktopSysmonStat stat) const {
     return "--";
 
   case DesktopSysmonStat::NetRx:
-    return FormatUnits::formatDecimalBytesPerSecond(stats.netRxBytesPerSec);
+    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netRxBytesPerSec(m_networkInterface));
 
   case DesktopSysmonStat::NetTx:
-    return FormatUnits::formatDecimalBytesPerSecond(stats.netTxBytesPerSec);
+    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netTxBytesPerSec(m_networkInterface));
   }
 
   return "--";
@@ -413,15 +430,18 @@ void DesktopSysmonWidget::updateGraph(Renderer& renderer) {
   const auto n = hist.size();
   std::vector<float> data1(n);
   for (std::size_t i = 0; i < n; ++i) {
-    data1[i] = static_cast<float>(std::clamp(normalizedFromStats(m_stat, hist[i], m_tempMin1, m_tempMax1), 0.0, 1.0));
+    data1[i] = static_cast<float>(
+        std::clamp(normalizedFromStats(m_stat, hist[i], m_tempMin1, m_tempMax1, m_networkInterface), 0.0, 1.0)
+    );
   }
   m_graph->setValues(std::move(data1));
 
   if (m_stat2.has_value()) {
     std::vector<float> data2(n);
     for (std::size_t i = 0; i < n; ++i) {
-      data2[i] =
-          static_cast<float>(std::clamp(normalizedFromStats(*m_stat2, hist[i], m_tempMin2, m_tempMax2), 0.0, 1.0));
+      data2[i] = static_cast<float>(
+          std::clamp(normalizedFromStats(*m_stat2, hist[i], m_tempMin2, m_tempMax2, m_networkInterface), 0.0, 1.0)
+      );
     }
     m_graph->setValues2(std::move(data2));
   }

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.h
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 
 struct SystemStats;
 
@@ -32,7 +33,7 @@ class DesktopSysmonWidget : public DesktopWidget {
 public:
   DesktopSysmonWidget(
       SystemMonitorService* monitor, DesktopSysmonStat stat, std::optional<DesktopSysmonStat> stat2,
-      ColorSpec lineColor, ColorSpec lineColor2, bool showLabel, bool shadow
+      ColorSpec lineColor, ColorSpec lineColor2, std::string networkInterface, bool showLabel, bool shadow
   );
   ~DesktopSysmonWidget() override;
 
@@ -54,8 +55,10 @@ private:
   void clearGraph();
   void updateGraph(Renderer& renderer);
   [[nodiscard]] float scrollProgressForSample(std::chrono::steady_clock::time_point sampledAt) const;
-  [[nodiscard]] static double
-  normalizedFromStats(DesktopSysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax);
+  [[nodiscard]] static double normalizedFromStats(
+      DesktopSysmonStat stat, const SystemStats& stats, double& tempMin, double& tempMax,
+      std::string_view networkInterface
+  );
   [[nodiscard]] static const char* glyphName(DesktopSysmonStat stat);
 
   SystemMonitorService* m_monitor;
@@ -63,6 +66,7 @@ private:
   std::optional<DesktopSysmonStat> m_stat2;
   ColorSpec m_lineColor;
   ColorSpec m_lineColor2;
+  std::string m_networkInterface;
   bool m_showLabel;
   bool m_shadow;
 

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -234,8 +234,7 @@ namespace settings {
       auto input = ui::input({
           .out = &inputPtr,
           .value = setting.value,
-          .placeholder = setting.placeholder.empty() ? i18n::tr("settings.controls.list.add-entry-placeholder")
-                                                     : setting.placeholder,
+          .placeholder = setting.placeholder,
           .fontSize = Style::fontSizeBody * scale,
           .controlHeight = Style::controlHeight * scale,
           .horizontalPadding = Style::spaceSm * scale,

--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -536,7 +536,7 @@ namespace settings {
     const float inputWidth = (width > 0.0f ? width : 190.0f) * scale;
     auto input = ui::input({
         .value = value,
-        .placeholder = placeholder.empty() ? i18n::tr("settings.controls.list.add-entry-placeholder") : placeholder,
+        .placeholder = placeholder,
         .fontSize = Style::fontSizeBody * scale,
         .controlHeight = Style::controlHeight * scale,
         .horizontalPadding = Style::spaceSm * scale,

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -751,6 +751,11 @@ namespace settings {
         path.visibleWhen = WidgetSettingVisibility{"stat", {"disk_pct"}};
         add(std::move(path));
       }
+      {
+        auto interface = stringSpec("interface");
+        interface.visibleWhen = WidgetSettingVisibility{"stat", {"net_rx", "net_tx"}};
+        add(std::move(interface));
+      }
       add(segmentedSpec("display", "gauge", sysmonDisplay));
       add(colorSpec("highlight_color", "error"));
       add(boolSpec("show_label", true));

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -138,6 +138,28 @@ namespace {
     return fastest;
   }
 
+  [[nodiscard]] double netRxFromStats(const SystemStats& stats, std::string_view interfaceName) {
+    if (interfaceName.empty()) {
+      return stats.netRxBytesPerSec;
+    }
+    if (const auto it = stats.netThroughputByInterface.find(std::string(interfaceName));
+        it != stats.netThroughputByInterface.end()) {
+      return it->second.rxBytesPerSec;
+    }
+    return 0.0;
+  }
+
+  [[nodiscard]] double netTxFromStats(const SystemStats& stats, std::string_view interfaceName) {
+    if (interfaceName.empty()) {
+      return stats.netTxBytesPerSec;
+    }
+    if (const auto it = stats.netThroughputByInterface.find(std::string(interfaceName));
+        it != stats.netThroughputByInterface.end()) {
+      return it->second.txBytesPerSec;
+    }
+    return 0.0;
+  }
+
   [[nodiscard]] SystemConfig::MonitorConfig sanitizeMonitorConfig(SystemConfig::MonitorConfig config) {
     config.cpuPollSeconds = clampPollSeconds(config.cpuPollSeconds);
     config.gpuPollSeconds = clampPollSeconds(config.gpuPollSeconds);
@@ -924,6 +946,16 @@ std::vector<SystemStats> SystemMonitorService::history(int windowSize) const {
   return historyWindowFromRing(m_history, m_historyHead, windowSize);
 }
 
+double SystemMonitorService::netRxBytesPerSec(std::string_view interfaceName) const {
+  std::lock_guard lock{m_statsMutex};
+  return netRxFromStats(m_latest, interfaceName);
+}
+
+double SystemMonitorService::netTxBytesPerSec(std::string_view interfaceName) const {
+  std::lock_guard lock{m_statsMutex};
+  return netTxFromStats(m_latest, interfaceName);
+}
+
 void SystemMonitorService::retainCpuTemp() { m_cpuTempRefs.fetch_add(1, std::memory_order_relaxed); }
 
 void SystemMonitorService::releaseCpuTemp() { m_cpuTempRefs.fetch_sub(1, std::memory_order_relaxed); }
@@ -1138,21 +1170,30 @@ void SystemMonitorService::samplingLoop() {
         const double scale = intervalSeconds > 0.0 ? 1.0 / intervalSeconds : 1.0;
         double totalRx = 0.0;
         double totalTx = 0.0;
+        std::unordered_map<std::string, SystemStats::NetThroughput> byInterface;
         for (const auto& [iface, cur] : *currentNetBytes) {
           const auto it = m_prevNetBytes.find(iface);
+          double ifaceRx = 0.0;
+          double ifaceTx = 0.0;
           if (it != m_prevNetBytes.end()) {
             if (cur.rx >= it->second.rx) {
-              totalRx += static_cast<double>(cur.rx - it->second.rx) * scale;
+              ifaceRx = static_cast<double>(cur.rx - it->second.rx) * scale;
             }
             if (cur.tx >= it->second.tx) {
-              totalTx += static_cast<double>(cur.tx - it->second.tx) * scale;
+              ifaceTx = static_cast<double>(cur.tx - it->second.tx) * scale;
             }
           }
+          if (iface != "lo") {
+            totalRx += ifaceRx;
+            totalTx += ifaceTx;
+          }
+          byInterface.emplace(iface, SystemStats::NetThroughput{.rxBytesPerSec = ifaceRx, .txBytesPerSec = ifaceTx});
         }
         m_prevNetBytes = *currentNetBytes;
         std::lock_guard lock{m_statsMutex};
         m_latest.netRxBytesPerSec = totalRx;
         m_latest.netTxBytesPerSec = totalTx;
+        m_latest.netThroughputByInterface = std::move(byInterface);
       }
       nextNetwork = now + networkInterval;
       statsTouched = true;
@@ -1597,9 +1638,6 @@ SystemMonitorService::readNetBytes() {
     std::string iface = line.substr(0, colonPos);
     while (!iface.empty() && iface.front() == ' ') {
       iface.erase(iface.begin());
-    }
-    if (iface == "lo") {
-      continue;
     }
 
     std::istringstream iss{line.substr(colonPos + 1)};

--- a/src/system/system_monitor_service.h
+++ b/src/system/system_monitor_service.h
@@ -11,11 +11,17 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
 struct SystemStats {
+  struct NetThroughput {
+    double rxBytesPerSec{0.0};
+    double txBytesPerSec{0.0};
+  };
+
   std::chrono::steady_clock::time_point sampledAt{};
   double cpuUsagePercent{0.0};
   double ramUsagePercent{0.0};
@@ -30,6 +36,7 @@ struct SystemStats {
   std::optional<std::uint64_t> gpuVramTotalBytes;
   double netRxBytesPerSec{0.0};
   double netTxBytesPerSec{0.0};
+  std::unordered_map<std::string, NetThroughput> netThroughputByInterface;
   double loadAvg1{0.0};
   double loadAvg5{0.0};
   double loadAvg15{0.0};
@@ -51,6 +58,8 @@ public:
   [[nodiscard]] SystemStats latest() const;
   [[nodiscard]] std::vector<SystemStats> history(int windowSize = kHistorySize) const;
   [[nodiscard]] std::chrono::steady_clock::duration historySampleInterval() const noexcept;
+  [[nodiscard]] double netRxBytesPerSec(std::string_view interfaceName = {}) const;
+  [[nodiscard]] double netTxBytesPerSec(std::string_view interfaceName = {}) const;
 
   void retainCpuTemp();
   void releaseCpuTemp();


### PR DESCRIPTION
The network usage widgets would show the sum of traffic from all network interfaces. With this commit, it's not possible to specify a network interface to only show the traffic from that.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.