### PR TITLE
feat(notifications): filter option added to disable permanent notifications

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -994,11 +994,13 @@
       "filter": {
         "add": "Add filter",
         "add-title": "Add Notification Filter",
+        "allow-permanent": "Allow permanent",
         "allowed-urgencies-label": "Allowed urgencies",
         "flag": {
           "history": "history",
           "sound": "sound",
-          "toast": "toast"
+          "toast": "toast",
+          "permanent": "permanent"
         },
         "flags-label": "When matched",
         "match-label": "App",

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -522,6 +522,7 @@ namespace {
               row.insert_or_assign("show_toast", item.showToast);
               row.insert_or_assign("save_history", item.saveHistory);
               row.insert_or_assign("play_sound", item.playSound);
+              row.insert_or_assign("allow_permanent", item.allowPermanent);
               if (!item.allowedUrgencies.empty()) {
                 toml::array urgencies;
                 for (const auto& urgency : item.allowedUrgencies) {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -216,6 +216,7 @@ struct NotificationFilterConfig {
   bool showToast = true;
   bool saveHistory = true;
   bool playSound = true;
+  bool allowPermanent = true;
   /// Empty = allow low, normal, and critical. Otherwise only listed urgencies pass this filter.
   std::vector<std::string> allowedUrgencies;
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -203,6 +203,7 @@ namespace noctalia::config::schema {
         field(&NotificationFilterConfig::showToast, "show_toast"),
         field(&NotificationFilterConfig::saveHistory, "save_history"),
         field(&NotificationFilterConfig::playSound, "play_sound"),
+        field(&NotificationFilterConfig::allowPermanent, "allow_permanent"),
         field(&NotificationFilterConfig::allowedUrgencies, "allowed_urgencies"),
         custom<NotificationFilterConfig>(
             "allow_critical", [](const toml::table&, NotificationFilterConfig&, std::string_view, Diagnostics&) {},

--- a/src/notification/notification_filter.cpp
+++ b/src/notification/notification_filter.cpp
@@ -133,11 +133,17 @@ ResolvedNotificationFilter resolveNotificationFilter(
     if (!notificationMatchesToken(filter.match, fields)) {
       continue;
     }
+
+    const auto allowedUrgencies = normalizeAllowedUrgencies(filter.allowedUrgencies);
+    if (!urgencyIsAllowed(allowedUrgencies, fields.urgency)) {
+      continue;
+    }
     return ResolvedNotificationFilter{
         .showToast = filter.showToast,
         .saveHistory = filter.saveHistory,
         .playSound = filter.playSound,
-        .allowedUrgencies = normalizeAllowedUrgencies(filter.allowedUrgencies),
+        .allowPermanent = filter.allowPermanent,
+        .allowedUrgencies = allowedUrgencies,
         .matched = true,
     };
   }

--- a/src/notification/notification_filter.cpp
+++ b/src/notification/notification_filter.cpp
@@ -133,17 +133,12 @@ ResolvedNotificationFilter resolveNotificationFilter(
     if (!notificationMatchesToken(filter.match, fields)) {
       continue;
     }
-
-    const auto allowedUrgencies = normalizeAllowedUrgencies(filter.allowedUrgencies);
-    if (!urgencyIsAllowed(allowedUrgencies, fields.urgency)) {
-      continue;
-    }
     return ResolvedNotificationFilter{
         .showToast = filter.showToast,
         .saveHistory = filter.saveHistory,
         .playSound = filter.playSound,
         .allowPermanent = filter.allowPermanent,
-        .allowedUrgencies = allowedUrgencies,
+        .allowedUrgencies = normalizeAllowedUrgencies(filter.allowedUrgencies),
         .matched = true,
     };
   }

--- a/src/notification/notification_filter.h
+++ b/src/notification/notification_filter.h
@@ -13,7 +13,6 @@ struct NotificationFilterFields {
   std::string_view appName;
   std::optional<std::string_view> category;
   std::optional<std::string_view> desktopEntry;
-  Urgency urgency;
 };
 
 struct ResolvedNotificationFilter {

--- a/src/notification/notification_filter.h
+++ b/src/notification/notification_filter.h
@@ -13,12 +13,14 @@ struct NotificationFilterFields {
   std::string_view appName;
   std::optional<std::string_view> category;
   std::optional<std::string_view> desktopEntry;
+  Urgency urgency;
 };
 
 struct ResolvedNotificationFilter {
   bool showToast = true;
   bool saveHistory = true;
   bool playSound = true;
+  bool allowPermanent = true;
   /// Empty = all urgencies allowed for this filter.
   std::unordered_set<Urgency> allowedUrgencies;
   bool matched = false;

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -96,7 +96,6 @@ namespace {
             .desktopEntry = notification.desktopEntry.has_value()
                 ? std::optional<std::string_view>{*notification.desktopEntry}
                 : std::nullopt,
-            .urgency = notification.urgency,
         }
     );
     return resolved.saveHistory
@@ -196,28 +195,14 @@ uint32_t NotificationManager::addOrReplace(
     );
   };
 
-  if (timeout == 0) {
-    const auto resolved = resolveNotificationFilter(
-        m_filters,
-        NotificationFilterFields{
-            .appName = appName,
-            .category = category.has_value() ? std::optional<std::string_view>{*category} : std::nullopt,
-            .desktopEntry = desktopEntry.has_value() ? std::optional<std::string_view>{*desktopEntry} : std::nullopt,
-            .urgency = urgency,
-        }
-    );
-
-    kLog.debug(
-        "notification allowPermanent filter-matched={} filter-allow={}", resolved.matched, resolved.allowPermanent
-    );
-    if (resolved.matched && !resolved.allowPermanent) {
-      timeout = kDefaultNotificationTimeout;
-    }
-  }
-
   const ExternalNotificationDispatch externalDispatch = origin == NotificationOrigin::External
       ? evaluateExternalDispatch(urgency, appName, category, desktopEntry, transient)
       : ExternalNotificationDispatch{};
+
+  // A matching filter with allow_permanent = false expires otherwise-permanent (timeout 0) notifications.
+  if (timeout == 0 && externalDispatch.disallowPermanent) {
+    timeout = kDefaultNotificationTimeout;
+  }
 
   if (replacesId != 0) {
     if (m_suppressedIds.contains(replacesId)) {
@@ -610,9 +595,16 @@ NotificationManager::ExternalNotificationDispatch NotificationManager::evaluateE
           .appName = appName,
           .category = category.has_value() ? std::optional<std::string_view>{*category} : std::nullopt,
           .desktopEntry = desktopEntry.has_value() ? std::optional<std::string_view>{*desktopEntry} : std::nullopt,
-          .urgency = urgency,
       }
   );
+  dispatch.disallowPermanent = resolved.matched && !resolved.allowPermanent;
+  if (resolved.matched && !urgencyIsAllowed(resolved.allowedUrgencies, urgency)) {
+    dispatch.fullySuppress = true;
+    dispatch.showToast = false;
+    dispatch.saveHistory = false;
+    dispatch.playSound = false;
+    return dispatch;
+  }
   dispatch.showToast = resolved.showToast;
   dispatch.saveHistory = resolved.saveHistory && shouldTrackHistory(NotificationOrigin::External, urgency, transient);
   dispatch.playSound = resolved.playSound && dispatch.showToast;

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -96,6 +96,7 @@ namespace {
             .desktopEntry = notification.desktopEntry.has_value()
                 ? std::optional<std::string_view>{*notification.desktopEntry}
                 : std::nullopt,
+            .urgency = notification.urgency,
         }
     );
     return resolved.saveHistory
@@ -194,6 +195,25 @@ uint32_t NotificationManager::addOrReplace(
         n.appName, urgencyStr(n.urgency), n.timeout
     );
   };
+
+  if (timeout == 0) {
+    const auto resolved = resolveNotificationFilter(
+        m_filters,
+        NotificationFilterFields{
+            .appName = appName,
+            .category = category.has_value() ? std::optional<std::string_view>{*category} : std::nullopt,
+            .desktopEntry = desktopEntry.has_value() ? std::optional<std::string_view>{*desktopEntry} : std::nullopt,
+            .urgency = urgency,
+        }
+    );
+
+    kLog.debug(
+        "notification allowPermanent filter-matched={} filter-allow={}", resolved.matched, resolved.allowPermanent
+    );
+    if (resolved.matched && !resolved.allowPermanent) {
+      timeout = kDefaultNotificationTimeout;
+    }
+  }
 
   const ExternalNotificationDispatch externalDispatch = origin == NotificationOrigin::External
       ? evaluateExternalDispatch(urgency, appName, category, desktopEntry, transient)
@@ -590,15 +610,9 @@ NotificationManager::ExternalNotificationDispatch NotificationManager::evaluateE
           .appName = appName,
           .category = category.has_value() ? std::optional<std::string_view>{*category} : std::nullopt,
           .desktopEntry = desktopEntry.has_value() ? std::optional<std::string_view>{*desktopEntry} : std::nullopt,
+          .urgency = urgency,
       }
   );
-  if (resolved.matched && !urgencyIsAllowed(resolved.allowedUrgencies, urgency)) {
-    dispatch.fullySuppress = true;
-    dispatch.showToast = false;
-    dispatch.saveHistory = false;
-    dispatch.playSound = false;
-    return dispatch;
-  }
   dispatch.showToast = resolved.showToast;
   dispatch.saveHistory = resolved.saveHistory && shouldTrackHistory(NotificationOrigin::External, urgency, transient);
   dispatch.playSound = resolved.playSound && dispatch.showToast;

--- a/src/notification/notification_manager.h
+++ b/src/notification/notification_manager.h
@@ -133,6 +133,7 @@ private:
     bool showToast = true;
     bool saveHistory = true;
     bool playSound = true;
+    bool disallowPermanent = false;
   };
   [[nodiscard]] ExternalNotificationDispatch evaluateExternalDispatch(
       Urgency urgency, std::string_view appName, const std::optional<std::string>& category,

--- a/src/shell/settings/settings_content_common.cpp
+++ b/src/shell/settings/settings_content_common.cpp
@@ -324,6 +324,9 @@ namespace settings {
     if (filter.playSound) {
       parts.emplace_back(i18n::tr("settings.notifications.filter.flag.sound"));
     }
+    if (filter.allowPermanent) {
+      parts.emplace_back(i18n::tr("settings.notifications.filter.flag.permanent"));
+    }
     if (!filter.allowedUrgencies.empty()) {
       std::vector<std::string> urgencyLabels;
       urgencyLabels.reserve(filter.allowedUrgencies.size());

--- a/src/shell/settings/settings_content_notification_filter.cpp
+++ b/src/shell/settings/settings_content_notification_filter.cpp
@@ -158,6 +158,13 @@ namespace settings {
           persist();
         }
     );
+    addToggleRow(
+        *flagsBlock, scale, i18n::tr("settings.notifications.filter.allow-permanent"), row.allowPermanent,
+        [&row, persist](bool value) {
+          row.allowPermanent = value;
+          persist();
+        }
+    );
     body->addChild(std::move(flagsBlock));
 
     parent.addChild(std::move(body));

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -871,6 +871,7 @@ void SettingsWindow::openNotificationFilterCreateEditor() {
       .showToast = true,
       .saveHistory = true,
       .playSound = true,
+      .allowPermanent = true,
       .allowedUrgencies = {},
   });
 

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -304,6 +304,7 @@ location = "https://example.invalid/bad"
             .showToast = false,
             .saveHistory = false,
             .playSound = false,
+            .allowPermanent = false,
             .allowedUrgencies = {"normal", "critical"},
         }},
     };

--- a/tests/notification_filter_test.cpp
+++ b/tests/notification_filter_test.cpp
@@ -1,4 +1,5 @@
 #include "config/config_types.h"
+#include "notification/notification.h"
 #include "notification/notification_filter.h"
 
 #include <iostream>
@@ -23,7 +24,7 @@ int main() {
   ok &= check(blacklist.size() == 1, "blacklist dedupes and normalizes");
   ok &= check(
       notificationMatchesBlacklist(
-          blacklist, NotificationFilterFields{.appName = "Discord", .category = std::nullopt, .desktopEntry = std::nullopt}
+          blacklist, NotificationFilterFields{.appName = "Discord", .category = std::nullopt, .desktopEntry = std::nullopt, .urgency = Urgency::Normal}
       ),
       "app name exact match"
   );
@@ -34,6 +35,7 @@ int main() {
               .appName = "My Discord Client",
               .category = std::nullopt,
               .desktopEntry = std::nullopt,
+              .urgency = Urgency::Normal,
           }
       ),
       "app name substring match"
@@ -45,6 +47,7 @@ int main() {
               .appName = "Other",
               .category = std::nullopt,
               .desktopEntry = std::optional<std::string_view>{"org.telegram.desktop"},
+              .urgency = Urgency::Normal,
           }
       ),
       "desktop entry no match"
@@ -56,6 +59,7 @@ int main() {
               .appName = "Telegram",
               .category = std::nullopt,
               .desktopEntry = std::optional<std::string_view>{"org.telegram.desktop"},
+              .urgency = Urgency::Normal,
           }
       ),
       "desktop entry exact match"
@@ -67,6 +71,7 @@ int main() {
               .appName = "Chat",
               .category = std::optional<std::string_view>{"im.received"},
               .desktopEntry = std::nullopt,
+              .urgency = Urgency::Normal,
           }
       ),
       "category exact match"

--- a/tests/notification_filter_test.cpp
+++ b/tests/notification_filter_test.cpp
@@ -1,5 +1,4 @@
 #include "config/config_types.h"
-#include "notification/notification.h"
 #include "notification/notification_filter.h"
 
 #include <iostream>
@@ -24,7 +23,7 @@ int main() {
   ok &= check(blacklist.size() == 1, "blacklist dedupes and normalizes");
   ok &= check(
       notificationMatchesBlacklist(
-          blacklist, NotificationFilterFields{.appName = "Discord", .category = std::nullopt, .desktopEntry = std::nullopt, .urgency = Urgency::Normal}
+          blacklist, NotificationFilterFields{.appName = "Discord", .category = std::nullopt, .desktopEntry = std::nullopt}
       ),
       "app name exact match"
   );
@@ -35,7 +34,6 @@ int main() {
               .appName = "My Discord Client",
               .category = std::nullopt,
               .desktopEntry = std::nullopt,
-              .urgency = Urgency::Normal,
           }
       ),
       "app name substring match"
@@ -47,7 +45,6 @@ int main() {
               .appName = "Other",
               .category = std::nullopt,
               .desktopEntry = std::optional<std::string_view>{"org.telegram.desktop"},
-              .urgency = Urgency::Normal,
           }
       ),
       "desktop entry no match"
@@ -59,7 +56,6 @@ int main() {
               .appName = "Telegram",
               .category = std::nullopt,
               .desktopEntry = std::optional<std::string_view>{"org.telegram.desktop"},
-              .urgency = Urgency::Normal,
           }
       ),
       "desktop entry exact match"
@@ -71,7 +67,6 @@ int main() {
               .appName = "Chat",
               .category = std::optional<std::string_view>{"im.received"},
               .desktopEntry = std::nullopt,
-              .urgency = Urgency::Normal,
           }
       ),
       "category exact match"
@@ -133,6 +128,22 @@ int main() {
   );
   ok &= check(lowOnlyFilter.matched && urgencyIsAllowed(lowOnlyFilter.allowedUrgencies, Urgency::Low), "filter low allowed");
   ok &= check(!urgencyIsAllowed(lowOnlyFilter.allowedUrgencies, Urgency::Normal), "filter normal blocked");
+
+  const auto noPermanent = resolveNotificationFilter(
+      {NotificationFilterConfig{
+          .name = "browser",
+          .enabled = true,
+          .match = "browser",
+          .allowPermanent = false,
+      }},
+      NotificationFilterFields{
+          .appName = "Browser",
+          .category = std::nullopt,
+          .desktopEntry = std::nullopt,
+      }
+  );
+  ok &= check(noPermanent.matched && !noPermanent.allowPermanent, "filter disallows permanent");
+  ok &= check(resolveNotificationFilter({}, NotificationFilterFields{.appName = "Browser"}).allowPermanent, "default allows permanent");
 
   const auto music = resolveNotificationFilter(
       filters,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary & Motivation

My webbrowser sends notifications as permanent notifications (timeout = 0). This sometimes results in a big list of notifications, that I have to click away manually on browser startup.
This PR adds a filter setting, which allows disabling permanent notifications and have them timeout normally.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Running `notify-send -t 0 Test` before and after setting the `allow_permanent` option.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->