### PR TITLE
feat(wallpaper): add Span fill mode across monitors

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1125,6 +1125,7 @@
           "crop": "Crop",
           "fit": "Fit",
           "repeat": "Repeat",
+          "span": "Span",
           "stretch": "Stretch"
         },
         "order": {

--- a/example.toml
+++ b/example.toml
@@ -60,7 +60,7 @@ blacklist = []                      # ignore MPRIS players by bus/identity/deskt
 
 [wallpaper]
 enabled             = true
-fill_mode           = "crop"        # center | crop | fit | stretch | repeat
+fill_mode           = "crop"        # center | crop | fit | stretch | repeat | span
 fill_color          = ""            # optional fallback/fill color: prefer a color role token; fixed hex also works
 transition          = ["fade", "wipe", "disc", "stripes", "zoom", "honeycomb"]
 transition_duration = 1500          # milliseconds

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -354,6 +354,7 @@ enum class WallpaperFillMode : std::uint8_t {
   Fit = 2,
   Stretch = 3,
   Repeat = 4,
+  Span = 5,
 };
 
 enum class WallpaperTransition : std::uint8_t {
@@ -734,6 +735,7 @@ constexpr EnumOption<WallpaperFillMode> kWallpaperFillModes[] = {
     {WallpaperFillMode::Fit, "fit", "settings.options.wallpaper.fill.fit"},
     {WallpaperFillMode::Stretch, "stretch", "settings.options.wallpaper.fill.stretch"},
     {WallpaperFillMode::Repeat, "repeat", "settings.options.wallpaper.fill.repeat"},
+    {WallpaperFillMode::Span, "span", "settings.options.wallpaper.fill.span"},
 };
 
 constexpr EnumOption<WallpaperAutomationConfig::Order> kWallpaperAutomationOrders[] = {

--- a/src/render/backend/gles_render_backend.cpp
+++ b/src/render/backend/gles_render_backend.cpp
@@ -514,13 +514,13 @@ void GlesRenderBackend::drawWallpaper(
     WallpaperSourceKind sourceKind2, TextureId texture2, const Color& sourceColor2, float surfaceWidth,
     float surfaceHeight, float width, float height, float imageWidth1, float imageHeight1, float imageWidth2,
     float imageHeight2, float progress, float fillMode, const TransitionParams& params, const Color& fillColor,
-    const Mat3& transform
+    const Mat3& transform, const WallpaperSpanParams& span
 ) {
   m_wallpaperProgram.ensureInitialized();
   m_wallpaperProgram.draw(
       transition, sourceKind1, texture1, sourceColor1, sourceKind2, texture2, sourceColor2, surfaceWidth, surfaceHeight,
       width, height, imageWidth1, imageHeight1, imageWidth2, imageHeight2, progress, fillMode, params, fillColor,
-      transform
+      transform, span
   );
 }
 

--- a/src/render/backend/gles_render_backend.h
+++ b/src/render/backend/gles_render_backend.h
@@ -82,7 +82,7 @@ public:
       WallpaperSourceKind sourceKind2, TextureId texture2, const Color& sourceColor2, float surfaceWidth,
       float surfaceHeight, float width, float height, float imageWidth1, float imageHeight1, float imageWidth2,
       float imageHeight2, float progress, float fillMode, const TransitionParams& params, const Color& fillColor,
-      const Mat3& transform
+      const Mat3& transform, const WallpaperSpanParams& span
   ) override;
   void drawFullscreenTexture(TextureId texture, bool flipY) override;
   void drawFullscreenTint(Color color) override;

--- a/src/render/backend/render_backend.h
+++ b/src/render/backend/render_backend.h
@@ -22,6 +22,7 @@ struct RoundedRectStyle;
 struct ScreenCornerStyle;
 struct SpinnerStyle;
 struct TransitionParams;
+struct WallpaperSpanParams;
 
 class RenderFramebuffer {
 public:
@@ -166,7 +167,7 @@ public:
       WallpaperSourceKind sourceKind2, TextureId texture2, const Color& sourceColor2, float surfaceWidth,
       float surfaceHeight, float width, float height, float imageWidth1, float imageHeight1, float imageWidth2,
       float imageHeight2, float progress, float fillMode, const TransitionParams& params, const Color& fillColor,
-      const Mat3& transform
+      const Mat3& transform, const WallpaperSpanParams& span
   ) = 0;
   virtual void drawFullscreenTexture(TextureId texture, bool flipY) = 0;
   virtual void drawFullscreenTint(Color color) = 0;

--- a/src/render/core/wallpaper_types.h
+++ b/src/render/core/wallpaper_types.h
@@ -18,3 +18,19 @@ struct TransitionParams {
   float smoothness = 0.5f;    // wipe, disc, stripes
   float aspectRatio = 1.777f; // disc, stripes, honeycomb (computed at render time)
 };
+
+// Geometry for the Span fill mode: a single wallpaper stretched across the whole
+// multi-monitor desktop, with each output showing the portion that matches its
+// position. All values are in the compositor's logical coordinate space; offset is
+// this output's top-left relative to the desktop bounding-box origin. A zero total
+// size means span geometry is unavailable and the shader falls back to Crop.
+struct WallpaperSpanParams {
+  float offsetX = 0.0f;
+  float offsetY = 0.0f;
+  float monitorWidth = 0.0f;
+  float monitorHeight = 0.0f;
+  float totalWidth = 0.0f;
+  float totalHeight = 0.0f;
+
+  bool operator==(const WallpaperSpanParams&) const = default;
+};

--- a/src/render/programs/wallpaper_program.cpp
+++ b/src/render/programs/wallpaper_program.cpp
@@ -44,6 +44,9 @@ uniform float u_imageHeight2;
 uniform float u_screenWidth;
 uniform float u_screenHeight;
 uniform vec4 u_fillColor;
+uniform vec2 u_spanOffset;
+uniform vec2 u_spanMonitorSize;
+uniform vec2 u_spanTotalSize;
 
 varying vec2 v_texcoord;
 
@@ -76,10 +79,28 @@ vec2 calculateUV(vec2 uv, float imgWidth, float imgHeight) {
     else if (u_fillMode < 3.5) {
         // Stretch - no transform
     }
-    else {
+    else if (u_fillMode < 4.5) {
         // Repeat (tile)
         vec2 screenPixel = uv * vec2(u_screenWidth, u_screenHeight);
         transformedUV = screenPixel / vec2(imgWidth, imgHeight);
+    }
+    else {
+        // Span: cover-fit the image across the whole multi-monitor desktop and
+        // sample the slice that belongs to this output.
+        if (u_spanTotalSize.x <= 0.0 || u_spanTotalSize.y <= 0.0) {
+            // Span geometry unavailable: behave like Crop.
+            float scale = max(u_screenWidth / imgWidth, u_screenHeight / imgHeight);
+            vec2 scaledImageSize = vec2(imgWidth, imgHeight) * scale;
+            vec2 offset = (scaledImageSize - vec2(u_screenWidth, u_screenHeight)) / scaledImageSize;
+            transformedUV = uv * (vec2(1.0) - offset) + offset * 0.5;
+        } else {
+            vec2 imageSize = vec2(imgWidth, imgHeight);
+            float scale = max(u_spanTotalSize.x / imageSize.x, u_spanTotalSize.y / imageSize.y);
+            vec2 scaledImageSize = imageSize * scale;
+            vec2 desktopPixel = u_spanOffset + uv * u_spanMonitorSize;
+            vec2 imagePixel = desktopPixel + (scaledImageSize - u_spanTotalSize) * 0.5;
+            transformedUV = imagePixel / scaledImageSize;
+        }
     }
 
     return transformedUV;
@@ -88,7 +109,7 @@ vec2 calculateUV(vec2 uv, float imgWidth, float imgHeight) {
 vec4 sampleWithFillMode(sampler2D tex, vec2 uv, float imgWidth, float imgHeight) {
     vec2 transformedUV = calculateUV(uv, imgWidth, imgHeight);
 
-    if (u_fillMode > 3.5) {
+    if (u_fillMode > 3.5 && u_fillMode < 4.5) {
         return texture2D(tex, fract(transformedUV));
     }
 
@@ -369,6 +390,9 @@ void WallpaperProgram::initProgram(std::size_t index, const char* fragSource) {
   pd.screenWidthLoc = glGetUniformLocation(id, "u_screenWidth");
   pd.screenHeightLoc = glGetUniformLocation(id, "u_screenHeight");
   pd.fillColorLoc = glGetUniformLocation(id, "u_fillColor");
+  pd.spanOffsetLoc = glGetUniformLocation(id, "u_spanOffset");
+  pd.spanMonitorSizeLoc = glGetUniformLocation(id, "u_spanMonitorSize");
+  pd.spanTotalSizeLoc = glGetUniformLocation(id, "u_spanTotalSize");
 
   // Per-transition (may be -1 if not used by this shader)
   pd.directionLoc = glGetUniformLocation(id, "u_direction");
@@ -396,7 +420,7 @@ void WallpaperProgram::draw(
     WallpaperSourceKind sourceKind2, TextureId texture2, const Color& sourceColor2, float surfaceWidth,
     float surfaceHeight, float quadWidth, float quadHeight, float imageWidth1, float imageHeight1, float imageWidth2,
     float imageHeight2, float progress, float fillMode, const TransitionParams& params, const Color& fillColor,
-    const Mat3& transform
+    const Mat3& transform, const WallpaperSpanParams& span
 ) const {
   auto idx = static_cast<std::size_t>(type);
   if (idx >= kTransitionCount || !m_programs[idx].program.isValid() || quadWidth <= 0.0f || quadHeight <= 0.0f) {
@@ -454,6 +478,12 @@ void WallpaperProgram::draw(
     glUniform1f(pd.screenHeightLoc, quadHeight);
   if (pd.fillColorLoc >= 0)
     glUniform4f(pd.fillColorLoc, fillColor.r, fillColor.g, fillColor.b, fillColor.a);
+  if (pd.spanOffsetLoc >= 0)
+    glUniform2f(pd.spanOffsetLoc, span.offsetX, span.offsetY);
+  if (pd.spanMonitorSizeLoc >= 0)
+    glUniform2f(pd.spanMonitorSizeLoc, span.monitorWidth, span.monitorHeight);
+  if (pd.spanTotalSizeLoc >= 0)
+    glUniform2f(pd.spanTotalSizeLoc, span.totalWidth, span.totalHeight);
 
   // Per-transition uniforms
   if (pd.directionLoc >= 0)

--- a/src/render/programs/wallpaper_program.h
+++ b/src/render/programs/wallpaper_program.h
@@ -27,7 +27,8 @@ public:
       WallpaperSourceKind sourceKind2, TextureId texture2, const Color& sourceColor2, float surfaceWidth,
       float surfaceHeight, float quadWidth, float quadHeight, float imageWidth1, float imageHeight1, float imageWidth2,
       float imageHeight2, float progress, float fillMode, const TransitionParams& params,
-      const Color& fillColor = rgba(0.0f, 0.0f, 0.0f, 1.0f), const Mat3& transform = Mat3::identity()
+      const Color& fillColor = rgba(0.0f, 0.0f, 0.0f, 1.0f), const Mat3& transform = Mat3::identity(),
+      const WallpaperSpanParams& span = {}
   ) const;
 
 private:
@@ -56,6 +57,9 @@ private:
     GLint screenWidthLoc = -1;
     GLint screenHeightLoc = -1;
     GLint fillColorLoc = -1;
+    GLint spanOffsetLoc = -1;
+    GLint spanMonitorSizeLoc = -1;
+    GLint spanTotalSizeLoc = -1;
     // Per-transition uniforms
     GLint directionLoc = -1;
     GLint smoothnessLoc = -1;

--- a/src/render/render_context.cpp
+++ b/src/render/render_context.cpp
@@ -477,7 +477,7 @@ void RenderContext::renderNode(
           wallpaper->transition(), wallpaper->sourceKind1(), wallpaper->texture1(), wallpaper->sourceColor1(),
           sourceKind2, texture2, sourceColor2, sw, sh, node->width(), node->height(), wallpaper->imageWidth1(),
           wallpaper->imageHeight1(), imageWidth2, imageHeight2, progress, static_cast<float>(wallpaper->fillMode()),
-          wallpaper->transitionParams(), wallpaper->fillColor(), worldTransform
+          wallpaper->transitionParams(), wallpaper->fillColor(), worldTransform, wallpaper->spanParams()
       );
     }
     break;

--- a/src/render/scene/wallpaper_node.h
+++ b/src/render/scene/wallpaper_node.h
@@ -27,6 +27,7 @@ public:
   [[nodiscard]] WallpaperFillMode fillMode() const noexcept { return m_fillMode; }
   [[nodiscard]] const Color& fillColor() const noexcept { return m_fillColor; }
   [[nodiscard]] const TransitionParams& transitionParams() const noexcept { return m_params; }
+  [[nodiscard]] const WallpaperSpanParams& spanParams() const noexcept { return m_span; }
 
   void setTextures(
       TextureId texture1, TextureId texture2, float imageWidth1, float imageHeight1, float imageWidth2,
@@ -104,6 +105,14 @@ public:
     markPaintDirty();
   }
 
+  void setSpan(const WallpaperSpanParams& span) {
+    if (m_span == span) {
+      return;
+    }
+    m_span = span;
+    markPaintDirty();
+  }
+
 private:
   WallpaperSourceKind m_sourceKind1 = WallpaperSourceKind::Image;
   WallpaperSourceKind m_sourceKind2 = WallpaperSourceKind::Image;
@@ -120,4 +129,5 @@ private:
   WallpaperFillMode m_fillMode = WallpaperFillMode::Crop;
   Color m_fillColor = rgba(0.0f, 0.0f, 0.0f, 1.0f);
   TransitionParams m_params;
+  WallpaperSpanParams m_span;
 };

--- a/src/render/wallpaper_renderer.cpp
+++ b/src/render/wallpaper_renderer.cpp
@@ -105,7 +105,7 @@ void WallpaperRenderer::render() {
   m_backend->drawWallpaper(
       m_transition, WallpaperSourceKind::Image, m_tex1, rgba(0.0f, 0.0f, 0.0f, 1.0f), WallpaperSourceKind::Image, tex2,
       rgba(0.0f, 0.0f, 0.0f, 1.0f), sw, sh, sw, sh, m_imgW1, m_imgH1, m_imgW2, m_imgH2, progress,
-      static_cast<float>(m_fillMode), m_params, m_fillColor, Mat3::identity()
+      static_cast<float>(m_fillMode), m_params, m_fillColor, Mat3::identity(), WallpaperSpanParams{}
   );
 
   float ms = elapsedSince(drawStart);
@@ -149,7 +149,7 @@ void WallpaperRenderer::renderToFramebuffer(const RenderFramebuffer& target) {
   m_backend->drawWallpaper(
       m_transition, WallpaperSourceKind::Image, m_tex1, rgba(0.0f, 0.0f, 0.0f, 1.0f), WallpaperSourceKind::Image, tex2,
       rgba(0.0f, 0.0f, 0.0f, 1.0f), sw, sh, sw, sh, m_imgW1, m_imgH1, m_imgW2, m_imgH2, progress,
-      static_cast<float>(m_fillMode), m_params, m_fillColor, Mat3::identity()
+      static_cast<float>(m_fillMode), m_params, m_fillColor, Mat3::identity(), WallpaperSpanParams{}
   );
   float ms = elapsedSince(drawStart);
   logSlowWallpaperRenderOperation(

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -245,6 +245,57 @@ namespace {
     return tryParseHexColor(path.substr(kPrefix.size()), out);
   }
 
+  // Build the Span geometry for one output: the desktop bounding box across every
+  // ready output and this output's offset/size within it. Returns a zeroed result
+  // (which makes the shader fall back to Crop) when geometry is not yet available.
+  WallpaperSpanParams computeSpanParams(const std::vector<WaylandOutput>& outputs, std::uint32_t outputName) {
+    WallpaperSpanParams span;
+
+    bool haveBounds = false;
+    std::int32_t minX = 0;
+    std::int32_t minY = 0;
+    std::int32_t maxX = 0;
+    std::int32_t maxY = 0;
+    const WaylandOutput* self = nullptr;
+
+    for (const auto& out : outputs) {
+      if (!out.done || out.logicalWidth <= 0 || out.logicalHeight <= 0) {
+        continue;
+      }
+      const std::int32_t left = out.logicalX;
+      const std::int32_t top = out.logicalY;
+      const std::int32_t right = out.logicalX + out.logicalWidth;
+      const std::int32_t bottom = out.logicalY + out.logicalHeight;
+      if (!haveBounds) {
+        minX = left;
+        minY = top;
+        maxX = right;
+        maxY = bottom;
+        haveBounds = true;
+      } else {
+        minX = std::min(minX, left);
+        minY = std::min(minY, top);
+        maxX = std::max(maxX, right);
+        maxY = std::max(maxY, bottom);
+      }
+      if (out.name == outputName) {
+        self = &out;
+      }
+    }
+
+    if (!haveBounds || self == nullptr) {
+      return span;
+    }
+
+    span.offsetX = static_cast<float>(self->logicalX - minX);
+    span.offsetY = static_cast<float>(self->logicalY - minY);
+    span.monitorWidth = static_cast<float>(self->logicalWidth);
+    span.monitorHeight = static_cast<float>(self->logicalHeight);
+    span.totalWidth = static_cast<float>(maxX - minX);
+    span.totalHeight = static_cast<float>(maxY - minY);
+    return span;
+  }
+
 } // namespace
 
 Wallpaper::Wallpaper() = default;
@@ -421,6 +472,18 @@ void Wallpaper::onOutputChange() {
     return;
   }
   syncInstances();
+
+  // Span fill mode maps a single image across the whole desktop, so a geometry
+  // change on any output shifts the slice shown on every other output. Refresh
+  // all instances; the node setters no-op when the span geometry is unchanged.
+  if (m_config->config().wallpaper.fillMode == WallpaperFillMode::Span) {
+    for (auto& inst : m_instances) {
+      updateRendererState(*inst);
+      if (inst->surface != nullptr) {
+        inst->surface->requestRedraw();
+      }
+    }
+  }
 }
 
 void Wallpaper::onStateChange() {
@@ -1200,4 +1263,10 @@ void Wallpaper::updateRendererState(WallpaperInstance& instance) {
   wallpaperNode->setTransition(instance.activeTransition, instance.transitionProgress, instance.transitionParams);
   wallpaperNode->setFillMode(wpConfig.fillMode);
   wallpaperNode->setFillColor(fillColor);
+
+  if (wpConfig.fillMode == WallpaperFillMode::Span && m_wayland != nullptr) {
+    wallpaperNode->setSpan(computeSpanParams(m_wayland->outputs(), instance.outputName));
+  } else {
+    wallpaperNode->setSpan(WallpaperSpanParams{});
+  }
 }


### PR DESCRIPTION
## Summary

Add a new `span` wallpaper fill mode that maps a single wallpaper across the whole multi-monitor desktop, so each output shows the slice that matches its position in the compositor layout (instead of every screen repeating the same framing).

## Motivation

The existing fill modes (`center`, `crop`, `fit`, `stretch`, `repeat`) all frame the image independently per output. There was no way to treat the monitors as one continuous canvas. `span` fills that gap: a wide wallpaper now flows continuously across monitors, honoring each output's logical position and any offset between them.

## How it works

- The image is cover-fit onto the desktop **bounding box** (the union of every ready output's logical geometry).
- Each output samples the sub-rectangle at its logical offset, so the slices line up across screens.
- Geometry (offset, monitor size, total desktop size) reaches the wallpaper shader through new uniforms via a small `WallpaperSpanParams` struct; the new branch in `calculateUV` reuses the existing cover math.
- Falls back to `crop` when span geometry is unavailable (e.g. the standalone `WallpaperRenderer` path, or before `xdg_output` geometry is known). Single-monitor setups naturally degenerate to `crop`.
- Output-layout changes refresh every instance so the slices stay coherent when a monitor is moved/added/removed.
- The `repeat` (tile) sampling path is now gated to fill mode `4` only, so `span` (`5`) uses clamped sampling.

The new mode is picked up automatically by the settings UI (it iterates `kWallpaperFillModes`) and the config schema. English string added to `assets/translations/en.json` only, per the translation workflow.

## Type of Change

- [x] New feature

## Related Issue

<!-- none -->

## Testing

- Built with `meson` / `ninja` (C++23, clang-format v22.1.6 clean; `python3 tools/i18n-check.py` → OK).
- Ran on **Niri** with two monitors in an L-shaped layout: DP-1 `3440x1440` at `(0,0)` and HDMI-A-1 `1920x1080` at `(760,1440)`. With `fill_mode = "span"` the wallpaper renders as one continuous image across both outputs, and HDMI-A-1's `760px` horizontal offset is correctly reflected in the slice it shows. Verified the seam between the two outputs is continuous; areas of the bounding box not covered by any output simply stay empty as expected.
- Verified single-monitor behavior matches `crop`.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested with multiple monitors