### PR TITLE
Add cusomizable fallback colors when using wallpaper for palette source

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -695,6 +695,9 @@
       "list": {
         "add-entry-placeholder": "Add entry…"
       },
+      "color-list": {
+        "add-entry": "Add color"
+      },
       "path-browse": {
         "file-title": "Choose file",
         "folder-title": "Choose folder"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1232,6 +1232,10 @@
         "wallpaper-generation-scheme": {
           "description": "Choose how wallpaper colors are converted into a palette",
           "label": "Wallpaper Generation Scheme"
+        },
+        "wallpaper-fallback-colors": {
+          "description": "Color to use for the palette when the wallpaper doesn't contains suitable colors",
+          "label": "Wallpaper Fallback Colors"
         }
       },
       "backdrop": {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1190,6 +1190,7 @@ struct ThemeConfig {
   std::string communityPalette = "Oxocarbon";
   std::string customPalette;
   std::string wallpaperScheme = "m3-content";
+  std::vector<std::string> wallpaperFallbackColor = {"#4285f4"};
   ThemeMode mode = ThemeMode::Dark;
   TemplatesConfig templates;
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1076,6 +1076,7 @@ namespace noctalia::config::schema {
         field(&ThemeConfig::communityPalette, "community_palette"),
         field(&ThemeConfig::customPalette, "custom_palette"),
         field(&ThemeConfig::wallpaperScheme, "wallpaper_scheme"),
+        field(&ThemeConfig::wallpaperFallbackColor, "wallpaper_fallback_colors"),
         enumField(&ThemeConfig::mode, "mode", kThemeModes),
         subTable(&ThemeConfig::templates, "templates", templatesSchema()),
     };

--- a/src/core/random.h
+++ b/src/core/random.h
@@ -14,4 +14,9 @@ namespace Random {
     return dist(rng());
   }
 
+  template <typename T> inline T randomInt(T min, T max) {
+    std::uniform_int_distribution<T> dist(min, max);
+    return dist(rng());
+  }
+
 } // namespace Random

--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -90,6 +90,13 @@ void rgbToHsv(const Color& rgb, float& h, float& s, float& v) {
   h = h - std::floor(h);
 }
 
+uint32_t rgbToArgb(const Color& rgb) {
+  return (static_cast<uint32_t>(rgb.a * 255.0f) << 24U)
+      | (static_cast<uint32_t>(rgb.r * 255.0f) << 16U)
+      | (static_cast<uint32_t>(rgb.g * 255.0f) << 8U)
+      | static_cast<uint32_t>(rgb.b * 255.0f);
+}
+
 float relativeLuminance(const Color& color) {
   return 0.2126f * linearizedColorChannel(color.r)
       + 0.7152f * linearizedColorChannel(color.g)

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -127,3 +127,4 @@ void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
 [[nodiscard]] Color readableTextColorForBackground(const Color& background);
 [[nodiscard]] std::string formatRgbHex(const Color& color);
 [[nodiscard]] bool tryParseHexColor(std::string_view input, Color& out);
+[[nodiscard]] uint32_t rgbToArgb(const Color& rgb);

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -659,6 +659,10 @@ namespace settings {
       factory.makeListBlock(section, entry, list);
     };
 
+    const auto makeColorListBlock = [&](Flex& section, const SettingEntry& entry, const ColorListSetting& list) {
+      factory.makeColorListBlock(section, entry, list);
+    };
+
     const auto makeKeybindListBlock = [&](Flex& section, const SettingEntry& entry,
                                           const KeybindListSetting& keybinds) {
       const bool overridden = (ctx.configService != nullptr && ctx.configService->hasEffectiveOverride(entry.path));
@@ -1178,6 +1182,8 @@ namespace settings {
               return nullptr;
             } else if constexpr (std::is_same_v<T, ListSetting>) {
               return nullptr;
+            } else if constexpr (std::is_same_v<T, ColorListSetting>) {
+              return nullptr;
             } else if constexpr (std::is_same_v<T, ShortcutListSetting>) {
               return nullptr;
             } else if constexpr (std::is_same_v<T, KeybindListSetting>) {
@@ -1346,6 +1352,8 @@ namespace settings {
           } else if (!isBarWidgetListPath(entry.path)) {
             makeListBlock(*activeSection, entry, *list);
           }
+        } else if (const auto* colorList = std::get_if<ColorListSetting>(&entry.control)) {
+          makeColorListBlock(*activeSection, entry, *colorList);
         } else if (const auto* shortcuts = std::get_if<ShortcutListSetting>(&entry.control)) {
           makeShortcutListBlock(*activeSection, entry, *shortcuts);
         } else if (const auto* keybindList = std::get_if<KeybindListSetting>(&entry.control)) {

--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -2,6 +2,7 @@
 
 #include "config/config_types.h"
 #include "i18n/i18n.h"
+#include "render/core/color.h"
 #include "shell/settings/color_spec_picker.h"
 #include "shell/settings/settings_content_common.h"
 #include "ui/builders.h"
@@ -14,6 +15,7 @@
 #include "ui/controls/slider.h"
 #include "ui/controls/stepper.h"
 #include "ui/controls/toggle.h"
+#include "ui/dialogs/color_picker_dialog.h"
 #include "ui/palette.h"
 #include "ui/style.h"
 
@@ -770,6 +772,112 @@ namespace settings {
       setOverride(path, items);
     });
     block->addChild(std::move(listEditor));
+
+    section.addChild(std::move(block));
+  }
+
+  void
+  SettingsControlFactory::makeColorListBlock(Flex& section, const SettingEntry& entry, const ColorListSetting& list) {
+
+    constexpr float kSwatchSize = 16.0f;
+    constexpr float kLabelCellWidth = 200.0f;
+    constexpr float kAddButtonWidth = 190.0f;
+    constexpr float kItemRowHeight = 26.0f;
+
+    auto& ctx = m_ctx;
+    const float scale = m_scale;
+    const bool overridden = (ctx.configService != nullptr && ctx.configService->hasEffectiveOverride(entry.path));
+
+    auto block = makeCollectionBlock(entry, overridden);
+
+    auto addRow = ui::row({
+        .align = FlexAlign::Start,
+        .gap = Style::spaceSm * scale,
+    });
+    addRow->addChild(
+        ui::button({
+            .text = i18n::tr("settings.controls.color-list.add-entry"),
+            .glyph = "add",
+            .fontSize = Style::fontSizeBody * scale,
+            .glyphSize = Style::fontSizeBody * scale,
+            .variant = ButtonVariant::Outline,
+            .minWidth = kAddButtonWidth * scale,
+            .minHeight = Style::controlHeight * scale,
+            .radius = Style::scaledRadiusMd(scale),
+            .onClick = [setOverride = ctx.setOverride, items = list.items, path = entry.path] {
+              ColorPickerDialogOptions dialogOptions;
+              dialogOptions.title = i18n::tr("settings.dialogs.color-picker.title");
+              if (const auto last = ColorPickerDialog::lastResult()) {
+                dialogOptions.initialColor = *last;
+              }
+              (void)ColorPickerDialog::open(
+                  std::move(dialogOptions), [setOverride, items, path](std::optional<Color> result) mutable {
+                    if (!result.has_value()) {
+                      return;
+                    }
+                    Color rgb = *result;
+                    rgb.a = 1.0f;
+                    items.push_back(formatRgbHex(rgb));
+                    setOverride(path, items);
+                  }
+              );
+            },
+        })
+    );
+    block->addChild(std::move(addRow));
+
+    const float itemRowHeight = kItemRowHeight * scale;
+    const float labelCellWidth = kLabelCellWidth * scale;
+
+    for (std::size_t i = 0; i < list.items.size(); ++i) {
+      Color color;
+      if (!tryParseHexColor(list.items[i], color)) {
+        continue;
+      }
+
+      auto itemRow = ui::row({
+          .align = FlexAlign::Center,
+          .gap = Style::spaceXs * scale,
+          .minHeight = itemRowHeight,
+      });
+
+      itemRow->addChild(
+          ui::box({
+              .fill = fixedColorSpec(color),
+              .radius = kSwatchSize * scale / 2.0f,
+              .width = kSwatchSize * scale,
+              .height = kSwatchSize * scale,
+          })
+      );
+      itemRow->addChild(
+          ui::label({
+              .text = list.items[i],
+              .fontSize = Style::fontSizeBody * scale,
+              .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+              .minWidth = labelCellWidth,
+          })
+      );
+      itemRow->addChild(
+          ui::button({
+              .glyph = "close",
+              .glyphSize = Style::fontSizeCaption * scale,
+              .variant = ButtonVariant::Ghost,
+              .minWidth = kItemRowHeight * scale,
+              .minHeight = kItemRowHeight * scale,
+              .padding = Style::spaceXs * scale,
+              .radius = Style::scaledRadiusSm(scale),
+              .onClick = [setOverride = ctx.setOverride, items = list.items, path = entry.path, i] mutable {
+                if (i >= items.size()) {
+                  return;
+                }
+                items.erase(items.begin() + static_cast<std::ptrdiff_t>(i));
+                setOverride(path, items);
+              },
+          })
+      );
+
+      block->addChild(std::move(itemRow));
+    }
 
     section.addChild(std::move(block));
   }

--- a/src/shell/settings/settings_control_factory.h
+++ b/src/shell/settings/settings_control_factory.h
@@ -77,6 +77,7 @@ namespace settings {
     );
 
     void makeListBlock(Flex& section, const SettingEntry& entry, const ListSetting& list);
+    void makeColorListBlock(Flex& section, const SettingEntry& entry, const ColorListSetting& list);
     void makeStringMapBlock(Flex& section, const SettingEntry& entry, const StringMapSetting& map);
 
   private:

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -401,12 +401,15 @@ namespace settings {
           tr("settings.schema.appearance.wallpaper-generation-scheme.description"), {"theme", "wallpaper_scheme"},
           wallpaperSchemeSelect(cfg.theme.wallpaperScheme), "wallpaper palette generator scheme material you m3 colors"
       ));
-      entries.push_back(makeEntry(
+
+      SettingEntry fallbackColorsEntry = makeEntry(
           SettingsSection::Appearance, "theme", tr("settings.schema.appearance.wallpaper-fallback-colors.label"),
           tr("settings.schema.appearance.wallpaper-fallback-colors.description"),
-          {"theme", "wallpaper_fallback_colors"}, ListSetting{.items = cfg.theme.wallpaperFallbackColor},
+          {"theme", "wallpaper_fallback_colors"}, ColorListSetting{.items = cfg.theme.wallpaperFallbackColor},
           "fallback colors for wallpaper palette generation"
-      ));
+      );
+      fallbackColorsEntry.advanced = true;
+      entries.push_back(fallbackColorsEntry);
     } else if (cfg.theme.source == PaletteSource::Community) {
       SettingControl communityPaletteControl =
           TextSetting{.value = cfg.theme.communityPalette, .placeholder = "Oxocarbon", .browseFileExtensions = {}};

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -401,6 +401,12 @@ namespace settings {
           tr("settings.schema.appearance.wallpaper-generation-scheme.description"), {"theme", "wallpaper_scheme"},
           wallpaperSchemeSelect(cfg.theme.wallpaperScheme), "wallpaper palette generator scheme material you m3 colors"
       ));
+      entries.push_back(makeEntry(
+          SettingsSection::Appearance, "theme", tr("settings.schema.appearance.wallpaper-fallback-colors.label"),
+          tr("settings.schema.appearance.wallpaper-fallback-colors.description"),
+          {"theme", "wallpaper_fallback_colors"}, ListSetting{.items = cfg.theme.wallpaperFallbackColor},
+          "fallback colors for wallpaper palette generation"
+      ));
     } else if (cfg.theme.source == PaletteSource::Community) {
       SettingControl communityPaletteControl =
           TextSetting{.value = cfg.theme.communityPalette, .placeholder = "Oxocarbon", .browseFileExtensions = {}};

--- a/src/shell/settings/settings_registry.h
+++ b/src/shell/settings/settings_registry.h
@@ -188,6 +188,10 @@ namespace settings {
     std::size_t maxItems = 0;
   };
 
+  struct ColorListSetting {
+    std::vector<std::string> items;
+  };
+
   struct SessionPanelActionsSetting {
     std::vector<SessionPanelActionConfig> items;
   };
@@ -228,7 +232,7 @@ namespace settings {
 
   using SettingControl = std::variant<
       ToggleSetting, SelectSetting, SliderSetting, RangeSliderSetting, TextSetting, OptionalNumberSetting,
-      OptionalStepperSetting, StepperSetting, ListSetting, ShortcutListSetting, KeybindListSetting,
+      OptionalStepperSetting, StepperSetting, ListSetting, ShortcutListSetting, KeybindListSetting, ColorListSetting,
       SessionPanelActionsSetting, IdleBehaviorsSetting, NotificationFiltersSetting, MultiSelectSetting,
       TemplateGridSetting, ButtonSetting, ColorSpecPickerSetting, SearchPickerSetting>;
 

--- a/src/theme/cli.cpp
+++ b/src/theme/cli.cpp
@@ -38,28 +38,29 @@ namespace noctalia::theme {
         "schemes produce very different results.\n"
         "\n"
         "Options:\n"
-        "  --scheme <name>   Material You (Material Design 3):\n"
-        "                      m3-tonal-spot  (default)\n"
-        "                      m3-content\n"
-        "                      m3-fruit-salad\n"
-        "                      m3-rainbow\n"
-        "                      m3-monochrome\n"
-        "                    Custom (HSL-space, non-M3):\n"
-        "                      vibrant\n"
-        "                      faithful\n"
-        "                      dysfunctional\n"
-        "                      muted\n"
-        "  --dark            Emit only the dark variant (default)\n"
-        "  --light           Emit only the light variant\n"
-        "  --both            Emit both variants under dark/light keys\n"
-        "  --theme-json <f>  Load precomputed dark/light token maps from JSON\n"
-        "  -o <file>         Write JSON to file instead of stdout\n"
-        "  -r <in:out>       Render a template file to an output path\n"
-        "  -c <file>         Process a TOML template config file\n"
-        "  --builtin-config  Process the shipped built-in template catalog\n"
-        "  --list-templates  List built-in, cached community, and configured user templates\n"
-        "                    Use -c <file> to include a specific template config\n"
-        "  --default-mode    Template default mode: dark or light";
+        "  --scheme <name>           Material You (Material Design 3):\n"
+        "                              m3-tonal-spot  (default)\n"
+        "                              m3-content\n"
+        "                              m3-fruit-salad\n"
+        "                              m3-rainbow\n"
+        "                              m3-monochrome\n"
+        "                            Custom (HSL-space, non-M3):\n"
+        "                              vibrant\n"
+        "                              faithful\n"
+        "                              dysfunctional\n"
+        "                              muted\n"
+        "  --dark                    Emit only the dark variant (default)\n"
+        "  --light                   Emit only the light variant\n"
+        "  --both                    Emit both variants under dark/light keys\n"
+        "  --theme-json <f>          Load precomputed dark/light token maps from JSON\n"
+        "  --fallback-color <color>  Color to use if no good color found from the image\n"
+        "  -o <file>                 Write JSON to file instead of stdout\n"
+        "  -r <in:out>               Render a template file to an output path\n"
+        "  -c <file>                 Process a TOML template config file\n"
+        "  --builtin-config          Process the shipped built-in template catalog\n"
+        "  --list-templates          List built-in, cached community, and configured user templates\n"
+        "                            Use -c <file> to include a specific template config\n"
+        "  --default-mode            Template default mode: dark or light";
 
     std::filesystem::path builtinTemplateConfigPath() { return paths::assetPath("templates/builtin.toml"); }
 
@@ -429,6 +430,7 @@ namespace noctalia::theme {
     bool listTemplatesRequested = false;
     std::string defaultMode = "dark";
     std::vector<std::string> renderSpecs;
+    std::string fallbackColor = "#4285f4";
 
     for (int i = 2; i < argc; ++i) {
       const char* a = argv[i];
@@ -442,6 +444,10 @@ namespace noctalia::theme {
       }
       if (std::strcmp(a, "--theme-json") == 0 && i + 1 < argc) {
         themeJsonPath = argv[++i];
+        continue;
+      }
+      if (std::strcmp(a, "--fallback-color") == 0 && i + 1 < argc) {
+        fallbackColor = argv[++i];
         continue;
       }
       if (std::strcmp(a, "--dark") == 0) {
@@ -525,7 +531,9 @@ namespace noctalia::theme {
         return 1;
       }
 
-      palette = generate(loaded->rgb, *schemeOpt, &err);
+      const Color fallback = Color::fromHex(fallbackColor);
+
+      palette = generate(loaded->rgb, {fallback.toArgb()}, *schemeOpt, &err);
       if (palette.dark.empty() && palette.light.empty()) {
         std::fprintf(stderr, "error: palette generation failed: %s\n", err.empty() ? "unknown error" : err.c_str());
         return 1;

--- a/src/theme/m3_schemes.cpp
+++ b/src/theme/m3_schemes.cpp
@@ -1,3 +1,4 @@
+#include "core/log.h"
 #include "core/random.h"
 #include "cpp/cam/cam.h"
 #include "cpp/cam/hct.h"
@@ -37,6 +38,8 @@ namespace mcu = material_color_utilities;
 namespace noctalia::theme {
 
   namespace {
+
+    constexpr auto kLog = Logger("theme");
 
     // ─── Matugen-faithful quant + score ────────────────────────────────
     //
@@ -341,6 +344,9 @@ namespace noctalia::theme {
       );
 
       auto ranked = scoreMatugen(clusters, 4, true);
+      if (ranked.empty()) {
+        kLog.warn("no seeds after chroma filter, using fallback color {}", fallback);
+      }
       return ranked.empty() ? fallback : ranked.front();
     }
 

--- a/src/theme/m3_schemes.cpp
+++ b/src/theme/m3_schemes.cpp
@@ -1,3 +1,4 @@
+#include "core/random.h"
 #include "cpp/cam/cam.h"
 #include "cpp/cam/hct.h"
 #include "cpp/dynamiccolor/dynamic_scheme.h"
@@ -299,8 +300,6 @@ namespace noctalia::theme {
       }
 
       std::vector<mcu::Argb> out;
-      if (chosen.empty())
-        out.push_back(0xff4285f4u);
       for (auto& h : chosen)
         out.push_back(h.ToInt());
       return out;
@@ -308,7 +307,7 @@ namespace noctalia::theme {
 
     // Build pixels → wu seeds → wsmeans (matugen order) → chroma filter →
     // matugen-style score → first ranked.
-    mcu::Argb extractSeed(const std::vector<uint8_t>& rgb112) {
+    mcu::Argb extractSeed(const std::vector<uint8_t>& rgb112, const uint32_t fallback) {
       std::vector<mcu::Argb> pixels;
       pixels.reserve(rgb112.size() / 3);
       for (size_t i = 0; i + 2 < rgb112.size(); i += 3) {
@@ -342,7 +341,7 @@ namespace noctalia::theme {
       );
 
       auto ranked = scoreMatugen(clusters, 4, true);
-      return ranked.empty() ? 0xff4285f4u : ranked.front();
+      return ranked.empty() ? fallback : ranked.front();
     }
 
     std::unique_ptr<mcu::DynamicScheme> makeScheme(const mcu::Hct& source, Scheme scheme, bool isDark) {
@@ -441,8 +440,14 @@ namespace noctalia::theme {
 
   } // namespace
 
-  GeneratedPalette generateMaterial(const std::vector<uint8_t>& rgb112, Scheme scheme) {
-    const mcu::Argb seed = extractSeed(rgb112);
+  GeneratedPalette
+  generateMaterial(const std::vector<uint8_t>& rgb112, const std::vector<uint32_t>& fallback_colors, Scheme scheme) {
+    // Pick a fallback color if quantization fails to yield any seeds.
+    const uint32_t fallback_color = fallback_colors.empty()
+        ? 0xff4285f4u
+        : fallback_colors[Random::randomInt<size_t>(0, fallback_colors.size() - 1)];
+
+    const mcu::Argb seed = extractSeed(rgb112, fallback_color);
     const mcu::Hct source(seed);
 
     auto darkScheme = makeScheme(source, scheme, true);

--- a/src/theme/palette_generator.cpp
+++ b/src/theme/palette_generator.cpp
@@ -2,14 +2,17 @@
 
 namespace noctalia::theme {
 
-  GeneratedPalette generate(const std::vector<uint8_t>& rgb112, Scheme scheme, std::string* errorMessage) {
+  GeneratedPalette generate(
+      const std::vector<uint8_t>& rgb112, const std::vector<uint32_t>& fallback_colors, Scheme scheme,
+      std::string* errorMessage
+  ) {
     if (rgb112.size() != 112u * 112u * 3u) {
       if (errorMessage)
         *errorMessage = "expected 112x112x3 pixel buffer";
       return {};
     }
     if (isMaterialScheme(scheme))
-      return generateMaterial(rgb112, scheme);
+      return generateMaterial(rgb112, fallback_colors, scheme);
     return generateCustom(rgb112, scheme);
   }
 

--- a/src/theme/palette_generator.h
+++ b/src/theme/palette_generator.h
@@ -15,10 +15,14 @@ namespace noctalia::theme {
   //
   // The buffer must contain exactly 112 * 112 * 3 bytes. Returns an empty
   // palette and writes an error message if generation fails.
-  GeneratedPalette generate(const std::vector<uint8_t>& rgb112, Scheme scheme, std::string* errorMessage = nullptr);
+  GeneratedPalette generate(
+      const std::vector<uint8_t>& rgb112, const std::vector<uint32_t>& fallback_colors, Scheme scheme,
+      std::string* errorMessage = nullptr
+  );
 
   // Internal paths — exposed for unit testing / analysis tool reuse.
-  GeneratedPalette generateMaterial(const std::vector<uint8_t>& rgb112, Scheme scheme);
+  GeneratedPalette
+  generateMaterial(const std::vector<uint8_t>& rgb112, const std::vector<uint32_t>& fallback_colors, Scheme scheme);
   GeneratedPalette generateCustom(const std::vector<uint8_t>& rgb112, Scheme scheme);
 
 } // namespace noctalia::theme

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -6,6 +6,7 @@
 #include "core/scoped_timer.h"
 #include "ipc/ipc_service.h"
 #include "net/http_client.h"
+#include "render/core/color.h"
 #include "system/day_night_schedule.h"
 #include "theme/builtin_palettes.h"
 #include "theme/community_palettes.h"
@@ -436,7 +437,18 @@ namespace noctalia::theme {
       return std::nullopt;
     }
     profiling::StopWatch genWatch;
-    auto generated = generate(image->rgb, *scheme, &err);
+
+    std::vector<uint32_t> fallbackColors;
+    for (const auto& c : cfg.wallpaperFallbackColor) {
+      Color color;
+      if (tryParseHexColor(c, color)) {
+        fallbackColors.push_back(rgbToArgb(color));
+      } else {
+        kLog.warn("failed to parse wallpaper fallback color '{}'; ignoring", c);
+      }
+    }
+
+    auto generated = generate(image->rgb, fallbackColors, *scheme, &err);
     if (profiling::enabled()) {
       kLog.info("theme: wallpaper palette generate: {:.1f} ms", genWatch.elapsedMs());
     }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

This change adds a configuration field for wallpaper fallback colors, such that when picking a seed color from the wallpaper fails the user can configure the fallback color. It also allows multiple fallback colors which it picks one at random.

Then I also added a color list picker to allow the configuration of this field from the settings UI.

## Motivation

<!-- What problem does this solve? -->

Currently when generating a palette from a wallpaper using the Material themes, the logic scores the colors from the wallpaper image to find one with high chroma to use for the seed color. For low chroma images (e.g. black & white) this fails to find any suitable seed color and uses a hard-coded fallback of #4285f4 for all wallpapers. This change allows user configuration of the fallback.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

I ran the standard unit-tests and manual testing. For manual testing I tested these cases:

- Black & White images with a single fallback color, always uses that color
- Black & White images with no fallback color set uses the hard-coded color
- Black & White images with multiple fallback colors pick one at random
- Colorful images ignore the fallback and pick a color from the image

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/594b147c-1b6d-4d3b-a3a9-d295c4b04e23

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

I made sure to keep the hard-coded color as the default value, and as a fallback if unset or set to an empty list, so behavior should be unchanged by default.