### PR TITLE
feat(i18n): add Catalan (ca) translation

### DIFF
--- a/assets/translations/ca.json
+++ b/assets/translations/ca.json
@@ -1,0 +1,3035 @@
+{
+  "auth": {
+    "fingerprint": {
+      "disconnected": "Lector d'empremtes desconnectat",
+      "error": "Error d'autenticació d'empremta",
+      "no-match": "L'empremta no coincideix",
+      "not-centered": "Centra el dit i torna-ho a provar",
+      "present": "Llegint empremta...",
+      "ready": "Posa el dit al lector",
+      "remove-and-retry": "Retira el dit i torna-ho a provar",
+      "retry": "Torna a escanejar l'empremta",
+      "swipe-too-short": "El lliscament ha estat massa curt, torna-ho a provar",
+      "too-many-attempts": "Empremta desactivada (massa intents)"
+    },
+    "pam": {
+      "authentication-failed": "Autenticació fallida",
+      "start-failed": "Inici de PAM fallit",
+      "user-unavailable": "No s'ha pogut resoldre l'usuari actual"
+    },
+    "polkit": {
+      "authenticate": "Autentica",
+      "authenticating": "Autenticant...",
+      "default-message": "Autenticació requerida",
+      "invalid-password": "Contrasenya no vàlida",
+      "password-placeholder": "Contrasenya",
+      "title": "Autenticació requerida"
+    }
+  },
+  "bar": {
+    "screenshot": {
+      "choose-display": "Tria la pantalla",
+      "fullscreen": "Pantalla completa",
+      "region": "Selecciona la regió"
+    },
+    "widgets": {
+      "active-window": {
+        "no-active-window": "No hi ha cap finestra activa"
+      },
+      "lock-keys": {
+        "caps": "Majús",
+        "caps-short": "M",
+        "num": "Num",
+        "num-short": "N",
+        "scroll": "Despl",
+        "scroll-short": "D"
+      },
+      "media": {
+        "nothing-playing": "No s'està reproduint res",
+        "playing": "Reproduint"
+      },
+      "network": {
+        "wired": "Amb cable"
+      },
+      "scripted": {
+        "reload-failed": "Ha fallat la recàrrega de l'script",
+        "reloaded": "Script recarregat"
+      },
+      "weather": {
+        "default": "Temps",
+        "error": "Error del temps",
+        "loading": "Temps...",
+        "no-location": "Sense ubicació",
+        "off": "Temps desactivat"
+      }
+    }
+  },
+  "clipboard": {
+    "actions": {
+      "clear-all": "Netejar-ho tot",
+      "delete-item": "Elimina l'element",
+      "keep-pinned": "Manté fixat"
+    },
+    "confirm": {
+      "clear-desc": "Tria si vols mantenir els elements fixats.",
+      "clear-desc-all-pinned": "Totes les entrades estan fixades. Fes servir Netejar-ho tot per eliminar-les totes.",
+      "clear-desc-no-pinned": "Això elimina totes les entrades de l'historial del porta-retalls.",
+      "clear-title": "Vols netejar l'historial del porta-retalls?",
+      "delete-desc": "Això elimina l'element seleccionat de l'historial del porta-retalls.",
+      "delete-title": "Vols eliminar l'element del porta-retalls?"
+    },
+    "empty": {
+      "history-message": "No hi ha entrades a l'historial del porta-retalls.",
+      "history-title": "L'historial del porta-retalls està buit",
+      "no-matches-message": "No hi ha entrades que coincideixin amb el filtre actual.",
+      "no-matches-title": "No hi ha coincidències"
+    },
+    "entry": {
+      "image": "Imatge",
+      "title": "Entrada del porta-retalls"
+    },
+    "filter-placeholder": "Filtra el porta-retalls...",
+    "preview": {
+      "empty-text-payload": "(contingut de text buit)",
+      "image-title": "Entrada d'imatge del porta-retalls",
+      "loading": "S'està carregant la previsualització...",
+      "text-title": "Entrada de text del porta-retalls",
+      "truncated": "… truncat"
+    },
+    "title": "Porta-retalls"
+  },
+  "common": {
+    "actions": {
+      "apply": "Aplica",
+      "cancel": "Cancel·la"
+    },
+    "states": {
+      "auto": "Auto",
+      "custom": "Personalitzat",
+      "inherit": "Hereta",
+      "off": "Desactivat"
+    }
+  },
+  "control-center": {
+    "audio": {
+      "application-volumes": "Volum d'aplicacions",
+      "choose-effects-profile": "Tria un perfil",
+      "effects-profile": "Efectes:",
+      "input-volume": "Volum d'entrada",
+      "no-application-audio": "Sense àudio d'aplicacions",
+      "no-application-audio-body": "No hi ha cap flux de reproducció d'aplicació disponible.",
+      "no-input-devices": "No hi ha dispositius d'entrada",
+      "no-input-devices-body": "No hi ha cap font d'enregistrament disponible.",
+      "no-input-selected": "No s'ha seleccionat cap dispositiu d'entrada",
+      "no-output-devices": "No hi ha dispositius de sortida",
+      "no-output-devices-body": "No hi ha cap dispositiu de sortida d'àudio disponible.",
+      "no-output-selected": "No s'ha seleccionat cap dispositiu de sortida",
+      "output-volume": "Volum de sortida",
+      "unavailable-body": "El PipeWire no està actiu.",
+      "unavailable-title": "Àudio no disponible"
+    },
+    "bluetooth": {
+      "accept": "Accepta",
+      "auto-reconnect": "Reconnexió automàtica",
+      "bluetooth": "Bluetooth",
+      "enter-code": "Introdueix el codi",
+      "no-devices": "No s'han trobat dispositius. Inicia l'escaneig per descobrir dispositius Bluetooth propers.",
+      "off": "El Bluetooth està desactivat",
+      "pair-title": "Aparella {device}",
+      "pairing-detail": {
+        "authorize": "Acceptes la sol·licitud d'aparellament entrant?",
+        "authorize-service": "Permets l'accés al servei {uuid}?",
+        "confirm": "Confirma que aquest codi coincideix amb el que es mostra al dispositiu:",
+        "display-passkey": "Introdueix aquest codi al dispositiu:",
+        "display-pin": "Introdueix aquest PIN al dispositiu:",
+        "passkey": "Introdueix la clau d'accés que es mostra al dispositiu:",
+        "pin-code": "Introdueix el PIN que es mostra al dispositiu:"
+      },
+      "reject": "Rebutja",
+      "rfkill-blocked": "El Bluetooth està blocat pel sistema. Activa'l per treure el blocatge.",
+      "sections": {
+        "available": "Disponible",
+        "connected": "Connectat",
+        "paired": "Aparellat"
+      },
+      "unavailable": "El servei Bluetooth no està disponible",
+      "unknown-device": "Dispositiu desconegut",
+      "visible": "Visible per a dispositius propers"
+    },
+    "calendar": {
+      "all-day": "Tot el dia",
+      "events": "Esdeveniments",
+      "no-events": "No hi ha esdeveniments.",
+      "today": "Avui"
+    },
+    "display": {
+      "disabled": "Desactivat",
+      "no-displays": "No hi ha monitors disponibles",
+      "unknown-resolution": "Resolució desconeguda"
+    },
+    "home": {
+      "avatar-error-title": "L'avatar no s'ha actualitzat",
+      "media": {
+        "idle": "Inactiu",
+        "no-active-player": "No hi ha cap reproductor actiu",
+        "nothing-playing": "No s'està reproduint res",
+        "paused": "En pausa",
+        "playback-unavailable": "Reproducció no disponible",
+        "playing": "Reproduint",
+        "unavailable": "No disponible",
+        "unknown-artist": "Artista desconegut",
+        "unknown-track": "Pista desconeguda"
+      },
+      "select-avatar": "Selecciona l'avatar",
+      "unknown": "Desconegut",
+      "uptime": "Temps actiu - {uptime}",
+      "weather": {
+        "configure-location": "Afegeix [weather].address o activa auto_locate.",
+        "data-unavailable": "Dades meteorològiques no disponibles.",
+        "disabled": "El temps està desactivat a la configuració.",
+        "fetching": "S'està obtenint la previsió..."
+      }
+    },
+    "media": {
+      "active-player": "Reproductor actiu",
+      "nothing-playing": "No s'està reproduint res",
+      "now-playing": "S'està reproduint",
+      "start-playback": "Inicia la reproducció en una aplicació MPRIS"
+    },
+    "network": {
+      "connect": "Connecta",
+      "current-connection": "Connexió actual",
+      "no-networks": "No hi ha xarxes disponibles a prop",
+      "not-connected": "No connectat",
+      "password": "Contrasenya",
+      "password-prompt": "Introdueix la contrasenya",
+      "password-prompt-for": "Introdueix la contrasenya per a {ssid}",
+      "unavailable-detail": "Instal·la i activa el NetworkManager per gestionar xarxes des d'aquí.",
+      "unavailable-title": "NetworkManager no disponible",
+      "vpns": "VPNs",
+      "wi-fi": "Wi-Fi",
+      "wifi": "Wi-Fi",
+      "wifi-off": "Wi-Fi desactivat",
+      "wifi-on": "Wi-Fi activat",
+      "wired-connection": "Connexió per cable"
+    },
+    "notifications": {
+      "empty-body": "Les notificacions recents es mostraran aquí.",
+      "empty-title": "No hi ha notificacions",
+      "filter": {
+        "all": "Totes",
+        "older": "Anteriors",
+        "today": "Avui",
+        "yesterday": "Ahir"
+      },
+      "filter-empty-body": "No hi ha notificacions que coincideixin amb aquest filtre.",
+      "filter-empty-title": "No hi ha res aquí",
+      "untitled": "Notificació sense títol"
+    },
+    "screen-time": {
+      "disabled": "El seguiment del temps de pantalla està desactivat. Activa'l a Configuració per registrar l'ús de cada aplicació.",
+      "empty": "Encara no s'ha registrat l'ús de cap aplicació. Focalitza una finestra per començar el seguiment.",
+      "hour-0": "12 AM",
+      "hour-12": "12 PM",
+      "hour-18": "6 PM",
+      "hour-6": "6 AM",
+      "most-used": "MÉS UTILITZADES",
+      "range": {
+        "14-days": "14 dies",
+        "3-days": "3 dies",
+        "today": "Avui"
+      }
+    },
+    "shortcuts": {
+      "audio": "Àudio",
+      "bluetooth": "Bluetooth",
+      "caffeine": "Caffeine",
+      "clipboard": "Porta-retalls",
+      "dark-mode": {
+        "auto": "Mode auto",
+        "dark": "Mode fosc",
+        "light": "Mode clar"
+      },
+      "keyboard-layout": "Disposició",
+      "media": "Multimèdia",
+      "mic-mute": "Micròfon",
+      "nightlight": "Night Light",
+      "nightlight-states": {
+        "forced": "Sempre actiu",
+        "off": "Night Light",
+        "scheduled-day": "Programat",
+        "scheduled-night": "Actiu"
+      },
+      "notification": "DND",
+      "power-profile": "Energia",
+      "screen-time": "Temps de pantalla",
+      "session": "Sessió",
+      "system": "Sistema",
+      "wallpaper": "Fons de pantalla",
+      "weather": "Temps",
+      "wifi": "Wi-Fi"
+    },
+    "system": {
+      "labels": {
+        "load": "Càrrega CPU",
+        "ram": "RAM",
+        "swap": "Swap"
+      },
+      "titles": {
+        "cpu": "CPU",
+        "gpu": "GPU",
+        "memory": "Memòria",
+        "network": "Xarxa",
+        "resources": "Recursos",
+        "system": "Sistema"
+      },
+      "tooltips": {
+        "load": "Mitjana de càrrega en 1 / 5 / 15 minuts"
+      },
+      "unknown": "desconegut",
+      "uptime-prefix": "Actiu {uptime} · {osAge}"
+    },
+    "tabs": {
+      "audio": "Àudio",
+      "bluetooth": "Bluetooth",
+      "calendar": "Calendari",
+      "display": "Monitor",
+      "home": "Inici",
+      "media": "Multimèdia",
+      "network": "Xarxa",
+      "notifications": "Notificacions",
+      "screen-time": "Temps de pantalla",
+      "system": "Sistema",
+      "weather": "Temps"
+    },
+    "weather": {
+      "configure-location": "Configura [weather].address o activa auto_locate",
+      "data-unavailable": "Dades meteorològiques no disponibles",
+      "details": {
+        "elevation": "Elevació",
+        "sunrise": "Sortida del sol",
+        "sunset": "Posta de sol",
+        "temp-max": "Temperatura màxima",
+        "temp-min": "Temperatura mínima",
+        "timezone": "Zona horària",
+        "wind": "Vent"
+      },
+      "disabled": "Activa [weather] a config.toml",
+      "fetching": "S'està obtenint la previsió...",
+      "forecast-placeholder": {
+        "day": "Diumenge",
+        "description": "Temps",
+        "temperature": "10 / 4C"
+      },
+      "location-unavailable": "Ubicació no disponible",
+      "refreshing": "S'està actualitzant el temps...",
+      "waiting": "Esperant les dades meteorològiques"
+    }
+  },
+  "desktop-widgets": {
+    "editor": {
+      "actions": {
+        "add": "Afegeix",
+        "clone": "Duplica (Ctrl+C, Ctrl+V per copiar/enganxar)",
+        "done": "Fet",
+        "flip-horizontal": "Gira horitzontalment",
+        "flip-vertical": "Gira verticalment",
+        "hide": "Amaga",
+        "settings": "Configuració",
+        "show": "Mostra",
+        "stack-back": "Envia al darrere",
+        "stack-front": "Porta al davant",
+        "trash": "Elimina"
+      },
+      "dialogs": {
+        "select-sticker-image": "Selecciona una imatge d'adhesiu"
+      },
+      "settings": {
+        "aspect-ratio": "Relació d'aspecte",
+        "background": "Fons",
+        "background-color": "Color",
+        "background-opacity": "Opacitat",
+        "background-padding": "Farcit",
+        "background-radius": "Radi",
+        "background-section": "Fons",
+        "bands": "Bandes",
+        "bar-width": "Amplada de la barra",
+        "bloom-intensity": "Bloom",
+        "centered": "Centrat",
+        "change-image": "Canvia…",
+        "circle": "Cercle",
+        "clock-style": "Estil del rellotge",
+        "clock-style-analog": "Analògic",
+        "clock-style-digital": "Digital",
+        "color": "Color",
+        "color-1": "Color u",
+        "color-2": "Color dos",
+        "color2": "Color 2",
+        "custom-color": "Personalitzat…",
+        "description": "Descripció",
+        "fade-when-idle": "Atenua quan està inactiu",
+        "font-family": "Font",
+        "font-family-default": "Per defecte del sistema",
+        "forecast-days": "Dies de previsió",
+        "format": "Format",
+        "interface": "Interfície",
+        "hide-when-no-media": "Amaga sense multimèdia",
+        "horizontal": "Horitzontal",
+        "image-path": "Imatge",
+        "inner-diameter": "Diàmetre interior",
+        "input-opacity": "Opacitat d'entrada",
+        "input-radius": "Radi d'entrada",
+        "layout": "Disposició",
+        "mirrored": "Mirall",
+        "opacity": "Opacitat",
+        "primary-color": "Color primari",
+        "reset-defaults": "Restableix als valors per defecte",
+        "ring-opacity": "Opacitat de l'anell",
+        "rotation-speed": "Velocitat de rotació",
+        "secondary-color": "Color secundari",
+        "sensitivity": "Sensibilitat",
+        "shadow": "Ombra",
+        "show-forecast": "Mostra la previsió",
+        "show-label": "Mostra l'etiqueta",
+        "show-login-button": "Botó d'inici de sessió",
+        "show-when-idle": "Mostra quan està inactiu",
+        "stat": "Estadística",
+        "stat-cpu-temp": "Temp. CPU",
+        "stat-cpu-usage": "Ús CPU",
+        "stat-gpu-temp": "Temp. GPU",
+        "stat-gpu-usage": "Ús GPU",
+        "stat-gpu-vram": "VRAM GPU",
+        "stat-net-rx": "Xarxa Rx",
+        "stat-net-tx": "Xarxa Tx",
+        "stat-none": "Cap",
+        "stat-ram-pct": "RAM %",
+        "stat-swap-pct": "Swap %",
+        "stat2": "Estadística 2",
+        "title": "Títol",
+        "vertical": "Vertical",
+        "visualization-mode": "Mode",
+        "visualization-mode-all": "Tot",
+        "visualization-mode-bars": "Barres",
+        "visualization-mode-bars-rings": "Barres + Anells",
+        "visualization-mode-rings": "Anells",
+        "visualization-mode-wave": "Ona",
+        "visualization-mode-wave-rings": "Ona + Anells",
+        "wave-thickness": "Gruix de l'ona",
+        "widget-section": "Widget"
+      },
+      "state": {
+        "grid-off": "Graella desactivada",
+        "grid-on": "Graella activada"
+      },
+      "title": "Widgets d'escriptori",
+      "types": {
+        "audio-visualizer": "Visualitzador d'àudio",
+        "clock": "Rellotge",
+        "fancy-audio-visualizer": "Visualitzador d'àudio avançat",
+        "label": "Etiqueta",
+        "login-box": "Caixa d'inici de sessió",
+        "media-player": "Reproductor multimèdia",
+        "sticker": "Adhesiu",
+        "system-monitor": "Monitor del sistema",
+        "weather": "Temps"
+      }
+    },
+    "media": {
+      "nothing-playing": "No s'està reproduint res"
+    },
+    "weather": {
+      "error": "Error",
+      "loading": "S'està carregant",
+      "no-location": "Sense ubicació",
+      "off": "Temps desactivat"
+    }
+  },
+  "dock": {
+    "actions": {
+      "close": "Tanca",
+      "close-all": "Tanca-ho tot"
+    },
+    "launcher": "Launcher"
+  },
+  "internal-apps": {
+    "settings": {
+      "display-name": "Configuració"
+    }
+  },
+  "launcher": {
+    "categories": {
+      "all": "Totes",
+      "applications": {
+        "development": "Desenvolupament",
+        "education": "Educació",
+        "games": "Jocs",
+        "graphics": "Gràfics",
+        "internet": "Internet",
+        "multimedia": "Multimèdia",
+        "office": "Oficina",
+        "system": "Sistema",
+        "utilities": "Utilitats"
+      },
+      "emoji": {
+        "activity": "Activitat",
+        "animals": "Animals",
+        "flags": "Banderes",
+        "food": "Menjar",
+        "nature": "Natura",
+        "objects": "Objectes",
+        "people": "Persones",
+        "symbols": "Símbols",
+        "travel": "Viatges"
+      },
+      "recently-used": "Utilitzades recentment"
+    },
+    "context-menu": {
+      "open": "Obre",
+      "pin-to-dock": "Fixa al dock",
+      "unpin-from-dock": "Desfixa del dock"
+    },
+    "empty": {
+      "no-results": "No s'han trobat resultats",
+      "type-to-search": "Escriu per cercar..."
+    },
+    "providers": {
+      "applications": {
+        "title": "Aplicacions"
+      },
+      "calculator": {
+        "title": "Calculadora"
+      },
+      "emoji": {
+        "title": "Emoji"
+      },
+      "session": {
+        "action-subtitle": "Executa acció de sessió",
+        "command-subtitle": "Executa l'ordre configurada",
+        "title": "Sessió"
+      },
+      "wallpaper": {
+        "title": "Fons de pantalla"
+      },
+      "window": {
+        "title": "Finestres"
+      }
+    },
+    "search-placeholder": "Cerca aplicacions..."
+  },
+  "location": {
+    "errors": {
+      "address-lookup-failed": "Ha fallat la cerca de l'adreça",
+      "ip-geolocation-failed": "Ha fallat la geolocalització per IP",
+      "parse-geocode": "No s'ha pogut analitzar la resposta de geocodificació",
+      "parse-ip-geolocation": "No s'ha pogut analitzar la resposta de geolocalització IP"
+    },
+    "locations": {
+      "current": "Ubicació actual"
+    },
+    "source": {
+      "address": "Adreça",
+      "auto": "Auto"
+    }
+  },
+  "lockscreen": {
+    "authenticating": "Autenticant...",
+    "authentication-failed": "Autenticació fallida",
+    "password-cleared": "Contrasenya esborrada",
+    "password-placeholder": "Contrasenya",
+    "ready": "Escriu la contrasenya i prem Enter.",
+    "unlocked": "Desbloquejat",
+    "waiting": "Esperant la confirmació del bloqueig..."
+  },
+  "notifications": {
+    "actions": {
+      "fallback": "Acció",
+      "open": "Obre"
+    },
+    "inline-reply": {
+      "button": "Respon",
+      "placeholder": "Escriu una resposta..."
+    },
+    "internal": {
+      "battery": "Bateria",
+      "battery-device": "Dispositiu de bateria",
+      "battery-low-body": "{device}: {percent}% restant",
+      "battery-low-title": "Bateria baixa",
+      "calendar": "Calendari",
+      "calendar-google-connect-browser-failed": "No s'ha pogut obrir el navegador per a l'autorització de Google. Comprova el navegador per defecte o la configuració xdg-open.",
+      "calendar-google-connect-expired": "L'autorització de Google ha caducat abans de finalitzar l'inici de sessió. Torna a iniciar la connexió.",
+      "calendar-google-connect-failed-title": "Ha fallat la connexió del Calendari de Google",
+      "calendar-google-connect-missing-account": "No s'ha trobat cap compte de Google Calendar configurat que coincideixi amb \"{account}\".",
+      "calendar-google-connect-rate-limited": "L'autorització de Google està temporalment limitada. Espera una mica i torna-ho a provar.",
+      "calendar-google-connect-result-failed": "No s'ha pogut finalitzar l'autorització de Google. Torna a iniciar la connexió.",
+      "calendar-google-connect-start-failed": "No s'ha pogut iniciar l'autorització de Google. Comprova la connexió de xarxa i torna-ho a provar.",
+      "calendar-google-connect-start-http": "No s'ha pogut iniciar l'autorització de Google. El broker OAuth ha retornat HTTP {status}.",
+      "calendar-google-connect-timeout": "L'autorització de Google ha superat el temps d'espera. Torna a iniciar la connexió quan estiguis preparat per iniciar sessió.",
+      "dbus-disabled": "Notificacions DBus desactivades",
+      "desktop-widgets-editor": "Editor de widgets",
+      "desktop-widgets-editor-enabled": "L'editor de widgets d'escriptori està activat. Canvia a un espai de treball buit per veure la superposició de l'editor.",
+      "greeter-sync": "Noctalia Greeter",
+      "greeter-sync-success": "Aparença sincronitzada. Els canvis s'apliquen a la següent pantalla d'inici de sessió.",
+      "keybind-app": "Noctalia",
+      "keybind-invalid-modifier": "Aquesta drecera accepta una sola tecla sense modificadors.",
+      "keybind-invalid-printable": "Les tecles imprimibles (lletres, números, símbols) requereixen un modificador com Ctrl o Alt.",
+      "keybind-invalid-super": "La tecla Super/Windows no es pot utilitzar a les dreceres del shell.",
+      "keybind-invalid-title": "Drecera no permesa",
+      "launcher-usage-reset": "Launcher",
+      "launcher-usage-reset-success": "Dades d'ús esborrades.",
+      "lockscreen-widgets-editor": "Editor de widgets de la pantalla de bloqueig",
+      "lockscreen-widgets-editor-blocked-locked": "Desbloqueja la sessió abans d'editar els widgets de la pantalla de bloqueig.",
+      "lockscreen-widgets-editor-enabled": "L'editor de widgets de la pantalla de bloqueig està activat. Organitza els widgets a la superposició de previsualització i després bloqueja la sessió per verificar-ne la disposició.",
+      "mpris-disabled": "MPRIS desactivat",
+      "screen-time-reset": "Temps de pantalla",
+      "screen-time-reset-success": "Historial d'ús esborrat.",
+      "session-bus-unavailable": "Bus de sessió no disponible",
+      "wallpaper-palette-export": "Paleta personalitzada",
+      "wallpaper-palette-export-success": "S'ha desat \"{name}\" i s'ha canviat l'origen de la paleta a personalitzada."
+    }
+  },
+  "osd": {
+    "bluetooth": {
+      "off": "Bluetooth desactivat",
+      "on": "Bluetooth activat"
+    },
+    "caffeine": {
+      "off": "Caffeine desactivat",
+      "on": "Caffeine activat"
+    },
+    "dnd": {
+      "off": "DND desactivat",
+      "on": "DND activat"
+    },
+    "effects": {
+      "input": "Efectes d'entrada",
+      "output": "Efectes de sortida"
+    },
+    "lock-keys": {
+      "caps-off": "Bloq Majús desactivat",
+      "caps-on": "Bloq Majús activat",
+      "num-off": "Bloq Num desactivat",
+      "num-on": "Bloq Num activat",
+      "scroll-off": "Bloq Despl desactivat",
+      "scroll-on": "Bloq Despl activat"
+    },
+    "wifi": {
+      "off": "Wi-Fi desactivat",
+      "on": "Wi-Fi activat"
+    }
+  },
+  "power": {
+    "battery": {
+      "states": {
+        "battery": "Bateria",
+        "charging": "Carregant",
+        "discharging": "Descarregant",
+        "empty": "Buida",
+        "pending-discharge": "Descàrrega pendent",
+        "plugged-in": "Endollada"
+      },
+      "tooltip": {
+        "health": "Salut",
+        "rate": "Taxa",
+        "status": "Estat",
+        "time-left": "Temps restant",
+        "time-to-full": "Temps fins a completar"
+      }
+    },
+    "profiles": {
+      "balanced": "Equilibrat",
+      "performance": "Rendiment",
+      "power-saver": "Estalvi d'energia"
+    }
+  },
+  "session": {
+    "actions": {
+      "custom": "Personalitzada",
+      "lock": "Bloqueja",
+      "lock-and-suspend": "Bloqueja i suspèn",
+      "logout": "Tanca la sessió",
+      "reboot": "Reinicia",
+      "shutdown": "Apaga",
+      "suspend": "Suspèn"
+    },
+    "errors": {
+      "lock-body": "El protocol de bloqueig de sessió no està disponible.",
+      "lock-title": "Bloqueig no disponible"
+    }
+  },
+  "settings": {
+    "actions": {
+      "reset": "Restableix"
+    },
+    "badges": {
+      "advanced": "Avançat",
+      "inherited": "Heretat",
+      "monitor": "Monitor",
+      "official": "Oficial",
+      "override": "Sobreescriu"
+    },
+    "calendar-accounts": {
+      "add-title": "Afegeix un compte de calendari",
+      "color-label": "Color",
+      "delete-error": "No s'ha pogut eliminar el compte de calendari.",
+      "edit-title": "Edita el compte de calendari",
+      "id-label": "ID del compte",
+      "invalid": "Comprova els camps del compte de calendari ressaltats.",
+      "name-label": "Nom de visualització",
+      "name-placeholder": "Calendari personal",
+      "password-keep-placeholder": "Deixa en blanc per mantenir la contrasenya actual",
+      "password-label": "Contrasenya d'aplicació",
+      "password-placeholder": "Contrasenya específica de l'aplicació",
+      "password-save-error": "No s'ha pogut desar la contrasenya del compte de calendari.",
+      "provider": {
+        "custom": "CalDAV",
+        "google": "Google",
+        "icloud": "iCloud"
+      },
+      "provider-label": "Proveïdor",
+      "save": "Desa",
+      "save-connect": "Desa i connecta",
+      "save-error": "No s'ha pogut desar el compte de calendari.",
+      "server-url-label": "URL del servidor",
+      "username-label": "Nom d'usuari",
+      "username-placeholder": "nom@exemple.cat"
+    },
+    "controls": {
+      "keybind": {
+        "add": "Click to add keybind",
+        "recording-placeholder": "Press a key combination…",
+        "unset-placeholder": "Click to bind…"
+      },
+      "list": {
+        "add-entry-placeholder": "Add entry…"
+      },
+      "path-browse": {
+        "file-title": "Choose file",
+        "folder-title": "Choose folder"
+      },
+      "select": {
+        "unknown-value": "Unknown: {value}"
+      }
+    },
+    "dialogs": {
+      "color-picker": {
+        "title": "Pick a Color"
+      }
+    },
+    "entities": {
+      "bar": {
+        "create": "Create",
+        "delete": "Delete",
+        "delete-confirm-desc": "This GUI-created bar will be removed from settings.toml.",
+        "delete-confirm-title": "Delete \"{name}\"?",
+        "id-placeholder": "Bar id",
+        "label": "Bar: {name}",
+        "management": "Bar",
+        "move-down": "Move Down",
+        "move-up": "Move Up",
+        "new": "New Bar",
+        "rename": "Rename",
+        "rename-save": "Save"
+      },
+      "monitor-override": {
+        "create": "Create",
+        "delete": "Delete",
+        "delete-confirm-desc": "This GUI-created monitor override will be removed from settings.toml.",
+        "delete-confirm-title": "Delete \"{name}\"?",
+        "label": "Monitor: {name}",
+        "management": "Monitor Override",
+        "match-placeholder": "Monitor match",
+        "new": "Monitor Override",
+        "rename": "Rename",
+        "rename-save": "Save"
+      },
+      "widget": {
+        "add": "Add widget",
+        "detail": {
+          "custom": "custom widget"
+        },
+        "editor": {
+          "description": "Arrange widgets across the bar lanes",
+          "title": "Bar Widgets"
+        },
+        "group": {
+          "action": "Group",
+          "border": "Border",
+          "border-description": "Capsule outline color role; leave on Default for no outline",
+          "clear": "Clear",
+          "edit": "Edit style",
+          "fill": "Background",
+          "fill-description": "Capsule background color role; fixed hex colors are also supported",
+          "foreground": "Foreground",
+          "foreground-description": "Icon and label color role for widgets in this group",
+          "hint": "Part of a capsule group",
+          "members": "{count} widgets",
+          "opacity": "Opacity",
+          "opacity-description": "Capsule background opacity",
+          "orphan": "Unknown group",
+          "padding": "Padding",
+          "padding-description": "Inner padding between the capsule edge and its widgets, in pixels",
+          "radius": "Radius",
+          "radius-description": "Capsule corner radius in pixels; Auto inherits the bar's capsule radius",
+          "selected": "{count} selected",
+          "style": "Style",
+          "title": "Capsule group",
+          "ungroup": "Ungroup"
+        },
+        "inspector": {
+          "add-instance-title": "Add new named {widget} widget to {lane}",
+          "add-title": "Add widget to {lane}",
+          "move-to-lane": "Move to {lane}"
+        },
+        "instance": {
+          "create-save": "Create",
+          "delete": "Delete",
+          "delete-confirm-desc": "This named widget will be removed from every bar and its settings discarded.",
+          "delete-confirm-title": "Delete \"{name}\"?",
+          "id-description": "Use letters, numbers, underscores, or hyphens only. No spaces; must be unique.",
+          "id-placeholder": "Widget id",
+          "rename": "Rename",
+          "rename-save": "Save"
+        },
+        "lanes": {
+          "center": "Center",
+          "customize": "Customize",
+          "empty": "No widgets",
+          "empty-hint": "Add a widget to populate this lane.",
+          "end": "End",
+          "start": "Start"
+        },
+        "picker": {
+          "empty": "No widgets found",
+          "instance-description": "Named widget for type \"{type}\"",
+          "instance-toggle": "Named Widget",
+          "placeholder": "Search widgets..."
+        },
+        "raw": {
+          "delete": "Delete",
+          "description": "Unsupported keys preserved from this widget config.",
+          "title": "Raw Settings"
+        },
+        "settings": {
+          "empty": "No settings match the current filters.",
+          "groups": {
+            "grouping": "Grouping",
+            "presentation": "Presentation",
+            "runtime": "Runtime",
+            "widget": "Widget"
+          }
+        }
+      }
+    },
+    "errors": {
+      "avatar-accounts": "Could not update the system account avatar.",
+      "avatar-invalid-path": "The selected avatar path is not a readable image file.",
+      "avatar-load": "Could not load the selected image. Use PNG, JPEG, WebP, GIF, BMP, or SVG.",
+      "avatar-write": "Could not prepare the avatar image for saving.",
+      "bar": {
+        "create": "Could not create bar.",
+        "delete": "Could not delete bar.",
+        "move": "Could not move bar.",
+        "rename": "Could not rename bar."
+      },
+      "batch-write": "Some settings could not be saved.",
+      "export-config": "Failed to save config export.",
+      "export-wallpaper-palette": "Could not save the wallpaper palette as a custom palette.",
+      "monitor-override": {
+        "create": "Could not create monitor override.",
+        "delete": "Could not delete monitor override.",
+        "rename": "Could not rename monitor override."
+      },
+      "reset-page": "Failed to reset some settings.",
+      "support-report": "Failed to save support report.",
+      "sync-greeter": "Could not sync appearance to Noctalia Greeter.",
+      "widget": {
+        "rename": "Could not rename named widget."
+      },
+      "write": "Failed to save settings."
+    },
+    "export-config": {
+      "export": "Export",
+      "full-effective-description": "Exports every active setting, including built-in defaults. Useful for inspection or sharing a snapshot, but pins current defaults explicitly.",
+      "full-effective-save-title": "Save Full Effective Config",
+      "full-effective-title": "Full Effective Config",
+      "merged-user-description": "Combines config files and GUI overrides into one TOML file. Built-in defaults stay implicit.",
+      "merged-user-save-title": "Save Merged User Config",
+      "merged-user-title": "Merged User Config (Recommended)",
+      "title": "Export Config"
+    },
+    "idle": {
+      "behavior": {
+        "add": "Add behavior",
+        "command-label": "Idle command",
+        "command-placeholder": "notify-send \"Idle\"",
+        "kind": {
+          "custom": "Custom",
+          "lock": "Lock",
+          "lock-and-suspend": "Lock & Suspend",
+          "screen-off": "Screen Off",
+          "suspend": "Suspend"
+        },
+        "kind-section-label": "Action",
+        "name-label": "Name",
+        "name-placeholder": "idle-behavior",
+        "resume-command-label": "Resume command",
+        "resume-command-placeholder": "noctalia:dpms-on",
+        "summary": "{name} · {seconds}s",
+        "summary-disabled-timeout": "{name} · timeout disabled",
+        "timeout-label": "Timeout seconds",
+        "unnamed": "Unnamed behavior"
+      },
+      "live-status": {
+        "active": "Active",
+        "idle-for-one": "Idle for 1 second",
+        "idle-for-seconds": "Idle for {seconds} seconds"
+      }
+    },
+    "navigation": {
+      "groups": {
+        "audio": "Audio",
+        "automation": "Automation",
+        "backdrop": "Backdrop",
+        "background": "Background",
+        "battery": "Battery",
+        "behavior": "Behavior",
+        "brightness": "Brightness",
+        "built-in": "Built-In",
+        "calendar": "Calendar",
+        "capsules": "Capsules",
+        "clipboard": "Clipboard",
+        "community": "Community",
+        "control-center": "Control Center",
+        "directories": "Directories",
+        "effects": "Effects",
+        "filtering": "Filtering",
+        "focus-styling": "Focus Styling",
+        "formats": "Formats",
+        "general": "General",
+        "grouping": "Grouping",
+        "home": "Home",
+        "idle": "Idle",
+        "interface": "Interface",
+        "keybinds": "Keybinds",
+        "kinds": "Kinds",
+        "launcher": "Launcher",
+        "layout": "Layout",
+        "lifecycle": "Lifecycle",
+        "location": "Location",
+        "lock-screen": "Lock Screen",
+        "media": "Media",
+        "monitor": "System Monitor",
+        "monitor-polling": "Poll Intervals",
+        "monitor-thresholds": "Highlight Thresholds",
+        "monitors": "Monitors",
+        "motion": "Motion",
+        "network": "Network",
+        "night-light": "Night Light",
+        "notifications": "Notifications",
+        "osd": "OSD",
+        "overview": "Overview",
+        "pinned-apps": "Pinned Apps",
+        "power": "Power",
+        "privacy-security": "Privacy & Security",
+        "profile": "Profile",
+        "screen-corners": "Screen Corners",
+        "screen-time": "Screen Time",
+        "screenshot": "Screenshot",
+        "security": "Security",
+        "session-panel": "Session",
+        "shape": "Shape",
+        "system": "System",
+        "theme": "Theme",
+        "toasts": "Toasts",
+        "transition": "Transition",
+        "user": "User",
+        "wallpaper": "Wallpaper",
+        "weather": "Weather",
+        "widget-list": "Widget List",
+        "widgets": "Widgets"
+      },
+      "sections": {
+        "appearance": "Appearance",
+        "backdrop": "Backdrop",
+        "bar": "Bar",
+        "desktop": "Desktop",
+        "dock": "Dock",
+        "hooks": "Hooks",
+        "location": "Location",
+        "niri": "Niri",
+        "notifications": "Notifications",
+        "osd": "OSD",
+        "panels": "Panels",
+        "plugins": "Plugins",
+        "popups": "Popups",
+        "power": "Power",
+        "security": "Security",
+        "services": "Services",
+        "shell": "Shell",
+        "system": "System",
+        "templates": "Templates",
+        "wallpaper": "Wallpaper"
+      }
+    },
+    "notifications": {
+      "filter": {
+        "add": "Add filter",
+        "add-title": "Add Notification Filter",
+        "allowed-urgencies-label": "Allowed urgencies",
+        "flag": {
+          "history": "history",
+          "sound": "sound",
+          "toast": "toast"
+        },
+        "flags-label": "When matched",
+        "match-label": "App",
+        "match-placeholder": "App name, desktop entry, or category…",
+        "play-sound": "Play sound",
+        "save-history": "Save to history",
+        "show-toast": "Show toast",
+        "summary": "{match} · {flags}",
+        "summary-blocked": "{match} · blocked",
+        "summary-disabled": "{match} · disabled",
+        "unnamed": "Unnamed filter"
+      }
+    },
+    "options": {
+      "clipboard": {
+        "auto-paste": {
+          "ctrl-shift-v": "Ctrl+Shift+V",
+          "ctrl-v": "Ctrl+V",
+          "shift-insert": "Shift+Insert"
+        }
+      },
+      "control-center": {
+        "sidebar": {
+          "compact": "Compact",
+          "full": "Full",
+          "none": "None"
+        }
+      },
+      "dock-launcher-position": {
+        "end": "End",
+        "none": "None",
+        "start": "Start"
+      },
+      "edge": {
+        "bottom": "Bottom",
+        "left": "Left",
+        "right": "Right",
+        "top": "Top"
+      },
+      "font-weight": {
+        "bold": "Bold",
+        "book": "Book",
+        "default": "Default (bar)",
+        "heavy": "Heavy",
+        "light": "Light",
+        "medium": "Medium",
+        "regular": "Regular",
+        "semi-bold": "Semi Bold",
+        "semi-light": "Semi Light",
+        "thin": "Thin",
+        "ultra-bold": "Ultra Bold",
+        "ultra-heavy": "Ultra Heavy",
+        "ultra-light": "Ultra Light"
+      },
+      "layer": {
+        "overlay": "Overlay",
+        "top": "Top"
+      },
+      "notification-urgency": {
+        "critical": "Critical",
+        "low": "Low",
+        "normal": "Normal"
+      },
+      "orientation": {
+        "horizontal": "Horizontal",
+        "vertical": "Vertical"
+      },
+      "screen-position": {
+        "bottom-center": "Bottom Center",
+        "bottom-left": "Bottom Left",
+        "bottom-right": "Bottom Right",
+        "center-left": "Center Left",
+        "center-right": "Center Right",
+        "top-center": "Top Center",
+        "top-left": "Top Left",
+        "top-right": "Top Right"
+      },
+      "shell": {
+        "panel-placement": {
+          "attached": "Attached",
+          "centered": "Centered",
+          "floating": "Floating"
+        },
+        "panel-transparency": {
+          "glass": "Glass",
+          "soft": "Soft",
+          "solid": "Solid"
+        },
+        "password-style": {
+          "filled-circles": "Filled Circles",
+          "random-icons": "Random Icons"
+        },
+        "shadow-direction": {
+          "center": "Center",
+          "down": "Down",
+          "down-left": "Down Left",
+          "down-right": "Down Right",
+          "left": "Left",
+          "right": "Right",
+          "up": "Up",
+          "up-left": "Up Left",
+          "up-right": "Up Right"
+        }
+      },
+      "theme": {
+        "mode": {
+          "dark": "Dark",
+          "light": "Light"
+        },
+        "source": {
+          "built-in": "Built-In",
+          "community": "Community",
+          "custom": "Custom",
+          "wallpaper": "Wallpaper"
+        }
+      },
+      "theme-role": {
+        "custom": "Custom…",
+        "default": "Default"
+      },
+      "wallpaper": {
+        "fill": {
+          "center": "Center",
+          "crop": "Crop",
+          "fit": "Fit",
+          "repeat": "Repeat",
+          "stretch": "Stretch"
+        },
+        "order": {
+          "alphabetical": "Alphabetical",
+          "random": "Random"
+        },
+        "transition": {
+          "disc": "Disc",
+          "fade": "Fade",
+          "honeycomb": "Honeycomb",
+          "stripes": "Stripes",
+          "wipe": "Wipe",
+          "zoom": "Zoom"
+        }
+      },
+      "weather": {
+        "unit": {
+          "imperial": "Imperial",
+          "metric": "Metric"
+        }
+      }
+    },
+    "plugins": {
+      "plugins": {
+        "configure": "Configure",
+        "deprecated": "deprecated",
+        "empty": "No plugins found. Add a source, or check your network.",
+        "loading": "Loading plugins...",
+        "refreshing": "Refreshing plugins...",
+        "requires-newer-noctalia": "requires newer Noctalia",
+        "title": "Plugins"
+      },
+      "settings": {
+        "empty": "No settings available."
+      },
+      "sources": {
+        "add": "Add source",
+        "add-title": "Add plugin source",
+        "edit": "Edit source",
+        "edit-title": "Edit plugin source",
+        "empty": "No sources configured.",
+        "errors": {
+          "duplicate-name": "A source with this ID already exists.",
+          "invalid-name": "Source ID must use letters, digits, '.', '_' or '-', starting with a letter or digit.",
+          "location-required": "Source location is required."
+        },
+        "kind": {
+          "git": "Git",
+          "path": "Path"
+        },
+        "kind-label": "Kind",
+        "location-label": "Location",
+        "location-placeholder-git": "https://github.com/me/noctalia-plugins",
+        "location-placeholder-path": "~/dev/noctalia-plugins",
+        "name-label": "Source ID",
+        "name-placeholder": "my-plugins",
+        "remove": "Remove source",
+        "save": "Save",
+        "title": "Sources",
+        "update": "Update",
+        "update-on-startup": "Update on startup"
+      }
+    },
+    "schema": {
+      "appearance": {
+        "animation-speed": {
+          "description": "Speed multiplier for all animations",
+          "label": "Animation Speed"
+        },
+        "animations": {
+          "description": "Enable or disable UI animations",
+          "label": "Animations"
+        },
+        "app-icon-color": {
+          "description": "Palette color used when colorizing application icons",
+          "label": "App Icon Color"
+        },
+        "app-icon-colorize": {
+          "description": "Recolor application icons across the shell to match the active palette",
+          "label": "Colorize App Icons"
+        },
+        "builtin-palette": {
+          "description": "Choose a palette from the bundled catalog",
+          "label": "Built-In Palette"
+        },
+        "community-palette": {
+          "description": "Choose a palette from the community catalog",
+          "label": "Community Palette",
+          "search-placeholder": "Search palettes..."
+        },
+        "corner-roundness": {
+          "description": "Scale corner radius across shell UI containers and controls",
+          "label": "Corner Roundness"
+        },
+        "custom-palette": {
+          "description": "Choose a palette from ~/.config/noctalia/palettes/",
+          "label": "Custom Palette",
+          "search-placeholder": "Search custom palettes..."
+        },
+        "export-wallpaper-palette": {
+          "button": "Save as Custom Palette",
+          "description": "Save the current wallpaper-generated palette as a reusable custom palette file",
+          "label": "Export Wallpaper Palette"
+        },
+        "font-family": {
+          "description": "Font family for the shell interface",
+          "label": "Font Family"
+        },
+        "global-shadow-alpha": {
+          "description": "Global surface shadow opacity"
+        },
+        "global-shadow-direction": {
+          "description": "Direction the shadow is cast from surfaces"
+        },
+        "language": {
+          "description": "Override automatic locale detection",
+          "label": "Language"
+        },
+        "palette-source": {
+          "description": "Where to derive the color palette from",
+          "label": "Palette Source"
+        },
+        "theme-mode": {
+          "description": "Choose dark, light, or auto based on time of day",
+          "label": "Theme Mode"
+        },
+        "ui-scale": {
+          "description": "Scale the entire interface up or down",
+          "label": "UI Scale"
+        },
+        "wallpaper-generation-scheme": {
+          "description": "Choose how wallpaper colors are converted into a palette",
+          "label": "Wallpaper Generation Scheme"
+        }
+      },
+      "backdrop": {
+        "blur-intensity": {
+          "description": "Blur intensity of the backdrop",
+          "label": "Blur Intensity"
+        },
+        "enabled": {
+          "description": "Enable the backdrop"
+        },
+        "tint-intensity": {
+          "description": "Tint intensity of the backdrop",
+          "label": "Tint Intensity"
+        }
+      },
+      "bar": {
+        "auto-hide": {
+          "description": "Automatically hide the bar when not in use"
+        },
+        "background-opacity": {
+          "description": "Background opacity of the bar"
+        },
+        "border": {
+          "description": "Color role for the bar outline; fixed hex colors are also supported",
+          "label": "Border"
+        },
+        "border-width": {
+          "description": "Inside outline width for the bar",
+          "label": "Border Width"
+        },
+        "capsule-border": {
+          "description": "Default capsule outline color role; fixed hex colors are also supported",
+          "label": "Capsule Border"
+        },
+        "capsule-fill": {
+          "description": "Default capsule background color role; fixed hex colors are also supported",
+          "label": "Capsule Fill"
+        },
+        "capsule-foreground": {
+          "description": "Default icon and label color role inside capsules; fixed hex colors are also supported",
+          "label": "Capsule Foreground"
+        },
+        "capsule-opacity": {
+          "description": "Opacity of widget capsule backgrounds",
+          "label": "Capsule Opacity"
+        },
+        "capsule-padding": {
+          "description": "Padding inside widget capsules",
+          "label": "Capsule Padding"
+        },
+        "capsule-radius": {
+          "description": "Default corner radius for widget capsules, workspace pills, and taskbar workspace groups; leave blank for automatic pill shape, or set 0 for square corners",
+          "label": "Capsule Radius"
+        },
+        "capsule-thickness": {
+          "description": "Capsule size across the bar as a fraction of the bar thickness (1.0 fills the bar)",
+          "label": "Capsule Thickness"
+        },
+        "center-widgets": {
+          "description": "Widgets in the center of the bar",
+          "label": "Center Widgets"
+        },
+        "contact-shadow": {
+          "description": "Dark gradient between an attached panel and the bar to suggest depth at the seam"
+        },
+        "content-padding": {
+          "description": "Padding inside the bar content area",
+          "label": "Content Padding"
+        },
+        "content-scale": {
+          "description": "Scale factor for bar content",
+          "label": "Content Scale"
+        },
+        "corner-bottom-left": {
+          "description": "Bottom left corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+        },
+        "corner-bottom-right": {
+          "description": "Bottom right corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+        },
+        "corner-radius": {
+          "description": "Corner radius of the bar"
+        },
+        "corner-top-left": {
+          "description": "Top left corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+        },
+        "corner-top-right": {
+          "description": "Top right corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+        },
+        "edge-margin": {
+          "description": "Distance from the nearest screen edge; positive values float the bar away from it"
+        },
+        "enabled": {
+          "description": "Show or hide this bar"
+        },
+        "end-widgets": {
+          "description": "Widgets on the end (right/bottom) side of the bar",
+          "label": "End Widgets"
+        },
+        "ends-margin": {
+          "description": "Inset from each end of the bar along its main axis"
+        },
+        "font-family": {
+          "description": "Typeface for this bar's widgets; leave empty to inherit the global font. Per-widget Font Family overrides this.",
+          "label": "Font Family"
+        },
+        "font-weight": {
+          "description": "Default weight for widget labels on this bar.",
+          "label": "Font Weight"
+        },
+        "layer": {
+          "description": "Use Overlay to show the bar above fullscreen apps. Attached panels follow the bar.",
+          "label": "Wayland Layer"
+        },
+        "panel-overlap": {
+          "description": "Pixels an attached panel overlaps the bar edge to hide the seam (adjust if you see a line or gap)",
+          "label": "Panel Overlap"
+        },
+        "position": {
+          "description": "Which screen edge the bar sits on"
+        },
+        "reserve-space": {
+          "description": "Push windows away from the bar edge"
+        },
+        "shadow": {
+          "description": "Cast the global surface shadow from the bar"
+        },
+        "start-widgets": {
+          "description": "Widgets on the start (left/top) side of the bar",
+          "label": "Start Widgets"
+        },
+        "thickness": {
+          "description": "Bar thickness in pixels",
+          "label": "Thickness"
+        },
+        "widget-capsules": {
+          "description": "Wrap widgets in capsule backgrounds",
+          "label": "Widget Capsules"
+        },
+        "widget-color": {
+          "description": "Default icon and label color role for widgets on this bar; fixed hex colors are also supported",
+          "label": "Widget Color"
+        },
+        "widget-icon-color": {
+          "description": "Overrides the widget color for icons on this bar; fixed hex colors are also supported",
+          "label": "Widget Icon Color"
+        },
+        "widget-spacing": {
+          "description": "Space between bar widgets",
+          "label": "Widget Spacing"
+        }
+      },
+      "desktop": {
+        "screen-corners-enabled": {
+          "description": "Round the screen corners with a black overlay",
+          "label": "Screen Corners"
+        },
+        "screen-corners-size": {
+          "description": "Radius of the rounded screen corners in pixels",
+          "label": "Corner Size"
+        },
+        "widgets": {
+          "description": "Show widgets on the desktop",
+          "label": "Desktop Widgets"
+        },
+        "widgets-editor": {
+          "button": "Toggle Editor",
+          "description": "Add, move, and resize desktop widgets",
+          "label": "Widget Editor"
+        }
+      },
+      "dock": {
+        "active-icon-opacity": {
+          "description": "Opacity of the focused dock icon",
+          "label": "Active Icon Opacity"
+        },
+        "active-icon-scale": {
+          "description": "Scale of the focused dock icon",
+          "label": "Active Icon Scale"
+        },
+        "active-monitor-only": {
+          "description": "Only show applications running on the active monitor",
+          "label": "Active Monitor Only"
+        },
+        "auto-hide": {
+          "description": "Automatically hide the dock when not in use"
+        },
+        "background-opacity": {
+          "description": "Background opacity of the dock"
+        },
+        "corner-bottom-left": {
+          "description": "Bottom left corner radius for the dock"
+        },
+        "corner-bottom-right": {
+          "description": "Bottom right corner radius for the dock"
+        },
+        "corner-radius": {
+          "description": "Corner radius of the dock"
+        },
+        "corner-top-left": {
+          "description": "Top left corner radius for the dock"
+        },
+        "corner-top-right": {
+          "description": "Top right corner radius for the dock"
+        },
+        "cross-axis-padding": {
+          "description": "Inner padding along the dock's cross axis (between icons and the screen edge)"
+        },
+        "edge-margin": {
+          "description": "Distance from the nearest screen edge; positive values float the dock away from it"
+        },
+        "enabled": {
+          "description": "Show or hide the dock"
+        },
+        "ends-margin": {
+          "description": "Inset from each end of the dock along its main axis"
+        },
+        "icon-size": {
+          "description": "Size of dock icons in pixels",
+          "label": "Icon Size"
+        },
+        "inactive-icon-opacity": {
+          "description": "Opacity of unfocused dock icons",
+          "label": "Inactive Icon Opacity"
+        },
+        "inactive-icon-scale": {
+          "description": "Scale of unfocused dock icons",
+          "label": "Inactive Icon Scale"
+        },
+        "item-spacing": {
+          "description": "Space between dock items",
+          "label": "Item Spacing"
+        },
+        "launcher-icon": {
+          "description": "Tabler icon shown on the dock launcher button",
+          "label": "Launcher Icon"
+        },
+        "launcher-position": {
+          "description": "Show a launcher button at the start or end of the dock",
+          "label": "Launcher Button"
+        },
+        "magnification": {
+          "description": "Magnify dock icons near the pointer, macOS-style",
+          "label": "Magnification"
+        },
+        "magnification-scale": {
+          "description": "Maximum icon scale multiplier at the pointer center (1.0 disables magnification)",
+          "label": "Magnification Scale"
+        },
+        "main-axis-padding": {
+          "description": "Inner padding along the dock's main axis (between icons and the short ends of the capsule)"
+        },
+        "monitors": {
+          "description": "Choose which monitors show the dock (leave empty for all); active-monitor filtering applies within these monitors",
+          "label": "Monitors"
+        },
+        "pinned-apps": {
+          "description": "Desktop entry IDs of apps pinned to the dock",
+          "label": "Pinned Apps"
+        },
+        "position": {
+          "description": "Which screen edge the dock sits on"
+        },
+        "reserve-space": {
+          "description": "Push windows away from the dock edge"
+        },
+        "shadow": {
+          "description": "Cast the global surface shadow from the dock"
+        },
+        "show-dots": {
+          "description": "Show running window dots beside dock icons",
+          "label": "Show Dots"
+        },
+        "show-instance-count": {
+          "description": "Show a badge with the number of open instances",
+          "label": "Show Instance Count"
+        },
+        "show-running": {
+          "description": "Show running applications that are not pinned",
+          "label": "Show Running"
+        }
+      },
+      "hooks": {
+        "command-placeholder": "shell command or script path",
+        "events": {
+          "battery-charging": {
+            "description": "Command to run when the battery starts charging",
+            "label": "On Battery Charging"
+          },
+          "battery-discharging": {
+            "description": "Command to run when the battery starts discharging",
+            "label": "On Battery Discharging"
+          },
+          "battery-percentage-changed": {
+            "description": "Command to run when the battery percentage changes",
+            "label": "On Battery Percentage Changed"
+          },
+          "battery-plugged": {
+            "description": "Command to run when the battery becomes fully charged or pending charge",
+            "label": "On Battery Plugged"
+          },
+          "bluetooth-disabled": {
+            "description": "Command to run when Bluetooth is disabled",
+            "label": "On Bluetooth Disabled"
+          },
+          "bluetooth-enabled": {
+            "description": "Command to run when Bluetooth is enabled",
+            "label": "On Bluetooth Enabled"
+          },
+          "colors-changed": {
+            "description": "Command to run when the active color palette changes",
+            "label": "On Colors Changed"
+          },
+          "logging-out": {
+            "description": "Command to run before logging out",
+            "label": "On Logout"
+          },
+          "power-profile-changed": {
+            "description": "Command to run when the active UPower/PPD power profile changes",
+            "label": "On Power Profile Changed"
+          },
+          "rebooting": {
+            "description": "Command to run before rebooting",
+            "label": "On Reboot"
+          },
+          "session-locked": {
+            "description": "Command to run when the session is locked",
+            "label": "On Session Locked"
+          },
+          "session-unlocked": {
+            "description": "Command to run after the session is unlocked",
+            "label": "On Session Unlocked"
+          },
+          "shutting-down": {
+            "description": "Command to run before shutdown",
+            "label": "On Shutdown"
+          },
+          "started": {
+            "description": "Command to run after Noctalia starts",
+            "label": "On Started"
+          },
+          "theme-mode-changed": {
+            "description": "Command to run when the resolved theme mode changes between light and dark",
+            "label": "On Theme Mode Changed"
+          },
+          "wallpaper-changed": {
+            "description": "Command to run when the wallpaper changes",
+            "label": "On Wallpaper Changed"
+          },
+          "wifi-disabled": {
+            "description": "Command to run when Wi-Fi is disabled",
+            "label": "On Wi-Fi Disabled"
+          },
+          "wifi-enabled": {
+            "description": "Command to run when Wi-Fi is enabled",
+            "label": "On Wi-Fi Enabled"
+          }
+        }
+      },
+      "idle": {
+        "behaviors": {
+          "description": "Named idle actions with presets (lock, displays off, suspend) or custom commands, timeouts, resume pairing, and order",
+          "label": "Behaviors"
+        },
+        "pre-action-fade": {
+          "description": "Seconds of fullscreen dim before the idle command; use 0 to disable",
+          "label": "Idle Dim"
+        }
+      },
+      "keybinds": {
+        "cancel": {
+          "description": "Close popups, dismiss panels, or abort the current operation",
+          "label": "Cancel"
+        },
+        "down": {
+          "description": "Move focus or selection down one row",
+          "label": "Navigate Down"
+        },
+        "left": {
+          "description": "Move focus or selection to the left",
+          "label": "Navigate Left"
+        },
+        "right": {
+          "description": "Move focus or selection to the right",
+          "label": "Navigate Right"
+        },
+        "up": {
+          "description": "Move focus or selection up one row",
+          "label": "Navigate Up"
+        },
+        "validate": {
+          "description": "Confirm selections, submit inputs, or activate the focused item",
+          "label": "Confirm"
+        }
+      },
+      "lockscreen": {
+        "allow-empty-password": {
+          "description": "Let Enter submit an empty password. Enable for security-key or other passwordless PAM stacks; keep off to avoid accidental wake-key lockouts.",
+          "label": "Empty Password Submit"
+        },
+        "blur-intensity": {
+          "description": "How much the lock screen background is blurred",
+          "label": "Blur Intensity"
+        },
+        "blurred-desktop": {
+          "description": "Use a snapshot of the desktop as the lock screen background",
+          "label": "Desktop Capture"
+        },
+        "enabled": {
+          "description": "Enable session lock, logind integration, and lock actions",
+          "label": "Lock Screen"
+        },
+        "fingerprint": {
+          "description": "Unlock with a fingerprint reader via fprintd, alongside password entry",
+          "label": "Fingerprint Unlock"
+        },
+        "monitors": {
+          "description": "Choose which monitors show the lock screen; leave empty to show on all monitors",
+          "label": "Monitors"
+        },
+        "tint-intensity": {
+          "description": "Surface-color tint over the lock screen background",
+          "label": "Tint Intensity"
+        },
+        "wallpaper": {
+          "description": "Custom image for the lock screen background. Leave empty to use the desktop wallpaper.",
+          "label": "Wallpaper",
+          "placeholder": "Use desktop wallpaper"
+        },
+        "widgets": {
+          "description": "Show configurable widgets on the lock screen",
+          "label": "Lockscreen Widgets"
+        },
+        "widgets-editor": {
+          "button": "Toggle Editor",
+          "description": "Add, move, and resize widgets on the lock screen",
+          "label": "Lockscreen Widget Editor"
+        }
+      },
+      "notifications": {
+        "allowed-urgencies": {
+          "description": "Only show external notifications at the selected urgency levels",
+          "label": "Allowed Urgencies"
+        },
+        "blacklist": {
+          "description": "Hide matching senders (app name, desktop entry, or category)",
+          "label": "Notification Blacklist"
+        },
+        "blacklist-allow-critical": {
+          "description": "Still show critical notifications from blacklisted senders"
+        },
+        "collapse-on-dismiss": {
+          "description": "Slide remaining toasts to close gaps when one is dismissed",
+          "label": "Collapse on Dismiss"
+        },
+        "daemon": {
+          "description": "Enable the built-in notification daemon",
+          "label": "Notification Daemon"
+        },
+        "filters": {
+          "description": "Per-sender rules for toasts, history, and sounds; first matching enabled filter wins",
+          "label": "Notification Filters"
+        },
+        "layer": {
+          "description": "Use Overlay to show notification toasts above fullscreen apps.",
+          "label": "Wayland Layer"
+        },
+        "monitors": {
+          "description": "Choose which monitors show notification toasts; leave empty to show on all monitors",
+          "label": "Monitors"
+        },
+        "offset-x": {
+          "description": "Absolute horizontal margin from the screen or bar edge",
+          "label": "Horizontal Margin"
+        },
+        "offset-y": {
+          "description": "Absolute vertical margin from the screen or bar edge",
+          "label": "Vertical Margin"
+        },
+        "position": {
+          "description": "Screen position for notification toasts",
+          "label": "Screen Position"
+        },
+        "scale": {
+          "description": "Scale notification toasts relative to the shell UI scale",
+          "label": "Size"
+        },
+        "show-actions": {
+          "description": "Show action buttons in notification toasts; when disabled, clicking the toast triggers its default action",
+          "label": "Show Action Buttons"
+        },
+        "show-app-name": {
+          "description": "Show the sending application's name in notification toasts",
+          "label": "Show App Name"
+        },
+        "toast-opacity": {
+          "description": "Background opacity of notification toasts",
+          "label": "Background Opacity"
+        }
+      },
+      "panels": {
+        "borders": {
+          "description": "Draw an outline on panels and section cards inside panels",
+          "label": "Borders"
+        },
+        "control-center-sidebar": {
+          "description": "Choose how to display the sidebar",
+          "label": "Sidebar"
+        },
+        "control-center-sidebar-section": {
+          "description": "When opening a specific tab (volume, media etc.)",
+          "label": "Sidebar When Opening a Tab"
+        },
+        "home-shortcuts": {
+          "description": "Choose up to six shortcut buttons for the home tab",
+          "label": "Home Shortcuts"
+        },
+        "launcher-categories": {
+          "description": "Display category filters in the launcher; reveal with F6, then cycle with F6 and Shift+F6",
+          "label": "Show Categories"
+        },
+        "launcher-compact": {
+          "description": "Use smaller icons and tighter result rows",
+          "label": "Compact Rows"
+        },
+        "launcher-reset-usage": {
+          "button": "Reset",
+          "description": "Clear launch counts and recently used history used for launcher sorting",
+          "label": "Reset Usage Data"
+        },
+        "launcher-session-search": {
+          "description": "Include session actions (lock, suspend, reboot, shutdown, logout) in general launcher searches, not only behind the /session prefix",
+          "label": "Enable Session Search"
+        },
+        "launcher-show-icons": {
+          "description": "Show application icons in launcher results",
+          "label": "Show App Icons"
+        },
+        "launcher-sort-by-usage": {
+          "description": "Boost frequently used apps toward the top and show a Recently Used category filter",
+          "label": "Sort by Usage"
+        },
+        "open-near-click-clipboard": {
+          "description": "Position the clipboard panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
+        "open-near-click-control-center": {
+          "description": "Position the Control Center panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
+        "open-near-click-launcher": {
+          "description": "Position the launcher panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
+        "open-near-click-session": {
+          "description": "Position the session menu panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
+        "open-near-click-wallpaper": {
+          "description": "Position the wallpaper picker panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
+        "placement-clipboard": {
+          "description": "Choose whether the clipboard attaches to the bar, floats near it, or opens centered",
+          "label": "Placement"
+        },
+        "placement-control-center": {
+          "description": "Choose whether Control Center attaches to the bar, floats near it, or opens centered",
+          "label": "Placement"
+        },
+        "placement-launcher": {
+          "description": "Choose whether the launcher attaches to the bar, floats near it, or opens centered",
+          "label": "Placement"
+        },
+        "placement-session": {
+          "description": "Choose whether the session menu attaches to the bar, floats near it, or opens centered",
+          "label": "Placement"
+        },
+        "placement-wallpaper": {
+          "description": "Choose whether the wallpaper picker attaches to the bar, floats near it, or opens centered",
+          "label": "Placement"
+        },
+        "shadow": {
+          "description": "Cast the global surface shadow from panel surfaces"
+        },
+        "transparency-mode": {
+          "description": "Panel glass style, including floating/centered panel opacity and card translucency",
+          "label": "Transparency"
+        }
+      },
+      "power": {
+        "session-actions": {
+          "description": "Power menu entries, order, custom commands, and icons",
+          "label": "Entries"
+        }
+      },
+      "services": {
+        "audio-overdrive": {
+          "description": "Allow volume above 100%",
+          "label": "Audio Overdrive"
+        },
+        "calendar": {
+          "description": "Show events from your online calendar accounts",
+          "label": "Calendar"
+        },
+        "calendar-add": {
+          "button": "Add Account",
+          "description": "Add iCloud, CalDAV, or Google accounts",
+          "label": "Calendar Accounts"
+        },
+        "calendar-edit": {
+          "button": "Edit",
+          "description": "Update this calendar account"
+        },
+        "calendar-refresh-interval": {
+          "description": "How often to sync calendar events (minutes)",
+          "label": "Refresh Interval"
+        },
+        "day-temperature": {
+          "description": "Color temperature during the day (Kelvin)",
+          "label": "Day Temperature"
+        },
+        "ddcutil": {
+          "description": "Control external monitor brightness via DDC/CI",
+          "label": "DDC/CI (ddcutil)",
+          "requires-ddcutil": "Install ddcutil to enable DDC/CI brightness control"
+        },
+        "force-night-light": {
+          "description": "Always apply night light regardless of time",
+          "label": "Force Night Light"
+        },
+        "latitude": {
+          "description": "Manual latitude for the sunrise/sunset schedule, used when auto-locate and address are off",
+          "label": "Latitude"
+        },
+        "location-address": {
+          "description": "City or address to locate, used when auto-locate is off",
+          "label": "Address",
+          "placeholder": "City, Country"
+        },
+        "location-auto-locate": {
+          "description": "Detect your location automatically from your IP address",
+          "label": "Auto-Locate (IP)"
+        },
+        "longitude": {
+          "description": "Manual longitude for the sunrise/sunset schedule, used when auto-locate and address are off",
+          "label": "Longitude"
+        },
+        "minimum-brightness": {
+          "description": "Prevent the screen from going completely dark",
+          "label": "Minimum Brightness"
+        },
+        "mpris-blacklist": {
+          "description": "Players to ignore for media controls and Now Playing",
+          "label": "MPRIS Player Blacklist"
+        },
+        "night-light": {
+          "description": "Shift screen colors warmer at night",
+          "label": "Night Light",
+          "requires-gamma-control": "Compositor does not support gamma control"
+        },
+        "night-temperature": {
+          "description": "Color temperature at night (Kelvin)",
+          "label": "Night Temperature"
+        },
+        "notification-sound": {
+          "description": "Sound file used for notification feedback",
+          "label": "Notification Sound",
+          "placeholder": "/path/to/sound.wav"
+        },
+        "shell-sounds": {
+          "description": "Play sound effects for shell events",
+          "label": "Shell Sounds"
+        },
+        "sound-volume": {
+          "description": "Volume for shell sound effects",
+          "label": "Sound Volume"
+        },
+        "sunrise": {
+          "description": "Manual sunrise time in HH:MM, used when no location is set",
+          "label": "Sunrise"
+        },
+        "sunset": {
+          "description": "Manual sunset time in HH:MM, used when no location is set",
+          "label": "Sunset"
+        },
+        "system-monitor": {
+          "cpu-poll": {
+            "description": "Seconds between CPU usage, CPU temperature, and load-average samples (0 disables)",
+            "label": "CPU Poll Interval"
+          },
+          "description": "Sample CPU, memory, network, load, temperature, and disk statistics",
+          "disk-poll": {
+            "description": "Seconds between disk usage and swap usage samples (0 disables)",
+            "label": "Disk Poll Interval"
+          },
+          "gpu-poll": {
+            "description": "Seconds between GPU temperature and VRAM samples. 0 disables it (default), which avoids waking a discrete GPU; 5 is a good interval if you do enable it",
+            "label": "GPU Poll Interval"
+          },
+          "label": "System Monitor",
+          "memory-poll": {
+            "description": "Seconds between RAM usage samples (0 disables)",
+            "label": "Memory Poll Interval"
+          },
+          "network-poll": {
+            "description": "Seconds between network throughput samples (0 disables)",
+            "label": "Network Poll Interval"
+          },
+          "stats": {
+            "cpu-temp": "CPU Temp",
+            "cpu-usage": "CPU Usage",
+            "disk-usage": "Disk Usage",
+            "gpu-temp": "GPU Temp",
+            "gpu-usage": "GPU Usage",
+            "gpu-vram": "GPU VRAM",
+            "network-rx": "Download",
+            "network-tx": "Upload",
+            "ram-usage": "RAM Usage",
+            "swap-usage": "Swap Usage"
+          },
+          "threshold": {
+            "description": "Activity threshold (left) and critical threshold (right)",
+            "label": "{stat}"
+          }
+        },
+        "volume-change-sound": {
+          "description": "Sound file used for volume feedback",
+          "label": "Volume Change Sound",
+          "placeholder": "/path/to/sound.wav"
+        },
+        "weather": {
+          "description": "Enable the weather service",
+          "label": "Weather"
+        },
+        "weather-effects": {
+          "description": "Show visual weather effects",
+          "label": "Weather Effects"
+        },
+        "weather-refresh-interval": {
+          "description": "How often to refresh weather data (minutes)",
+          "label": "Refresh Interval"
+        },
+        "weather-unit": {
+          "description": "Unit system for weather display",
+          "label": "Units"
+        }
+      },
+      "shared": {
+        "auto-hide": {
+          "label": "Auto-Hide"
+        },
+        "background-opacity": {
+          "label": "Background Opacity"
+        },
+        "contact-shadow": {
+          "label": "Contact Shadow"
+        },
+        "corner-bottom-left": {
+          "label": "Bottom Left Radius"
+        },
+        "corner-bottom-right": {
+          "label": "Bottom Right Radius"
+        },
+        "corner-radius": {
+          "label": "Corner Radius"
+        },
+        "corner-top-left": {
+          "label": "Top Left Radius"
+        },
+        "corner-top-right": {
+          "label": "Top Right Radius"
+        },
+        "cross-axis-padding": {
+          "label": "Cross Axis Padding"
+        },
+        "edge-margin": {
+          "label": "Edge Margin"
+        },
+        "enabled": {
+          "label": "Enabled"
+        },
+        "ends-margin": {
+          "label": "Ends Margin"
+        },
+        "main-axis-padding": {
+          "label": "Main Axis Padding"
+        },
+        "position": {
+          "label": "Position"
+        },
+        "reserve-space": {
+          "label": "Reserve Space"
+        },
+        "shadow": {
+          "label": "Shadow"
+        },
+        "shadow-alpha": {
+          "label": "Shadow Opacity"
+        },
+        "shadow-direction": {
+          "label": "Shadow Direction"
+        }
+      },
+      "shell": {
+        "avatar-path": {
+          "description": "Path to a custom avatar image. Large images are cropped and resized automatically.",
+          "label": "Avatar Path",
+          "placeholder": "/path/to/avatar.png"
+        },
+        "clipboard-auto-paste": {
+          "description": "Automatically paste clipboard selections",
+          "label": "Clipboard Auto-Paste"
+        },
+        "clipboard-confirm-clear-history": {
+          "description": "Ask before clearing clipboard history or deleting an unpinned entry from the panel; when off, those actions apply immediately (pinned entries still ask before delete)",
+          "label": "Confirm Clear History"
+        },
+        "clipboard-enabled": {
+          "description": "Enable clipboard history, the clipboard panel, and copy/paste integration",
+          "label": "Clipboard"
+        },
+        "clipboard-history-max-entries": {
+          "description": "Maximum unpinned entries kept in clipboard history",
+          "label": "History Size"
+        },
+        "clipboard-image-action": {
+          "description": "Command to run from image clipboard entries; use {path} for the file path, {stdin} to mark the stdin position, or omit {path} to pipe automatically",
+          "label": "Image Action Command",
+          "placeholder": "gimp {path} or satty -f -"
+        },
+        "date-format": {
+          "description": "Default date format for shell UI without its own setting",
+          "label": "Date Format"
+        },
+        "launch-apps-as-systemd-services": {
+          "description": "Launches applications in separate systemd services so they don't share Noctalia's cgroup",
+          "label": "Launch Apps as systemd Services"
+        },
+        "middle-click-opens-widget-settings": {
+          "description": "Open a bar widget's settings from the bar with middle click",
+          "label": "Middle Click Opens Widget Settings"
+        },
+        "niri-overview-type-to-launch": {
+          "description": "Open the launcher when typing in niri overview; uses a tiny keyboard-focus surface while overview is open",
+          "label": "Type to Launch"
+        },
+        "offline-mode": {
+          "description": "Block all outgoing network requests",
+          "label": "Offline Mode"
+        },
+        "osd-background-opacity": {
+          "description": "Background opacity of OSD popups",
+          "label": "Background Opacity"
+        },
+        "osd-kinds-bluetooth": {
+          "description": "Show an OSD popup when Bluetooth is toggled",
+          "label": "Bluetooth"
+        },
+        "osd-kinds-brightness": {
+          "description": "Show an OSD popup when display brightness changes",
+          "label": "Brightness"
+        },
+        "osd-kinds-caffeine": {
+          "description": "Show an OSD popup when the caffeine (idle inhibitor) state changes",
+          "label": "Caffeine"
+        },
+        "osd-kinds-dnd": {
+          "description": "Show an OSD popup when Do Not Disturb is toggled",
+          "label": "Do Not Disturb"
+        },
+        "osd-kinds-keyboard-layout": {
+          "description": "Show an OSD popup when the input keyboard layout changes",
+          "label": "Keyboard Layout"
+        },
+        "osd-kinds-lock-keys": {
+          "description": "Show OSD popups for Caps Lock, Num Lock, and Scroll Lock changes",
+          "label": "Lock Keys"
+        },
+        "osd-kinds-media": {
+          "description": "Show an OSD popup when a new track starts playing",
+          "label": "Now Playing"
+        },
+        "osd-kinds-power-profile": {
+          "description": "Show an OSD popup when the power profile changes",
+          "label": "Power Profile"
+        },
+        "osd-kinds-volume": {
+          "description": "Show OSD popups when volume changes; use advanced settings to control output and input separately",
+          "label": "Volume"
+        },
+        "osd-kinds-volume-input": {
+          "description": "Show an OSD popup when input (microphone) volume changes",
+          "label": "Input Volume"
+        },
+        "osd-kinds-volume-output": {
+          "description": "Show an OSD popup when output (speaker) volume changes",
+          "label": "Output Volume"
+        },
+        "osd-kinds-wifi": {
+          "description": "Show an OSD popup when Wi-Fi is toggled",
+          "label": "Wi-Fi"
+        },
+        "osd-monitors": {
+          "description": "Choose which monitors show OSD popups; leave empty to show on all monitors",
+          "label": "Monitors"
+        },
+        "osd-offset-x": {
+          "description": "Absolute horizontal margin from the screen edge",
+          "label": "Horizontal Margin"
+        },
+        "osd-offset-y": {
+          "description": "Absolute vertical margin from the screen edge",
+          "label": "Vertical Margin"
+        },
+        "osd-orientation": {
+          "description": "Layout direction for OSD popups",
+          "label": "Orientation"
+        },
+        "osd-position": {
+          "description": "Screen position for OSD popups",
+          "label": "Screen Position"
+        },
+        "osd-scale": {
+          "description": "Scale OSD popups relative to the shell UI scale (1.0 keeps the default size)",
+          "label": "Scale"
+        },
+        "password-style": {
+          "description": "Visual style for password input masking",
+          "label": "Password Style"
+        },
+        "polkit-agent": {
+          "description": "Enable the built-in authentication agent",
+          "label": "Polkit Agent"
+        },
+        "screen-time-enabled": {
+          "description": "Track per-app usage and show it in Control Center",
+          "label": "Screen Time"
+        },
+        "screen-time-reset": {
+          "button": "Reset",
+          "description": "Clear stored per-app foreground usage history",
+          "label": "Reset Screen Time Data"
+        },
+        "screenshot-copy-to-clipboard": {
+          "description": "Place the captured PNG on the clipboard selection",
+          "label": "Copy to Clipboard"
+        },
+        "screenshot-directory": {
+          "description": "Folder for saved PNG files; leave empty to use ~/Pictures",
+          "label": "Output Directory",
+          "placeholder": "~/Pictures"
+        },
+        "screenshot-filename-pattern": {
+          "description": "strftime pattern without extension (.png is added); use %s for unix epoch",
+          "label": "Filename Pattern"
+        },
+        "screenshot-freeze-screen": {
+          "description": "Capture the desktop before region selection so moving content stays still",
+          "label": "Freeze Screen"
+        },
+        "screenshot-pipe-command": {
+          "description": "Command run as /bin/sh -lc with the PNG on stdin; for annotators or uploaders (for example: swappy -f - or satty -f -)",
+          "label": "Pipe Command",
+          "placeholder": "swappy -f -"
+        },
+        "screenshot-pipe-to-command": {
+          "description": "Send the captured PNG to a shell command on stdin",
+          "label": "Pipe to Command"
+        },
+        "screenshot-save-to-file": {
+          "description": "Write screenshots as PNG files to the output directory",
+          "label": "Save to File"
+        },
+        "show-location": {
+          "description": "Show location name in weather widgets",
+          "label": "Show Location"
+        },
+        "sync-greeter": {
+          "button": "Sync Now",
+          "description": "Copy the current wallpaper and colors to Noctalia Greeter (requires administrator approval)",
+          "label": "Noctalia Greeter"
+        },
+        "telemetry": {
+          "description": "Sends a small anonymous startup ping with version, OS, compositor, monitor resolutions, RAM, and UI scale",
+          "label": "Anonymous Startup Ping"
+        },
+        "time-format": {
+          "description": "Default time format for shell UI without its own setting",
+          "label": "Time Format"
+        }
+      },
+      "system": {
+        "battery-device-warning-threshold": {
+          "description": "Override the battery warning threshold for this device. Set 0 to disable warnings for this device.",
+          "label": "{device} Warning Threshold"
+        },
+        "battery-warning-threshold": {
+          "description": "System battery percentage at or below which the shell sends a low-battery notification and battery widgets use their warning color. Set 0 to disable.",
+          "label": "Battery Warning Threshold"
+        }
+      },
+      "templates": {
+        "builtin-ids": {
+          "description": "Toggle bundled app templates to render on each theme change",
+          "empty": "No built-in templates are available.",
+          "label": "Built-In Templates"
+        },
+        "community-ids": {
+          "description": "Toggle cached community templates to render on each theme change",
+          "empty": "No community templates are available yet. Enable community templates and refresh the catalog first.",
+          "label": "Community Templates"
+        },
+        "enable-builtins": {
+          "description": "Use the bundled catalog of theme templates for apps",
+          "label": "Enable Built-In Templates"
+        },
+        "enable-community-templates": {
+          "description": "Download and apply templates from the community catalog",
+          "label": "Enable Community Templates"
+        }
+      },
+      "wallpaper": {
+        "automation": {
+          "description": "Cycle wallpapers automatically on a timer",
+          "label": "Automatic Rotation"
+        },
+        "automation-interval": {
+          "description": "Seconds between wallpaper changes",
+          "label": "Rotation Interval"
+        },
+        "automation-order": {
+          "description": "Pick wallpapers randomly or alphabetically",
+          "label": "Order"
+        },
+        "automation-recursive": {
+          "description": "Search nested folders for wallpapers",
+          "label": "Include Subfolders"
+        },
+        "directory": {
+          "description": "Folder containing wallpapers",
+          "label": "Wallpaper Directory"
+        },
+        "directory-dark": {
+          "description": "Wallpaper folder used in dark theme mode",
+          "label": "Dark Mode Directory",
+          "placeholder": "~/Pictures/Wallpapers"
+        },
+        "directory-light": {
+          "description": "Wallpaper folder used in light theme mode",
+          "label": "Light Mode Directory",
+          "placeholder": "~/Pictures/Wallpapers"
+        },
+        "edge-smoothness": {
+          "description": "Feathering of transition edges between wallpapers",
+          "label": "Edge Smoothness"
+        },
+        "enabled": {
+          "description": "Enable the wallpaper service"
+        },
+        "fill-color": {
+          "description": "Solid color shown behind image in uncovered areas",
+          "label": "Fill Color"
+        },
+        "fill-mode": {
+          "description": "How wallpapers fit the screen",
+          "label": "Fill Mode"
+        },
+        "monitor-directory": {
+          "label": "Wallpaper Directory"
+        },
+        "monitor-directory-dark": {
+          "label": "Dark Mode Directory",
+          "placeholder": "~/Pictures/Wallpapers"
+        },
+        "monitor-directory-light": {
+          "label": "Light Mode Directory",
+          "placeholder": "~/Pictures/Wallpapers"
+        },
+        "panel": {
+          "button": "Open Panel",
+          "description": "Open the wallpaper picker panel",
+          "label": "Wallpaper Panel"
+        },
+        "per-monitor-directories": {
+          "description": "Use separate wallpaper folders for each monitor",
+          "label": "Per-Monitor Directories"
+        },
+        "transition-duration": {
+          "description": "Length of the wallpaper change animation in milliseconds",
+          "label": "Transition Duration"
+        },
+        "transition-on-startup": {
+          "description": "Play a transition when the shell first shows a wallpaper",
+          "label": "Animate on Startup"
+        },
+        "transitions": {
+          "description": "Effects available when changing wallpaper (one is picked at random per change)",
+          "label": "Transition Effects"
+        }
+      }
+    },
+    "session-actions": {
+      "add": "Add action",
+      "clear-glyph": "Clear",
+      "command-label": "Shell command",
+      "command-placeholder": "Optional bash command, leave empty for built-in behavior",
+      "command-required-placeholder": "Shell command to run",
+      "glyph-label": "Glyph",
+      "glyph-picker-title": "Action glyph",
+      "kind-section-label": "Behavior",
+      "label-field": "Label",
+      "label-placeholder": "Optional button text",
+      "shortcut-label": "Shortcut",
+      "variant": {
+        "default": "Default",
+        "destructive": "Destructive",
+        "ghost": "Ghost",
+        "outline": "Outline",
+        "primary": "Primary",
+        "secondary": "Secondary"
+      },
+      "variant-label": "Button style"
+    },
+    "widgets": {
+      "instances": {
+        "cpu": "CPU",
+        "date": "Date",
+        "input-volume": "Input Volume",
+        "network-rx": "Network RX",
+        "network-tx": "Network TX",
+        "output-volume": "Output Volume",
+        "ram": "RAM",
+        "temp": "Temperature"
+      },
+      "options": {
+        "always": "Always",
+        "cpu-temp": "CPU Temperature",
+        "cpu-usage": "CPU Usage",
+        "disk-percent": "Disk Percent",
+        "full": "Full",
+        "gauge": "Gauge",
+        "glyph": "Glyph",
+        "gpu-temp": "GPU Temperature",
+        "gpu-usage": "GPU Usage",
+        "gpu-vram": "GPU VRAM",
+        "graph": "Graph",
+        "graphic": "Graphic",
+        "icon-and-text": "Icon and Text",
+        "icon-only": "Icon Only",
+        "id": "ID",
+        "input": "Input",
+        "instance": "Per Placement",
+        "name": "Name",
+        "net-rx": "Network RX",
+        "net-tx": "Network TX",
+        "none": "None",
+        "on-hover": "On Hover",
+        "output": "Output",
+        "ram-percent": "RAM Percent",
+        "ram-used": "RAM Used",
+        "screenshot-primary-fullscreen": "Fullscreen",
+        "screenshot-primary-region": "Region",
+        "shared": "Shared",
+        "short": "Short",
+        "swap-percent": "Swap Percent",
+        "text": "Text",
+        "text-only": "Text Only",
+        "workspace-label-centered": "Centered",
+        "workspace-label-corner": "Corner",
+        "workspace-label-inside": "Inside pill"
+      },
+      "settings": {
+        "active-opacity": {
+          "description": "Opacity of the icon for the active (focused) window.",
+          "label": "Active Icon Opacity"
+        },
+        "album-art-only": {
+          "description": "Show only the circular album artwork without the track title",
+          "label": "Album Art Only"
+        },
+        "anchor": {
+          "description": "Pin this widget as the center alignment anchor",
+          "label": "Anchor"
+        },
+        "art-size": {
+          "description": "Media artwork size in pixels",
+          "label": "Art Size"
+        },
+        "bands": {
+          "description": "Number of visualizer bands",
+          "label": "Bands"
+        },
+        "capsule": {
+          "description": "Draw a capsule behind this widget",
+          "label": "Capsule"
+        },
+        "capsule-border": {
+          "description": "Color role for the capsule outline; fixed hex colors are also supported",
+          "label": "Capsule Border"
+        },
+        "capsule-fill": {
+          "description": "Color role for the capsule background; fixed hex colors are also supported",
+          "label": "Capsule Fill"
+        },
+        "capsule-foreground": {
+          "description": "Color role for content inside the capsule; fixed hex colors are also supported",
+          "label": "Capsule Foreground"
+        },
+        "capsule-opacity": {
+          "description": "Opacity of the capsule background",
+          "label": "Capsule Opacity"
+        },
+        "capsule-padding": {
+          "description": "Inner padding inside the capsule",
+          "label": "Capsule Padding"
+        },
+        "capsule-radius": {
+          "description": "Corner radius for this widget capsule; leave blank for automatic pill shape, or set 0 for square corners",
+          "label": "Capsule Radius",
+          "taskbar-description": "Corner radius for the widget capsule, workspace disc indicators, and workspace group capsules; leave blank for automatic pill shape, or set 0 for square corners",
+          "workspaces-description": "Corner radius for this widget capsule and workspace pills; leave blank for automatic pill shape, or set 0 for square corners"
+        },
+        "centered": {
+          "description": "Center visualizer bars instead of aligning them to the edge",
+          "label": "Centered"
+        },
+        "color": {
+          "description": "Color role for this widget's icon and label; fixed hex colors are also supported",
+          "label": "Color"
+        },
+        "color-1": {
+          "description": "First gradient color in the visualizer",
+          "label": "Color One"
+        },
+        "color-2": {
+          "description": "Second gradient color in the visualizer",
+          "label": "Color Two"
+        },
+        "command": {
+          "description": "Shell command run when left-clicking this button",
+          "label": "Left Click Command"
+        },
+        "custom-image": {
+          "description": "Path to a custom image. Leave empty to use the icon glyph.",
+          "dialog-title": "Select custom image",
+          "label": "Custom image"
+        },
+        "custom-image-colorize": {
+          "description": "Tint the custom image with the widget Icon Color setting",
+          "label": "Colorize custom image"
+        },
+        "custom-labels": {
+          "description": "Map keyboard layout names to custom labels",
+          "label": "Custom Labels"
+        },
+        "cycle-command": {
+          "description": "Command run when cycling keyboard layouts",
+          "label": "Cycle Command"
+        },
+        "detached-panel": {
+          "description": "Open the drawer as a floating panel with its own background instead of merging with the bar",
+          "label": "Detached Panel"
+        },
+        "device": {
+          "description": "Device to monitor or control",
+          "label": "Device"
+        },
+        "display": {
+          "active-window-description": "Icon, title, or both on horizontal bars. Vertical bars stay icon-only.",
+          "description": "Display mode for this widget",
+          "label": "Display"
+        },
+        "display-mode": {
+          "description": "Render the battery as a graphical shape or a Tabler glyph",
+          "label": "Display Mode"
+        },
+        "drawer": {
+          "description": "Show a tray button in the bar and open items in a panel",
+          "label": "Use Drawer Panel"
+        },
+        "drawer-columns": {
+          "description": "Number of tray icons per row in the drawer panel",
+          "label": "Drawer Columns"
+        },
+        "empty-color": {
+          "description": "Color role used for empty workspaces; fixed hex colors are also supported",
+          "label": "Empty Color"
+        },
+        "focused-color": {
+          "description": "Color role used for the focused workspace; fixed hex colors are also supported",
+          "label": "Focused Color"
+        },
+        "font-family": {
+          "description": "Typeface for this widget; leave empty to inherit the bar font",
+          "label": "Font Family"
+        },
+        "font-weight": {
+          "description": "Default inherits the bar font weight",
+          "label": "Font Weight"
+        },
+        "format": {
+          "description": "Time format string",
+          "label": "Format"
+        },
+        "glyph": {
+          "description": "Icon glyph name",
+          "label": "Glyph"
+        },
+        "group-by-workspace": {
+          "description": "Group taskbar icons into workspace capsules when compositor data is available",
+          "label": "Group by Workspace"
+        },
+        "group-single-icon-per-app": {
+          "description": "When grouping by workspace, collapse multiple windows from the same app into one icon with a count badge.",
+          "label": "Single Icon per App"
+        },
+        "height": {
+          "description": "Widget height in pixels",
+          "label": "Height"
+        },
+        "hidden": {
+          "description": "Tray item ids to hide",
+          "label": "Hidden Items"
+        },
+        "hide-empty-workspaces": {
+          "description": "When grouping by workspace, omit capsules that have no running windows in the taskbar list.",
+          "label": "Hide Empty Workspaces"
+        },
+        "hide-when-empty": {
+          "description": "Hide workspace pills when there are no open windows",
+          "label": "Hide When Empty",
+          "workspaces-description": "Hide workspace pills that have no open windows"
+        },
+        "hide-when-full": {
+          "description": "Hide the battery widget when fully charged",
+          "label": "Hide When Full"
+        },
+        "hide-when-no-connected-device": {
+          "description": "Hide the bluetooth widget when no device is connected",
+          "label": "Hide When No Connected Device"
+        },
+        "hide-when-no-media": {
+          "description": "Hide the media widget when no MPRIS player is active",
+          "label": "Hide When No Media"
+        },
+        "hide-when-no-unread": {
+          "description": "Hide the notifications widget when there are no unread notifications",
+          "label": "Hide When No New"
+        },
+        "hide-when-off": {
+          "description": "Hide the lock key indicator when inactive",
+          "label": "Hide When Off"
+        },
+        "hide-when-plugged": {
+          "description": "Hide the battery widget while connected to AC power",
+          "label": "Hide When Plugged In"
+        },
+        "hide-when-single-layout": {
+          "description": "Hide the keyboard layout widget unless more than one layout is configured",
+          "label": "Hide When Single Layout"
+        },
+        "highlight-color": {
+          "description": "Color reached at or above the critical threshold",
+          "label": "Highlight Color"
+        },
+        "hot-reload": {
+          "description": "Reload the scripted widget when its source changes",
+          "label": "Hot Reload"
+        },
+        "icon-color": {
+          "description": "Overrides the widget color for icons only; fixed hex colors are also supported",
+          "label": "Icon Color"
+        },
+        "icon-size": {
+          "description": "Icon size in pixels",
+          "label": "Icon Size"
+        },
+        "interface": {
+          "description": "Network interface to monitor; leave empty to use the total across all interfaces",
+          "label": "Interface"
+        },
+        "inactive-opacity": {
+          "description": "Opacity of icons for inactive (unfocused) windows.",
+          "label": "Inactive Icon Opacity"
+        },
+        "label": {
+          "description": "Optional static text shown on this button",
+          "label": "Label"
+        },
+        "label-min-width": {
+          "description": "Minimum label width in pixels to prevent resizing",
+          "label": "Label Min Width"
+        },
+        "labels-only-when-occupied": {
+          "description": "Hide workspace labels on empty, inactive workspaces",
+          "label": "Labels Only When Occupied",
+          "workspaces-description": "Show workspace id or name labels on workspaces with open windows and on the active workspace even when it is empty; other empty tags stay unlabeled"
+        },
+        "length": {
+          "description": "Spacer length in pixels",
+          "label": "Length"
+        },
+        "match-adjacent-spacing": {
+          "description": "Widen gaps between inline tray icons to match the visual spacing of neighboring bar widgets (includes capsule padding)",
+          "label": "Match Adjacent Widget Spacing"
+        },
+        "max-label-chars": {
+          "description": "Maximum number of characters to show for workspace names",
+          "label": "Max Label Characters",
+          "workspaces-description": "Maximum characters for workspace name labels"
+        },
+        "max-length": {
+          "description": "Maximum widget length in pixels",
+          "label": "Max Length"
+        },
+        "middle-command": {
+          "description": "Shell command run when middle-clicking this button. When set, middle-click opens this command instead of widget settings.",
+          "label": "Middle Click Command"
+        },
+        "min-length": {
+          "description": "Minimum widget length in pixels",
+          "label": "Min Length"
+        },
+        "minimal": {
+          "description": "Show workspace id or name labels only, without animated pills",
+          "label": "Minimal Style",
+          "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation"
+        },
+        "mirrored": {
+          "description": "Mirror the visualizer around its center",
+          "label": "Mirrored"
+        },
+        "occupied-color": {
+          "description": "Color role used for occupied workspaces; fixed hex colors are also supported",
+          "label": "Occupied Color"
+        },
+        "only-active-workspace": {
+          "description": "Hide windows on inactive workspaces.",
+          "label": "Only Active Workspace"
+        },
+        "path": {
+          "description": "Path used by disk statistics",
+          "label": "Path"
+        },
+        "pill-scale": {
+          "description": "Adjust the scale of workspace pills",
+          "label": "Pill Scale",
+          "workspaces-description": "Adjust the scale of workspace pills"
+        },
+        "pinned": {
+          "description": "Tray item ids that stay visible in the bar when drawer mode is enabled",
+          "label": "Pinned Items"
+        },
+        "primary-click": {
+          "description": "Action performed when left-clicking the bar button",
+          "label": "Primary click"
+        },
+        "right-command": {
+          "description": "Shell command run when right-clicking this button",
+          "label": "Right Click Command"
+        },
+        "scale": {
+          "description": "Scale this widget relative to the bar content scale",
+          "label": "Scale"
+        },
+        "scope": {
+          "description": "Run one script runtime per live widget placement, or share one runtime across bars with the same widget id",
+          "label": "Runtime Scope"
+        },
+        "script": {
+          "description": "Path to the lua script",
+          "label": "Script"
+        },
+        "scroll-down-command": {
+          "description": "Shell command run when scrolling down over this button",
+          "label": "Scroll Down Command"
+        },
+        "scroll-step": {
+          "description": "Percentage change applied on each mouse wheel step",
+          "label": "Scroll Step"
+        },
+        "scroll-up-command": {
+          "description": "Shell command run when scrolling up over this button",
+          "label": "Scroll Up Command"
+        },
+        "show-active-indicator": {
+          "description": "Show a small dot below the active window icon in the taskbar.",
+          "label": "Active Window Indicator"
+        },
+        "show-all-outputs": {
+          "description": "Include windows from every display on this widget.",
+          "label": "Show All Monitors"
+        },
+        "show-caps-lock": {
+          "description": "Show Caps Lock state",
+          "label": "Show Caps Lock"
+        },
+        "show-condition": {
+          "description": "Show weather condition text",
+          "label": "Show Condition"
+        },
+        "show-empty-label": {
+          "description": "Show placeholder text when no window is focused instead of hiding the widget",
+          "label": "Show Empty Label"
+        },
+        "show-icon": {
+          "description": "Show this widget's icon",
+          "label": "Show Icon"
+        },
+        "show-label": {
+          "description": "Show text next to the icon",
+          "label": "Show Label"
+        },
+        "show-num-lock": {
+          "description": "Show Num Lock state",
+          "label": "Show Num Lock"
+        },
+        "show-scroll-lock": {
+          "description": "Show Scroll Lock state",
+          "label": "Show Scroll Lock"
+        },
+        "show-when-idle": {
+          "description": "Keep the visualizer visible even when no media is playing",
+          "label": "Show When Idle"
+        },
+        "show-window-title": {
+          "description": "Show the window title next to its icon (only on horizontal bars)",
+          "label": "Show Window Title"
+        },
+        "show-workspace-label": {
+          "description": "Show the small workspace tag on grouped taskbar capsules. Turn off for icon-only groups.",
+          "label": "Workspace Capsule Label"
+        },
+        "stat": {
+          "description": "System statistic to display",
+          "label": "Stat"
+        },
+        "taskbar-max-width": {
+          "description": "Total width budget in pixels; window titles shrink to fit and hide when too narrow",
+          "label": "Taskbar Max Width"
+        },
+        "title-scroll": {
+          "description": "When the widget title should scroll",
+          "label": "Title Scroll"
+        },
+        "tooltip": {
+          "description": "Tooltip shown when hovering this button",
+          "label": "Tooltip"
+        },
+        "tooltip-format": {
+          "description": "Optional format for the tooltip",
+          "label": "Tooltip Format"
+        },
+        "type": {
+          "description": "Built-in widget type for this named widget",
+          "label": "Type"
+        },
+        "vertical-format": {
+          "description": "Optional format used on vertical bars",
+          "label": "Vertical Format"
+        },
+        "warning-color": {
+          "description": "Color applied when charge is at or below the System battery warning threshold",
+          "label": "Warning Color"
+        },
+        "width": {
+          "description": "Widget width in pixels",
+          "label": "Width"
+        },
+        "window-title-max-width": {
+          "description": "Maximum width in pixels for window titles",
+          "label": "Window Title Max Width"
+        },
+        "workspace-group-capsule": {
+          "description": "Draw the background and border around each grouped workspace. Turn off to keep icon grouping and workspace disc labels only.",
+          "label": "Workspace Group Capsule"
+        },
+        "workspace-label-placement": {
+          "description": "Corner, centered on the edge, or inside the pill.",
+          "label": "Workspace Label Placement"
+        }
+      },
+      "types": {
+        "active-window": "Active Window",
+        "audio-visualizer": "Audio Visualizer",
+        "battery": "Battery",
+        "bluetooth": "Bluetooth",
+        "brightness": "Brightness",
+        "caffeine": "Caffeine",
+        "clipboard": "Clipboard",
+        "clock": "Clock",
+        "control-center": "Control Center",
+        "custom-button": "Custom Button",
+        "keyboard-layout": "Keyboard Layout",
+        "launcher": "Launcher",
+        "lock-keys": "Lock Keys",
+        "media": "Media",
+        "network": "Network",
+        "nightlight": "Night Light",
+        "notifications": "Notifications",
+        "power-profile": "Power Profile",
+        "screenshot": "Screenshot",
+        "scripted": "Scripted",
+        "session": "Session",
+        "settings": "Settings",
+        "spacer": "Spacer",
+        "sysmon": "System Monitor",
+        "taskbar": "Taskbar",
+        "test": "Test",
+        "theme-mode": "Theme Mode",
+        "tray": "Tray",
+        "volume": "Volume",
+        "wallpaper": "Wallpaper",
+        "weather": "Weather",
+        "workspaces": "Workspaces"
+      }
+    },
+    "window": {
+      "export-config": "Export Config…",
+      "export-config-saved": "Config export saved.",
+      "filter-modified": "Modified",
+      "native-title": "Noctalia Settings",
+      "no-results": "No settings found",
+      "no-results-hint": "Try a different setting name or config key.",
+      "reset-page": "Reset Page",
+      "reset-page-confirm": "Confirm Reset",
+      "search-placeholder": "Search settings…",
+      "support-report": "Support Report",
+      "support-report-saved": "Support report saved.",
+      "support-report-title": "Save Support Report",
+      "title": "Settings"
+    }
+  },
+  "setup-wizard": {
+    "browse": "Browse",
+    "builtin-palette": "Built-In Palette",
+    "footer-note": "You can change these later in settings.",
+    "get-started": "Get Started",
+    "mode": "Mode",
+    "no-wallpaper-selected": "No wallpaper selected",
+    "select-wallpaper": "Select Wallpaper",
+    "subtitle": "A few quick choices to get you started.",
+    "title": "Welcome to Noctalia",
+    "wallpaper": "Wallpaper",
+    "wallpaper-scheme": "Wallpaper Scheme"
+  },
+  "system": {
+    "hardware": {
+      "unknown": "Unknown",
+      "unknown-cpu": "Unknown CPU",
+      "unknown-distro": "Unknown distro",
+      "unknown-gpu": "Unknown GPU"
+    }
+  },
+  "theme": {
+    "scheme": {
+      "dysfunctional": "Dysfunctional",
+      "faithful": "Faithful",
+      "m3-content": "M3 Content",
+      "m3-fruit-salad": "M3 Fruit Salad",
+      "m3-monochrome": "M3 Monochrome",
+      "m3-rainbow": "M3 Rainbow",
+      "m3-tonal-spot": "M3 Tonal Spot",
+      "muted": "Muted",
+      "vibrant": "Vibrant"
+    }
+  },
+  "time": {
+    "duration": {
+      "days-hours-minutes": "{days}d {hours}h {minutes}m",
+      "hours-minutes": "{hours}h {minutes}m",
+      "less-than-minute": "<1m",
+      "minutes": "{minutes}m"
+    },
+    "file": {
+      "unknown": "Unknown"
+    },
+    "relative": {
+      "days-ago": "{count} day ago",
+      "days-ago-plural": "{count} days ago",
+      "hours-ago": "{count} hr ago",
+      "hours-ago-plural": "{count} hr ago",
+      "just-now": "just now",
+      "minutes-ago": "{count} min ago",
+      "minutes-ago-plural": "{count} min ago"
+    }
+  },
+  "tray": {
+    "menu": {
+      "empty": "No menu items...",
+      "pin": "Pin",
+      "unpin": "Unpin"
+    }
+  },
+  "ui": {
+    "controls": {
+      "search-picker": {
+        "empty": "No results",
+        "placeholder": "Search..."
+      },
+      "select": {
+        "placeholder": "Select an option"
+      }
+    },
+    "dialogs": {
+      "color-picker": {
+        "title": "Color"
+      },
+      "file": {
+        "actions": {
+          "open": "Open",
+          "save": "Save",
+          "select-folder": "Select Folder"
+        },
+        "empty-filtered": "No files match the current filter",
+        "entry": {
+          "folder": "Folder"
+        },
+        "filename-placeholder": "Filename",
+        "filter-placeholder": "Filter...",
+        "sort": {
+          "ascending": "↑",
+          "date": "Date",
+          "descending": "↓",
+          "name": "Name",
+          "size": "Size"
+        },
+        "title": {
+          "default": "File Dialog",
+          "open": "Open File",
+          "save": "Save File",
+          "select-folder": "Select Folder"
+        }
+      },
+      "glyph-picker": {
+        "all-categories": "All",
+        "search-placeholder": "Search glyphs…",
+        "title": "Pick a Glyph"
+      }
+    }
+  },
+  "wallpaper": {
+    "panel": {
+      "all-monitors": "ALL",
+      "color-title": "Wallpaper color",
+      "filter-placeholder": "Filter...",
+      "flatten": "Flatten",
+      "sort-date-asc": "Sort by date (oldest first)",
+      "sort-date-desc": "Sort by date (newest first)",
+      "sort-name-asc": "Sort by name (A-Z)",
+      "sort-name-desc": "Sort by name (Z-A)",
+      "title": "Wallpaper"
+    }
+  },
+  "weather": {
+    "conditions": {
+      "full": {
+        "clear-sky": "Clear sky",
+        "drizzle": "Drizzle",
+        "fog": "Fog",
+        "mainly-clear": "Mainly clear",
+        "overcast": "Overcast",
+        "partly-cloudy": "Partly cloudy",
+        "rain-showers": "Rain showers",
+        "snow": "Snow",
+        "snow-showers": "Snow showers",
+        "thunderstorm": "Thunderstorm",
+        "unknown": "Unknown"
+      },
+      "short": {
+        "clear": "Clear",
+        "cloudy": "Cloudy",
+        "drizzle": "Drizzle",
+        "fog": "Fog",
+        "mostly-clear": "Mostly clear",
+        "overcast": "Overcast",
+        "showers": "Showers",
+        "snow": "Snow",
+        "snow-showers": "Snow showers",
+        "storm": "Storm",
+        "weather": "Weather"
+      }
+    },
+    "errors": {
+      "fetch-failed": "Weather fetch failed",
+      "parse-weather": "Could not parse weather response"
+    }
+  },
+  "window-switcher": {
+    "empty": "No open windows",
+    "hint": "Tab · Shift+Tab · Arrow keys · Release Alt to switch · Esc to cancel",
+    "title": "Windows"
+  }
+}

--- a/assets/translations/ca.json
+++ b/assets/translations/ca.json
@@ -695,2214 +695,2214 @@
     },
     "controls": {
       "keybind": {
-        "add": "Click to add keybind",
-        "recording-placeholder": "Press a key combination…",
-        "unset-placeholder": "Click to bind…"
+        "add": "Fes clic per afegir una drecera",
+        "recording-placeholder": "Prem una combinació de tecles…",
+        "unset-placeholder": "Fes clic per vincular…"
       },
       "list": {
-        "add-entry-placeholder": "Add entry…"
+        "add-entry-placeholder": "Afegeix una entrada…"
       },
       "path-browse": {
-        "file-title": "Choose file",
-        "folder-title": "Choose folder"
+        "file-title": "Tria un fitxer",
+        "folder-title": "Tria una carpeta"
       },
       "select": {
-        "unknown-value": "Unknown: {value}"
+        "unknown-value": "Desconegut: {value}"
       }
     },
     "dialogs": {
       "color-picker": {
-        "title": "Pick a Color"
+        "title": "Tria un color"
       }
     },
     "entities": {
       "bar": {
-        "create": "Create",
-        "delete": "Delete",
-        "delete-confirm-desc": "This GUI-created bar will be removed from settings.toml.",
-        "delete-confirm-title": "Delete \"{name}\"?",
-        "id-placeholder": "Bar id",
-        "label": "Bar: {name}",
-        "management": "Bar",
-        "move-down": "Move Down",
-        "move-up": "Move Up",
-        "new": "New Bar",
-        "rename": "Rename",
-        "rename-save": "Save"
+        "create": "Crea",
+        "delete": "Elimina",
+        "delete-confirm-desc": "Aquesta barra creada per la GUI s'eliminarà de settings.toml.",
+        "delete-confirm-title": "Vols eliminar «{name}»?",
+        "id-placeholder": "Id de la barra",
+        "label": "Barra: {name}",
+        "management": "Barra",
+        "move-down": "Mou avall",
+        "move-up": "Mou amunt",
+        "new": "Barra nova",
+        "rename": "Canvia el nom",
+        "rename-save": "Desa"
       },
       "monitor-override": {
-        "create": "Create",
-        "delete": "Delete",
-        "delete-confirm-desc": "This GUI-created monitor override will be removed from settings.toml.",
-        "delete-confirm-title": "Delete \"{name}\"?",
+        "create": "Crea",
+        "delete": "Elimina",
+        "delete-confirm-desc": "Aquesta sobrescriptura de monitor creada per la GUI s'eliminarà de settings.toml.",
+        "delete-confirm-title": "Vols eliminar «{name}»?",
         "label": "Monitor: {name}",
-        "management": "Monitor Override",
-        "match-placeholder": "Monitor match",
-        "new": "Monitor Override",
-        "rename": "Rename",
-        "rename-save": "Save"
+        "management": "Sobreescriptura de monitor",
+        "match-placeholder": "Coincidència del monitor",
+        "new": "Sobreescriptura de monitor",
+        "rename": "Canvia el nom",
+        "rename-save": "Desa"
       },
       "widget": {
-        "add": "Add widget",
+        "add": "Afegeix un widget",
         "detail": {
-          "custom": "custom widget"
+          "custom": "widget personalitzat"
         },
         "editor": {
-          "description": "Arrange widgets across the bar lanes",
-          "title": "Bar Widgets"
+          "description": "Organitza els widgets a través dels carrils de la barra",
+          "title": "Widgets de la barra"
         },
         "group": {
-          "action": "Group",
-          "border": "Border",
-          "border-description": "Capsule outline color role; leave on Default for no outline",
-          "clear": "Clear",
-          "edit": "Edit style",
-          "fill": "Background",
-          "fill-description": "Capsule background color role; fixed hex colors are also supported",
-          "foreground": "Foreground",
-          "foreground-description": "Icon and label color role for widgets in this group",
-          "hint": "Part of a capsule group",
+          "action": "Agrupa",
+          "border": "Vora",
+          "border-description": "Color de la vora de la càpsula; deixa a Per defecte per no tenir vora",
+          "clear": "Esborra",
+          "edit": "Edita l'estil",
+          "fill": "Fons",
+          "fill-description": "Color de fons de la càpsula; també s'admeten colors hex fixos",
+          "foreground": "Primer pla",
+          "foreground-description": "Color d'icona i etiqueta per als widgets d'aquest grup",
+          "hint": "Part d'un grup de càpsula",
           "members": "{count} widgets",
-          "opacity": "Opacity",
-          "opacity-description": "Capsule background opacity",
-          "orphan": "Unknown group",
-          "padding": "Padding",
-          "padding-description": "Inner padding between the capsule edge and its widgets, in pixels",
-          "radius": "Radius",
-          "radius-description": "Capsule corner radius in pixels; Auto inherits the bar's capsule radius",
-          "selected": "{count} selected",
-          "style": "Style",
-          "title": "Capsule group",
-          "ungroup": "Ungroup"
+          "opacity": "Opacitat",
+          "opacity-description": "Opacitat del fons de la càpsula",
+          "orphan": "Grup desconegut",
+          "padding": "Farcit",
+          "padding-description": "Farcit interior entre la vora de la càpsula i els widgets, en píxels",
+          "radius": "Radi",
+          "radius-description": "Radi de les cantonades de la càpsula en píxels; Auto hereta el radi de la barra",
+          "selected": "{count} seleccionats",
+          "style": "Estil",
+          "title": "Grup de càpsula",
+          "ungroup": "Desagrupa"
         },
         "inspector": {
-          "add-instance-title": "Add new named {widget} widget to {lane}",
-          "add-title": "Add widget to {lane}",
-          "move-to-lane": "Move to {lane}"
+          "add-instance-title": "Afegeix el widget {widget} a {lane}",
+          "add-title": "Afegeix un widget a {lane}",
+          "move-to-lane": "Mou a {lane}"
         },
         "instance": {
-          "create-save": "Create",
-          "delete": "Delete",
-          "delete-confirm-desc": "This named widget will be removed from every bar and its settings discarded.",
-          "delete-confirm-title": "Delete \"{name}\"?",
-          "id-description": "Use letters, numbers, underscores, or hyphens only. No spaces; must be unique.",
-          "id-placeholder": "Widget id",
-          "rename": "Rename",
-          "rename-save": "Save"
+          "create-save": "Crea",
+          "delete": "Elimina",
+          "delete-confirm-desc": "Aquest widget s'eliminarà de totes les barres i la seva configuració es descartarà.",
+          "delete-confirm-title": "Vols eliminar «{name}»?",
+          "id-description": "Utilitza només lletres, números, guions baixos o guions. Sense espais; ha de ser únic.",
+          "id-placeholder": "Id del widget",
+          "rename": "Canvia el nom",
+          "rename-save": "Desa"
         },
         "lanes": {
-          "center": "Center",
-          "customize": "Customize",
-          "empty": "No widgets",
-          "empty-hint": "Add a widget to populate this lane.",
-          "end": "End",
-          "start": "Start"
+          "center": "Centre",
+          "customize": "Personalitza",
+          "empty": "No hi ha widgets",
+          "empty-hint": "Afegeix un widget per omplir aquest carril.",
+          "end": "Final",
+          "start": "Inici"
         },
         "picker": {
-          "empty": "No widgets found",
-          "instance-description": "Named widget for type \"{type}\"",
-          "instance-toggle": "Named Widget",
-          "placeholder": "Search widgets..."
+          "empty": "No s'han trobat widgets",
+          "instance-description": "Widget amb nom del tipus «{type}»",
+          "instance-toggle": "Widget amb nom",
+          "placeholder": "Cerca widgets..."
         },
         "raw": {
-          "delete": "Delete",
-          "description": "Unsupported keys preserved from this widget config.",
-          "title": "Raw Settings"
+          "delete": "Elimina",
+          "description": "Claus no suportades conservades de la configuració d'aquest widget.",
+          "title": "Configuració sense processar"
         },
         "settings": {
-          "empty": "No settings match the current filters.",
+          "empty": "No hi ha paràmetres que coincideixin amb els filtres actuals.",
           "groups": {
-            "grouping": "Grouping",
-            "presentation": "Presentation",
-            "runtime": "Runtime",
+            "grouping": "Agrupació",
+            "presentation": "Presentació",
+            "runtime": "Execució",
             "widget": "Widget"
           }
         }
       }
     },
     "errors": {
-      "avatar-accounts": "Could not update the system account avatar.",
-      "avatar-invalid-path": "The selected avatar path is not a readable image file.",
-      "avatar-load": "Could not load the selected image. Use PNG, JPEG, WebP, GIF, BMP, or SVG.",
-      "avatar-write": "Could not prepare the avatar image for saving.",
+      "avatar-accounts": "No s'ha pogut actualitzar l'avatar del compte del sistema.",
+      "avatar-invalid-path": "El camí de l'avatar seleccionat no és un fitxer d'imatge llegible.",
+      "avatar-load": "No s'ha pogut carregar la imatge seleccionada. Utilitza PNG, JPEG, WebP, GIF, BMP o SVG.",
+      "avatar-write": "No s'ha pogut preparar la imatge de l'avatar per desar-la.",
       "bar": {
-        "create": "Could not create bar.",
-        "delete": "Could not delete bar.",
-        "move": "Could not move bar.",
-        "rename": "Could not rename bar."
+        "create": "No s'ha pogut crear la barra.",
+        "delete": "No s'ha pogut eliminar la barra.",
+        "move": "No s'ha pogut moure la barra.",
+        "rename": "No s'ha pogut canviar el nom de la barra."
       },
-      "batch-write": "Some settings could not be saved.",
-      "export-config": "Failed to save config export.",
-      "export-wallpaper-palette": "Could not save the wallpaper palette as a custom palette.",
+      "batch-write": "No s'han pogut desar alguns paràmetres.",
+      "export-config": "No s'ha pogut desar l'exportació de la configuració.",
+      "export-wallpaper-palette": "No s'ha pogut desar la paleta del fons de pantalla com a paleta personalitzada.",
       "monitor-override": {
-        "create": "Could not create monitor override.",
-        "delete": "Could not delete monitor override.",
-        "rename": "Could not rename monitor override."
+        "create": "No s'ha pogut crear la sobrescriptura de monitor.",
+        "delete": "No s'ha pogut eliminar la sobrescriptura de monitor.",
+        "rename": "No s'ha pogut canviar el nom de la sobrescriptura de monitor."
       },
-      "reset-page": "Failed to reset some settings.",
-      "support-report": "Failed to save support report.",
-      "sync-greeter": "Could not sync appearance to Noctalia Greeter.",
+      "reset-page": "No s'han pogut restablir alguns paràmetres.",
+      "support-report": "No s'ha pogut desar l'informe d'assistència.",
+      "sync-greeter": "No s'ha pogut sincronitzar l'aparença amb el Noctalia Greeter.",
       "widget": {
-        "rename": "Could not rename named widget."
+        "rename": "No s'ha pogut canviar el nom del widget."
       },
-      "write": "Failed to save settings."
+      "write": "No s'han pogut desar els paràmetres."
     },
     "export-config": {
-      "export": "Export",
-      "full-effective-description": "Exports every active setting, including built-in defaults. Useful for inspection or sharing a snapshot, but pins current defaults explicitly.",
-      "full-effective-save-title": "Save Full Effective Config",
-      "full-effective-title": "Full Effective Config",
-      "merged-user-description": "Combines config files and GUI overrides into one TOML file. Built-in defaults stay implicit.",
-      "merged-user-save-title": "Save Merged User Config",
-      "merged-user-title": "Merged User Config (Recommended)",
-      "title": "Export Config"
+      "export": "Exporta",
+      "full-effective-description": "Exporta tots els paràmetres actius, inclosos els valors per defecte integrats. Útil per inspeccionar o compartir una instantània, però fixa els valors per defecte actuals explícitament.",
+      "full-effective-save-title": "Desa la configuració efectiva completa",
+      "full-effective-title": "Configuració efectiva completa",
+      "merged-user-description": "Combina fitxers de configuració i canvis de la GUI en un fitxer TOML. Els valors per defecte integrats romanen implícits.",
+      "merged-user-save-title": "Desa la configuració d'usuari combinada",
+      "merged-user-title": "Configuració d'usuari combinada (recomanada)",
+      "title": "Exporta la configuració"
     },
     "idle": {
       "behavior": {
-        "add": "Add behavior",
-        "command-label": "Idle command",
-        "command-placeholder": "notify-send \"Idle\"",
+        "add": "Afegeix un comportament",
+        "command-label": "Ordre d'inactivitat",
+        "command-placeholder": "notify-send \"Inactiu\"",
         "kind": {
-          "custom": "Custom",
-          "lock": "Lock",
-          "lock-and-suspend": "Lock & Suspend",
-          "screen-off": "Screen Off",
-          "suspend": "Suspend"
+          "custom": "Personalitzada",
+          "lock": "Bloqueja",
+          "lock-and-suspend": "Bloqueja i suspèn",
+          "screen-off": "Pantalla apagada",
+          "suspend": "Suspèn"
         },
-        "kind-section-label": "Action",
-        "name-label": "Name",
-        "name-placeholder": "idle-behavior",
-        "resume-command-label": "Resume command",
+        "kind-section-label": "Acció",
+        "name-label": "Nom",
+        "name-placeholder": "comportament-inactivitat",
+        "resume-command-label": "Ordre de represa",
         "resume-command-placeholder": "noctalia:dpms-on",
         "summary": "{name} · {seconds}s",
-        "summary-disabled-timeout": "{name} · timeout disabled",
-        "timeout-label": "Timeout seconds",
-        "unnamed": "Unnamed behavior"
+        "summary-disabled-timeout": "{name} · temps d'espera desactivat",
+        "timeout-label": "Temps d'espera en segons",
+        "unnamed": "Comportament sense nom"
       },
       "live-status": {
-        "active": "Active",
-        "idle-for-one": "Idle for 1 second",
-        "idle-for-seconds": "Idle for {seconds} seconds"
+        "active": "Actiu",
+        "idle-for-one": "Inactiu durant 1 segon",
+        "idle-for-seconds": "Inactiu durant {seconds} segons"
       }
     },
     "navigation": {
       "groups": {
-        "audio": "Audio",
-        "automation": "Automation",
+        "audio": "Àudio",
+        "automation": "Automatització",
         "backdrop": "Backdrop",
-        "background": "Background",
-        "battery": "Battery",
-        "behavior": "Behavior",
-        "brightness": "Brightness",
-        "built-in": "Built-In",
-        "calendar": "Calendar",
-        "capsules": "Capsules",
-        "clipboard": "Clipboard",
-        "community": "Community",
-        "control-center": "Control Center",
-        "directories": "Directories",
-        "effects": "Effects",
-        "filtering": "Filtering",
-        "focus-styling": "Focus Styling",
+        "background": "Fons",
+        "battery": "Bateria",
+        "behavior": "Comportament",
+        "brightness": "Brillantor",
+        "built-in": "Integrat",
+        "calendar": "Calendari",
+        "capsules": "Càpsules",
+        "clipboard": "Porta-retalls",
+        "community": "Comunitat",
+        "control-center": "Centre de control",
+        "directories": "Directoris",
+        "effects": "Efectes",
+        "filtering": "Filtratge",
+        "focus-styling": "Estil de focus",
         "formats": "Formats",
         "general": "General",
-        "grouping": "Grouping",
-        "home": "Home",
-        "idle": "Idle",
-        "interface": "Interface",
-        "keybinds": "Keybinds",
-        "kinds": "Kinds",
+        "grouping": "Agrupació",
+        "home": "Inici",
+        "idle": "Inactivitat",
+        "interface": "Interfície",
+        "keybinds": "Dreceres",
+        "kinds": "Tipus",
         "launcher": "Launcher",
-        "layout": "Layout",
-        "lifecycle": "Lifecycle",
-        "location": "Location",
-        "lock-screen": "Lock Screen",
-        "media": "Media",
-        "monitor": "System Monitor",
-        "monitor-polling": "Poll Intervals",
-        "monitor-thresholds": "Highlight Thresholds",
+        "layout": "Disposició",
+        "lifecycle": "Cicle de vida",
+        "location": "Ubicació",
+        "lock-screen": "Pantalla de bloqueig",
+        "media": "Multimèdia",
+        "monitor": "Monitor del sistema",
+        "monitor-polling": "Intervals de sondeig",
+        "monitor-thresholds": "Llindars de ressaltat",
         "monitors": "Monitors",
-        "motion": "Motion",
-        "network": "Network",
+        "motion": "Moviment",
+        "network": "Xarxa",
         "night-light": "Night Light",
-        "notifications": "Notifications",
+        "notifications": "Notificacions",
         "osd": "OSD",
-        "overview": "Overview",
-        "pinned-apps": "Pinned Apps",
-        "power": "Power",
-        "privacy-security": "Privacy & Security",
-        "profile": "Profile",
-        "screen-corners": "Screen Corners",
-        "screen-time": "Screen Time",
-        "screenshot": "Screenshot",
-        "security": "Security",
-        "session-panel": "Session",
-        "shape": "Shape",
-        "system": "System",
-        "theme": "Theme",
+        "overview": "Vista general",
+        "pinned-apps": "Aplicacions fixades",
+        "power": "Energia",
+        "privacy-security": "Privadesa i seguretat",
+        "profile": "Perfil",
+        "screen-corners": "Cantonades de pantalla",
+        "screen-time": "Temps de pantalla",
+        "screenshot": "Captura de pantalla",
+        "security": "Seguretat",
+        "session-panel": "Sessió",
+        "shape": "Forma",
+        "system": "Sistema",
+        "theme": "Tema",
         "toasts": "Toasts",
-        "transition": "Transition",
-        "user": "User",
-        "wallpaper": "Wallpaper",
-        "weather": "Weather",
-        "widget-list": "Widget List",
+        "transition": "Transició",
+        "user": "Usuari",
+        "wallpaper": "Fons de pantalla",
+        "weather": "Temps",
+        "widget-list": "Llista de widgets",
         "widgets": "Widgets"
       },
       "sections": {
-        "appearance": "Appearance",
+        "appearance": "Aparença",
         "backdrop": "Backdrop",
-        "bar": "Bar",
-        "desktop": "Desktop",
+        "bar": "Barra",
+        "desktop": "Escriptori",
         "dock": "Dock",
         "hooks": "Hooks",
-        "location": "Location",
+        "location": "Ubicació",
         "niri": "Niri",
-        "notifications": "Notifications",
+        "notifications": "Notificacions",
         "osd": "OSD",
-        "panels": "Panels",
+        "panels": "Panells",
         "plugins": "Plugins",
-        "popups": "Popups",
-        "power": "Power",
-        "security": "Security",
-        "services": "Services",
+        "popups": "Finestres emergents",
+        "power": "Energia",
+        "security": "Seguretat",
+        "services": "Serveis",
         "shell": "Shell",
-        "system": "System",
-        "templates": "Templates",
-        "wallpaper": "Wallpaper"
+        "system": "Sistema",
+        "templates": "Plantilles",
+        "wallpaper": "Fons de pantalla"
       }
     },
     "notifications": {
       "filter": {
-        "add": "Add filter",
-        "add-title": "Add Notification Filter",
-        "allowed-urgencies-label": "Allowed urgencies",
+        "add": "Afegeix un filtre",
+        "add-title": "Afegeix un filtre de notificacions",
+        "allowed-urgencies-label": "Urgències permeses",
         "flag": {
-          "history": "history",
-          "sound": "sound",
+          "history": "historial",
+          "sound": "so",
           "toast": "toast"
         },
-        "flags-label": "When matched",
-        "match-label": "App",
-        "match-placeholder": "App name, desktop entry, or category…",
-        "play-sound": "Play sound",
-        "save-history": "Save to history",
-        "show-toast": "Show toast",
+        "flags-label": "Quan coincideix",
+        "match-label": "Aplicació",
+        "match-placeholder": "Nom de l'aplicació, entrada d'escriptori o categoria…",
+        "play-sound": "Reprodueix so",
+        "save-history": "Desa a l'historial",
+        "show-toast": "Mostra toast",
         "summary": "{match} · {flags}",
-        "summary-blocked": "{match} · blocked",
-        "summary-disabled": "{match} · disabled",
-        "unnamed": "Unnamed filter"
+        "summary-blocked": "{match} · blocat",
+        "summary-disabled": "{match} · desactivat",
+        "unnamed": "Filtre sense nom"
       }
     },
     "options": {
       "clipboard": {
         "auto-paste": {
-          "ctrl-shift-v": "Ctrl+Shift+V",
+          "ctrl-shift-v": "Ctrl+Maj+V",
           "ctrl-v": "Ctrl+V",
-          "shift-insert": "Shift+Insert"
+          "shift-insert": "Maj+Insert"
         }
       },
       "control-center": {
         "sidebar": {
-          "compact": "Compact",
-          "full": "Full",
-          "none": "None"
+          "compact": "Compacte",
+          "full": "Complet",
+          "none": "Cap"
         }
       },
       "dock-launcher-position": {
-        "end": "End",
-        "none": "None",
-        "start": "Start"
+        "end": "Final",
+        "none": "Cap",
+        "start": "Inici"
       },
       "edge": {
-        "bottom": "Bottom",
-        "left": "Left",
-        "right": "Right",
-        "top": "Top"
+        "bottom": "Inferior",
+        "left": "Esquerra",
+        "right": "Dreta",
+        "top": "Superior"
       },
       "font-weight": {
-        "bold": "Bold",
-        "book": "Book",
-        "default": "Default (bar)",
-        "heavy": "Heavy",
-        "light": "Light",
-        "medium": "Medium",
-        "regular": "Regular",
-        "semi-bold": "Semi Bold",
-        "semi-light": "Semi Light",
-        "thin": "Thin",
-        "ultra-bold": "Ultra Bold",
-        "ultra-heavy": "Ultra Heavy",
-        "ultra-light": "Ultra Light"
+        "bold": "Negreta",
+        "book": "Llibre",
+        "default": "Per defecte (barra)",
+        "heavy": "Molt gruixut",
+        "light": "Prim",
+        "medium": "Mitjà",
+        "regular": "Normal",
+        "semi-bold": "Semi negreta",
+        "semi-light": "Semi prim",
+        "thin": "Fi",
+        "ultra-bold": "Ultra negreta",
+        "ultra-heavy": "Ultra gruixut",
+        "ultra-light": "Ultra prim"
       },
       "layer": {
         "overlay": "Overlay",
-        "top": "Top"
+        "top": "Superior"
       },
       "notification-urgency": {
-        "critical": "Critical",
-        "low": "Low",
+        "critical": "Crítica",
+        "low": "Baixa",
         "normal": "Normal"
       },
       "orientation": {
-        "horizontal": "Horizontal",
+        "horizontal": "Horitzontal",
         "vertical": "Vertical"
       },
       "screen-position": {
-        "bottom-center": "Bottom Center",
-        "bottom-left": "Bottom Left",
-        "bottom-right": "Bottom Right",
-        "center-left": "Center Left",
-        "center-right": "Center Right",
-        "top-center": "Top Center",
-        "top-left": "Top Left",
-        "top-right": "Top Right"
+        "bottom-center": "Inferior centre",
+        "bottom-left": "Inferior esquerra",
+        "bottom-right": "Inferior dreta",
+        "center-left": "Centre esquerra",
+        "center-right": "Centre dreta",
+        "top-center": "Superior centre",
+        "top-left": "Superior esquerra",
+        "top-right": "Superior dreta"
       },
       "shell": {
         "panel-placement": {
-          "attached": "Attached",
-          "centered": "Centered",
-          "floating": "Floating"
+          "attached": "Adjunt",
+          "centered": "Centrat",
+          "floating": "Flotant"
         },
         "panel-transparency": {
-          "glass": "Glass",
-          "soft": "Soft",
-          "solid": "Solid"
+          "glass": "Vidre",
+          "soft": "Suau",
+          "solid": "Sòlid"
         },
         "password-style": {
-          "filled-circles": "Filled Circles",
-          "random-icons": "Random Icons"
+          "filled-circles": "Cercles plens",
+          "random-icons": "Icones aleatòries"
         },
         "shadow-direction": {
-          "center": "Center",
-          "down": "Down",
-          "down-left": "Down Left",
-          "down-right": "Down Right",
-          "left": "Left",
-          "right": "Right",
-          "up": "Up",
-          "up-left": "Up Left",
-          "up-right": "Up Right"
+          "center": "Centre",
+          "down": "Avall",
+          "down-left": "Avall esquerra",
+          "down-right": "Avall dreta",
+          "left": "Esquerra",
+          "right": "Dreta",
+          "up": "Amunt",
+          "up-left": "Amunt esquerra",
+          "up-right": "Amunt dreta"
         }
       },
       "theme": {
         "mode": {
-          "dark": "Dark",
-          "light": "Light"
+          "dark": "Fosc",
+          "light": "Clar"
         },
         "source": {
-          "built-in": "Built-In",
-          "community": "Community",
-          "custom": "Custom",
-          "wallpaper": "Wallpaper"
+          "built-in": "Integrat",
+          "community": "Comunitat",
+          "custom": "Personalitzat",
+          "wallpaper": "Fons de pantalla"
         }
       },
       "theme-role": {
-        "custom": "Custom…",
-        "default": "Default"
+        "custom": "Personalitzat…",
+        "default": "Per defecte"
       },
       "wallpaper": {
         "fill": {
-          "center": "Center",
-          "crop": "Crop",
-          "fit": "Fit",
-          "repeat": "Repeat",
-          "stretch": "Stretch"
+          "center": "Centre",
+          "crop": "Retalla",
+          "fit": "Ajusta",
+          "repeat": "Repeteix",
+          "stretch": "Estira"
         },
         "order": {
-          "alphabetical": "Alphabetical",
-          "random": "Random"
+          "alphabetical": "Alfabètic",
+          "random": "Aleatori"
         },
         "transition": {
           "disc": "Disc",
-          "fade": "Fade",
-          "honeycomb": "Honeycomb",
-          "stripes": "Stripes",
-          "wipe": "Wipe",
+          "fade": "Esvaeix",
+          "honeycomb": "Panell",
+          "stripes": "Ratlles",
+          "wipe": "Escombra",
           "zoom": "Zoom"
         }
       },
       "weather": {
         "unit": {
           "imperial": "Imperial",
-          "metric": "Metric"
+          "metric": "Mètric"
         }
       }
     },
     "plugins": {
       "plugins": {
-        "configure": "Configure",
-        "deprecated": "deprecated",
-        "empty": "No plugins found. Add a source, or check your network.",
-        "loading": "Loading plugins...",
-        "refreshing": "Refreshing plugins...",
-        "requires-newer-noctalia": "requires newer Noctalia",
+        "configure": "Configura",
+        "deprecated": "obsolet",
+        "empty": "No s'han trobat plugins. Afegeix una font o comprova la xarxa.",
+        "loading": "S'estan carregant els plugins...",
+        "refreshing": "S'estan actualitzant els plugins...",
+        "requires-newer-noctalia": "requereix una versió més recent del Noctalia",
         "title": "Plugins"
       },
       "settings": {
-        "empty": "No settings available."
+        "empty": "No hi ha paràmetres disponibles."
       },
       "sources": {
-        "add": "Add source",
-        "add-title": "Add plugin source",
-        "edit": "Edit source",
-        "edit-title": "Edit plugin source",
-        "empty": "No sources configured.",
+        "add": "Afegeix una font",
+        "add-title": "Afegeix una font de plugins",
+        "edit": "Edita la font",
+        "edit-title": "Edita la font de plugins",
+        "empty": "No hi ha fonts configurades.",
         "errors": {
-          "duplicate-name": "A source with this ID already exists.",
-          "invalid-name": "Source ID must use letters, digits, '.', '_' or '-', starting with a letter or digit.",
-          "location-required": "Source location is required."
+          "duplicate-name": "Ja existeix una font amb aquest ID.",
+          "invalid-name": "L'ID de la font ha d'utilitzar lletres, dígits, '.', '_' o '-', començant per una lletra o dígit.",
+          "location-required": "La ubicació de la font és obligatòria."
         },
         "kind": {
           "git": "Git",
-          "path": "Path"
+          "path": "Camí"
         },
-        "kind-label": "Kind",
-        "location-label": "Location",
-        "location-placeholder-git": "https://github.com/me/noctalia-plugins",
+        "kind-label": "Tipus",
+        "location-label": "Ubicació",
+        "location-placeholder-git": "https://github.com/jo/noctalia-plugins",
         "location-placeholder-path": "~/dev/noctalia-plugins",
-        "name-label": "Source ID",
-        "name-placeholder": "my-plugins",
-        "remove": "Remove source",
-        "save": "Save",
-        "title": "Sources",
-        "update": "Update",
-        "update-on-startup": "Update on startup"
+        "name-label": "ID de la font",
+        "name-placeholder": "els-meus-plugins",
+        "remove": "Elimina la font",
+        "save": "Desa",
+        "title": "Fonts",
+        "update": "Actualitza",
+        "update-on-startup": "Actualitza a l'inici"
       }
     },
     "schema": {
       "appearance": {
         "animation-speed": {
-          "description": "Speed multiplier for all animations",
-          "label": "Animation Speed"
+          "description": "Multiplicador de velocitat per a totes les animacions",
+          "label": "Velocitat d'animació"
         },
         "animations": {
-          "description": "Enable or disable UI animations",
-          "label": "Animations"
+          "description": "Activa o desactiva les animacions de la interfície",
+          "label": "Animacions"
         },
         "app-icon-color": {
-          "description": "Palette color used when colorizing application icons",
-          "label": "App Icon Color"
+          "description": "Color de la paleta utilitzat en acolorir les icones de les aplicacions",
+          "label": "Color d'icona d'aplicació"
         },
         "app-icon-colorize": {
-          "description": "Recolor application icons across the shell to match the active palette",
-          "label": "Colorize App Icons"
+          "description": "Recoloreja les icones d'aplicació a tot el shell perquè coincideixin amb la paleta activa",
+          "label": "Acoloreix les icones d'aplicació"
         },
         "builtin-palette": {
-          "description": "Choose a palette from the bundled catalog",
-          "label": "Built-In Palette"
+          "description": "Tria una paleta del catàleg integrat",
+          "label": "Paleta integrada"
         },
         "community-palette": {
-          "description": "Choose a palette from the community catalog",
-          "label": "Community Palette",
-          "search-placeholder": "Search palettes..."
+          "description": "Tria una paleta del catàleg de la comunitat",
+          "label": "Paleta de la comunitat",
+          "search-placeholder": "Cerca paletes..."
         },
         "corner-roundness": {
-          "description": "Scale corner radius across shell UI containers and controls",
-          "label": "Corner Roundness"
+          "description": "Escala el radi de les cantonades en els contenidors i controls de la interfície del shell",
+          "label": "Arrodoniment de cantonades"
         },
         "custom-palette": {
-          "description": "Choose a palette from ~/.config/noctalia/palettes/",
-          "label": "Custom Palette",
-          "search-placeholder": "Search custom palettes..."
+          "description": "Tria una paleta de ~/.config/noctalia/palettes/",
+          "label": "Paleta personalitzada",
+          "search-placeholder": "Cerca paletes personalitzades..."
         },
         "export-wallpaper-palette": {
-          "button": "Save as Custom Palette",
-          "description": "Save the current wallpaper-generated palette as a reusable custom palette file",
-          "label": "Export Wallpaper Palette"
+          "button": "Desa com a paleta personalitzada",
+          "description": "Desa la paleta actual generada pel fons de pantalla com un fitxer de paleta personalitzada reutilitzable",
+          "label": "Exporta la paleta del fons de pantalla"
         },
         "font-family": {
-          "description": "Font family for the shell interface",
-          "label": "Font Family"
+          "description": "Família de tipus de lletra per a la interfície del shell",
+          "label": "Tipus de lletra"
         },
         "global-shadow-alpha": {
-          "description": "Global surface shadow opacity"
+          "description": "Opacitat global de l'ombra de les superfícies"
         },
         "global-shadow-direction": {
-          "description": "Direction the shadow is cast from surfaces"
+          "description": "Direcció de l'ombra projectada per les superfícies"
         },
         "language": {
-          "description": "Override automatic locale detection",
-          "label": "Language"
+          "description": "Sobreescriu la detecció automàtica de la configuració regional",
+          "label": "Idioma"
         },
         "palette-source": {
-          "description": "Where to derive the color palette from",
-          "label": "Palette Source"
+          "description": "D'on derivar la paleta de colors",
+          "label": "Origen de la paleta"
         },
         "theme-mode": {
-          "description": "Choose dark, light, or auto based on time of day",
-          "label": "Theme Mode"
+          "description": "Tria fosc, clar o automàtic segons l'hora del dia",
+          "label": "Mode del tema"
         },
         "ui-scale": {
-          "description": "Scale the entire interface up or down",
-          "label": "UI Scale"
+          "description": "Escala tota la interfície cap amunt o cap avall",
+          "label": "Escala de la interfície"
         },
         "wallpaper-generation-scheme": {
-          "description": "Choose how wallpaper colors are converted into a palette",
-          "label": "Wallpaper Generation Scheme"
+          "description": "Tria com es converteixen els colors del fons de pantalla en una paleta",
+          "label": "Esquema de generació del fons de pantalla"
         }
       },
       "backdrop": {
         "blur-intensity": {
-          "description": "Blur intensity of the backdrop",
-          "label": "Blur Intensity"
+          "description": "Intensitat del desenfocament del backdrop",
+          "label": "Intensitat del desenfocament"
         },
         "enabled": {
-          "description": "Enable the backdrop"
+          "description": "Activa el backdrop"
         },
         "tint-intensity": {
-          "description": "Tint intensity of the backdrop",
-          "label": "Tint Intensity"
+          "description": "Intensitat del tint del backdrop",
+          "label": "Intensitat del tint"
         }
       },
       "bar": {
         "auto-hide": {
-          "description": "Automatically hide the bar when not in use"
+          "description": "Amaga automàticament la barra quan no s'utilitza"
         },
         "background-opacity": {
-          "description": "Background opacity of the bar"
+          "description": "Opacitat del fons de la barra"
         },
         "border": {
-          "description": "Color role for the bar outline; fixed hex colors are also supported",
-          "label": "Border"
+          "description": "Color de la vora de la barra; també s'admeten colors hex fixos",
+          "label": "Vora"
         },
         "border-width": {
-          "description": "Inside outline width for the bar",
-          "label": "Border Width"
+          "description": "Amplada de la vora interior de la barra",
+          "label": "Amplada de la vora"
         },
         "capsule-border": {
-          "description": "Default capsule outline color role; fixed hex colors are also supported",
-          "label": "Capsule Border"
+          "description": "Color de la vora de la càpsula per defecte; també s'admeten colors hex fixos",
+          "label": "Vora de la càpsula"
         },
         "capsule-fill": {
-          "description": "Default capsule background color role; fixed hex colors are also supported",
-          "label": "Capsule Fill"
+          "description": "Color de fons de la càpsula per defecte; també s'admeten colors hex fixos",
+          "label": "Fons de la càpsula"
         },
         "capsule-foreground": {
-          "description": "Default icon and label color role inside capsules; fixed hex colors are also supported",
-          "label": "Capsule Foreground"
+          "description": "Color d'icona i etiqueta per defecte dins de les càpsules; també s'admeten colors hex fixos",
+          "label": "Primer pla de la càpsula"
         },
         "capsule-opacity": {
-          "description": "Opacity of widget capsule backgrounds",
-          "label": "Capsule Opacity"
+          "description": "Opacitat dels fons de les càpsules dels widgets",
+          "label": "Opacitat de la càpsula"
         },
         "capsule-padding": {
-          "description": "Padding inside widget capsules",
-          "label": "Capsule Padding"
+          "description": "Farcit interior de les càpsules dels widgets",
+          "label": "Farcit de la càpsula"
         },
         "capsule-radius": {
-          "description": "Default corner radius for widget capsules, workspace pills, and taskbar workspace groups; leave blank for automatic pill shape, or set 0 for square corners",
-          "label": "Capsule Radius"
+          "description": "Radi de les cantonades per defecte per a les càpsules dels widgets, les pastilles d'espais de treball i els grups d'espais de treball de la barra de tasques; deixa en blanc per a forma de pastilla automàtica o posa 0 per a cantonades quadrades",
+          "label": "Radi de la càpsula"
         },
         "capsule-thickness": {
-          "description": "Capsule size across the bar as a fraction of the bar thickness (1.0 fills the bar)",
-          "label": "Capsule Thickness"
+          "description": "Mida de la càpsula a través de la barra com a fracció del gruix de la barra (1.0 omple la barra)",
+          "label": "Gruix de la càpsula"
         },
         "center-widgets": {
-          "description": "Widgets in the center of the bar",
-          "label": "Center Widgets"
+          "description": "Widgets al centre de la barra",
+          "label": "Widgets centrals"
         },
         "contact-shadow": {
-          "description": "Dark gradient between an attached panel and the bar to suggest depth at the seam"
+          "description": "Gradient fosc entre un panell adjunt i la barra per suggerir profunditat a la unió"
         },
         "content-padding": {
-          "description": "Padding inside the bar content area",
-          "label": "Content Padding"
+          "description": "Farcit interior de l'àrea de contingut de la barra",
+          "label": "Farcit del contingut"
         },
         "content-scale": {
-          "description": "Scale factor for bar content",
-          "label": "Content Scale"
+          "description": "Factor d'escala per al contingut de la barra",
+          "label": "Escala del contingut"
         },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+          "description": "Radi de la cantonada inferior esquerra de la barra; els valors negatius tallen una cantonada còncava quan aquesta cantonada està oposada a la vora de la pantalla"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+          "description": "Radi de la cantonada inferior dreta de la barra; els valors negatius tallen una cantonada còncava quan aquesta cantonada està oposada a la vora de la pantalla"
         },
         "corner-radius": {
-          "description": "Corner radius of the bar"
+          "description": "Radi de les cantonades de la barra"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+          "description": "Radi de la cantonada superior esquerra de la barra; els valors negatius tallen una cantonada còncava quan aquesta cantonada està oposada a la vora de la pantalla"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the bar; negative values carve a concave corner when this corner faces away from the screen edge"
+          "description": "Radi de la cantonada superior dreta de la barra; els valors negatius tallen una cantonada còncava quan aquesta cantonada està oposada a la vora de la pantalla"
         },
         "edge-margin": {
-          "description": "Distance from the nearest screen edge; positive values float the bar away from it"
+          "description": "Distància des de la vora de pantalla més propera; els valors positius fan flotar la barra"
         },
         "enabled": {
-          "description": "Show or hide this bar"
+          "description": "Mostra o amaga aquesta barra"
         },
         "end-widgets": {
-          "description": "Widgets on the end (right/bottom) side of the bar",
-          "label": "End Widgets"
+          "description": "Widgets al final (dreta/avall) de la barra",
+          "label": "Widgets del final"
         },
         "ends-margin": {
-          "description": "Inset from each end of the bar along its main axis"
+          "description": "Marge des de cada extrem de la barra al llarg del seu eix principal"
         },
         "font-family": {
-          "description": "Typeface for this bar's widgets; leave empty to inherit the global font. Per-widget Font Family overrides this.",
-          "label": "Font Family"
+          "description": "Tipus de lletra per als widgets d'aquesta barra; deixa buit per heretar el tipus de lletra global. El tipus de lletra per widget el sobrescriu.",
+          "label": "Tipus de lletra"
         },
         "font-weight": {
-          "description": "Default weight for widget labels on this bar.",
-          "label": "Font Weight"
+          "description": "Pes per defecte de les etiquetes dels widgets d'aquesta barra.",
+          "label": "Pes de la lletra"
         },
         "layer": {
-          "description": "Use Overlay to show the bar above fullscreen apps. Attached panels follow the bar.",
-          "label": "Wayland Layer"
+          "description": "Utilitza Overlay per mostrar la barra per sobre de les aplicacions a pantalla completa. Els panells adjunts segueixen la barra.",
+          "label": "Capa Wayland"
         },
         "panel-overlap": {
-          "description": "Pixels an attached panel overlaps the bar edge to hide the seam (adjust if you see a line or gap)",
-          "label": "Panel Overlap"
+          "description": "Píxels que un panell adjunt se superposa a la vora de la barra per amagar la unió (ajusta si veus una línia o espai)",
+          "label": "Superposició del panell"
         },
         "position": {
-          "description": "Which screen edge the bar sits on"
+          "description": "A quina vora de la pantalla se situa la barra"
         },
         "reserve-space": {
-          "description": "Push windows away from the bar edge"
+          "description": "Empeny les finestres lluny de la vora de la barra"
         },
         "shadow": {
-          "description": "Cast the global surface shadow from the bar"
+          "description": "Projecta l'ombra global de la superfície des de la barra"
         },
         "start-widgets": {
-          "description": "Widgets on the start (left/top) side of the bar",
-          "label": "Start Widgets"
+          "description": "Widgets a l'inici (esquerra/amunt) de la barra",
+          "label": "Widgets d'inici"
         },
         "thickness": {
-          "description": "Bar thickness in pixels",
-          "label": "Thickness"
+          "description": "Gruix de la barra en píxels",
+          "label": "Gruix"
         },
         "widget-capsules": {
-          "description": "Wrap widgets in capsule backgrounds",
-          "label": "Widget Capsules"
+          "description": "Embolcalla els widgets en fons de càpsula",
+          "label": "Càpsules de widgets"
         },
         "widget-color": {
-          "description": "Default icon and label color role for widgets on this bar; fixed hex colors are also supported",
-          "label": "Widget Color"
+          "description": "Color d'icona i etiqueta per defecte per als widgets d'aquesta barra; també s'admeten colors hex fixos",
+          "label": "Color del widget"
         },
         "widget-icon-color": {
-          "description": "Overrides the widget color for icons on this bar; fixed hex colors are also supported",
-          "label": "Widget Icon Color"
+          "description": "Sobreescriu el color del widget per a les icones d'aquesta barra; també s'admeten colors hex fixos",
+          "label": "Color d'icona del widget"
         },
         "widget-spacing": {
-          "description": "Space between bar widgets",
-          "label": "Widget Spacing"
+          "description": "Espai entre els widgets de la barra",
+          "label": "Espaiat dels widgets"
         }
       },
       "desktop": {
         "screen-corners-enabled": {
-          "description": "Round the screen corners with a black overlay",
-          "label": "Screen Corners"
+          "description": "Arrodoneix les cantonades de la pantalla amb una superposició negra",
+          "label": "Cantonades de pantalla"
         },
         "screen-corners-size": {
-          "description": "Radius of the rounded screen corners in pixels",
-          "label": "Corner Size"
+          "description": "Radi de les cantonades arrodonides de la pantalla en píxels",
+          "label": "Mida de la cantonada"
         },
         "widgets": {
-          "description": "Show widgets on the desktop",
-          "label": "Desktop Widgets"
+          "description": "Mostra widgets a l'escriptori",
+          "label": "Widgets d'escriptori"
         },
         "widgets-editor": {
-          "button": "Toggle Editor",
-          "description": "Add, move, and resize desktop widgets",
-          "label": "Widget Editor"
+          "button": "Commuta l'editor",
+          "description": "Afegeix, mou i redimensiona widgets d'escriptori",
+          "label": "Editor de widgets"
         }
       },
       "dock": {
         "active-icon-opacity": {
-          "description": "Opacity of the focused dock icon",
-          "label": "Active Icon Opacity"
+          "description": "Opacitat de la icona del dock enfocada",
+          "label": "Opacitat d'icona activa"
         },
         "active-icon-scale": {
-          "description": "Scale of the focused dock icon",
-          "label": "Active Icon Scale"
+          "description": "Escala de la icona del dock enfocada",
+          "label": "Escala d'icona activa"
         },
         "active-monitor-only": {
-          "description": "Only show applications running on the active monitor",
-          "label": "Active Monitor Only"
+          "description": "Mostra només les aplicacions en execució al monitor actiu",
+          "label": "Només al monitor actiu"
         },
         "auto-hide": {
-          "description": "Automatically hide the dock when not in use"
+          "description": "Amaga automàticament el dock quan no s'utilitza"
         },
         "background-opacity": {
-          "description": "Background opacity of the dock"
+          "description": "Opacitat del fons del dock"
         },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the dock"
+          "description": "Radi de la cantonada inferior esquerra del dock"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the dock"
+          "description": "Radi de la cantonada inferior dreta del dock"
         },
         "corner-radius": {
-          "description": "Corner radius of the dock"
+          "description": "Radi de cantonada del dock"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the dock"
+          "description": "Radi de la cantonada superior esquerra del dock"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the dock"
+          "description": "Radi de la cantonada superior dreta del dock"
         },
         "cross-axis-padding": {
-          "description": "Inner padding along the dock's cross axis (between icons and the screen edge)"
+          "description": "Farcit interior a l'eix transversal del dock (entre les icones i la vora de la pantalla)"
         },
         "edge-margin": {
-          "description": "Distance from the nearest screen edge; positive values float the dock away from it"
+          "description": "Distància des de la vora de pantalla més propera; els valors positius fan flotar el dock"
         },
         "enabled": {
-          "description": "Show or hide the dock"
+          "description": "Mostra o amaga el dock"
         },
         "ends-margin": {
-          "description": "Inset from each end of the dock along its main axis"
+          "description": "Marge des de cada extrem del dock al llarg del seu eix principal"
         },
         "icon-size": {
-          "description": "Size of dock icons in pixels",
-          "label": "Icon Size"
+          "description": "Mida de les icones del dock en píxels",
+          "label": "Mida d'icona"
         },
         "inactive-icon-opacity": {
-          "description": "Opacity of unfocused dock icons",
-          "label": "Inactive Icon Opacity"
+          "description": "Opacitat de les icones del dock no enfocades",
+          "label": "Opacitat d'icona inactiva"
         },
         "inactive-icon-scale": {
-          "description": "Scale of unfocused dock icons",
-          "label": "Inactive Icon Scale"
+          "description": "Escala de les icones del dock no enfocades",
+          "label": "Escala d'icona inactiva"
         },
         "item-spacing": {
-          "description": "Space between dock items",
-          "label": "Item Spacing"
+          "description": "Espai entre elements del dock",
+          "label": "Espaiat d'elements"
         },
         "launcher-icon": {
-          "description": "Tabler icon shown on the dock launcher button",
-          "label": "Launcher Icon"
+          "description": "Icona Tabler que es mostra al botó del launcher del dock",
+          "label": "Icona del Launcher"
         },
         "launcher-position": {
-          "description": "Show a launcher button at the start or end of the dock",
-          "label": "Launcher Button"
+          "description": "Mostra un botó de launcher a l'inici o al final del dock",
+          "label": "Botó del Launcher"
         },
         "magnification": {
-          "description": "Magnify dock icons near the pointer, macOS-style",
-          "label": "Magnification"
+          "description": "Amplia les icones del dock a prop del punter, estil macOS",
+          "label": "Ampliació"
         },
         "magnification-scale": {
-          "description": "Maximum icon scale multiplier at the pointer center (1.0 disables magnification)",
-          "label": "Magnification Scale"
+          "description": "Multiplicador d'escala màxima d'icona al centre del punter (1.0 desactiva l'ampliació)",
+          "label": "Escala d'ampliació"
         },
         "main-axis-padding": {
-          "description": "Inner padding along the dock's main axis (between icons and the short ends of the capsule)"
+          "description": "Farcit interior al llarg de l'eix principal del dock (entre les icones i els extrems curts de la càpsula)"
         },
         "monitors": {
-          "description": "Choose which monitors show the dock (leave empty for all); active-monitor filtering applies within these monitors",
+          "description": "Tria quins monitors mostren el dock (deixa buit per a tots); el filtratge de monitor actiu s'aplica dins d'aquests monitors",
           "label": "Monitors"
         },
         "pinned-apps": {
-          "description": "Desktop entry IDs of apps pinned to the dock",
-          "label": "Pinned Apps"
+          "description": "IDs d'entrada d'escriptori de les aplicacions fixades al dock",
+          "label": "Aplicacions fixades"
         },
         "position": {
-          "description": "Which screen edge the dock sits on"
+          "description": "A quina vora de la pantalla se situa el dock"
         },
         "reserve-space": {
-          "description": "Push windows away from the dock edge"
+          "description": "Empeny les finestres lluny de la vora del dock"
         },
         "shadow": {
-          "description": "Cast the global surface shadow from the dock"
+          "description": "Projecta l'ombra global de la superfície des del dock"
         },
         "show-dots": {
-          "description": "Show running window dots beside dock icons",
-          "label": "Show Dots"
+          "description": "Mostra punts de finestres en execució al costat de les icones del dock",
+          "label": "Mostra punts"
         },
         "show-instance-count": {
-          "description": "Show a badge with the number of open instances",
-          "label": "Show Instance Count"
+          "description": "Mostra una insígnia amb el nombre d'instàncies obertes",
+          "label": "Mostra el nombre d'instàncies"
         },
         "show-running": {
-          "description": "Show running applications that are not pinned",
-          "label": "Show Running"
+          "description": "Mostra aplicacions en execució que no estan fixades",
+          "label": "Mostra en execució"
         }
       },
       "hooks": {
-        "command-placeholder": "shell command or script path",
+        "command-placeholder": "ordre de shell o camí de l'script",
         "events": {
           "battery-charging": {
-            "description": "Command to run when the battery starts charging",
-            "label": "On Battery Charging"
+            "description": "Ordre a executar quan la bateria comença a carregar",
+            "label": "En carregar la bateria"
           },
           "battery-discharging": {
-            "description": "Command to run when the battery starts discharging",
-            "label": "On Battery Discharging"
+            "description": "Ordre a executar quan la bateria comença a descarregar",
+            "label": "En descarregar la bateria"
           },
           "battery-percentage-changed": {
-            "description": "Command to run when the battery percentage changes",
-            "label": "On Battery Percentage Changed"
+            "description": "Ordre a executar quan canvia el percentatge de bateria",
+            "label": "En canviar el percentatge de bateria"
           },
           "battery-plugged": {
-            "description": "Command to run when the battery becomes fully charged or pending charge",
-            "label": "On Battery Plugged"
+            "description": "Ordre a executar quan la bateria està completament carregada o en càrrega pendent",
+            "label": "En endollar la bateria"
           },
           "bluetooth-disabled": {
-            "description": "Command to run when Bluetooth is disabled",
-            "label": "On Bluetooth Disabled"
+            "description": "Ordre a executar quan es desactiva el Bluetooth",
+            "label": "En desactivar el Bluetooth"
           },
           "bluetooth-enabled": {
-            "description": "Command to run when Bluetooth is enabled",
-            "label": "On Bluetooth Enabled"
+            "description": "Ordre a executar quan s'activa el Bluetooth",
+            "label": "En activar el Bluetooth"
           },
           "colors-changed": {
-            "description": "Command to run when the active color palette changes",
-            "label": "On Colors Changed"
+            "description": "Ordre a executar quan canvia la paleta de colors activa",
+            "label": "En canviar els colors"
           },
           "logging-out": {
-            "description": "Command to run before logging out",
-            "label": "On Logout"
+            "description": "Ordre a executar abans de tancar la sessió",
+            "label": "En tancar la sessió"
           },
           "power-profile-changed": {
-            "description": "Command to run when the active UPower/PPD power profile changes",
-            "label": "On Power Profile Changed"
+            "description": "Ordre a executar quan canvia el perfil d'energia UPower/PPD actiu",
+            "label": "En canviar el perfil d'energia"
           },
           "rebooting": {
-            "description": "Command to run before rebooting",
-            "label": "On Reboot"
+            "description": "Ordre a executar abans de reiniciar",
+            "label": "En reiniciar"
           },
           "session-locked": {
-            "description": "Command to run when the session is locked",
-            "label": "On Session Locked"
+            "description": "Ordre a executar quan es bloqueja la sessió",
+            "label": "En bloquejar la sessió"
           },
           "session-unlocked": {
-            "description": "Command to run after the session is unlocked",
-            "label": "On Session Unlocked"
+            "description": "Ordre a executar després de desbloquejar la sessió",
+            "label": "En desbloquejar la sessió"
           },
           "shutting-down": {
-            "description": "Command to run before shutdown",
-            "label": "On Shutdown"
+            "description": "Ordre a executar abans d'apagar",
+            "label": "En apagar"
           },
           "started": {
-            "description": "Command to run after Noctalia starts",
-            "label": "On Started"
+            "description": "Ordre a executar després que el Noctalia s'iniciï",
+            "label": "En iniciar"
           },
           "theme-mode-changed": {
-            "description": "Command to run when the resolved theme mode changes between light and dark",
-            "label": "On Theme Mode Changed"
+            "description": "Ordre a executar quan el mode del tema canvïa entre clar i fosc",
+            "label": "En canviar el mode del tema"
           },
           "wallpaper-changed": {
-            "description": "Command to run when the wallpaper changes",
-            "label": "On Wallpaper Changed"
+            "description": "Ordre a executar quan canvia el fons de pantalla",
+            "label": "En canviar el fons de pantalla"
           },
           "wifi-disabled": {
-            "description": "Command to run when Wi-Fi is disabled",
-            "label": "On Wi-Fi Disabled"
+            "description": "Ordre a executar quan es desactiva el Wi-Fi",
+            "label": "En desactivar el Wi-Fi"
           },
           "wifi-enabled": {
-            "description": "Command to run when Wi-Fi is enabled",
-            "label": "On Wi-Fi Enabled"
+            "description": "Ordre a executar quan s'activa el Wi-Fi",
+            "label": "En activar el Wi-Fi"
           }
         }
       },
       "idle": {
         "behaviors": {
-          "description": "Named idle actions with presets (lock, displays off, suspend) or custom commands, timeouts, resume pairing, and order",
-          "label": "Behaviors"
+          "description": "Accions d'inactivitat amb nom amb ajustos predefinits (bloqueig, pantalles apagades, suspensió) o ordres personalitzades, temps d'espera, aparellament de represa i ordre",
+          "label": "Comportaments"
         },
         "pre-action-fade": {
-          "description": "Seconds of fullscreen dim before the idle command; use 0 to disable",
-          "label": "Idle Dim"
+          "description": "Segons d'atenuació de pantalla completa abans de l'ordre d'inactivitat; utilitza 0 per desactivar",
+          "label": "Atenuació d'inactivitat"
         }
       },
       "keybinds": {
         "cancel": {
-          "description": "Close popups, dismiss panels, or abort the current operation",
-          "label": "Cancel"
+          "description": "Tanca finestres emergents, descarta panells o cancel·la l'operació actual",
+          "label": "Cancel·la"
         },
         "down": {
-          "description": "Move focus or selection down one row",
-          "label": "Navigate Down"
+          "description": "Mou el focus o la selecció una fila cap avall",
+          "label": "Navega avall"
         },
         "left": {
-          "description": "Move focus or selection to the left",
-          "label": "Navigate Left"
+          "description": "Mou el focus o la selecció cap a l'esquerra",
+          "label": "Navega a l'esquerra"
         },
         "right": {
-          "description": "Move focus or selection to the right",
-          "label": "Navigate Right"
+          "description": "Mou el focus o la selecció cap a la dreta",
+          "label": "Navega a la dreta"
         },
         "up": {
-          "description": "Move focus or selection up one row",
-          "label": "Navigate Up"
+          "description": "Mou el focus o la selecció una fila cap amunt",
+          "label": "Navega amunt"
         },
         "validate": {
-          "description": "Confirm selections, submit inputs, or activate the focused item",
-          "label": "Confirm"
+          "description": "Confirma seleccions, envia entrades o activa l'element enfocat",
+          "label": "Confirma"
         }
       },
       "lockscreen": {
         "allow-empty-password": {
-          "description": "Let Enter submit an empty password. Enable for security-key or other passwordless PAM stacks; keep off to avoid accidental wake-key lockouts.",
-          "label": "Empty Password Submit"
+          "description": "Permet que Enter enviï una contrasenya buida. Activa-ho per a piles PAM sense contrasenya o amb clau de seguretat; mantén-ho desactivat per evitar bloquejos accidentals amb la tecla de despertar.",
+          "label": "Enviament de contrasenya buida"
         },
         "blur-intensity": {
-          "description": "How much the lock screen background is blurred",
-          "label": "Blur Intensity"
+          "description": "Quant es desenfoca el fons de la pantalla de bloqueig",
+          "label": "Intensitat del desenfocament"
         },
         "blurred-desktop": {
-          "description": "Use a snapshot of the desktop as the lock screen background",
-          "label": "Desktop Capture"
+          "description": "Utilitza una instantània de l'escriptori com a fons de la pantalla de bloqueig",
+          "label": "Captura d'escriptori"
         },
         "enabled": {
-          "description": "Enable session lock, logind integration, and lock actions",
-          "label": "Lock Screen"
+          "description": "Activa el bloqueig de sessió, la integració amb logind i les accions de bloqueig",
+          "label": "Pantalla de bloqueig"
         },
         "fingerprint": {
-          "description": "Unlock with a fingerprint reader via fprintd, alongside password entry",
-          "label": "Fingerprint Unlock"
+          "description": "Desbloqueja amb un lector d'empremtes via fprintd, juntament amb l'entrada de contrasenya",
+          "label": "Desbloqueig per empremta"
         },
         "monitors": {
-          "description": "Choose which monitors show the lock screen; leave empty to show on all monitors",
+          "description": "Tria quins monitors mostren la pantalla de bloqueig; deixa buit per mostrar a tots els monitors",
           "label": "Monitors"
         },
         "tint-intensity": {
-          "description": "Surface-color tint over the lock screen background",
-          "label": "Tint Intensity"
+          "description": "Tint de color de superfície sobre el fons de la pantalla de bloqueig",
+          "label": "Intensitat del tint"
         },
         "wallpaper": {
-          "description": "Custom image for the lock screen background. Leave empty to use the desktop wallpaper.",
-          "label": "Wallpaper",
-          "placeholder": "Use desktop wallpaper"
+          "description": "Imatge personalitzada per al fons de la pantalla de bloqueig. Deixa buit per utilitzar el fons de pantalla de l'escriptori.",
+          "label": "Fons de pantalla",
+          "placeholder": "Utilitza el fons de pantalla de l'escriptori"
         },
         "widgets": {
-          "description": "Show configurable widgets on the lock screen",
-          "label": "Lockscreen Widgets"
+          "description": "Mostra widgets configurables a la pantalla de bloqueig",
+          "label": "Widgets de la pantalla de bloqueig"
         },
         "widgets-editor": {
-          "button": "Toggle Editor",
-          "description": "Add, move, and resize widgets on the lock screen",
-          "label": "Lockscreen Widget Editor"
+          "button": "Commuta l'editor",
+          "description": "Afegeix, mou i redimensiona widgets a la pantalla de bloqueig",
+          "label": "Editor de widgets de la pantalla de bloqueig"
         }
       },
       "notifications": {
         "allowed-urgencies": {
-          "description": "Only show external notifications at the selected urgency levels",
-          "label": "Allowed Urgencies"
+          "description": "Mostra només notificacions externes als nivells d'urgència seleccionats",
+          "label": "Urgències permeses"
         },
         "blacklist": {
-          "description": "Hide matching senders (app name, desktop entry, or category)",
-          "label": "Notification Blacklist"
+          "description": "Amaga els remitents coincidents (nom d'aplicació, entrada d'escriptori o categoria)",
+          "label": "Llista negra de notificacions"
         },
         "blacklist-allow-critical": {
-          "description": "Still show critical notifications from blacklisted senders"
+          "description": "Mostra igualment les notificacions crítiques dels remitents a la llista negra"
         },
         "collapse-on-dismiss": {
-          "description": "Slide remaining toasts to close gaps when one is dismissed",
-          "label": "Collapse on Dismiss"
+          "description": "Llisca els toasts restants per tancar espais quan se'n descarta un",
+          "label": "Col·lapsa en descartar"
         },
         "daemon": {
-          "description": "Enable the built-in notification daemon",
-          "label": "Notification Daemon"
+          "description": "Activa el dimoni de notificacions integrat",
+          "label": "Dimoni de notificacions"
         },
         "filters": {
-          "description": "Per-sender rules for toasts, history, and sounds; first matching enabled filter wins",
-          "label": "Notification Filters"
+          "description": "Regles per remitent per a toasts, historial i sons; el primer filtre actiu que coincideixi guanya",
+          "label": "Filtres de notificacions"
         },
         "layer": {
-          "description": "Use Overlay to show notification toasts above fullscreen apps.",
-          "label": "Wayland Layer"
+          "description": "Utilitza Overlay per mostrar els toasts de notificació per sobre de les aplicacions a pantalla completa.",
+          "label": "Capa Wayland"
         },
         "monitors": {
-          "description": "Choose which monitors show notification toasts; leave empty to show on all monitors",
+          "description": "Tria quins monitors mostren els toasts de notificació; deixa buit per mostrar a tots els monitors",
           "label": "Monitors"
         },
         "offset-x": {
-          "description": "Absolute horizontal margin from the screen or bar edge",
-          "label": "Horizontal Margin"
+          "description": "Marge horitzontal absolut des de la vora de la pantalla o de la barra",
+          "label": "Marge horitzontal"
         },
         "offset-y": {
-          "description": "Absolute vertical margin from the screen or bar edge",
-          "label": "Vertical Margin"
+          "description": "Marge vertical absolut des de la vora de la pantalla o de la barra",
+          "label": "Marge vertical"
         },
         "position": {
-          "description": "Screen position for notification toasts",
-          "label": "Screen Position"
+          "description": "Posició a la pantalla per als toasts de notificació",
+          "label": "Posició a la pantalla"
         },
         "scale": {
-          "description": "Scale notification toasts relative to the shell UI scale",
-          "label": "Size"
+          "description": "Escala els toasts de notificació en relació amb l'escala de la interfície del shell",
+          "label": "Mida"
         },
         "show-actions": {
-          "description": "Show action buttons in notification toasts; when disabled, clicking the toast triggers its default action",
-          "label": "Show Action Buttons"
+          "description": "Mostra botons d'acció als toasts de notificació; quan està desactivat, fer clic al toast activa la seva acció per defecte",
+          "label": "Mostra botons d'acció"
         },
         "show-app-name": {
-          "description": "Show the sending application's name in notification toasts",
-          "label": "Show App Name"
+          "description": "Mostra el nom de l'aplicació remitent als toasts de notificació",
+          "label": "Mostra el nom de l'aplicació"
         },
         "toast-opacity": {
-          "description": "Background opacity of notification toasts",
-          "label": "Background Opacity"
+          "description": "Opacitat del fons dels toasts de notificació",
+          "label": "Opacitat del fons"
         }
       },
       "panels": {
         "borders": {
-          "description": "Draw an outline on panels and section cards inside panels",
-          "label": "Borders"
+          "description": "Dibuixa una vora als panells i a les targetes de secció dins dels panells",
+          "label": "Vores"
         },
         "control-center-sidebar": {
-          "description": "Choose how to display the sidebar",
-          "label": "Sidebar"
+          "description": "Tria com mostrar la barra lateral",
+          "label": "Barra lateral"
         },
         "control-center-sidebar-section": {
-          "description": "When opening a specific tab (volume, media etc.)",
-          "label": "Sidebar When Opening a Tab"
+          "description": "En obrir una pestanya específica (volum, multimèdia, etc.)",
+          "label": "Barra lateral en obrir una pestanya"
         },
         "home-shortcuts": {
-          "description": "Choose up to six shortcut buttons for the home tab",
-          "label": "Home Shortcuts"
+          "description": "Tria fins a sis botons de drecera per a la pestanya d'inici",
+          "label": "Dreceres d'inici"
         },
         "launcher-categories": {
-          "description": "Display category filters in the launcher; reveal with F6, then cycle with F6 and Shift+F6",
-          "label": "Show Categories"
+          "description": "Mostra filtres de categoria al launcher; mostra amb F6, després alterna amb F6 i Maj+F6",
+          "label": "Mostra categories"
         },
         "launcher-compact": {
-          "description": "Use smaller icons and tighter result rows",
-          "label": "Compact Rows"
+          "description": "Utilitza icones més petites i files de resultats més ajustades",
+          "label": "Files compactes"
         },
         "launcher-reset-usage": {
-          "button": "Reset",
-          "description": "Clear launch counts and recently used history used for launcher sorting",
-          "label": "Reset Usage Data"
+          "button": "Restableix",
+          "description": "Esborra els recomptes de llançament i l'historial d'ús recent per a l'ordenació del launcher",
+          "label": "Restableix les dades d'ús"
         },
         "launcher-session-search": {
-          "description": "Include session actions (lock, suspend, reboot, shutdown, logout) in general launcher searches, not only behind the /session prefix",
-          "label": "Enable Session Search"
+          "description": "Inclou les accions de sessió (bloqueig, suspensió, reinici, apagada, tancament de sessió) a les cerques generals del launcher, no només darrere del prefix /session",
+          "label": "Activa la cerca de sessió"
         },
         "launcher-show-icons": {
-          "description": "Show application icons in launcher results",
-          "label": "Show App Icons"
+          "description": "Mostra icones d'aplicació als resultats del launcher",
+          "label": "Mostra icones d'aplicació"
         },
         "launcher-sort-by-usage": {
-          "description": "Boost frequently used apps toward the top and show a Recently Used category filter",
-          "label": "Sort by Usage"
+          "description": "Impulsa les aplicacions més utilitzades cap a dalt i mostra un filtre de categoria d'ús recent",
+          "label": "Ordena per ús"
         },
         "open-near-click-clipboard": {
-          "description": "Position the clipboard panel near the bar click instead of centering it along the bar",
-          "label": "Open Near Click"
+          "description": "Posiciona el panell del porta-retalls a prop del clic de la barra en lloc de centrar-lo al llarg de la barra",
+          "label": "Obre a prop del clic"
         },
         "open-near-click-control-center": {
-          "description": "Position the Control Center panel near the bar click instead of centering it along the bar",
-          "label": "Open Near Click"
+          "description": "Posiciona el panell del centre de control a prop del clic de la barra en lloc de centrar-lo al llarg de la barra",
+          "label": "Obre a prop del clic"
         },
         "open-near-click-launcher": {
-          "description": "Position the launcher panel near the bar click instead of centering it along the bar",
-          "label": "Open Near Click"
+          "description": "Posiciona el panell del launcher a prop del clic de la barra en lloc de centrar-lo al llarg de la barra",
+          "label": "Obre a prop del clic"
         },
         "open-near-click-session": {
-          "description": "Position the session menu panel near the bar click instead of centering it along the bar",
-          "label": "Open Near Click"
+          "description": "Posiciona el panell del menú de sessió a prop del clic de la barra en lloc de centrar-lo al llarg de la barra",
+          "label": "Obre a prop del clic"
         },
         "open-near-click-wallpaper": {
-          "description": "Position the wallpaper picker panel near the bar click instead of centering it along the bar",
-          "label": "Open Near Click"
+          "description": "Posiciona el panell del selector de fons de pantalla a prop del clic de la barra en lloc de centrar-lo al llarg de la barra",
+          "label": "Obre a prop del clic"
         },
         "placement-clipboard": {
-          "description": "Choose whether the clipboard attaches to the bar, floats near it, or opens centered",
-          "label": "Placement"
+          "description": "Tria si el porta-retalls s'adjunta a la barra, flota a prop o s'obre centrat",
+          "label": "Ubicació"
         },
         "placement-control-center": {
-          "description": "Choose whether Control Center attaches to the bar, floats near it, or opens centered",
-          "label": "Placement"
+          "description": "Tria si el centre de control s'adjunta a la barra, flota a prop o s'obre centrat",
+          "label": "Ubicació"
         },
         "placement-launcher": {
-          "description": "Choose whether the launcher attaches to the bar, floats near it, or opens centered",
-          "label": "Placement"
+          "description": "Tria si el launcher s'adjunta a la barra, flota a prop o s'obre centrat",
+          "label": "Ubicació"
         },
         "placement-session": {
-          "description": "Choose whether the session menu attaches to the bar, floats near it, or opens centered",
-          "label": "Placement"
+          "description": "Tria si el menú de sessió s'adjunta a la barra, flota a prop o s'obre centrat",
+          "label": "Ubicació"
         },
         "placement-wallpaper": {
-          "description": "Choose whether the wallpaper picker attaches to the bar, floats near it, or opens centered",
-          "label": "Placement"
+          "description": "Tria si el selector de fons de pantalla s'adjunta a la barra, flota a prop o s'obre centrat",
+          "label": "Ubicació"
         },
         "shadow": {
-          "description": "Cast the global surface shadow from panel surfaces"
+          "description": "Projecta l'ombra global de la superfície des de les superfícies dels panells"
         },
         "transparency-mode": {
-          "description": "Panel glass style, including floating/centered panel opacity and card translucency",
-          "label": "Transparency"
+          "description": "Estil de vidre del panell, incloent l'opacitat del panell flotant/centrat i la translucidesa de les targetes",
+          "label": "Transparència"
         }
       },
       "power": {
         "session-actions": {
-          "description": "Power menu entries, order, custom commands, and icons",
-          "label": "Entries"
+          "description": "Entrades del menú d'energia, ordre, ordres personalitzades i icones",
+          "label": "Entrades"
         }
       },
       "services": {
         "audio-overdrive": {
-          "description": "Allow volume above 100%",
-          "label": "Audio Overdrive"
+          "description": "Permet un volum superior al 100%",
+          "label": "Sobremarxa d'àudio"
         },
         "calendar": {
-          "description": "Show events from your online calendar accounts",
-          "label": "Calendar"
+          "description": "Mostra esdeveniments dels teus comptes de calendari en línia",
+          "label": "Calendari"
         },
         "calendar-add": {
-          "button": "Add Account",
-          "description": "Add iCloud, CalDAV, or Google accounts",
-          "label": "Calendar Accounts"
+          "button": "Afegeix un compte",
+          "description": "Afegeix comptes d'iCloud, CalDAV o Google",
+          "label": "Comptes de calendari"
         },
         "calendar-edit": {
-          "button": "Edit",
-          "description": "Update this calendar account"
+          "button": "Edita",
+          "description": "Actualitza aquest compte de calendari"
         },
         "calendar-refresh-interval": {
-          "description": "How often to sync calendar events (minutes)",
-          "label": "Refresh Interval"
+          "description": "Cada quants minuts se sincronitzen els esdeveniments del calendari",
+          "label": "Interval d'actualització"
         },
         "day-temperature": {
-          "description": "Color temperature during the day (Kelvin)",
-          "label": "Day Temperature"
+          "description": "Temperatura de color durant el dia (Kelvin)",
+          "label": "Temperatura de dia"
         },
         "ddcutil": {
-          "description": "Control external monitor brightness via DDC/CI",
+          "description": "Controla la brillantor del monitor extern mitjançant DDC/CI",
           "label": "DDC/CI (ddcutil)",
-          "requires-ddcutil": "Install ddcutil to enable DDC/CI brightness control"
+          "requires-ddcutil": "Instal·la ddcutil per activar el control de brillantor DDC/CI"
         },
         "force-night-light": {
-          "description": "Always apply night light regardless of time",
-          "label": "Force Night Light"
+          "description": "Aplica sempre el Night Light independentment de l'hora",
+          "label": "Força el Night Light"
         },
         "latitude": {
-          "description": "Manual latitude for the sunrise/sunset schedule, used when auto-locate and address are off",
-          "label": "Latitude"
+          "description": "Latitud manual per a l'horari de sortida/posta de sol, utilitzat quan auto-locate i adreça estan desactivats",
+          "label": "Latitud"
         },
         "location-address": {
-          "description": "City or address to locate, used when auto-locate is off",
-          "label": "Address",
-          "placeholder": "City, Country"
+          "description": "Ciutat o adreça per localitzar, utilitzat quan auto-locate està desactivat",
+          "label": "Adreça",
+          "placeholder": "Ciutat, País"
         },
         "location-auto-locate": {
-          "description": "Detect your location automatically from your IP address",
-          "label": "Auto-Locate (IP)"
+          "description": "Detecta la teva ubicació automàticament des de la teva adreça IP",
+          "label": "Auto-localització (IP)"
         },
         "longitude": {
-          "description": "Manual longitude for the sunrise/sunset schedule, used when auto-locate and address are off",
-          "label": "Longitude"
+          "description": "Longitud manual per a l'horari de sortida/posta de sol, utilitzat quan auto-locate i adreça estan desactivats",
+          "label": "Longitud"
         },
         "minimum-brightness": {
-          "description": "Prevent the screen from going completely dark",
-          "label": "Minimum Brightness"
+          "description": "Evita que la pantalla es quedi completament fosca",
+          "label": "Brillantor mínima"
         },
         "mpris-blacklist": {
-          "description": "Players to ignore for media controls and Now Playing",
-          "label": "MPRIS Player Blacklist"
+          "description": "Reproductors a ignorar per als controls multimèdia i Reproduint",
+          "label": "Llista negra de reproductors MPRIS"
         },
         "night-light": {
-          "description": "Shift screen colors warmer at night",
+          "description": "Canvia els colors de la pantalla a més càlids a la nit",
           "label": "Night Light",
-          "requires-gamma-control": "Compositor does not support gamma control"
+          "requires-gamma-control": "El compositor no suporta el control de gamma"
         },
         "night-temperature": {
-          "description": "Color temperature at night (Kelvin)",
-          "label": "Night Temperature"
+          "description": "Temperatura de color a la nit (Kelvin)",
+          "label": "Temperatura nocturna"
         },
         "notification-sound": {
-          "description": "Sound file used for notification feedback",
-          "label": "Notification Sound",
-          "placeholder": "/path/to/sound.wav"
+          "description": "Fitxer de so utilitzat per a la retroalimentació de notificacions",
+          "label": "So de notificació",
+          "placeholder": "/camí/al/so.wav"
         },
         "shell-sounds": {
-          "description": "Play sound effects for shell events",
-          "label": "Shell Sounds"
+          "description": "Reprodueix efectes de so per als esdeveniments del shell",
+          "label": "Sons del shell"
         },
         "sound-volume": {
-          "description": "Volume for shell sound effects",
-          "label": "Sound Volume"
+          "description": "Volum dels efectes de so del shell",
+          "label": "Volum dels sons"
         },
         "sunrise": {
-          "description": "Manual sunrise time in HH:MM, used when no location is set",
-          "label": "Sunrise"
+          "description": "Hora de sortida del sol manual en HH:MM, utilitzat quan no hi ha ubicació configurada",
+          "label": "Sortida del sol"
         },
         "sunset": {
-          "description": "Manual sunset time in HH:MM, used when no location is set",
-          "label": "Sunset"
+          "description": "Hora de posta de sol manual en HH:MM, utilitzat quan no hi ha ubicació configurada",
+          "label": "Posta de sol"
         },
         "system-monitor": {
           "cpu-poll": {
-            "description": "Seconds between CPU usage, CPU temperature, and load-average samples (0 disables)",
-            "label": "CPU Poll Interval"
+            "description": "Segons entre mostres d'ús de CPU, temperatura de CPU i mitjana de càrrega (0 desactiva)",
+            "label": "Interval de sondeig de CPU"
           },
-          "description": "Sample CPU, memory, network, load, temperature, and disk statistics",
+          "description": "Mostreja estadístiques de CPU, memòria, xarxa, càrrega, temperatura i disc",
           "disk-poll": {
-            "description": "Seconds between disk usage and swap usage samples (0 disables)",
-            "label": "Disk Poll Interval"
+            "description": "Segons entre mostres d'ús de disc i ús de swap (0 desactiva)",
+            "label": "Interval de sondeig de disc"
           },
           "gpu-poll": {
-            "description": "Seconds between GPU temperature and VRAM samples. 0 disables it (default), which avoids waking a discrete GPU; 5 is a good interval if you do enable it",
-            "label": "GPU Poll Interval"
+            "description": "Segons entre mostres de temperatura de GPU i VRAM. 0 el desactiva (per defecte), la qual cosa evita despertar una GPU discreta; 5 és un bon interval si l'actives",
+            "label": "Interval de sondeig de GPU"
           },
-          "label": "System Monitor",
+          "label": "Monitor del sistema",
           "memory-poll": {
-            "description": "Seconds between RAM usage samples (0 disables)",
-            "label": "Memory Poll Interval"
+            "description": "Segons entre mostres d'ús de RAM (0 desactiva)",
+            "label": "Interval de sondeig de memòria"
           },
           "network-poll": {
-            "description": "Seconds between network throughput samples (0 disables)",
-            "label": "Network Poll Interval"
+            "description": "Segons entre mostres de rendiment de xarxa (0 desactiva)",
+            "label": "Interval de sondeig de xarxa"
           },
           "stats": {
-            "cpu-temp": "CPU Temp",
-            "cpu-usage": "CPU Usage",
-            "disk-usage": "Disk Usage",
-            "gpu-temp": "GPU Temp",
-            "gpu-usage": "GPU Usage",
-            "gpu-vram": "GPU VRAM",
-            "network-rx": "Download",
-            "network-tx": "Upload",
-            "ram-usage": "RAM Usage",
-            "swap-usage": "Swap Usage"
+            "cpu-temp": "Temp. CPU",
+            "cpu-usage": "Ús CPU",
+            "disk-usage": "Ús del disc",
+            "gpu-temp": "Temp. GPU",
+            "gpu-usage": "Ús GPU",
+            "gpu-vram": "VRAM GPU",
+            "network-rx": "Descàrrega",
+            "network-tx": "Càrrega",
+            "ram-usage": "Ús RAM",
+            "swap-usage": "Ús Swap"
           },
           "threshold": {
-            "description": "Activity threshold (left) and critical threshold (right)",
+            "description": "Llindar d'activitat (esquerra) i llindar crític (dreta)",
             "label": "{stat}"
           }
         },
         "volume-change-sound": {
-          "description": "Sound file used for volume feedback",
-          "label": "Volume Change Sound",
-          "placeholder": "/path/to/sound.wav"
+          "description": "Fitxer de so utilitzat per a la retroalimentació de volum",
+          "label": "So de canvi de volum",
+          "placeholder": "/camí/al/so.wav"
         },
         "weather": {
-          "description": "Enable the weather service",
-          "label": "Weather"
+          "description": "Activa el servei meteorològic",
+          "label": "Temps"
         },
         "weather-effects": {
-          "description": "Show visual weather effects",
-          "label": "Weather Effects"
+          "description": "Mostra efectes meteorològics visuals",
+          "label": "Efectes meteorològics"
         },
         "weather-refresh-interval": {
-          "description": "How often to refresh weather data (minutes)",
-          "label": "Refresh Interval"
+          "description": "Cada quants minuts s'actualitzen les dades meteorològiques",
+          "label": "Interval d'actualització"
         },
         "weather-unit": {
-          "description": "Unit system for weather display",
-          "label": "Units"
+          "description": "Sistema d'unitats per a la visualització meteorològica",
+          "label": "Unitats"
         }
       },
       "shared": {
         "auto-hide": {
-          "label": "Auto-Hide"
+          "label": "Amagat automàtic"
         },
         "background-opacity": {
-          "label": "Background Opacity"
+          "label": "Opacitat del fons"
         },
         "contact-shadow": {
-          "label": "Contact Shadow"
+          "label": "Ombra de contacte"
         },
         "corner-bottom-left": {
-          "label": "Bottom Left Radius"
+          "label": "Radi inferior esquerre"
         },
         "corner-bottom-right": {
-          "label": "Bottom Right Radius"
+          "label": "Radi inferior dret"
         },
         "corner-radius": {
-          "label": "Corner Radius"
+          "label": "Radi de cantonada"
         },
         "corner-top-left": {
-          "label": "Top Left Radius"
+          "label": "Radi superior esquerre"
         },
         "corner-top-right": {
-          "label": "Top Right Radius"
+          "label": "Radi superior dret"
         },
         "cross-axis-padding": {
-          "label": "Cross Axis Padding"
+          "label": "Farcit de l'eix transversal"
         },
         "edge-margin": {
-          "label": "Edge Margin"
+          "label": "Marge de vora"
         },
         "enabled": {
-          "label": "Enabled"
+          "label": "Activat"
         },
         "ends-margin": {
-          "label": "Ends Margin"
+          "label": "Marge dels extrems"
         },
         "main-axis-padding": {
-          "label": "Main Axis Padding"
+          "label": "Farcit de l'eix principal"
         },
         "position": {
-          "label": "Position"
+          "label": "Posició"
         },
         "reserve-space": {
-          "label": "Reserve Space"
+          "label": "Reserva espai"
         },
         "shadow": {
-          "label": "Shadow"
+          "label": "Ombra"
         },
         "shadow-alpha": {
-          "label": "Shadow Opacity"
+          "label": "Opacitat de l'ombra"
         },
         "shadow-direction": {
-          "label": "Shadow Direction"
+          "label": "Direcció de l'ombra"
         }
       },
       "shell": {
         "avatar-path": {
-          "description": "Path to a custom avatar image. Large images are cropped and resized automatically.",
-          "label": "Avatar Path",
-          "placeholder": "/path/to/avatar.png"
+          "description": "Camí a una imatge d'avatar personalitzada. Les imatges grans es retallen i redimensionen automàticament.",
+          "label": "Camí de l'avatar",
+          "placeholder": "/camí/al/avatar.png"
         },
         "clipboard-auto-paste": {
-          "description": "Automatically paste clipboard selections",
-          "label": "Clipboard Auto-Paste"
+          "description": "Enganxa automàticament les seleccions del porta-retalls",
+          "label": "Auto-enganxat del porta-retalls"
         },
         "clipboard-confirm-clear-history": {
-          "description": "Ask before clearing clipboard history or deleting an unpinned entry from the panel; when off, those actions apply immediately (pinned entries still ask before delete)",
-          "label": "Confirm Clear History"
+          "description": "Demana abans de netejar l'historial del porta-retalls o eliminar una entrada no fixada del panell; quan està desactivat, aquestes accions s'apliquen immediatament (les entrades fixades encara demanen confirmació abans d'eliminar)",
+          "label": "Confirma la neteja de l'historial"
         },
         "clipboard-enabled": {
-          "description": "Enable clipboard history, the clipboard panel, and copy/paste integration",
-          "label": "Clipboard"
+          "description": "Activa l'historial del porta-retalls, el panell del porta-retalls i la integració de copiar/enganxar",
+          "label": "Porta-retalls"
         },
         "clipboard-history-max-entries": {
-          "description": "Maximum unpinned entries kept in clipboard history",
-          "label": "History Size"
+          "description": "Nombre màxim d'entrades no fixades a l'historial del porta-retalls",
+          "label": "Mida de l'historial"
         },
         "clipboard-image-action": {
-          "description": "Command to run from image clipboard entries; use {path} for the file path, {stdin} to mark the stdin position, or omit {path} to pipe automatically",
-          "label": "Image Action Command",
-          "placeholder": "gimp {path} or satty -f -"
+          "description": "Ordre a executar des de les entrades d'imatge del porta-retalls; utilitza {path} per al camí del fitxer, {stdin} per marcar la posició stdin, o omet {path} per canalitzar automàticament",
+          "label": "Ordre d'acció d'imatge",
+          "placeholder": "gimp {path} o satty -f -"
         },
         "date-format": {
-          "description": "Default date format for shell UI without its own setting",
-          "label": "Date Format"
+          "description": "Format de data per defecte per a la interfície del shell sense la seva pròpia configuració",
+          "label": "Format de data"
         },
         "launch-apps-as-systemd-services": {
-          "description": "Launches applications in separate systemd services so they don't share Noctalia's cgroup",
-          "label": "Launch Apps as systemd Services"
+          "description": "Llança aplicacions en serveis systemd separats perquè no comparteixin el cgroup del Noctalia",
+          "label": "Llança aplicacions com a serveis systemd"
         },
         "middle-click-opens-widget-settings": {
-          "description": "Open a bar widget's settings from the bar with middle click",
-          "label": "Middle Click Opens Widget Settings"
+          "description": "Obre la configuració d'un widget de la barra des de la barra amb clic del mig",
+          "label": "El clic del mig obre la configuració del widget"
         },
         "niri-overview-type-to-launch": {
-          "description": "Open the launcher when typing in niri overview; uses a tiny keyboard-focus surface while overview is open",
-          "label": "Type to Launch"
+          "description": "Obre el launcher en escriure a la vista general de niri; utilitza una petita superfície d'enfocament del teclat mentre la vista general està oberta",
+          "label": "Escriu per llançar"
         },
         "offline-mode": {
-          "description": "Block all outgoing network requests",
-          "label": "Offline Mode"
+          "description": "Bloqueja totes les sol·licituds de xarxa sortints",
+          "label": "Mode fora de línia"
         },
         "osd-background-opacity": {
-          "description": "Background opacity of OSD popups",
-          "label": "Background Opacity"
+          "description": "Opacitat del fons de les finestres emergents OSD",
+          "label": "Opacitat del fons"
         },
         "osd-kinds-bluetooth": {
-          "description": "Show an OSD popup when Bluetooth is toggled",
+          "description": "Mostra una finestra emergent OSD quan es commuta el Bluetooth",
           "label": "Bluetooth"
         },
         "osd-kinds-brightness": {
-          "description": "Show an OSD popup when display brightness changes",
-          "label": "Brightness"
+          "description": "Mostra una finestra emergent OSD quan canvia la brillantor de la pantalla",
+          "label": "Brillantor"
         },
         "osd-kinds-caffeine": {
-          "description": "Show an OSD popup when the caffeine (idle inhibitor) state changes",
+          "description": "Mostra una finestra emergent OSD quan canvia l'estat de la cafeïna (inhibidor d'inactivitat)",
           "label": "Caffeine"
         },
         "osd-kinds-dnd": {
-          "description": "Show an OSD popup when Do Not Disturb is toggled",
-          "label": "Do Not Disturb"
+          "description": "Mostra una finestra emergent OSD quan es commuta No Molestar",
+          "label": "No molestar"
         },
         "osd-kinds-keyboard-layout": {
-          "description": "Show an OSD popup when the input keyboard layout changes",
-          "label": "Keyboard Layout"
+          "description": "Mostra una finestra emergent OSD quan canvia la disposició del teclat",
+          "label": "Disposició del teclat"
         },
         "osd-kinds-lock-keys": {
-          "description": "Show OSD popups for Caps Lock, Num Lock, and Scroll Lock changes",
-          "label": "Lock Keys"
+          "description": "Mostra finestres emergents OSD per als canvis de Bloq Majús, Bloq Num i Bloq Despl",
+          "label": "Tecles de bloqueig"
         },
         "osd-kinds-media": {
-          "description": "Show an OSD popup when a new track starts playing",
-          "label": "Now Playing"
+          "description": "Mostra una finestra emergent OSD quan comença una nova pista",
+          "label": "S'està reproduint"
         },
         "osd-kinds-power-profile": {
-          "description": "Show an OSD popup when the power profile changes",
-          "label": "Power Profile"
+          "description": "Mostra una finestra emergent OSD quan canvia el perfil d'energia",
+          "label": "Perfil d'energia"
         },
         "osd-kinds-volume": {
-          "description": "Show OSD popups when volume changes; use advanced settings to control output and input separately",
-          "label": "Volume"
+          "description": "Mostra finestres emergents OSD quan canvia el volum; utilitza la configuració avançada per controlar sortida i entrada per separat",
+          "label": "Volum"
         },
         "osd-kinds-volume-input": {
-          "description": "Show an OSD popup when input (microphone) volume changes",
-          "label": "Input Volume"
+          "description": "Mostra una finestra emergent OSD quan canvia el volum d'entrada (micròfon)",
+          "label": "Volum d'entrada"
         },
         "osd-kinds-volume-output": {
-          "description": "Show an OSD popup when output (speaker) volume changes",
-          "label": "Output Volume"
+          "description": "Mostra una finestra emergent OSD quan canvia el volum de sortida (altaveu)",
+          "label": "Volum de sortida"
         },
         "osd-kinds-wifi": {
-          "description": "Show an OSD popup when Wi-Fi is toggled",
+          "description": "Mostra una finestra emergent OSD quan es commuta el Wi-Fi",
           "label": "Wi-Fi"
         },
         "osd-monitors": {
-          "description": "Choose which monitors show OSD popups; leave empty to show on all monitors",
+          "description": "Tria quins monitors mostren les finestres emergents OSD; deixa buit per mostrar a tots els monitors",
           "label": "Monitors"
         },
         "osd-offset-x": {
-          "description": "Absolute horizontal margin from the screen edge",
-          "label": "Horizontal Margin"
+          "description": "Marge horitzontal absolut des de la vora de la pantalla",
+          "label": "Marge horitzontal"
         },
         "osd-offset-y": {
-          "description": "Absolute vertical margin from the screen edge",
-          "label": "Vertical Margin"
+          "description": "Marge vertical absolut des de la vora de la pantalla",
+          "label": "Marge vertical"
         },
         "osd-orientation": {
-          "description": "Layout direction for OSD popups",
-          "label": "Orientation"
+          "description": "Direcció de la disposició per a les finestres emergents OSD",
+          "label": "Orientació"
         },
         "osd-position": {
-          "description": "Screen position for OSD popups",
-          "label": "Screen Position"
+          "description": "Posició a la pantalla per a les finestres emergents OSD",
+          "label": "Posició a la pantalla"
         },
         "osd-scale": {
-          "description": "Scale OSD popups relative to the shell UI scale (1.0 keeps the default size)",
-          "label": "Scale"
+          "description": "Escala les finestres emergents OSD en relació amb l'escala de la interfície del shell (1.0 manté la mida per defecte)",
+          "label": "Escala"
         },
         "password-style": {
-          "description": "Visual style for password input masking",
-          "label": "Password Style"
+          "description": "Estil visual per a l'emmascarament de l'entrada de contrasenya",
+          "label": "Estil de contrasenya"
         },
         "polkit-agent": {
-          "description": "Enable the built-in authentication agent",
-          "label": "Polkit Agent"
+          "description": "Activa l'agent d'autenticació integrat",
+          "label": "Agent polkit"
         },
         "screen-time-enabled": {
-          "description": "Track per-app usage and show it in Control Center",
-          "label": "Screen Time"
+          "description": "Registra l'ús per aplicació i mostra-ho al centre de control",
+          "label": "Temps de pantalla"
         },
         "screen-time-reset": {
-          "button": "Reset",
-          "description": "Clear stored per-app foreground usage history",
-          "label": "Reset Screen Time Data"
+          "button": "Restableix",
+          "description": "Esborra l'historial d'ús en primer pla per aplicació emmagatzemat",
+          "label": "Restableix les dades de temps de pantalla"
         },
         "screenshot-copy-to-clipboard": {
-          "description": "Place the captured PNG on the clipboard selection",
-          "label": "Copy to Clipboard"
+          "description": "Col·loca el PNG capturat a la selecció del porta-retalls",
+          "label": "Copia al porta-retalls"
         },
         "screenshot-directory": {
-          "description": "Folder for saved PNG files; leave empty to use ~/Pictures",
-          "label": "Output Directory",
-          "placeholder": "~/Pictures"
+          "description": "Carpeta per als fitxers PNG desats; deixa buit per utilitzar ~/Imatges",
+          "label": "Directori de sortida",
+          "placeholder": "~/Imatges"
         },
         "screenshot-filename-pattern": {
-          "description": "strftime pattern without extension (.png is added); use %s for unix epoch",
-          "label": "Filename Pattern"
+          "description": "Patró strftime sense extensió (s'afegeix .png); utilitza %s per a l'època unix",
+          "label": "Patró del nom de fitxer"
         },
         "screenshot-freeze-screen": {
-          "description": "Capture the desktop before region selection so moving content stays still",
-          "label": "Freeze Screen"
+          "description": "Captura l'escriptori abans de la selecció de regió perquè el contingut en moviment es mantingui quiet",
+          "label": "Congela la pantalla"
         },
         "screenshot-pipe-command": {
-          "description": "Command run as /bin/sh -lc with the PNG on stdin; for annotators or uploaders (for example: swappy -f - or satty -f -)",
-          "label": "Pipe Command",
+          "description": "Ordre executada com a /bin/sh -lc amb el PNG a stdin; per a anotadors o carregadors (per exemple: swappy -f - o satty -f -)",
+          "label": "Ordre de canonada",
           "placeholder": "swappy -f -"
         },
         "screenshot-pipe-to-command": {
-          "description": "Send the captured PNG to a shell command on stdin",
-          "label": "Pipe to Command"
+          "description": "Envia el PNG capturat a una ordre de shell per stdin",
+          "label": "Canonada a l'ordre"
         },
         "screenshot-save-to-file": {
-          "description": "Write screenshots as PNG files to the output directory",
-          "label": "Save to File"
+          "description": "Escriu les captures de pantalla com a fitxers PNG al directori de sortida",
+          "label": "Desa al fitxer"
         },
         "show-location": {
-          "description": "Show location name in weather widgets",
-          "label": "Show Location"
+          "description": "Mostra el nom de la ubicació als widgets del temps",
+          "label": "Mostra la ubicació"
         },
         "sync-greeter": {
-          "button": "Sync Now",
-          "description": "Copy the current wallpaper and colors to Noctalia Greeter (requires administrator approval)",
+          "button": "Sincronitza ara",
+          "description": "Copia el fons de pantalla i els colors actuals al Noctalia Greeter (requereix aprovació d'administrador)",
           "label": "Noctalia Greeter"
         },
         "telemetry": {
-          "description": "Sends a small anonymous startup ping with version, OS, compositor, monitor resolutions, RAM, and UI scale",
-          "label": "Anonymous Startup Ping"
+          "description": "Envia un petit ping anònim d'inici amb versió, SO, compositor, resolucions de monitor, RAM i escala de la interfície",
+          "label": "Ping d'inici anònim"
         },
         "time-format": {
-          "description": "Default time format for shell UI without its own setting",
-          "label": "Time Format"
+          "description": "Format d'hora per defecte per a la interfície del shell sense la seva pròpia configuració",
+          "label": "Format d'hora"
         }
       },
       "system": {
         "battery-device-warning-threshold": {
-          "description": "Override the battery warning threshold for this device. Set 0 to disable warnings for this device.",
-          "label": "{device} Warning Threshold"
+          "description": "Sobreescriu el llindar d'advertència de bateria per a aquest dispositiu. Posa 0 per desactivar els avisos d'aquest dispositiu.",
+          "label": "Llindar d'advertència de {device}"
         },
         "battery-warning-threshold": {
-          "description": "System battery percentage at or below which the shell sends a low-battery notification and battery widgets use their warning color. Set 0 to disable.",
-          "label": "Battery Warning Threshold"
+          "description": "Percentatge de bateria del sistema en el qual o per sota del qual el shell envia una notificació de bateria baixa i els widgets de bateria utilitzen el seu color d'advertència. Posa 0 per desactivar.",
+          "label": "Llindar d'advertència de bateria"
         }
       },
       "templates": {
         "builtin-ids": {
-          "description": "Toggle bundled app templates to render on each theme change",
-          "empty": "No built-in templates are available.",
-          "label": "Built-In Templates"
+          "description": "Commuta les plantilles d'aplicació integrades per renderitzar a cada canvi de tema",
+          "empty": "No hi ha plantilles integrades disponibles.",
+          "label": "Plantilles integrades"
         },
         "community-ids": {
-          "description": "Toggle cached community templates to render on each theme change",
-          "empty": "No community templates are available yet. Enable community templates and refresh the catalog first.",
-          "label": "Community Templates"
+          "description": "Commuta les plantilles de la comunitat en memòria cau per renderitzar a cada canvi de tema",
+          "empty": "Encara no hi ha plantilles de la comunitat disponibles. Activa les plantilles de la comunitat i actualitza el catàleg primer.",
+          "label": "Plantilles de la comunitat"
         },
         "enable-builtins": {
-          "description": "Use the bundled catalog of theme templates for apps",
-          "label": "Enable Built-In Templates"
+          "description": "Utilitza el catàleg integrat de plantilles de tema per a aplicacions",
+          "label": "Activa les plantilles integrades"
         },
         "enable-community-templates": {
-          "description": "Download and apply templates from the community catalog",
-          "label": "Enable Community Templates"
+          "description": "Descarrega i aplica plantilles del catàleg de la comunitat",
+          "label": "Activa les plantilles de la comunitat"
         }
       },
       "wallpaper": {
         "automation": {
-          "description": "Cycle wallpapers automatically on a timer",
-          "label": "Automatic Rotation"
+          "description": "Canvia els fons de pantalla automàticament amb un temporitzador",
+          "label": "Rotació automàtica"
         },
         "automation-interval": {
-          "description": "Seconds between wallpaper changes",
-          "label": "Rotation Interval"
+          "description": "Segons entre canvis de fons de pantalla",
+          "label": "Interval de rotació"
         },
         "automation-order": {
-          "description": "Pick wallpapers randomly or alphabetically",
-          "label": "Order"
+          "description": "Tria fons de pantalla aleatòriament o alfabèticament",
+          "label": "Ordre"
         },
         "automation-recursive": {
-          "description": "Search nested folders for wallpapers",
-          "label": "Include Subfolders"
+          "description": "Cerca carpetes niades per a fons de pantalla",
+          "label": "Inclou subcarpetes"
         },
         "directory": {
-          "description": "Folder containing wallpapers",
-          "label": "Wallpaper Directory"
+          "description": "Carpeta que conté fons de pantalla",
+          "label": "Directori de fons de pantalla"
         },
         "directory-dark": {
-          "description": "Wallpaper folder used in dark theme mode",
-          "label": "Dark Mode Directory",
-          "placeholder": "~/Pictures/Wallpapers"
+          "description": "Carpeta de fons de pantalla utilitzada en mode de tema fosc",
+          "label": "Directori del mode fosc",
+          "placeholder": "~/Imatges/Fons"
         },
         "directory-light": {
-          "description": "Wallpaper folder used in light theme mode",
-          "label": "Light Mode Directory",
-          "placeholder": "~/Pictures/Wallpapers"
+          "description": "Carpeta de fons de pantalla utilitzada en mode de tema clar",
+          "label": "Directori del mode clar",
+          "placeholder": "~/Imatges/Fons"
         },
         "edge-smoothness": {
-          "description": "Feathering of transition edges between wallpapers",
-          "label": "Edge Smoothness"
+          "description": "Difuminat de les vores de transició entre fons de pantalla",
+          "label": "Suavitat de vores"
         },
         "enabled": {
-          "description": "Enable the wallpaper service"
+          "description": "Activa el servei de fons de pantalla"
         },
         "fill-color": {
-          "description": "Solid color shown behind image in uncovered areas",
-          "label": "Fill Color"
+          "description": "Color sòlid mostrat darrere de la imatge a les àrees no cobertes",
+          "label": "Color de farciment"
         },
         "fill-mode": {
-          "description": "How wallpapers fit the screen",
-          "label": "Fill Mode"
+          "description": "Com s'ajusten els fons de pantalla a la pantalla",
+          "label": "Mode d'ajust"
         },
         "monitor-directory": {
-          "label": "Wallpaper Directory"
+          "label": "Directori de fons de pantalla"
         },
         "monitor-directory-dark": {
-          "label": "Dark Mode Directory",
-          "placeholder": "~/Pictures/Wallpapers"
+          "label": "Directori del mode fosc",
+          "placeholder": "~/Imatges/Fons"
         },
         "monitor-directory-light": {
-          "label": "Light Mode Directory",
-          "placeholder": "~/Pictures/Wallpapers"
+          "label": "Directori del mode clar",
+          "placeholder": "~/Imatges/Fons"
         },
         "panel": {
-          "button": "Open Panel",
-          "description": "Open the wallpaper picker panel",
-          "label": "Wallpaper Panel"
+          "button": "Obre el panell",
+          "description": "Obre el panell del selector de fons de pantalla",
+          "label": "Panell de fons de pantalla"
         },
         "per-monitor-directories": {
-          "description": "Use separate wallpaper folders for each monitor",
-          "label": "Per-Monitor Directories"
+          "description": "Utilitza carpetes de fons de pantalla separades per a cada monitor",
+          "label": "Directoris per monitor"
         },
         "transition-duration": {
-          "description": "Length of the wallpaper change animation in milliseconds",
-          "label": "Transition Duration"
+          "description": "Durada de l'animació de canvi de fons de pantalla en mil·lisegons",
+          "label": "Durada de la transició"
         },
         "transition-on-startup": {
-          "description": "Play a transition when the shell first shows a wallpaper",
-          "label": "Animate on Startup"
+          "description": "Reprodueix una transició quan el shell mostra un fons de pantalla per primera vegada",
+          "label": "Anima a l'inici"
         },
         "transitions": {
-          "description": "Effects available when changing wallpaper (one is picked at random per change)",
-          "label": "Transition Effects"
+          "description": "Efectes disponibles en canviar el fons de pantalla (se'n tria un a l'atzar per canvi)",
+          "label": "Efectes de transició"
         }
       }
     },
     "session-actions": {
-      "add": "Add action",
-      "clear-glyph": "Clear",
-      "command-label": "Shell command",
-      "command-placeholder": "Optional bash command, leave empty for built-in behavior",
-      "command-required-placeholder": "Shell command to run",
-      "glyph-label": "Glyph",
-      "glyph-picker-title": "Action glyph",
-      "kind-section-label": "Behavior",
-      "label-field": "Label",
-      "label-placeholder": "Optional button text",
-      "shortcut-label": "Shortcut",
+      "add": "Afegeix una acció",
+      "clear-glyph": "Esborra",
+      "command-label": "Ordre de shell",
+      "command-placeholder": "Ordre bash opcional, deixa buit per al comportament integrat",
+      "command-required-placeholder": "Ordre de shell a executar",
+      "glyph-label": "Glif",
+      "glyph-picker-title": "Glif de l'acció",
+      "kind-section-label": "Comportament",
+      "label-field": "Etiqueta",
+      "label-placeholder": "Text del botó opcional",
+      "shortcut-label": "Drecera",
       "variant": {
-        "default": "Default",
-        "destructive": "Destructive",
+        "default": "Per defecte",
+        "destructive": "Destructiu",
         "ghost": "Ghost",
         "outline": "Outline",
-        "primary": "Primary",
-        "secondary": "Secondary"
+        "primary": "Primari",
+        "secondary": "Secundari"
       },
-      "variant-label": "Button style"
+      "variant-label": "Estil del botó"
     },
     "widgets": {
       "instances": {
         "cpu": "CPU",
-        "date": "Date",
-        "input-volume": "Input Volume",
-        "network-rx": "Network RX",
-        "network-tx": "Network TX",
-        "output-volume": "Output Volume",
+        "date": "Data",
+        "input-volume": "Volum d'entrada",
+        "network-rx": "Xarxa RX",
+        "network-tx": "Xarxa TX",
+        "output-volume": "Volum de sortida",
         "ram": "RAM",
-        "temp": "Temperature"
+        "temp": "Temperatura"
       },
       "options": {
-        "always": "Always",
-        "cpu-temp": "CPU Temperature",
-        "cpu-usage": "CPU Usage",
-        "disk-percent": "Disk Percent",
-        "full": "Full",
+        "always": "Sempre",
+        "cpu-temp": "Temperatura CPU",
+        "cpu-usage": "Ús CPU",
+        "disk-percent": "Percentatge disc",
+        "full": "Complet",
         "gauge": "Gauge",
-        "glyph": "Glyph",
-        "gpu-temp": "GPU Temperature",
-        "gpu-usage": "GPU Usage",
-        "gpu-vram": "GPU VRAM",
-        "graph": "Graph",
-        "graphic": "Graphic",
-        "icon-and-text": "Icon and Text",
-        "icon-only": "Icon Only",
+        "glyph": "Glif",
+        "gpu-temp": "Temperatura GPU",
+        "gpu-usage": "Ús GPU",
+        "gpu-vram": "VRAM GPU",
+        "graph": "Gràfic",
+        "graphic": "Gràfic",
+        "icon-and-text": "Icona i text",
+        "icon-only": "Només icona",
         "id": "ID",
-        "input": "Input",
-        "instance": "Per Placement",
-        "name": "Name",
-        "net-rx": "Network RX",
-        "net-tx": "Network TX",
-        "none": "None",
-        "on-hover": "On Hover",
-        "output": "Output",
-        "ram-percent": "RAM Percent",
-        "ram-used": "RAM Used",
-        "screenshot-primary-fullscreen": "Fullscreen",
-        "screenshot-primary-region": "Region",
-        "shared": "Shared",
-        "short": "Short",
-        "swap-percent": "Swap Percent",
+        "input": "Entrada",
+        "instance": "Per ubicació",
+        "name": "Nom",
+        "net-rx": "Xarxa RX",
+        "net-tx": "Xarxa TX",
+        "none": "Cap",
+        "on-hover": "En passar el ratolí",
+        "output": "Sortida",
+        "ram-percent": "Percentatge RAM",
+        "ram-used": "RAM utilitzada",
+        "screenshot-primary-fullscreen": "Pantalla completa",
+        "screenshot-primary-region": "Regió",
+        "shared": "Compartit",
+        "short": "Curt",
+        "swap-percent": "Percentatge Swap",
         "text": "Text",
-        "text-only": "Text Only",
-        "workspace-label-centered": "Centered",
-        "workspace-label-corner": "Corner",
-        "workspace-label-inside": "Inside pill"
+        "text-only": "Només text",
+        "workspace-label-centered": "Centrat",
+        "workspace-label-corner": "Cantonada",
+        "workspace-label-inside": "Dins de la pastilla"
       },
       "settings": {
         "active-opacity": {
-          "description": "Opacity of the icon for the active (focused) window.",
-          "label": "Active Icon Opacity"
+          "description": "Opacitat de la icona de la finestra activa (enfocada).",
+          "label": "Opacitat d'icona activa"
         },
         "album-art-only": {
-          "description": "Show only the circular album artwork without the track title",
-          "label": "Album Art Only"
+          "description": "Mostra només la caràtula circular sense el títol de la pista",
+          "label": "Només caràtula"
         },
         "anchor": {
-          "description": "Pin this widget as the center alignment anchor",
-          "label": "Anchor"
+          "description": "Fixa aquest widget com a àncora d'alineació central",
+          "label": "Àncora"
         },
         "art-size": {
-          "description": "Media artwork size in pixels",
-          "label": "Art Size"
+          "description": "Mida de la caràtula multimèdia en píxels",
+          "label": "Mida de la caràtula"
         },
         "bands": {
-          "description": "Number of visualizer bands",
-          "label": "Bands"
+          "description": "Nombre de bandes del visualitzador",
+          "label": "Bandes"
         },
         "capsule": {
-          "description": "Draw a capsule behind this widget",
-          "label": "Capsule"
+          "description": "Dibuixa una càpsula darrere d'aquest widget",
+          "label": "Càpsula"
         },
         "capsule-border": {
-          "description": "Color role for the capsule outline; fixed hex colors are also supported",
-          "label": "Capsule Border"
+          "description": "Color de la vora de la càpsula; també s'admeten colors hex fixos",
+          "label": "Vora de la càpsula"
         },
         "capsule-fill": {
-          "description": "Color role for the capsule background; fixed hex colors are also supported",
-          "label": "Capsule Fill"
+          "description": "Color de fons de la càpsula; també s'admeten colors hex fixos",
+          "label": "Fons de la càpsula"
         },
         "capsule-foreground": {
-          "description": "Color role for content inside the capsule; fixed hex colors are also supported",
-          "label": "Capsule Foreground"
+          "description": "Color del contingut dins de la càpsula; també s'admeten colors hex fixos",
+          "label": "Primer pla de la càpsula"
         },
         "capsule-opacity": {
-          "description": "Opacity of the capsule background",
-          "label": "Capsule Opacity"
+          "description": "Opacitat del fons de la càpsula",
+          "label": "Opacitat de la càpsula"
         },
         "capsule-padding": {
-          "description": "Inner padding inside the capsule",
-          "label": "Capsule Padding"
+          "description": "Farcit interior dins de la càpsula",
+          "label": "Farcit de la càpsula"
         },
         "capsule-radius": {
-          "description": "Corner radius for this widget capsule; leave blank for automatic pill shape, or set 0 for square corners",
-          "label": "Capsule Radius",
-          "taskbar-description": "Corner radius for the widget capsule, workspace disc indicators, and workspace group capsules; leave blank for automatic pill shape, or set 0 for square corners",
-          "workspaces-description": "Corner radius for this widget capsule and workspace pills; leave blank for automatic pill shape, or set 0 for square corners"
+          "description": "Radi de les cantonades d'aquesta càpsula de widget; deixa en blanc per a forma de pastilla automàtica o posa 0 per a cantonades quadrades",
+          "label": "Radi de la càpsula",
+          "taskbar-description": "Radi de les cantonades per a la càpsula del widget, els indicadors de disc d'espai de treball i les càpsules de grup d'espai de treball; deixa en blanc per a forma de pastilla automàtica o posa 0 per a cantonades quadrades",
+          "workspaces-description": "Radi de les cantonades per a aquesta càpsula de widget i les pastilles d'espai de treball; deixa en blanc per a forma de pastilla automàtica o posa 0 per a cantonades quadrades"
         },
         "centered": {
-          "description": "Center visualizer bars instead of aligning them to the edge",
-          "label": "Centered"
+          "description": "Centra les barres del visualitzador en lloc d'alinear-les a la vora",
+          "label": "Centrat"
         },
         "color": {
-          "description": "Color role for this widget's icon and label; fixed hex colors are also supported",
+          "description": "Color de la icona i l'etiqueta d'aquest widget; també s'admeten colors hex fixos",
           "label": "Color"
         },
         "color-1": {
-          "description": "First gradient color in the visualizer",
-          "label": "Color One"
+          "description": "Primer color del degradat al visualitzador",
+          "label": "Color u"
         },
         "color-2": {
-          "description": "Second gradient color in the visualizer",
-          "label": "Color Two"
+          "description": "Segon color del degradat al visualitzador",
+          "label": "Color dos"
         },
         "command": {
-          "description": "Shell command run when left-clicking this button",
-          "label": "Left Click Command"
+          "description": "Ordre de shell executada en fer clic esquerre en aquest botó",
+          "label": "Ordre del clic esquerre"
         },
         "custom-image": {
-          "description": "Path to a custom image. Leave empty to use the icon glyph.",
-          "dialog-title": "Select custom image",
-          "label": "Custom image"
+          "description": "Camí a una imatge personalitzada. Deixa buit per utilitzar el glif de la icona.",
+          "dialog-title": "Selecciona una imatge personalitzada",
+          "label": "Imatge personalitzada"
         },
         "custom-image-colorize": {
-          "description": "Tint the custom image with the widget Icon Color setting",
-          "label": "Colorize custom image"
+          "description": "Tinta la imatge personalitzada amb el color d'icona del widget",
+          "label": "Acoloreix la imatge personalitzada"
         },
         "custom-labels": {
-          "description": "Map keyboard layout names to custom labels",
-          "label": "Custom Labels"
+          "description": "Mapeja noms de disposició de teclat a etiquetes personalitzades",
+          "label": "Etiquetes personalitzades"
         },
         "cycle-command": {
-          "description": "Command run when cycling keyboard layouts",
-          "label": "Cycle Command"
+          "description": "Ordre executada en alternar les disposicions de teclat",
+          "label": "Ordre d'alternança"
         },
         "detached-panel": {
-          "description": "Open the drawer as a floating panel with its own background instead of merging with the bar",
-          "label": "Detached Panel"
+          "description": "Obre el calaix com a panell flotant amb el seu propi fons en lloc de fusionar-se amb la barra",
+          "label": "Panell desacoblat"
         },
         "device": {
-          "description": "Device to monitor or control",
-          "label": "Device"
+          "description": "Dispositiu a monitoritzar o controlar",
+          "label": "Dispositiu"
         },
         "display": {
-          "active-window-description": "Icon, title, or both on horizontal bars. Vertical bars stay icon-only.",
-          "description": "Display mode for this widget",
-          "label": "Display"
+          "active-window-description": "Icona, títol o tots dos a les barres horitzontals. Les barres verticals només mostren la icona.",
+          "description": "Mode de visualització per a aquest widget",
+          "label": "Visualització"
         },
         "display-mode": {
-          "description": "Render the battery as a graphical shape or a Tabler glyph",
-          "label": "Display Mode"
+          "description": "Renderitza la bateria com a forma gràfica o com a glif Tabler",
+          "label": "Mode de visualització"
         },
         "drawer": {
-          "description": "Show a tray button in the bar and open items in a panel",
-          "label": "Use Drawer Panel"
+          "description": "Mostra un botó de safata a la barra i obre els elements en un panell",
+          "label": "Utilitza panell calaix"
         },
         "drawer-columns": {
-          "description": "Number of tray icons per row in the drawer panel",
-          "label": "Drawer Columns"
+          "description": "Nombre d'icones de safata per fila al panell calaix",
+          "label": "Columnes del calaix"
         },
         "empty-color": {
-          "description": "Color role used for empty workspaces; fixed hex colors are also supported",
-          "label": "Empty Color"
+          "description": "Color utilitzat per als espais de treball buits; també s'admeten colors hex fixos",
+          "label": "Color buit"
         },
         "focused-color": {
-          "description": "Color role used for the focused workspace; fixed hex colors are also supported",
-          "label": "Focused Color"
+          "description": "Color utilitzat per a l'espai de treball enfocat; també s'admeten colors hex fixos",
+          "label": "Color enfocat"
         },
         "font-family": {
-          "description": "Typeface for this widget; leave empty to inherit the bar font",
-          "label": "Font Family"
+          "description": "Tipus de lletra per a aquest widget; deixa buit per heretar el tipus de lletra de la barra",
+          "label": "Tipus de lletra"
         },
         "font-weight": {
-          "description": "Default inherits the bar font weight",
-          "label": "Font Weight"
+          "description": "Per defecte hereta el pes de la lletra de la barra",
+          "label": "Pes de la lletra"
         },
         "format": {
-          "description": "Time format string",
+          "description": "Cadena de format d'hora",
           "label": "Format"
         },
         "glyph": {
-          "description": "Icon glyph name",
-          "label": "Glyph"
+          "description": "Nom del glif de la icona",
+          "label": "Glif"
         },
         "group-by-workspace": {
-          "description": "Group taskbar icons into workspace capsules when compositor data is available",
-          "label": "Group by Workspace"
+          "description": "Agrupa les icones de la barra de tasques en càpsules d'espai de treball quan hi ha dades del compositor",
+          "label": "Agrupa per espai de treball"
         },
         "group-single-icon-per-app": {
-          "description": "When grouping by workspace, collapse multiple windows from the same app into one icon with a count badge.",
-          "label": "Single Icon per App"
+          "description": "En agrupar per espai de treball, col·lapsa múltiples finestres de la mateixa aplicació en una sola icona amb una insígnia de recompte.",
+          "label": "Icona única per aplicació"
         },
         "height": {
-          "description": "Widget height in pixels",
-          "label": "Height"
+          "description": "Alçada del widget en píxels",
+          "label": "Alçada"
         },
         "hidden": {
-          "description": "Tray item ids to hide",
-          "label": "Hidden Items"
+          "description": "IDs d'elements de safata a amagar",
+          "label": "Elements amagats"
         },
         "hide-empty-workspaces": {
-          "description": "When grouping by workspace, omit capsules that have no running windows in the taskbar list.",
-          "label": "Hide Empty Workspaces"
+          "description": "En agrupar per espai de treball, omet les càpsules que no tenen finestres en execució a la llista de la barra de tasques.",
+          "label": "Amaga espais de treball buits"
         },
         "hide-when-empty": {
-          "description": "Hide workspace pills when there are no open windows",
-          "label": "Hide When Empty",
-          "workspaces-description": "Hide workspace pills that have no open windows"
+          "description": "Amaga les pastilles d'espai de treball quan no hi ha finestres obertes",
+          "label": "Amaga quan està buit",
+          "workspaces-description": "Amaga les pastilles d'espai de treball que no tenen finestres obertes"
         },
         "hide-when-full": {
-          "description": "Hide the battery widget when fully charged",
-          "label": "Hide When Full"
+          "description": "Amaga el widget de bateria quan està completament carregada",
+          "label": "Amaga quan està ple"
         },
         "hide-when-no-connected-device": {
-          "description": "Hide the bluetooth widget when no device is connected",
-          "label": "Hide When No Connected Device"
+          "description": "Amaga el widget de Bluetooth quan no hi ha cap dispositiu connectat",
+          "label": "Amaga sense dispositiu connectat"
         },
         "hide-when-no-media": {
-          "description": "Hide the media widget when no MPRIS player is active",
-          "label": "Hide When No Media"
+          "description": "Amaga el widget multimèdia quan no hi ha cap reproductor MPRIS actiu",
+          "label": "Amaga sense multimèdia"
         },
         "hide-when-no-unread": {
-          "description": "Hide the notifications widget when there are no unread notifications",
-          "label": "Hide When No New"
+          "description": "Amaga el widget de notificacions quan no hi ha notificacions no llegides",
+          "label": "Amaga sense novetats"
         },
         "hide-when-off": {
-          "description": "Hide the lock key indicator when inactive",
-          "label": "Hide When Off"
+          "description": "Amaga l'indicador de tecla de bloqueig quan està inactiu",
+          "label": "Amaga quan està desactivat"
         },
         "hide-when-plugged": {
-          "description": "Hide the battery widget while connected to AC power",
-          "label": "Hide When Plugged In"
+          "description": "Amaga el widget de bateria mentre està connectat a la corrent",
+          "label": "Amaga quan està endollat"
         },
         "hide-when-single-layout": {
-          "description": "Hide the keyboard layout widget unless more than one layout is configured",
-          "label": "Hide When Single Layout"
+          "description": "Amaga el widget de disposició de teclat tret que hi hagi més d'una disposició configurada",
+          "label": "Amaga amb una sola disposició"
         },
         "highlight-color": {
-          "description": "Color reached at or above the critical threshold",
-          "label": "Highlight Color"
+          "description": "Color aconseguit en o per sobre del llindar crític",
+          "label": "Color de ressaltat"
         },
         "hot-reload": {
-          "description": "Reload the scripted widget when its source changes",
-          "label": "Hot Reload"
+          "description": "Recarrega el widget amb script quan la seva font canvia",
+          "label": "Hot reload"
         },
         "icon-color": {
-          "description": "Overrides the widget color for icons only; fixed hex colors are also supported",
-          "label": "Icon Color"
+          "description": "Sobreescriu el color del widget només per a les icones; també s'admeten colors hex fixos",
+          "label": "Color d'icona"
         },
         "icon-size": {
-          "description": "Icon size in pixels",
-          "label": "Icon Size"
+          "description": "Mida de la icona en píxels",
+          "label": "Mida d'icona"
         },
         "interface": {
-          "description": "Network interface to monitor; leave empty to use the total across all interfaces",
-          "label": "Interface"
+          "description": "Interfície de xarxa a monitoritzar; deixa buit per utilitzar el total de totes les interfícies",
+          "label": "Interfície"
         },
         "inactive-opacity": {
-          "description": "Opacity of icons for inactive (unfocused) windows.",
-          "label": "Inactive Icon Opacity"
+          "description": "Opacitat de les icones de les finestres inactives (no enfocades).",
+          "label": "Opacitat d'icona inactiva"
         },
         "label": {
-          "description": "Optional static text shown on this button",
-          "label": "Label"
+          "description": "Text estàtic opcional mostrat en aquest botó",
+          "label": "Etiqueta"
         },
         "label-min-width": {
-          "description": "Minimum label width in pixels to prevent resizing",
-          "label": "Label Min Width"
+          "description": "Amplada mínima de l'etiqueta en píxels per evitar redimensionaments",
+          "label": "Amplada mínima de l'etiqueta"
         },
         "labels-only-when-occupied": {
-          "description": "Hide workspace labels on empty, inactive workspaces",
-          "label": "Labels Only When Occupied",
-          "workspaces-description": "Show workspace id or name labels on workspaces with open windows and on the active workspace even when it is empty; other empty tags stay unlabeled"
+          "description": "Amaga les etiquetes d'espai de treball als espais de treball buits i inactius",
+          "label": "Etiquetes només quan està ocupat",
+          "workspaces-description": "Mostra les etiquetes d'id o nom d'espai de treball als espais de treball amb finestres obertes i a l'espai de treball actiu encara que estigui buit; altres etiquetes buides romanen sense etiqueta"
         },
         "length": {
-          "description": "Spacer length in pixels",
-          "label": "Length"
+          "description": "Longitud de l'espaiador en píxels",
+          "label": "Longitud"
         },
         "match-adjacent-spacing": {
-          "description": "Widen gaps between inline tray icons to match the visual spacing of neighboring bar widgets (includes capsule padding)",
-          "label": "Match Adjacent Widget Spacing"
+          "description": "Amplia els espais entre les icones de safata en línia perquè coincideixin amb l'espaiat visual dels widgets de barra veïns (inclou el farcit de la càpsula)",
+          "label": "Iguala l'espaiat dels widgets adjacents"
         },
         "max-label-chars": {
-          "description": "Maximum number of characters to show for workspace names",
-          "label": "Max Label Characters",
-          "workspaces-description": "Maximum characters for workspace name labels"
+          "description": "Nombre màxim de caràcters a mostrar per als noms d'espai de treball",
+          "label": "Caràcters màx. de l'etiqueta",
+          "workspaces-description": "Caràcters màxims per a les etiquetes de nom d'espai de treball"
         },
         "max-length": {
-          "description": "Maximum widget length in pixels",
-          "label": "Max Length"
+          "description": "Longitud màxima del widget en píxels",
+          "label": "Longitud màxima"
         },
         "middle-command": {
-          "description": "Shell command run when middle-clicking this button. When set, middle-click opens this command instead of widget settings.",
-          "label": "Middle Click Command"
+          "description": "Ordre de shell executada en fer clic del mig en aquest botó. Quan està configurat, el clic del mig obre aquesta ordre en lloc de la configuració del widget.",
+          "label": "Ordre del clic del mig"
         },
         "min-length": {
-          "description": "Minimum widget length in pixels",
-          "label": "Min Length"
+          "description": "Longitud mínima del widget en píxels",
+          "label": "Longitud mínima"
         },
         "minimal": {
-          "description": "Show workspace id or name labels only, without animated pills",
-          "label": "Minimal Style",
-          "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation"
+          "description": "Mostra només les etiquetes d'id o nom d'espai de treball, sense pastilles animades",
+          "label": "Estil mínim",
+          "workspaces-description": "Etiquetes d'espai de treball només de text sense fons de pastilla ni animació de lliscament"
         },
         "mirrored": {
-          "description": "Mirror the visualizer around its center",
-          "label": "Mirrored"
+          "description": "Reflecteix el visualitzador al voltant del seu centre",
+          "label": "Mirall"
         },
         "occupied-color": {
-          "description": "Color role used for occupied workspaces; fixed hex colors are also supported",
-          "label": "Occupied Color"
+          "description": "Color utilitzat per als espais de treball ocupats; també s'admeten colors hex fixos",
+          "label": "Color ocupat"
         },
         "only-active-workspace": {
-          "description": "Hide windows on inactive workspaces.",
-          "label": "Only Active Workspace"
+          "description": "Amaga les finestres dels espais de treball inactius.",
+          "label": "Només espai de treball actiu"
         },
         "path": {
-          "description": "Path used by disk statistics",
-          "label": "Path"
+          "description": "Camí utilitzat per les estadístiques de disc",
+          "label": "Camí"
         },
         "pill-scale": {
-          "description": "Adjust the scale of workspace pills",
-          "label": "Pill Scale",
-          "workspaces-description": "Adjust the scale of workspace pills"
+          "description": "Ajusta l'escala de les pastilles d'espai de treball",
+          "label": "Escala de pastilla",
+          "workspaces-description": "Ajusta l'escala de les pastilles d'espai de treball"
         },
         "pinned": {
-          "description": "Tray item ids that stay visible in the bar when drawer mode is enabled",
-          "label": "Pinned Items"
+          "description": "IDs d'elements de safata que romanen visibles a la barra quan el mode calaix està activat",
+          "label": "Elements fixats"
         },
         "primary-click": {
-          "description": "Action performed when left-clicking the bar button",
-          "label": "Primary click"
+          "description": "Acció realitzada en fer clic esquerre al botó de la barra",
+          "label": "Clic principal"
         },
         "right-command": {
-          "description": "Shell command run when right-clicking this button",
-          "label": "Right Click Command"
+          "description": "Ordre de shell executada en fer clic dret en aquest botó",
+          "label": "Ordre del clic dret"
         },
         "scale": {
-          "description": "Scale this widget relative to the bar content scale",
-          "label": "Scale"
+          "description": "Escala aquest widget en relació amb l'escala del contingut de la barra",
+          "label": "Escala"
         },
         "scope": {
-          "description": "Run one script runtime per live widget placement, or share one runtime across bars with the same widget id",
-          "label": "Runtime Scope"
+          "description": "Executa un temps d'execució d'script per ubicació de widget en viu, o comparteix un temps d'execució entre barres amb el mateix id de widget",
+          "label": "Àmbit d'execució"
         },
         "script": {
-          "description": "Path to the lua script",
+          "description": "Camí a l'script lua",
           "label": "Script"
         },
         "scroll-down-command": {
-          "description": "Shell command run when scrolling down over this button",
-          "label": "Scroll Down Command"
+          "description": "Ordre de shell executada en desplaçar cap avall sobre aquest botó",
+          "label": "Ordre de desplaçament avall"
         },
         "scroll-step": {
-          "description": "Percentage change applied on each mouse wheel step",
-          "label": "Scroll Step"
+          "description": "Canvi percentual aplicat a cada pas de la roda del ratolí",
+          "label": "Pas de desplaçament"
         },
         "scroll-up-command": {
-          "description": "Shell command run when scrolling up over this button",
-          "label": "Scroll Up Command"
+          "description": "Ordre de shell executada en desplaçar cap amunt sobre aquest botó",
+          "label": "Ordre de desplaçament amunt"
         },
         "show-active-indicator": {
-          "description": "Show a small dot below the active window icon in the taskbar.",
-          "label": "Active Window Indicator"
+          "description": "Mostra un petit punt sota la icona de la finestra activa a la barra de tasques.",
+          "label": "Indicador de finestra activa"
         },
         "show-all-outputs": {
-          "description": "Include windows from every display on this widget.",
-          "label": "Show All Monitors"
+          "description": "Inclou finestres de totes les pantalles en aquest widget.",
+          "label": "Mostra tots els monitors"
         },
         "show-caps-lock": {
-          "description": "Show Caps Lock state",
-          "label": "Show Caps Lock"
+          "description": "Mostra l'estat de Bloq Majús",
+          "label": "Mostra Bloq Majús"
         },
         "show-condition": {
-          "description": "Show weather condition text",
-          "label": "Show Condition"
+          "description": "Mostra el text de la condició meteorològica",
+          "label": "Mostra la condició"
         },
         "show-empty-label": {
-          "description": "Show placeholder text when no window is focused instead of hiding the widget",
-          "label": "Show Empty Label"
+          "description": "Mostra text de marcador de posició quan no hi ha cap finestra enfocada en lloc d'amagar el widget",
+          "label": "Mostra l'etiqueta buida"
         },
         "show-icon": {
-          "description": "Show this widget's icon",
-          "label": "Show Icon"
+          "description": "Mostra la icona d'aquest widget",
+          "label": "Mostra la icona"
         },
         "show-label": {
-          "description": "Show text next to the icon",
-          "label": "Show Label"
+          "description": "Mostra text al costat de la icona",
+          "label": "Mostra l'etiqueta"
         },
         "show-num-lock": {
-          "description": "Show Num Lock state",
-          "label": "Show Num Lock"
+          "description": "Mostra l'estat de Bloq Num",
+          "label": "Mostra Bloq Num"
         },
         "show-scroll-lock": {
-          "description": "Show Scroll Lock state",
-          "label": "Show Scroll Lock"
+          "description": "Mostra l'estat de Bloq Despl",
+          "label": "Mostra Bloq Despl"
         },
         "show-when-idle": {
-          "description": "Keep the visualizer visible even when no media is playing",
-          "label": "Show When Idle"
+          "description": "Manté el visualitzador visible fins i tot quan no s'està reproduint multimèdia",
+          "label": "Mostra quan està inactiu"
         },
         "show-window-title": {
-          "description": "Show the window title next to its icon (only on horizontal bars)",
-          "label": "Show Window Title"
+          "description": "Mostra el títol de la finestra al costat de la seva icona (només a les barres horitzontals)",
+          "label": "Mostra el títol de la finestra"
         },
         "show-workspace-label": {
-          "description": "Show the small workspace tag on grouped taskbar capsules. Turn off for icon-only groups.",
-          "label": "Workspace Capsule Label"
+          "description": "Mostra la petita etiqueta d'espai de treball a les càpsules de la barra de tasques agrupades. Desactiva per a grups només amb icona.",
+          "label": "Etiqueta de càpsula d'espai de treball"
         },
         "stat": {
-          "description": "System statistic to display",
-          "label": "Stat"
+          "description": "Estadística del sistema a mostrar",
+          "label": "Estadística"
         },
         "taskbar-max-width": {
-          "description": "Total width budget in pixels; window titles shrink to fit and hide when too narrow",
-          "label": "Taskbar Max Width"
+          "description": "Pressupost total d'amplada en píxels; els títols de finestra es redueixen per ajustar-se i s'amaguen quan són massa estrets",
+          "label": "Amplada màx. de la barra de tasques"
         },
         "title-scroll": {
-          "description": "When the widget title should scroll",
-          "label": "Title Scroll"
+          "description": "Quan s'ha de desplaçar el títol del widget",
+          "label": "Desplaçament del títol"
         },
         "tooltip": {
-          "description": "Tooltip shown when hovering this button",
-          "label": "Tooltip"
+          "description": "Informació sobre eines mostrada en passar el ratolí per sobre d'aquest botó",
+          "label": "Informació sobre eines"
         },
         "tooltip-format": {
-          "description": "Optional format for the tooltip",
-          "label": "Tooltip Format"
+          "description": "Format opcional per a la informació sobre eines",
+          "label": "Format de la informació sobre eines"
         },
         "type": {
-          "description": "Built-in widget type for this named widget",
-          "label": "Type"
+          "description": "Tipus de widget integrat per a aquest widget amb nom",
+          "label": "Tipus"
         },
         "vertical-format": {
-          "description": "Optional format used on vertical bars",
-          "label": "Vertical Format"
+          "description": "Format opcional utilitzat a les barres verticals",
+          "label": "Format vertical"
         },
         "warning-color": {
-          "description": "Color applied when charge is at or below the System battery warning threshold",
-          "label": "Warning Color"
+          "description": "Color aplicat quan la càrrega està en o per sota del llindar d'advertència de bateria del sistema",
+          "label": "Color d'advertència"
         },
         "width": {
-          "description": "Widget width in pixels",
-          "label": "Width"
+          "description": "Amplada del widget en píxels",
+          "label": "Amplada"
         },
         "window-title-max-width": {
-          "description": "Maximum width in pixels for window titles",
-          "label": "Window Title Max Width"
+          "description": "Amplada màxima en píxels per als títols de finestra",
+          "label": "Amplada màx. del títol de finestra"
         },
         "workspace-group-capsule": {
-          "description": "Draw the background and border around each grouped workspace. Turn off to keep icon grouping and workspace disc labels only.",
-          "label": "Workspace Group Capsule"
+          "description": "Dibuixa el fons i la vora al voltant de cada espai de treball agrupat. Desactiva per mantenir només l'agrupació d'icones i les etiquetes de disc d'espai de treball.",
+          "label": "Càpsula de grup d'espai de treball"
         },
         "workspace-label-placement": {
-          "description": "Corner, centered on the edge, or inside the pill.",
-          "label": "Workspace Label Placement"
+          "description": "Cantonada, centrada a la vora o dins de la pastilla.",
+          "label": "Ubicació de l'etiqueta d'espai de treball"
         }
       },
       "types": {
-        "active-window": "Active Window",
-        "audio-visualizer": "Audio Visualizer",
-        "battery": "Battery",
+        "active-window": "Finestra activa",
+        "audio-visualizer": "Visualitzador d'àudio",
+        "battery": "Bateria",
         "bluetooth": "Bluetooth",
-        "brightness": "Brightness",
+        "brightness": "Brillantor",
         "caffeine": "Caffeine",
-        "clipboard": "Clipboard",
-        "clock": "Clock",
-        "control-center": "Control Center",
-        "custom-button": "Custom Button",
-        "keyboard-layout": "Keyboard Layout",
+        "clipboard": "Porta-retalls",
+        "clock": "Rellotge",
+        "control-center": "Centre de control",
+        "custom-button": "Botó personalitzat",
+        "keyboard-layout": "Disposició del teclat",
         "launcher": "Launcher",
-        "lock-keys": "Lock Keys",
-        "media": "Media",
-        "network": "Network",
+        "lock-keys": "Tecles de bloqueig",
+        "media": "Multimèdia",
+        "network": "Xarxa",
         "nightlight": "Night Light",
-        "notifications": "Notifications",
-        "power-profile": "Power Profile",
-        "screenshot": "Screenshot",
-        "scripted": "Scripted",
-        "session": "Session",
-        "settings": "Settings",
-        "spacer": "Spacer",
-        "sysmon": "System Monitor",
-        "taskbar": "Taskbar",
-        "test": "Test",
-        "theme-mode": "Theme Mode",
-        "tray": "Tray",
-        "volume": "Volume",
-        "wallpaper": "Wallpaper",
-        "weather": "Weather",
-        "workspaces": "Workspaces"
+        "notifications": "Notificacions",
+        "power-profile": "Perfil d'energia",
+        "screenshot": "Captura de pantalla",
+        "scripted": "Amb script",
+        "session": "Sessió",
+        "settings": "Configuració",
+        "spacer": "Espaiador",
+        "sysmon": "Monitor del sistema",
+        "taskbar": "Barra de tasques",
+        "test": "Prova",
+        "theme-mode": "Mode del tema",
+        "tray": "Safata",
+        "volume": "Volum",
+        "wallpaper": "Fons de pantalla",
+        "weather": "Temps",
+        "workspaces": "Espais de treball"
       }
     },
     "window": {
-      "export-config": "Export Config…",
-      "export-config-saved": "Config export saved.",
-      "filter-modified": "Modified",
-      "native-title": "Noctalia Settings",
-      "no-results": "No settings found",
-      "no-results-hint": "Try a different setting name or config key.",
-      "reset-page": "Reset Page",
-      "reset-page-confirm": "Confirm Reset",
-      "search-placeholder": "Search settings…",
-      "support-report": "Support Report",
-      "support-report-saved": "Support report saved.",
-      "support-report-title": "Save Support Report",
-      "title": "Settings"
+      "export-config": "Exporta la configuració…",
+      "export-config-saved": "Exportació de la configuració desada.",
+      "filter-modified": "Modificat",
+      "native-title": "Configuració del Noctalia",
+      "no-results": "No s'han trobat paràmetres",
+      "no-results-hint": "Prova amb un nom de paràmetre o una clau de configuració diferent.",
+      "reset-page": "Restableix la pàgina",
+      "reset-page-confirm": "Confirma el restabliment",
+      "search-placeholder": "Cerca paràmetres…",
+      "support-report": "Informe d'assistència",
+      "support-report-saved": "Informe d'assistència desat.",
+      "support-report-title": "Desa l'informe d'assistència",
+      "title": "Configuració"
     }
   },
   "setup-wizard": {
-    "browse": "Browse",
-    "builtin-palette": "Built-In Palette",
-    "footer-note": "You can change these later in settings.",
-    "get-started": "Get Started",
+    "browse": "Navega",
+    "builtin-palette": "Paleta integrada",
+    "footer-note": "Pots canviar-ho més tard a la configuració.",
+    "get-started": "Comença",
     "mode": "Mode",
-    "no-wallpaper-selected": "No wallpaper selected",
-    "select-wallpaper": "Select Wallpaper",
-    "subtitle": "A few quick choices to get you started.",
-    "title": "Welcome to Noctalia",
-    "wallpaper": "Wallpaper",
-    "wallpaper-scheme": "Wallpaper Scheme"
+    "no-wallpaper-selected": "No s'ha seleccionat cap fons de pantalla",
+    "select-wallpaper": "Selecciona un fons de pantalla",
+    "subtitle": "Unes quantes opcions ràpides per començar.",
+    "title": "Benvingut al Noctalia",
+    "wallpaper": "Fons de pantalla",
+    "wallpaper-scheme": "Esquema del fons de pantalla"
   },
   "system": {
     "hardware": {
-      "unknown": "Unknown",
-      "unknown-cpu": "Unknown CPU",
-      "unknown-distro": "Unknown distro",
-      "unknown-gpu": "Unknown GPU"
+      "unknown": "Desconegut",
+      "unknown-cpu": "CPU desconeguda",
+      "unknown-distro": "Distribució desconeguda",
+      "unknown-gpu": "GPU desconeguda"
     }
   },
   "theme": {
     "scheme": {
-      "dysfunctional": "Dysfunctional",
-      "faithful": "Faithful",
-      "m3-content": "M3 Content",
-      "m3-fruit-salad": "M3 Fruit Salad",
-      "m3-monochrome": "M3 Monochrome",
-      "m3-rainbow": "M3 Rainbow",
-      "m3-tonal-spot": "M3 Tonal Spot",
-      "muted": "Muted",
+      "dysfunctional": "Disfuncional",
+      "faithful": "Fidel",
+      "m3-content": "M3 Contingut",
+      "m3-fruit-salad": "M3 Amanida de fruites",
+      "m3-monochrome": "M3 Monocrom",
+      "m3-rainbow": "M3 Arc de Sant Martí",
+      "m3-tonal-spot": "M3 Punt tonal",
+      "muted": "Atenuat",
       "vibrant": "Vibrant"
     }
   },
@@ -2914,33 +2914,33 @@
       "minutes": "{minutes}m"
     },
     "file": {
-      "unknown": "Unknown"
+      "unknown": "Desconegut"
     },
     "relative": {
-      "days-ago": "{count} day ago",
-      "days-ago-plural": "{count} days ago",
-      "hours-ago": "{count} hr ago",
-      "hours-ago-plural": "{count} hr ago",
-      "just-now": "just now",
-      "minutes-ago": "{count} min ago",
-      "minutes-ago-plural": "{count} min ago"
+      "days-ago": "Fa {count} dia",
+      "days-ago-plural": "Fa {count} dies",
+      "hours-ago": "Fa {count} h",
+      "hours-ago-plural": "Fa {count} h",
+      "just-now": "ara mateix",
+      "minutes-ago": "Fa {count} min",
+      "minutes-ago-plural": "Fa {count} min"
     }
   },
   "tray": {
     "menu": {
-      "empty": "No menu items...",
-      "pin": "Pin",
-      "unpin": "Unpin"
+      "empty": "No hi ha elements del menú...",
+      "pin": "Fixa",
+      "unpin": "Desfixa"
     }
   },
   "ui": {
     "controls": {
       "search-picker": {
-        "empty": "No results",
-        "placeholder": "Search..."
+        "empty": "No hi ha resultats",
+        "placeholder": "Cerca..."
       },
       "select": {
-        "placeholder": "Select an option"
+        "placeholder": "Selecciona una opció"
       }
     },
     "dialogs": {
@@ -2949,87 +2949,87 @@
       },
       "file": {
         "actions": {
-          "open": "Open",
-          "save": "Save",
-          "select-folder": "Select Folder"
+          "open": "Obre",
+          "save": "Desa",
+          "select-folder": "Selecciona una carpeta"
         },
-        "empty-filtered": "No files match the current filter",
+        "empty-filtered": "No hi ha fitxers que coincideixin amb el filtre",
         "entry": {
-          "folder": "Folder"
+          "folder": "Carpeta"
         },
-        "filename-placeholder": "Filename",
-        "filter-placeholder": "Filter...",
+        "filename-placeholder": "Nom del fitxer",
+        "filter-placeholder": "Filtra...",
         "sort": {
           "ascending": "↑",
-          "date": "Date",
+          "date": "Data",
           "descending": "↓",
-          "name": "Name",
-          "size": "Size"
+          "name": "Nom",
+          "size": "Mida"
         },
         "title": {
-          "default": "File Dialog",
-          "open": "Open File",
-          "save": "Save File",
-          "select-folder": "Select Folder"
+          "default": "Diàleg de fitxer",
+          "open": "Obre un fitxer",
+          "save": "Desa un fitxer",
+          "select-folder": "Selecciona una carpeta"
         }
       },
       "glyph-picker": {
-        "all-categories": "All",
-        "search-placeholder": "Search glyphs…",
-        "title": "Pick a Glyph"
+        "all-categories": "Totes",
+        "search-placeholder": "Cerca glifs…",
+        "title": "Tria un glif"
       }
     }
   },
   "wallpaper": {
     "panel": {
-      "all-monitors": "ALL",
-      "color-title": "Wallpaper color",
-      "filter-placeholder": "Filter...",
-      "flatten": "Flatten",
-      "sort-date-asc": "Sort by date (oldest first)",
-      "sort-date-desc": "Sort by date (newest first)",
-      "sort-name-asc": "Sort by name (A-Z)",
-      "sort-name-desc": "Sort by name (Z-A)",
-      "title": "Wallpaper"
+      "all-monitors": "TOTS",
+      "color-title": "Color del fons de pantalla",
+      "filter-placeholder": "Filtra...",
+      "flatten": "Aplana",
+      "sort-date-asc": "Ordena per data (més antic primer)",
+      "sort-date-desc": "Ordena per data (més nou primer)",
+      "sort-name-asc": "Ordena per nom (A-Z)",
+      "sort-name-desc": "Ordena per nom (Z-A)",
+      "title": "Fons de pantalla"
     }
   },
   "weather": {
     "conditions": {
       "full": {
-        "clear-sky": "Clear sky",
-        "drizzle": "Drizzle",
-        "fog": "Fog",
-        "mainly-clear": "Mainly clear",
-        "overcast": "Overcast",
-        "partly-cloudy": "Partly cloudy",
-        "rain-showers": "Rain showers",
-        "snow": "Snow",
-        "snow-showers": "Snow showers",
-        "thunderstorm": "Thunderstorm",
-        "unknown": "Unknown"
+        "clear-sky": "Cel clar",
+        "drizzle": "Plugim",
+        "fog": "Boira",
+        "mainly-clear": "Majoritàriament clar",
+        "overcast": "Ennuvolat",
+        "partly-cloudy": "Parcialment ennuvolat",
+        "rain-showers": "Pluges",
+        "snow": "Neu",
+        "snow-showers": "Xàfecs de neu",
+        "thunderstorm": "Tempesta",
+        "unknown": "Desconegut"
       },
       "short": {
-        "clear": "Clear",
-        "cloudy": "Cloudy",
-        "drizzle": "Drizzle",
-        "fog": "Fog",
-        "mostly-clear": "Mostly clear",
-        "overcast": "Overcast",
-        "showers": "Showers",
-        "snow": "Snow",
-        "snow-showers": "Snow showers",
-        "storm": "Storm",
-        "weather": "Weather"
+        "clear": "Clar",
+        "cloudy": "Ennuvolat",
+        "drizzle": "Plugim",
+        "fog": "Boira",
+        "mostly-clear": "Majoritàriament clar",
+        "overcast": "Ennuvolat",
+        "showers": "Xàfecs",
+        "snow": "Neu",
+        "snow-showers": "Xàfecs de neu",
+        "storm": "Tempesta",
+        "weather": "Temps"
       }
     },
     "errors": {
-      "fetch-failed": "Weather fetch failed",
-      "parse-weather": "Could not parse weather response"
+      "fetch-failed": "Ha fallat l'obtenció del temps",
+      "parse-weather": "No s'ha pogut analitzar la resposta del temps"
     }
   },
   "window-switcher": {
-    "empty": "No open windows",
-    "hint": "Tab · Shift+Tab · Arrow keys · Release Alt to switch · Esc to cancel",
-    "title": "Windows"
+    "empty": "No hi ha finestres obertes",
+    "hint": "Tab · Maj+Tab · Tecles de fletxa · Deixa anar Alt per canviar · Esc per cancel·lar",
+    "title": "Finestres"
   }
 }

--- a/src/i18n/i18n_service.h
+++ b/src/i18n/i18n_service.h
@@ -30,8 +30,9 @@ namespace i18n {
     std::string_view displayName;
   };
 
-  inline constexpr std::array<LanguageOption, 14> kSupportedLanguages = {{
+  inline constexpr std::array<LanguageOption, 15> kSupportedLanguages = {{
       {"be", "Беларуская"},
+      {"ca", "Català"},
       {"de", "Deutsch"},
       {"en", "English"},
       {"es", "Español"},


### PR DESCRIPTION
## Summary
Added Catalan first bulk translation



## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing
Exploratory test has been made to as much as strings as possible

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
This translation has been AI assisted and manually cross-checked between English and Spanish translations to be sure to get the most context out of it. Still, some translations might be slightly missplaced 