### PR TITLE
fix(fingerprint auth): do not look on dbus, fingerprint service might not be running

### DIFF
--- a/src/auth/fingerprint_authenticator.cpp
+++ b/src/auth/fingerprint_authenticator.cpp
@@ -88,10 +88,7 @@ void FingerprintAuthenticator::start() {
   if (m_active) {
     return;
   }
-  if (!m_bus.nameHasOwner(kFprintBusName)) {
-    kLog.debug("fprintd not available on system bus; fingerprint disabled");
-    return;
-  }
+
   m_active = true;
   m_abort = false;
   m_retries = 0;


### PR DESCRIPTION
## Summary

try to fix fingerprint in lock screen.  removed the condition that the fingerprint had to exist on dbus, since the fprintd.service is actiable, the name might not be there

we claim the fingerprint device if it exists so that:
- we can auth with fprintd
- deny pam (if login in with a password) to use the finger print device 

Next solution if this does not work: add a PAM service for noctalia akin to hyprlock

## Motivation


## Type of Change


- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Should fix #2902 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->