### PR TITLE
fix(lockscreen): scale login panel and widget coordinates proportionally on monitor rotation

### DIFF
--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -482,9 +482,30 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
     if (const DesktopWidgetState* loginBox =
             lockscreen_login_box::findForOutput(m_config->config().lockscreenWidgets.widgets, m_outputKey);
         loginBox != nullptr) {
-      lockscreen_login_box::panelOriginFromCenter(loginBox->cx, loginBox->cy, sw, panelX, panelY, panelWidth);
+      float cx = loginBox->cx;
+      float cy = loginBox->cy;
+      const WaylandOutput* output = m_connection.findOutputByWl(m_output);
+      if (output != nullptr) {
+        float curW = sw;
+        float curH = sh;
+        bool isRotated90or270 =
+            (output->transform == WL_OUTPUT_TRANSFORM_90
+             || output->transform == WL_OUTPUT_TRANSFORM_270
+             || output->transform == WL_OUTPUT_TRANSFORM_FLIPPED_90
+             || output->transform == WL_OUTPUT_TRANSFORM_FLIPPED_270);
+        float refW = isRotated90or270 ? curH : curW;
+        float refH = isRotated90or270 ? curW : curH;
+        if (refW > 0.0f && refH > 0.0f) {
+          cx = cx * (curW / refW);
+          cy = cy * (curH / refH);
+        }
+      }
+      lockscreen_login_box::panelOriginFromCenter(cx, cy, sw, panelX, panelY, panelWidth);
     }
   }
+
+  panelX = std::clamp(panelX, Style::spaceLg, sw - panelWidth - Style::spaceLg);
+  panelY = std::clamp(panelY, Style::spaceLg, sh - panelHeight - Style::spaceLg);
 
   m_root.setSize(sw, sh);
 

--- a/src/shell/lockscreen/lockscreen_widgets_host.cpp
+++ b/src/shell/lockscreen/lockscreen_widgets_host.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <string>
+#include <wayland-client.h>
 
 namespace {
 
@@ -368,9 +369,30 @@ void LockscreenWidgetsHost::prepareFrame(LockSurface& surface, bool needsUpdate,
     }
 
     if (m_wayland != nullptr) {
+      DesktopWidgetState currentState = instance->state;
+      if (const DesktopWidgetState* origState = findStateById(m_snapshot, instance->state.id); origState != nullptr) {
+        currentState = *origState;
+      }
+      if (const WaylandOutput* output = desktop_widgets::resolveStateOutput(*m_wayland, currentState);
+          output != nullptr) {
+        float curW = surfaceW;
+        float curH = surfaceH;
+        bool isRotated90or270 =
+            (output->transform == WL_OUTPUT_TRANSFORM_90
+             || output->transform == WL_OUTPUT_TRANSFORM_270
+             || output->transform == WL_OUTPUT_TRANSFORM_FLIPPED_90
+             || output->transform == WL_OUTPUT_TRANSFORM_FLIPPED_270);
+        float refW = isRotated90or270 ? curH : curW;
+        float refH = isRotated90or270 ? curW : curH;
+        if (refW > 0.0f && refH > 0.0f) {
+          currentState.cx = currentState.cx * (curW / refW);
+          currentState.cy = currentState.cy * (curH / refH);
+        }
+      }
       desktop_widgets::clampStateToOutput(
-          *m_wayland, instance->state, instance->intrinsicWidth, instance->intrinsicHeight
+          *m_wayland, currentState, instance->intrinsicWidth, instance->intrinsicHeight
       );
+      instance->state = currentState;
     }
 
     if (instance->transformNode == nullptr) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This PR fixes an issue where the lockscreen login panel and widgets do not adapt correctly when the monitor orientation/resolution changes (e.g., when the monitor is rotated 90 or 270 degrees).

Specifically:
- In `lock_surface.cpp`, we fetch the output's current transform and dimensions. If the screen is rotated (90 or 270 degrees), we scale the login box's configured center coordinates (`cx` and `cy`) proportionally before computing its origin.
- In `lockscreen_widgets_host.cpp`, we similarly fetch the original coordinates of the lockscreen widgets from the config snapshot and scale them proportionally based on the transformed output size before clamping and positioning them.

## Motivation

<!-- What problem does this solve? -->
Previously, rotating the monitor on a running compositor (e.g., in Niri) caused the lockscreen elements to either render off-screen or get squished/positioned awkwardly near the screen edges. This PR ensures that all elements on the lockscreen remain properly centered and scaled relative to the new layout orientation.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #3043

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran the Noctalia test suite using `just`:
```bash
just test
```
All 28 unit tests passed successfully.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
