### PR TITLE
feat(osd): add privacy indicator OSD when mic, camera, screenshare enable/disable

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -631,6 +631,14 @@
       "scroll-off": "Scroll Lock Off",
       "scroll-on": "Scroll Lock On"
     },
+    "privacy": {
+      "camera-off": "Camera Stopped",
+      "camera-on": "Camera Active",
+      "mic-off": "Microphone Stopped",
+      "mic-on": "Microphone Active",
+      "screen-off": "Screen Sharing Stopped",
+      "screen-on": "Screen Sharing Active"
+    },
     "wifi": {
       "off": "Wi-Fi Off",
       "on": "Wi-Fi On"
@@ -2147,6 +2155,10 @@
         "osd-kinds-power-profile": {
           "description": "Show an OSD popup when the power profile changes",
           "label": "Power Profile"
+        },
+        "osd-kinds-privacy": {
+          "description": "Show an OSD popup when microphone, camera, or screen-share capture starts or stops",
+          "label": "Privacy"
         },
         "osd-kinds-volume": {
           "description": "Show OSD popups when volume changes; use advanced settings to control output and input separately",

--- a/example.toml
+++ b/example.toml
@@ -155,6 +155,7 @@ caffeine = true                     # idle inhibitor (caffeine) toggle
 dnd = true                          # Do Not Disturb toggle
 lock_keys = true                    # Caps/Num/Scroll Lock changes; disable to stop polling when no widget uses them
 keyboard_layout = true              # input keyboard layout changes
+privacy = true                      # microphone/camera/screen-share capture changes
 
 # ── Lock Screen ───────────────────────────────────────────────────────────────
 

--- a/meson.build
+++ b/meson.build
@@ -581,6 +581,7 @@ _noctalia_sources = files(
   'src/shell/osd/brightness_osd.cpp',
   'src/shell/osd/lock_keys_osd.cpp',
   'src/shell/osd/keyboard_layout_osd.cpp',
+  'src/shell/osd/privacy_osd.cpp',
   'src/shell/osd/osd_overlay.cpp',
   'src/shell/tooltip/tooltip_manager.cpp',
   'src/shell/screen_corners/screen_corners.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1679,6 +1679,10 @@ void Application::initUi() {
   m_keyboardLayoutOsd.bindOverlay(m_osdOverlay);
   m_keyboardLayoutOsd.prime(m_compositorPlatform);
   m_mediaOsd.bindOverlay(m_osdOverlay);
+  m_privacyOsd.bindOverlay(m_osdOverlay);
+  if (m_pipewireService != nullptr) {
+    m_privacyOsd.primeFromService(*m_pipewireService);
+  }
   m_screenCorners.initialize(m_wayland, &m_configService, &m_renderContext);
   m_screenCorners.onConfigReload();
 
@@ -1844,6 +1848,7 @@ void Application::initUi() {
       }
       if (m_pipewireService != nullptr) {
         m_audioOsd.onAudioStateChanged(*m_pipewireService);
+        m_privacyOsd.onPrivacyStateChanged(*m_pipewireService);
       }
     });
     m_pipewireService->setVolumePreviewCallback([this](bool isInput, std::uint32_t id, float volume, bool muted) {

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -71,6 +71,7 @@
 #include "shell/osd/lock_keys_osd.h"
 #include "shell/osd/media_osd.h"
 #include "shell/osd/osd_overlay.h"
+#include "shell/osd/privacy_osd.h"
 #include "shell/overview/overview_launcher_capture.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/polkit/polkit_panel.h"
@@ -249,6 +250,7 @@ private:
   MediaOsd m_mediaOsd;
   LockKeysOsd m_lockKeysOsd;
   KeyboardLayoutOsd m_keyboardLayoutOsd;
+  PrivacyOsd m_privacyOsd;
   OsdOverlay m_osdOverlay;
   ScreenCorners m_screenCorners;
   TrayMenu m_trayMenu;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -579,6 +579,7 @@ struct OsdKindsConfig {
   bool lockKeys = true;
   bool keyboardLayout = true;
   bool media = true;
+  bool privacy = true;
   bool operator==(const OsdKindsConfig&) const = default;
 };
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -50,6 +50,7 @@ namespace noctalia::config::schema {
         field(&OsdKindsConfig::lockKeys, "lock_keys"),
         field(&OsdKindsConfig::keyboardLayout, "keyboard_layout"),
         field(&OsdKindsConfig::media, "media"),
+        field(&OsdKindsConfig::privacy, "privacy"),
     };
     return s;
   }

--- a/src/shell/osd/osd_overlay.cpp
+++ b/src/shell/osd/osd_overlay.cpp
@@ -67,6 +67,8 @@ namespace {
       return kinds.keyboardLayout;
     case OsdKind::Media:
       return kinds.media;
+    case OsdKind::Privacy:
+      return kinds.privacy;
     }
     return true;
   }

--- a/src/shell/osd/osd_overlay.h
+++ b/src/shell/osd/osd_overlay.h
@@ -31,7 +31,8 @@ enum class OsdKind : std::uint8_t {
   Dnd,
   LockKeys,
   KeyboardLayout,
-  Media
+  Media,
+  Privacy
 };
 
 struct OsdContent {

--- a/src/shell/osd/privacy_osd.cpp
+++ b/src/shell/osd/privacy_osd.cpp
@@ -1,0 +1,86 @@
+#include "shell/osd/privacy_osd.h"
+
+#include "i18n/i18n.h"
+#include "pipewire/pipewire_service.h"
+#include "shell/osd/osd_overlay.h"
+
+namespace {
+
+  enum class PrivacyKind {
+    Mic,
+    Camera,
+    Screen,
+  };
+
+  OsdContent makePrivacyContent(PrivacyKind kind, bool active) {
+    switch (kind) {
+    case PrivacyKind::Mic:
+      return OsdContent{
+          .kind = OsdKind::Privacy,
+          .icon = active ? "microphone" : "microphone-off",
+          .value = i18n::tr(active ? "osd.privacy.mic-on" : "osd.privacy.mic-off"),
+          .showProgress = false,
+      };
+    case PrivacyKind::Camera:
+      return OsdContent{
+          .kind = OsdKind::Privacy,
+          .icon = active ? "camera" : "camera-off",
+          .value = i18n::tr(active ? "osd.privacy.camera-on" : "osd.privacy.camera-off"),
+          .showProgress = false,
+      };
+    case PrivacyKind::Screen:
+      return OsdContent{
+          .kind = OsdKind::Privacy,
+          .icon = active ? "screen-share" : "screen-share-off",
+          .value = i18n::tr(active ? "osd.privacy.screen-on" : "osd.privacy.screen-off"),
+          .showProgress = false,
+      };
+    }
+
+    return OsdContent{};
+  }
+
+} // namespace
+
+PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState) {
+  State out;
+  for (const auto& capture : privacyState.captures) {
+    switch (capture.kind) {
+    case PrivacyCaptureKind::Microphone:
+      out.mic = true;
+      break;
+    case PrivacyCaptureKind::Camera:
+      out.camera = true;
+      break;
+    case PrivacyCaptureKind::Screen:
+      out.screen = true;
+      break;
+    }
+  }
+  return out;
+}
+
+void PrivacyOsd::bindOverlay(OsdOverlay& overlay) { m_overlay = &overlay; }
+
+void PrivacyOsd::primeFromService(const PipeWireService& service) {
+  m_lastState = fromPipewireState(service.privacyState());
+}
+
+void PrivacyOsd::onPrivacyStateChanged(const PipeWireService& service) {
+  const State current = fromPipewireState(service.privacyState());
+
+  if (m_overlay == nullptr) {
+    m_lastState = current;
+    return;
+  }
+
+  if (m_lastState.mic != current.mic) {
+    m_overlay->show(makePrivacyContent(PrivacyKind::Mic, current.mic));
+  } else if (m_lastState.camera != current.camera) {
+    m_overlay->show(makePrivacyContent(PrivacyKind::Camera, current.camera));
+  } else if (m_lastState.screen != current.screen) {
+    m_overlay->show(makePrivacyContent(PrivacyKind::Screen, current.screen));
+  }
+
+  m_lastState = current;
+}

--- a/src/shell/osd/privacy_osd.h
+++ b/src/shell/osd/privacy_osd.h
@@ -1,0 +1,26 @@
+#pragma once
+
+class OsdOverlay;
+class PipeWireService;
+struct PrivacyState;
+
+class PrivacyOsd {
+public:
+  void bindOverlay(OsdOverlay& overlay);
+  void primeFromService(const PipeWireService& service);
+  void onPrivacyStateChanged(const PipeWireService& service);
+
+private:
+  struct State {
+    bool mic = false;
+    bool camera = false;
+    bool screen = false;
+
+    bool operator==(const State&) const = default;
+  };
+
+  [[nodiscard]] static State fromPipewireState(const PrivacyState& privacyState);
+
+  OsdOverlay* m_overlay = nullptr;
+  State m_lastState;
+};

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1490,6 +1490,11 @@ namespace settings {
         ToggleSetting{cfg.osd.kinds.media}, "hud overlay mpris audio music"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Osd, "kinds", tr("settings.schema.shell.osd-kinds-privacy.label"),
+        tr("settings.schema.shell.osd-kinds-privacy.description"), {"osd", "kinds", "privacy"},
+        ToggleSetting{cfg.osd.kinds.privacy}, "hud overlay microphone camera screen share recording"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Osd, "osd", tr("settings.schema.shell.osd-monitors.label"),
         tr("settings.schema.shell.osd-monitors.description"), {"osd", "monitors"},
         ListSetting{.items = cfg.osd.monitors, .suggestedOptions = env.availableOutputs},


### PR DESCRIPTION
## Summary

#3040 added a privacy indicator widget to show mic, camera, screenshare state. This PR adds OSD notifications when privacy indicator enables/disables.

This PR adds 6 i18n OSD keys:

- `osd.privacy.mic-on`
- `osd.privacy.mic-off`
- `osd.privacy.camera-on`
- `osd.privacy.camera-off`
- `osd.privacy.screen-on`
- `osd.privacy.screen-off`

It adds 2 i18n UI keys:
- `settings.schema.shell.osd-kinds-privacy.label`
- `settings.schema.shell.osd-kinds-privacy.description`

The new OSD config to toggle this feature is added to GUI settings. If the PR is accepted, I will create a docs PR to update the OSD config documentation.

## Motivation

Gives more visible notice of privacy state changes

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#3040 

## Testing

I tested with mic and screen share enable/disable. I don't have a camera and did not test it. When multiple privacy events happen in rapid succession (e.g. leave call that had screen share and mic enabled), the existing OSD popup logic handles animating the first and showing the others overwritten in succession.

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
