### PR TITLE
fix(ram): added zfsArc to avail memory calculation

### DIFF
--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -1333,6 +1333,36 @@ std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTota
   return totals;
 }
 
+std::uint64_t readZfsEvictableArcKb() {
+  std::ifstream file{"/proc/spl/kstat/zfs/arcstats"};
+  if (!file.is_open()) {
+    return 0;
+  }
+
+  std::uint64_t arcSize = 0;
+  std::uint64_t arcMin = 0;
+  std::string line;
+  while (std::getline(file, line)) {
+    std::string key;
+    std::uint32_t type = 0;
+    std::uint64_t value = 0;
+
+    std::istringstream iss{line};
+    if (iss >> key >> type >> value) {
+      if (key == "size") {
+        arcSize = value;
+      } else if (key == "c_min") {
+        arcMin = value;
+      }
+    }
+  }
+
+  if (arcSize > arcMin) {
+    return (arcSize - arcMin) / 1024;
+  }
+  return 0;
+}
+
 std::optional<SystemMonitorService::MemData> SystemMonitorService::readMemoryKb() {
   std::ifstream file{"/proc/meminfo"};
   if (!file.is_open()) {
@@ -1368,6 +1398,9 @@ std::optional<SystemMonitorService::MemData> SystemMonitorService::readMemoryKb(
   if (totalKb == 0 || availableKb == 0 || availableKb > totalKb) {
     return std::nullopt;
   }
+
+  std::uint64_t zfsArcKb = readZfsEvictableArcKb();
+  availableKb = std::min(availableKb + zfsArcKb, totalKb);
 
   MemData data;
   data.totalKb = totalKb;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Adds the zfs arc info to the RAM calculation.

## Motivation

<!-- What problem does this solve? -->
Before this PR the RAM used didn't include the ZFS cache, which is not included in /proc/meminfo.
This resulted in the calculation showing a higher RAM usage than it was.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
I used btop as the reference and with these changes it matches the value (aside from rounding errors)

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
