### PR TITLE
fix(brightness): scale DDC writes by the reported VCP max instead of 100

### DIFF
--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -1041,7 +1041,7 @@ struct BrightnessService::Impl {
         .writeEpoch = display.ddcWriteEpoch,
         .displayId = display.pub.id,
         .bus = display.ddcBus,
-        .targetRaw = static_cast<int>(std::round(value * 100.0f)),
+        .targetRaw = static_cast<int>(std::round(value * static_cast<float>(display.maxRaw))),
         .maxRaw = display.maxRaw,
     };
 
@@ -1137,7 +1137,7 @@ struct BrightnessService::Impl {
         args.push_back("--noverify");
         args.push_back("setvcp");
         args.push_back("10");
-        args.push_back(std::to_string(std::clamp(writeJob->targetRaw, 0, 100)));
+        args.push_back(std::to_string(std::clamp(writeJob->targetRaw, 0, std::max(1, writeJob->maxRaw))));
 
         const CommandResult result = runCommandCapture(args, kDdcSetTimeout);
         completion.timedOut = result.timedOut;


### PR DESCRIPTION
## Summary

Scale `ddcutil setvcp 10` brightness writes by the monitor-reported VCP max (`display.maxRaw`) instead of assuming a fixed `0..100` range.

## Motivation

The DDC write path built the target value as a hardcoded percentage:

```cpp
.targetRaw = static_cast<int>(std::round(value * 100.0f)),
...
args.push_back(std::to_string(std::clamp(writeJob->targetRaw, 0, 100)));
```

`value` is the normalized `0.0..1.0` brightness. `ddcutil setvcp 10 <N>` writes the *absolute* VCP value `N`, where the valid range is `0..max` and `max` is whatever the monitor reports for feature `0x10`. The rest of the service already treats that reported max as the real scale:

- the read path normalizes against it — `normalizedBrightness(currentRaw, maxRaw)` (e.g. after a refresh in `applyCompletion`), and
- the backlight write path scales by it — `rawValue = round(value * display.maxRaw)`.

So on a monitor whose brightness VCP reports a `max value` other than 100 (e.g. 255, or a stepped scale), dragging the slider to N% wrote the literal value `N` instead of `N%` of the real max. The panel applied the wrong brightness, and on the next `getvcp` read-back the value was re-normalized against the real max, so the slider jumped to a different position than where it was left.

`display.maxRaw` is seeded to the `getvcp 10` "max value" during detection and defaults to `100`, so the common monitor case (max = 100) produces byte-for-byte the same write as before — only displays reporting a different max change behavior.

## Type of Change

- [x] Bug fix

## Related Issue

<!-- none -->

## Testing

```
just build debug
```

Builds clean. I confirmed the inconsistency from source: the read/normalize path and the backlight write path both scale by `display.maxRaw`, while only the DDC write hardcoded `100`. I don't have a DDC/CI monitor that reports a brightness max other than 100 on hand, so I couldn't observe the misbehavior on real hardware; the change is a straight swap of the constant `100` for the already-available `display.maxRaw`/`writeJob->maxRaw`, and is a no-op for the max = 100 case.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested with multiple monitors

Left unchecked: verified from source and via a debug build; not exercised against a DDC monitor reporting a non-100 brightness max.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
