### PR TITLE
feat(idle-grace-overlay): use fade to black for smooth transition with noctalia:dpms-off

### DIFF
--- a/src/idle/idle_grace_overlay.cpp
+++ b/src/idle/idle_grace_overlay.cpp
@@ -212,7 +212,7 @@ void IdleGraceOverlay::buildScene(Instance& inst, std::uint32_t width, std::uint
   // Fullscreen tint: fade this layer only so the Wayland buffer stays a proper overlay (transparent
   // clear + premultiplied tint).
   auto dim = std::make_unique<Box>();
-  dim->setFill(colorSpecFromRole(ColorRole::Surface));
+  dim->setFill(fixedColorSpec(rgba(0.0f, 0.0f, 0.0f, 1.0f)));
   dim->setOpacity(0.0f);
   dim->setPosition(0.0f, 0.0f);
   dim->setSize(w, h);


### PR DESCRIPTION
## Summary

I changed the idle grace color to black instead of shell surface because the transition is smooth in conjunction with idle dpms-off behavior (and won't change with wallpaper theme changes).

## Motivation

Aesthetics are subjective, but I think this works as a better default. I considered adding a config field to let user choose but decided against it to avoid config bloat. Close if you disagree. :smiley: 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

Tested with:

```
[idle]
pre_action_fade_seconds = 4.0

[idle.behavior.screen-off]
enabled = true
timeout = 10
command = "noctalia:dpms-off"
resume_command = "noctalia:dpms-on"
```

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
