### PR TITLE
widgets: add privacy indicator

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -51,6 +51,11 @@
       "network": {
         "wired": "Wired"
       },
+      "privacy": {
+        "camera": "Camera",
+        "microphone": "Microphone",
+        "screen-sharing": "Screen Sharing"
+      },
       "scripted": {
         "reload-failed": "Script reload failed",
         "reloaded": "Reloaded script"
@@ -2427,6 +2432,10 @@
           "description": "Media artwork size in pixels",
           "label": "Art Size"
         },
+        "active-color": {
+          "description": "Color used for active privacy indicators; fixed hex colors are also supported",
+          "label": "Active Color"
+        },
         "bands": {
           "description": "Number of visualizer bands",
           "label": "Bands"
@@ -2563,9 +2572,17 @@
           "description": "Tray item ids to hide",
           "label": "Hidden Items"
         },
+        "cam-filter-regex": {
+          "description": "Regular expression for camera process names to ignore",
+          "label": "Camera Filter Regex"
+        },
         "hide-empty-workspaces": {
           "description": "When grouping by workspace, omit capsules that have no running windows in the taskbar list.",
           "label": "Hide Empty Workspaces"
+        },
+        "hide-inactive": {
+          "description": "Hide inactive privacy icons and hide the widget when nothing is active",
+          "label": "Hide Inactive"
         },
         "hide-when-empty": {
           "description": "Hide workspace pills when there are no open windows",
@@ -2616,6 +2633,14 @@
           "description": "Icon size in pixels",
           "label": "Icon Size"
         },
+        "icon-spacing": {
+          "description": "Spacing between privacy indicator icons in pixels",
+          "label": "Icon Spacing"
+        },
+        "inactive-color": {
+          "description": "Color used for inactive privacy indicators; fixed hex colors are also supported",
+          "label": "Inactive Color"
+        },
         "interface": {
           "description": "Network interface to monitor; leave empty to use the total across all interfaces",
           "label": "Interface"
@@ -2657,6 +2682,10 @@
         "middle-command": {
           "description": "Shell command run when middle-clicking this button. When set, middle-click opens this command instead of widget settings.",
           "label": "Middle Click Command"
+        },
+        "mic-filter-regex": {
+          "description": "Regular expression for microphone app names to ignore",
+          "label": "Microphone Filter Regex"
         },
         "min-length": {
           "description": "Minimum widget length in pixels",
@@ -2840,6 +2869,7 @@
         "nightlight": "Night Light",
         "notifications": "Notifications",
         "power-profile": "Power Profile",
+        "privacy": "Privacy Indicator",
         "screenshot": "Screenshot",
         "scripted": "Scripted",
         "session": "Session",

--- a/meson.build
+++ b/meson.build
@@ -646,6 +646,7 @@ _noctalia_sources = files(
   'src/shell/bar/widgets/notification_widget.cpp',
   'src/shell/bar/widgets/plugin_widget.cpp',
   'src/shell/bar/widgets/power_profile_widget.cpp',
+  'src/shell/bar/widgets/privacy_widget.cpp',
   'src/shell/bar/widgets/session_widget.cpp',
   'src/shell/bar/widgets/settings_widget.cpp',
   'src/shell/bar/widgets/spacer_widget.cpp',

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -8,6 +8,7 @@
 #include "util/string_utils.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <charconv>
 #include <chrono>
@@ -19,6 +20,7 @@
 #include <pipewire/extensions/metadata.h>
 #include <pipewire/keys.h>
 #include <pipewire/pipewire.h>
+#include <ranges>
 #include <spa/param/audio/format-utils.h>
 #include <spa/param/param.h>
 #include <spa/param/props.h>
@@ -31,6 +33,7 @@
 #include <spa/utils/type.h>
 #include <string>
 #include <string_view>
+#include <tuple>
 
 namespace {
 
@@ -222,13 +225,20 @@ namespace {
       }
     }
 
-    if (mergeOnly && !dictHas(props, PW_KEY_NODE_PASSIVE)) {
-      return changed;
+    if (!mergeOnly || dictHas(props, PW_KEY_NODE_PASSIVE)) {
+      const bool passive = isTruthyPipeWireProp(dictGet(props, PW_KEY_NODE_PASSIVE));
+      if (nd.nodePassive != passive) {
+        nd.nodePassive = passive;
+        changed = true;
+      }
     }
-    const bool passive = isTruthyPipeWireProp(dictGet(props, PW_KEY_NODE_PASSIVE));
-    if (nd.nodePassive != passive) {
-      nd.nodePassive = passive;
-      changed = true;
+
+    if (!mergeOnly || dictHas(props, "stream.capture.sink")) {
+      const bool captureSink = isTruthyPipeWireProp(dictGet(props, "stream.capture.sink"));
+      if (nd.streamCaptureSink != captureSink) {
+        nd.streamCaptureSink = captureSink;
+        changed = true;
+      }
     }
     return changed;
   }
@@ -479,7 +489,157 @@ namespace {
 
   constexpr Logger kLog("pipewire");
 
+  constexpr auto kTrackedNodeClasses = std::to_array<std::string_view>({
+      "Audio/Sink",
+      "Audio/Source",
+      "Stream/Output/Audio",
+      "Stream/Input/Audio",
+  });
+
+  constexpr auto kPrivacyAudioNodeClasses = std::to_array<std::string_view>({
+      "Stream/Input/Audio",
+  });
+
+  constexpr auto kMicrophoneSourceClasses = std::to_array<std::string_view>({
+      "Audio/Source",
+  });
+
+  constexpr auto kAudioCaptureConsumerClasses = std::to_array<std::string_view>({
+      "Stream/Input/Audio",
+  });
+
+  constexpr auto kCameraSourceClasses = std::to_array<std::string_view>({
+      "Video/Source",
+  });
+
+  constexpr auto kVideoCaptureConsumerClasses = std::to_array<std::string_view>({
+      "Stream/Input/Video",
+  });
+
+  constexpr auto kScreenShareNamePrefixes = std::to_array<std::string_view>({
+      "xdph-streaming",
+      "gsr-default",
+      "game capture",
+      "screen",
+      "desktop",
+      "display",
+      "cast",
+      "webrtc",
+  });
+
+  constexpr auto kScreenShareExactNames = std::to_array<std::string_view>({
+      "gsr-default_output",
+  });
+
+  constexpr auto kScreenShareWeakNamePrefixes = std::to_array<std::string_view>({
+      "v4l2",
+  });
+
+  constexpr auto kScreenShareNameFragments = std::to_array<std::string_view>({
+      "screen-cast",
+      "screen-capture",
+      "desktop-capture",
+      "monitor-capture",
+      "window-capture",
+      "game-capture",
+  });
+
   bool isProgramStreamClass(std::string_view mediaClass) { return mediaClass == "Stream/Output/Audio"; }
+
+  [[nodiscard]] bool isTrackedNodeClass(std::string_view mediaClass) {
+    return std::ranges::contains(kTrackedNodeClasses, mediaClass) || mediaClass.contains("Video");
+  }
+
+  [[nodiscard]] bool isPrivacyCandidateClass(std::string_view mediaClass) {
+    return std::ranges::contains(kPrivacyAudioNodeClasses, mediaClass)
+        || (mediaClass.contains("Video") && !mediaClass.contains("Audio"));
+  }
+
+  [[nodiscard]] std::string lowercaseAscii(std::string_view value) {
+    std::string out(value);
+    std::ranges::transform(out, out.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return out;
+  }
+
+  [[nodiscard]] bool matchesScreenShareName(std::string_view mediaName, bool includeWeakPrefixes) {
+    if (mediaName.empty()) {
+      return false;
+    }
+
+    const std::string lower = lowercaseAscii(mediaName);
+    return std::ranges::any_of(
+               kScreenShareNamePrefixes, [&lower](std::string_view prefix) { return lower.starts_with(prefix); }
+           )
+        || (includeWeakPrefixes
+            && std::ranges::any_of(
+                kScreenShareWeakNamePrefixes, [&lower](std::string_view prefix) { return lower.starts_with(prefix); }
+            ))
+        || std::ranges::contains(kScreenShareExactNames, lower)
+        || std::ranges::any_of(kScreenShareNameFragments, [&lower](std::string_view fragment) {
+             return lower.contains(fragment);
+           });
+  }
+
+  [[nodiscard]] bool isMicrophoneSource(const PipeWireService::NodeData& nd) {
+    return std::ranges::contains(kMicrophoneSourceClasses, nd.mediaClass);
+  }
+
+  [[nodiscard]] bool isAudioCaptureConsumer(const PipeWireService::NodeData& nd) {
+    return std::ranges::contains(kAudioCaptureConsumerClasses, nd.mediaClass) && !nd.streamCaptureSink;
+  }
+
+  [[nodiscard]] bool isCameraSource(const PipeWireService::NodeData& nd) {
+    return std::ranges::contains(kCameraSourceClasses, nd.mediaClass);
+  }
+
+  [[nodiscard]] bool isVideoCaptureConsumer(const PipeWireService::NodeData& nd) {
+    return std::ranges::contains(kVideoCaptureConsumerClasses, nd.mediaClass);
+  }
+
+  [[nodiscard]] bool isScreenSource(const PipeWireService::NodeData& nd) {
+    if (!nd.mediaClass.contains("Video") || nd.mediaClass.contains("Audio")) {
+      return false;
+    }
+
+    if (matchesScreenShareName(nd.mediaName, true) || matchesScreenShareName(nd.streamTitle, false)) {
+      return true;
+    }
+
+    if (isCameraSource(nd)) {
+      return matchesScreenShareName(nd.name, false);
+    }
+    return matchesScreenShareName(nd.name, true);
+  }
+
+  [[nodiscard]] std::string privacyAppName(const PipeWireService::NodeData& nd) {
+    if (!nd.applicationName.empty()) {
+      return nd.applicationName;
+    }
+    if (!nd.streamTitle.empty()) {
+      return nd.streamTitle;
+    }
+    if (!nd.description.empty()) {
+      return nd.description;
+    }
+    return nd.name;
+  }
+
+  [[nodiscard]] std::optional<PrivacyCaptureKind>
+  classifyPrivacyCapture(const PipeWireService::NodeData& source, const PipeWireService::NodeData& consumer) {
+    if (isMicrophoneSource(source) && isAudioCaptureConsumer(consumer)) {
+      return PrivacyCaptureKind::Microphone;
+    }
+
+    if (isScreenSource(source) && isVideoCaptureConsumer(consumer)) {
+      return PrivacyCaptureKind::Screen;
+    }
+
+    if (isCameraSource(source) && isVideoCaptureConsumer(consumer)) {
+      return PrivacyCaptureKind::Camera;
+    }
+
+    return std::nullopt;
+  }
 
   // QEMU's libvirt PipeWire backend (node.name "qemu-system-<arch>") is a program stream that needs
   // special handling: it sets target.object and never sets application.name.
@@ -728,10 +888,22 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
     return;
   }
 
-  // Track audio sink/source nodes
+  if (std::strcmp(type, PW_TYPE_INTERFACE_Link) == 0) {
+    LinkData link;
+    link.id = id;
+    link.outputNodeId = parseUint32Or(dictGet(props, PW_KEY_LINK_OUTPUT_NODE));
+    link.inputNodeId = parseUint32Or(dictGet(props, PW_KEY_LINK_INPUT_NODE));
+    if (link.outputNodeId != 0 && link.inputNodeId != 0) {
+      m_links.insert_or_assign(id, link);
+      rebuildState();
+    }
+    return;
+  }
+
+  // Track audio nodes and privacy-relevant stream nodes.
   if (std::strcmp(type, PW_TYPE_INTERFACE_Node) == 0) {
     std::string mediaClass = dictGet(props, PW_KEY_MEDIA_CLASS);
-    if (mediaClass != "Audio/Sink" && mediaClass != "Audio/Source" && mediaClass != "Stream/Output/Audio") {
+    if (!isTrackedNodeClass(mediaClass)) {
       return;
     }
 
@@ -765,8 +937,9 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
     }
 
     nd->streamTitle = dictGet(props, "media.title");
+    nd->mediaName = dictGet(props, "media.name");
     if (nd->streamTitle.empty()) {
-      nd->streamTitle = dictGet(props, "media.name");
+      nd->streamTitle = nd->mediaName;
     }
     if (nd->streamTitle.empty()) {
       nd->streamTitle = dictGet(props, "node.nick");
@@ -782,8 +955,8 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
     if (nd->iconName.empty()) {
       nd->iconName = nd->applicationBinary;
     }
-    applyStreamFilterPropsFromDict(*nd, props, false);
     nd->mediaClass = mediaClass;
+    applyStreamFilterPropsFromDict(*nd, props, false);
     const bool audioDeviceNode = mediaClass == "Audio/Sink" || mediaClass == "Audio/Source";
     applyVolumePropsFromDict(*nd, props, !audioDeviceNode);
     refreshNodeIdentity(*nd);
@@ -882,6 +1055,12 @@ void PipeWireService::onRegistryGlobalRemove(std::uint32_t id) {
     return;
   }
 
+  if (auto it = m_links.find(id); it != m_links.end()) {
+    m_links.erase(it);
+    rebuildState();
+    return;
+  }
+
   auto it = m_nodes.find(id);
   if (it == m_nodes.end()) {
     return;
@@ -911,10 +1090,15 @@ void PipeWireService::onNodeInfo(std::uint32_t id, const pw_node_info* info) {
 
   // Update name/description from props if available
   auto& nd = *it->second;
-  const bool isStream = isProgramStreamClass(nd.mediaClass);
+  const bool wasProgramStream = isProgramStreamClass(nd.mediaClass);
+  const bool wasPrivacyCandidate = isPrivacyCandidateClass(nd.mediaClass);
   bool filterPropsChanged = false;
 
   if (info->props != nullptr) {
+    std::string mediaClass = dictGet(info->props, PW_KEY_MEDIA_CLASS);
+    if (!mediaClass.empty()) {
+      nd.mediaClass = std::move(mediaClass);
+    }
     std::string desc = dictGet(info->props, PW_KEY_NODE_DESCRIPTION);
     if (!desc.empty()) {
       nd.description = desc;
@@ -953,8 +1137,12 @@ void PipeWireService::onNodeInfo(std::uint32_t id, const pw_node_info* info) {
       }
     }
     std::string mediaName = dictGet(info->props, "media.title");
+    std::string rawMediaName = dictGet(info->props, "media.name");
+    if (!rawMediaName.empty()) {
+      nd.mediaName = rawMediaName;
+    }
     if (mediaName.empty()) {
-      mediaName = dictGet(info->props, "media.name");
+      mediaName = rawMediaName;
     }
     if (!mediaName.empty()) {
       nd.streamTitle = mediaName;
@@ -972,11 +1160,16 @@ void PipeWireService::onNodeInfo(std::uint32_t id, const pw_node_info* info) {
     refreshNodeIdentity(nd);
   }
 
+  const bool isStream = isProgramStreamClass(nd.mediaClass);
+  const bool isPrivacyCandidate = isPrivacyCandidateClass(nd.mediaClass);
   const bool wasStreamReady = nd.streamClassificationReady;
   if (isStream) {
     nd.streamClassificationReady = true;
   }
-  if (isStream && (!wasStreamReady || filterPropsChanged)) {
+  if ((isStream && (!wasStreamReady || filterPropsChanged))
+      || wasProgramStream != isStream
+      || wasPrivacyCandidate
+      || isPrivacyCandidate) {
     rebuildState();
   }
 
@@ -1304,6 +1497,42 @@ void PipeWireService::refreshNodeIdentity(NodeData& nd) {
 
 void PipeWireService::rebuildState() {
   AudioState next;
+  PrivacyState nextPrivacy;
+
+  auto findNode = [this](std::uint32_t nodeId) -> const NodeData* {
+    const auto it = m_nodes.find(nodeId);
+    if (it == m_nodes.end() || it->second == nullptr) {
+      return nullptr;
+    }
+    return it->second.get();
+  };
+
+  auto addCapture = [&nextPrivacy](PrivacyCaptureKind kind, std::uint32_t nodeId, std::string appName) {
+    if (appName.empty()) {
+      return false;
+    }
+    const auto duplicate = std::ranges::find_if(nextPrivacy.captures, [&](const PrivacyCapture& capture) {
+      return capture.kind == kind && capture.appName == appName;
+    });
+    if (duplicate != nextPrivacy.captures.end()) {
+      return false;
+    }
+    nextPrivacy.captures.push_back(
+        PrivacyCapture{
+            .kind = kind,
+            .nodeId = nodeId,
+            .appName = std::move(appName),
+        }
+    );
+    return true;
+  };
+
+  auto addLinkedAudioCapture = [&addCapture](const NodeData* node) {
+    if (node == nullptr || !isAudioCaptureConsumer(*node)) {
+      return false;
+    }
+    return addCapture(PrivacyCaptureKind::Microphone, node->id, privacyAppName(*node));
+  };
 
   for (const auto& [id, nd] : m_nodes) {
     AudioNode node;
@@ -1337,16 +1566,38 @@ void PipeWireService::rebuildState() {
     }
   }
 
-  // Sort by id for stable ordering
-  std::ranges::sort(next.sinks, [](const auto& a, const auto& b) { return a.id < b.id; });
-  std::ranges::sort(next.sources, [](const auto& a, const auto& b) { return a.id < b.id; });
-  std::ranges::sort(next.programOutputs, [](const auto& a, const auto& b) { return a.id < b.id; });
+  for (const LinkData& link : std::views::values(m_links)) {
+    const NodeData* source = findNode(link.outputNodeId);
+    const NodeData* consumer = findNode(link.inputNodeId);
+    addLinkedAudioCapture(source);
+    addLinkedAudioCapture(consumer);
 
-  if (next == m_state) {
+    if (source == nullptr || consumer == nullptr) {
+      continue;
+    }
+
+    const std::optional<PrivacyCaptureKind> kind = classifyPrivacyCapture(*source, *consumer);
+    if (!kind.has_value()) {
+      continue;
+    }
+
+    addCapture(*kind, consumer->id, privacyAppName(*consumer));
+  }
+
+  // Sort by id for stable ordering
+  std::ranges::sort(next.sinks, {}, &AudioNode::id);
+  std::ranges::sort(next.sources, {}, &AudioNode::id);
+  std::ranges::sort(next.programOutputs, {}, &AudioNode::id);
+  std::ranges::sort(nextPrivacy.captures, {}, [](const PrivacyCapture& capture) {
+    return std::tie(capture.kind, capture.appName, capture.nodeId);
+  });
+
+  if (next == m_state && nextPrivacy == m_privacyState) {
     return;
   }
 
   m_state = std::move(next);
+  m_privacyState = std::move(nextPrivacy);
   ++m_changeSerial;
   emitChanged();
 }

--- a/src/pipewire/pipewire_service.h
+++ b/src/pipewire/pipewire_service.h
@@ -51,6 +51,26 @@ struct AudioState {
   bool operator==(const AudioState&) const = default;
 };
 
+enum class PrivacyCaptureKind : std::uint8_t {
+  Microphone,
+  Camera,
+  Screen,
+};
+
+struct PrivacyCapture {
+  PrivacyCaptureKind kind = PrivacyCaptureKind::Microphone;
+  std::uint32_t nodeId = 0;
+  std::string appName;
+
+  bool operator==(const PrivacyCapture&) const = default;
+};
+
+struct PrivacyState {
+  std::vector<PrivacyCapture> captures;
+
+  bool operator==(const PrivacyState&) const = default;
+};
+
 class PipeWireService {
 public:
   using ChangeCallback = std::function<void()>;
@@ -73,6 +93,7 @@ public:
 
   // State
   [[nodiscard]] const AudioState& state() const noexcept { return m_state; }
+  [[nodiscard]] const PrivacyState& privacyState() const noexcept { return m_privacyState; }
   [[nodiscard]] const AudioNode* defaultSink() const noexcept;
   [[nodiscard]] const AudioNode* defaultSource() const noexcept;
 
@@ -119,11 +140,13 @@ public:
     std::string applicationId;
     std::string applicationBinary;
     std::string streamTitle;
+    std::string mediaName;
     std::string iconName;
     std::string mediaClass;
     std::string linkGroup;
     std::string targetObject;
     bool nodePassive = false;
+    bool streamCaptureSink = false;
     bool streamClassificationReady = false;
     float volume = 1.0f;
     // Software / node-route mute from PipeWire props (SPA_PARAM_Props, node routes).
@@ -157,6 +180,11 @@ public:
     struct pw_device* proxy = nullptr;
     spa_hook* listener = nullptr;
     std::vector<DeviceRouteData> routes;
+  };
+  struct LinkData {
+    std::uint32_t id = 0;
+    std::uint32_t outputNodeId = 0;
+    std::uint32_t inputNodeId = 0;
   };
   void onRegistryGlobal(std::uint32_t id, const char* type, std::uint32_t version, const struct spa_dict* props);
   void onRegistryGlobalRemove(std::uint32_t id);
@@ -205,10 +233,12 @@ private:
   std::unordered_map<std::uint32_t, std::unique_ptr<NodeData>> m_nodes;
   std::unordered_map<std::uint32_t, ClientData> m_clients;
   std::unordered_map<std::uint32_t, DeviceData> m_devices;
+  std::unordered_map<std::uint32_t, LinkData> m_links;
   std::vector<std::function<void()>> m_metadataCleanups;
   std::string m_defaultSinkName;
   std::string m_defaultSourceName;
   AudioState m_state;
+  PrivacyState m_privacyState;
   ChangeCallback m_changeCallback;
   VolumePreviewCallback m_volumePreviewCallback;
   std::uint64_t m_changeSerial = 0;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -38,6 +38,7 @@
 #include "shell/bar/widgets/notification_widget.h"
 #include "shell/bar/widgets/plugin_widget.h"
 #include "shell/bar/widgets/power_profile_widget.h"
+#include "shell/bar/widgets/privacy_widget.h"
 #include "shell/bar/widgets/screenshot_widget.h"
 #include "shell/bar/widgets/session_widget.h"
 #include "shell/bar/widgets/settings_widget.h"
@@ -66,6 +67,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace {
   constexpr Logger kLog("shell");
@@ -356,6 +358,25 @@ std::unique_ptr<Widget> WidgetFactory::create(
 
   if (type == "power_profile") {
     auto widget = std::make_unique<PowerProfileWidget>(m_powerProfiles);
+    widget->setContentScale(contentScale);
+    return widget;
+  }
+
+  if (type == "privacy") {
+    PrivacyWidgetConfig config;
+
+    if (wc != nullptr) {
+      config.hideInactive = wc->getBool("hide_inactive", config.hideInactive);
+      config.iconSpacing =
+          static_cast<int>(std::clamp<std::int64_t>(wc->getInt("icon_spacing", config.iconSpacing), 0, 48));
+      config.activeColor = wc->getColorSpec("active_color", config.activeColor, "widget." + name + ".active_color");
+      config.inactiveColor =
+          wc->getColorSpec("inactive_color", config.inactiveColor, "widget." + name + ".inactive_color");
+      config.micFilterRegex = wc->getString("mic_filter_regex", "");
+      config.camFilterRegex = wc->getString("cam_filter_regex", "");
+    }
+
+    auto widget = std::make_unique<PrivacyWidget>(m_audio, std::move(config));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/privacy_widget.cpp
+++ b/src/shell/bar/widgets/privacy_widget.cpp
@@ -1,0 +1,245 @@
+#include "shell/bar/widgets/privacy_widget.h"
+
+#include "core/log.h"
+#include "i18n/i18n.h"
+#include "pipewire/pipewire_service.h"
+#include "render/core/renderer.h"
+#include "render/scene/input_area.h"
+#include "render/scene/node.h"
+#include "ui/builders.h"
+#include "ui/controls/glyph.h"
+#include "ui/style.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <ranges>
+#include <string_view>
+#include <utility>
+
+namespace {
+
+  constexpr Logger kLog("shell");
+
+  [[nodiscard]] std::optional<std::regex> compileFilter(std::string_view key, const std::string& pattern) {
+    if (pattern.empty()) {
+      return std::nullopt;
+    }
+    try {
+      return std::regex(pattern);
+    } catch (const std::regex_error& e) {
+      kLog.warn("privacy widget: invalid {} '{}': {}", key, pattern, e.what());
+      return std::nullopt;
+    }
+  }
+
+  void addUnique(std::vector<std::string>& values, std::string value) {
+    if (value.empty()) {
+      return;
+    }
+    if (std::ranges::find(values, value) != values.end()) {
+      return;
+    }
+    values.push_back(std::move(value));
+  }
+
+  void sortUnique(std::vector<std::string>& values) {
+    std::ranges::sort(values);
+    const auto duplicates = std::ranges::unique(values);
+    values.erase(duplicates.begin(), duplicates.end());
+  }
+
+  [[nodiscard]] std::string joinApps(const std::vector<std::string>& apps) {
+    auto joined = apps | std::views::join_with(std::string_view{", "});
+    return {joined.begin(), joined.end()};
+  }
+
+} // namespace
+
+PrivacyWidget::PrivacyWidget(PipeWireService* pipewire, PrivacyWidgetConfig config)
+    : m_pipewire(pipewire), m_config(std::move(config)),
+      m_micFilter(compileFilter("mic_filter_regex", m_config.micFilterRegex)),
+      m_camFilter(compileFilter("cam_filter_regex", m_config.camFilterRegex)) {
+  m_config.iconSpacing = std::clamp(m_config.iconSpacing, 0, 48);
+}
+
+void PrivacyWidget::create() {
+  setRoot(
+      ui::inputArea(
+          {
+              .out = &m_area,
+              .tooltipProvider = [this]() -> TooltipContent {
+                std::vector<TooltipRow> rows = buildTooltipRows();
+                if (rows.empty()) {
+                  return std::monostate{};
+                }
+                return TooltipContent{std::move(rows)};
+              },
+          },
+          ui::glyph({
+              .out = &m_micGlyph,
+              .glyph = "microphone-off",
+              .glyphSize = Style::baseGlyphSize * m_contentScale,
+              .color = m_config.inactiveColor,
+          }),
+          ui::glyph({
+              .out = &m_cameraGlyph,
+              .glyph = "camera-off",
+              .glyphSize = Style::baseGlyphSize * m_contentScale,
+              .color = m_config.inactiveColor,
+          }),
+          ui::glyph({
+              .out = &m_screenGlyph,
+              .glyph = "screen-share-off",
+              .glyphSize = Style::baseGlyphSize * m_contentScale,
+              .color = m_config.inactiveColor,
+          })
+      )
+  );
+}
+
+void PrivacyWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
+  auto* rootNode = root();
+  if (rootNode == nullptr) {
+    return;
+  }
+
+  m_isVertical = containerHeight > containerWidth;
+  syncState();
+
+  if (!rootNode->visible()) {
+    rootNode->setSize(0.0f, 0.0f);
+    return;
+  }
+
+  std::vector<Glyph*> glyphs;
+  for (Glyph* glyph : {m_micGlyph, m_cameraGlyph, m_screenGlyph}) {
+    if (glyph != nullptr && glyph->visible()) {
+      glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
+      glyph->measure(renderer);
+      glyphs.push_back(glyph);
+    }
+  }
+
+  if (glyphs.empty()) {
+    rootNode->setSize(0.0f, 0.0f);
+    return;
+  }
+
+  const float spacing = static_cast<float>(m_config.iconSpacing) * m_contentScale;
+  float width = 0.0f;
+  float height = 0.0f;
+
+  if (m_isVertical) {
+    for (Glyph* glyph : glyphs) {
+      width = std::max(width, glyph->width());
+      height += glyph->height();
+    }
+    height += spacing * static_cast<float>(glyphs.size() - 1);
+
+    float y = 0.0f;
+    for (Glyph* glyph : glyphs) {
+      glyph->setPosition(std::round((width - glyph->width()) * 0.5f), y);
+      y += glyph->height() + spacing;
+    }
+  } else {
+    for (Glyph* glyph : glyphs) {
+      width += glyph->width();
+      height = std::max(height, glyph->height());
+    }
+    width += spacing * static_cast<float>(glyphs.size() - 1);
+
+    float x = 0.0f;
+    for (Glyph* glyph : glyphs) {
+      glyph->setPosition(x, std::round((height - glyph->height()) * 0.5f));
+      x += glyph->width() + spacing;
+    }
+  }
+
+  rootNode->setSize(width, height);
+}
+
+void PrivacyWidget::doUpdate(Renderer&) { syncState(); }
+
+void PrivacyWidget::syncState() {
+  Snapshot current = snapshot();
+  current.vertical = m_isVertical;
+  if (m_cachedSnapshot.has_value() && *m_cachedSnapshot == current) {
+    return;
+  }
+
+  m_cachedSnapshot = current;
+
+  auto applyGlyph = [this](Glyph* glyph, bool active, std::string_view activeGlyph, std::string_view inactiveGlyph) {
+    if (glyph == nullptr) {
+      return;
+    }
+    const bool visible = active || !m_config.hideInactive;
+    glyph->setVisible(visible);
+    glyph->setParticipatesInLayout(visible);
+    glyph->setGlyph(active ? activeGlyph : inactiveGlyph);
+    glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
+    glyph->setColor(active ? m_config.activeColor : m_config.inactiveColor);
+  };
+
+  applyGlyph(m_micGlyph, current.micActive(), "microphone", "microphone-off");
+  applyGlyph(m_cameraGlyph, current.cameraActive(), "camera", "camera-off");
+  applyGlyph(m_screenGlyph, current.screenActive(), "screen-share", "screen-share-off");
+
+  if (auto* rootNode = root(); rootNode != nullptr) {
+    const bool visible = current.visible(m_config.hideInactive);
+    rootNode->setVisible(visible);
+    rootNode->setParticipatesInLayout(visible);
+    rootNode->markLayoutDirty();
+  }
+  if (m_area != nullptr) {
+    m_area->requestTooltipRefresh();
+  }
+
+  requestRedraw();
+}
+
+PrivacyWidget::Snapshot PrivacyWidget::snapshot() const {
+  Snapshot out;
+
+  if (m_pipewire != nullptr) {
+    const PrivacyState& state = m_pipewire->privacyState();
+    for (const auto& capture : state.captures) {
+      if (capture.kind == PrivacyCaptureKind::Microphone) {
+        if (!matchesFilter(m_micFilter, capture.appName)) {
+          addUnique(out.micApps, capture.appName);
+        }
+      } else if (capture.kind == PrivacyCaptureKind::Camera) {
+        if (!matchesFilter(m_camFilter, capture.appName)) {
+          addUnique(out.cameraApps, capture.appName);
+        }
+      } else if (capture.kind == PrivacyCaptureKind::Screen) {
+        addUnique(out.screenApps, capture.appName);
+      }
+    }
+  }
+
+  sortUnique(out.micApps);
+  sortUnique(out.cameraApps);
+  sortUnique(out.screenApps);
+  return out;
+}
+
+std::vector<TooltipRow> PrivacyWidget::buildTooltipRows() const {
+  const Snapshot current = snapshot();
+  std::vector<TooltipRow> rows;
+  if (current.micActive()) {
+    rows.push_back({i18n::tr("bar.widgets.privacy.microphone"), joinApps(current.micApps)});
+  }
+  if (current.cameraActive()) {
+    rows.push_back({i18n::tr("bar.widgets.privacy.camera"), joinApps(current.cameraApps)});
+  }
+  if (current.screenActive()) {
+    rows.push_back({i18n::tr("bar.widgets.privacy.screen-sharing"), joinApps(current.screenApps)});
+  }
+  return rows;
+}
+
+bool PrivacyWidget::matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const {
+  return filter.has_value() && std::regex_search(value, *filter);
+}

--- a/src/shell/bar/widgets/privacy_widget.h
+++ b/src/shell/bar/widgets/privacy_widget.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "shell/bar/widget.h"
+#include "shell/tooltip/tooltip_content.h"
+#include "ui/palette.h"
+
+#include <optional>
+#include <regex>
+#include <string>
+#include <vector>
+
+class Glyph;
+class InputArea;
+class PipeWireService;
+class Renderer;
+
+struct PrivacyWidgetConfig {
+  bool hideInactive = false;
+  int iconSpacing = 4;
+  ColorSpec activeColor = colorSpecFromRole(ColorRole::Primary);
+  ColorSpec inactiveColor = colorSpecFromRole(ColorRole::Outline);
+  std::string micFilterRegex;
+  std::string camFilterRegex;
+};
+
+class PrivacyWidget : public Widget {
+public:
+  PrivacyWidget(PipeWireService* pipewire, PrivacyWidgetConfig config);
+
+  void create() override;
+
+private:
+  struct Snapshot {
+    std::vector<std::string> micApps;
+    std::vector<std::string> cameraApps;
+    std::vector<std::string> screenApps;
+    bool vertical = false;
+
+    [[nodiscard]] bool micActive() const { return !micApps.empty(); }
+    [[nodiscard]] bool cameraActive() const { return !cameraApps.empty(); }
+    [[nodiscard]] bool screenActive() const { return !screenApps.empty(); }
+    [[nodiscard]] bool anyActive() const { return micActive() || cameraActive() || screenActive(); }
+    [[nodiscard]] bool visible(bool hideInactive) const { return !hideInactive || anyActive(); }
+
+    bool operator==(const Snapshot&) const = default;
+  };
+
+  void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
+  void doUpdate(Renderer& renderer) override;
+  void syncState();
+  [[nodiscard]] Snapshot snapshot() const;
+  [[nodiscard]] std::vector<TooltipRow> buildTooltipRows() const;
+  [[nodiscard]] bool matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const;
+
+  PipeWireService* m_pipewire = nullptr;
+  PrivacyWidgetConfig m_config;
+  std::optional<std::regex> m_micFilter;
+  std::optional<std::regex> m_camFilter;
+
+  InputArea* m_area = nullptr;
+  Glyph* m_micGlyph = nullptr;
+  Glyph* m_cameraGlyph = nullptr;
+  Glyph* m_screenGlyph = nullptr;
+
+  std::optional<Snapshot> m_cachedSnapshot;
+  bool m_isVertical = false;
+};

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -72,6 +72,7 @@ namespace settings {
         {.type = "nightlight", .labelKey = "settings.widgets.types.nightlight", .glyph = "nightlight-off"},
         {.type = "notifications", .labelKey = "settings.widgets.types.notifications", .glyph = "bell"},
         {.type = "power_profile", .labelKey = "settings.widgets.types.power-profile", .glyph = "balanced"},
+        {.type = "privacy", .labelKey = "settings.widgets.types.privacy", .glyph = "shield-lock"},
         {.type = "screenshot", .labelKey = "settings.widgets.types.screenshot", .glyph = "screenshot"},
         {.type = "session", .labelKey = "settings.widgets.types.session", .glyph = "shutdown"},
         {.type = "settings", .labelKey = "settings.widgets.types.settings", .glyph = "settings"},
@@ -738,6 +739,13 @@ namespace settings {
       add(boolSpec("show_label", true));
     } else if (type == "notifications") {
       add(boolSpec("hide_when_no_unread", false));
+    } else if (type == "privacy") {
+      add(boolSpec("hide_inactive", false));
+      add(intSpec("icon_spacing", 4, 0.0, 48.0, 1.0));
+      add(colorSpec("active_color", "primary"));
+      add(colorSpec("inactive_color", "outline"));
+      add(stringSpec("mic_filter_regex"));
+      add(stringSpec("cam_filter_regex"));
     } else if (type == "session") {
       add(glyphSpec("glyph", "shutdown"));
     } else if (type == "settings") {

--- a/src/ui/builders.cpp
+++ b/src/ui/builders.cpp
@@ -109,6 +109,89 @@ namespace ui {
     return control;
   }
 
+  std::unique_ptr<InputArea> inputArea(InputAreaProps props) {
+    auto control = std::make_unique<InputArea>();
+    if (props.acceptedButtons.has_value()) {
+      control->setAcceptedButtons(*props.acceptedButtons);
+    }
+    if (props.cursorShape.has_value()) {
+      control->setCursorShape(*props.cursorShape);
+    }
+    if (props.propagateEvents.has_value()) {
+      control->setPropagateEvents(*props.propagateEvents);
+    }
+    if (props.enabled.has_value()) {
+      control->setEnabled(*props.enabled);
+    }
+    if (props.hitShape.has_value()) {
+      control->setHitShape(*props.hitShape);
+    }
+    if (props.focusable.has_value()) {
+      control->setFocusable(*props.focusable);
+    }
+    if (props.tooltip.has_value()) {
+      control->setTooltip(std::move(*props.tooltip));
+    }
+    if (props.tooltipRows.has_value()) {
+      control->setTooltip(std::move(*props.tooltipRows));
+    }
+    if (props.tooltipProvider) {
+      control->setTooltipProvider(
+          std::move(props.tooltipProvider), props.tooltipRefreshInterval.value_or(std::chrono::milliseconds{})
+      );
+    }
+    if (props.tooltipPlacement.has_value()) {
+      control->setTooltipPlacement(*props.tooltipPlacement);
+    }
+    if (props.tooltipAnchorInsets.has_value()) {
+      control->setTooltipAnchorInsets(*props.tooltipAnchorInsets);
+    }
+    if (props.onEnter) {
+      control->setOnEnter(std::move(props.onEnter));
+    }
+    if (props.onLeave) {
+      control->setOnLeave(std::move(props.onLeave));
+    }
+    if (props.onMotion) {
+      control->setOnMotion(std::move(props.onMotion));
+    }
+    if (props.onPress) {
+      control->setOnPress(std::move(props.onPress));
+    }
+    if (props.onClick) {
+      control->setOnClick(std::move(props.onClick));
+    }
+    if (props.onAxis) {
+      control->setOnAxis(std::move(props.onAxis));
+    }
+    if (props.onAxisHandler) {
+      control->setOnAxisHandler(std::move(props.onAxisHandler));
+    }
+    if (props.onKeyDown) {
+      control->setOnKeyDown(std::move(props.onKeyDown));
+    }
+    if (props.onKeyUp) {
+      control->setOnKeyUp(std::move(props.onKeyUp));
+    }
+    if (props.onFocusGain) {
+      control->setOnFocusGain(std::move(props.onFocusGain));
+    }
+    if (props.onFocusLoss) {
+      control->setOnFocusLoss(std::move(props.onFocusLoss));
+    }
+    if (props.clipChildren.has_value()) {
+      control->setClipChildren(*props.clipChildren);
+    }
+    applyNodeProps(*control, props);
+    if (props.configure) {
+      props.configure(*control);
+    }
+    if (props.out != nullptr) {
+      *props.out = control.get();
+    }
+    return control;
+  }
+
   std::unique_ptr<Input> input(InputProps props) {
     auto control = std::make_unique<Input>();
     if (props.value.has_value()) {

--- a/src/ui/builders.h
+++ b/src/ui/builders.h
@@ -2,6 +2,7 @@
 
 #include "render/core/color.h"
 #include "render/core/renderer.h"
+#include "render/scene/input_area.h"
 #include "render/scene/node.h"
 #include "ui/controls/box.h"
 #include "ui/controls/button.h"
@@ -29,6 +30,7 @@
 #include "ui/controls/virtual_list_view.h"
 #include "ui/palette.h"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -53,6 +55,41 @@ namespace ui {
     std::optional<bool> participatesInLayout = std::nullopt;
     std::optional<bool> clipChildren = std::nullopt;
     std::function<void(Node&)> configure = nullptr;
+  };
+
+  struct InputAreaProps {
+    InputArea** out = nullptr;
+    std::optional<std::uint32_t> acceptedButtons = std::nullopt;
+    std::optional<std::uint32_t> cursorShape = std::nullopt;
+    std::optional<bool> propagateEvents = std::nullopt;
+    std::optional<bool> enabled = std::nullopt;
+    std::optional<InputArea::HitShape> hitShape = std::nullopt;
+    std::optional<bool> focusable = std::nullopt;
+    std::optional<std::string> tooltip = std::nullopt;
+    std::optional<std::vector<TooltipRow>> tooltipRows = std::nullopt;
+    std::function<TooltipContent()> tooltipProvider = nullptr;
+    std::optional<std::chrono::milliseconds> tooltipRefreshInterval = std::nullopt;
+    std::optional<TooltipPlacement> tooltipPlacement = std::nullopt;
+    std::optional<TooltipAnchorInsets> tooltipAnchorInsets = std::nullopt;
+    std::optional<float> width = std::nullopt;
+    std::optional<float> height = std::nullopt;
+    std::optional<float> flexGrow = std::nullopt;
+    std::optional<float> opacity = std::nullopt;
+    std::optional<bool> visible = std::nullopt;
+    std::optional<bool> participatesInLayout = std::nullopt;
+    std::optional<bool> clipChildren = std::nullopt;
+    std::function<void(const InputArea::PointerData&)> onEnter = nullptr;
+    std::function<void()> onLeave = nullptr;
+    std::function<void(const InputArea::PointerData&)> onMotion = nullptr;
+    std::function<void(const InputArea::PointerData&)> onPress = nullptr;
+    std::function<void(const InputArea::PointerData&)> onClick = nullptr;
+    std::function<void(const InputArea::PointerData&)> onAxis = nullptr;
+    std::function<bool(const InputArea::PointerData&)> onAxisHandler = nullptr;
+    std::function<void(const InputArea::KeyData&)> onKeyDown = nullptr;
+    std::function<void(const InputArea::KeyData&)> onKeyUp = nullptr;
+    std::function<void()> onFocusGain = nullptr;
+    std::function<void()> onFocusLoss = nullptr;
+    std::function<void(InputArea&)> configure = nullptr;
   };
 
   struct FlexProps {
@@ -543,6 +580,7 @@ namespace ui {
 
   [[nodiscard]] std::unique_ptr<Flex> flex(FlexDirection direction, FlexProps props);
   [[nodiscard]] std::unique_ptr<Input> input(InputProps props);
+  [[nodiscard]] std::unique_ptr<InputArea> inputArea(InputAreaProps props = {});
   [[nodiscard]] std::unique_ptr<Button> button(ButtonProps props);
   [[nodiscard]] std::unique_ptr<Label> label(LabelProps props);
   [[nodiscard]] std::unique_ptr<Node> node(NodeProps props = {});
@@ -581,6 +619,13 @@ namespace ui {
 
   template <typename... Children> [[nodiscard]] std::unique_ptr<Node> node(NodeProps props, Children&&... children) {
     auto container = node(std::move(props));
+    (container->addChild(std::forward<Children>(children)), ...);
+    return container;
+  }
+
+  template <typename... Children>
+  [[nodiscard]] std::unique_ptr<InputArea> inputArea(InputAreaProps props, Children&&... children) {
+    auto container = inputArea(std::move(props));
     (container->addChild(std::forward<Children>(children)), ...);
     return container;
   }


### PR DESCRIPTION
This reimplements the main functionality from the similar feature that was in noctalia v4.

The history list is not implemented, but could be added later.

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Screenshots

<img width="284" height="91" alt="image" src="https://github.com/user-attachments/assets/df13bc9b-4d8b-4d0e-b33c-7f10f3072be3" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.