### PR TITLE
feat: add focused_only option for workspaces and taskbar widgets

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3013,9 +3013,9 @@
           "label": "Minimal Style",
           "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation"
         },
-        "focused-only": {
+        "focused-output-only": {
           "description": "Only highlight the active workspace on the focused monitor",
-          "label": "Focused Highlight Only",
+          "label": "Highlight Focused Output Only",
           "workspaces-description": "Only highlight the active workspace on the monitor that has keyboard or pointer focus; other monitors show their active workspace as occupied instead",
           "taskbar-description": "Only use the focused color for the active workspace on the monitor that has keyboard or pointer focus; other monitors use the occupied color"
         },

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3013,6 +3013,12 @@
           "label": "Minimal Style",
           "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation"
         },
+        "focused-only": {
+          "description": "Only highlight the active workspace on the focused monitor",
+          "label": "Focused Highlight Only",
+          "workspaces-description": "Only highlight the active workspace on the monitor that has keyboard or pointer focus; other monitors show their active workspace as occupied instead",
+          "taskbar-description": "Only use the focused color for the active workspace on the monitor that has keyboard or pointer focus; other monitors use the occupied color"
+        },
         "mirrored": {
           "description": "Mirror the visualizer around its center",
           "label": "Mirrored"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3015,7 +3015,7 @@
         },
         "focused-output-only": {
           "description": "Only highlight the active workspace on the focused monitor",
-          "label": "Highlight Focused Output Only",
+          "label": "Highlight Focused Monitor Only",
           "workspaces-description": "Only highlight the active workspace on the monitor that has keyboard or pointer focus; other monitors show their active workspace as occupied instead",
           "taskbar-description": "Only use the focused color for the active workspace on the monitor that has keyboard or pointer focus; other monitors use the occupied color"
         },

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -526,7 +526,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .workspaceLabelPlacement = WorkspaceLabelPlacement::Corner,
         .hideEmptyWorkspaces = wc != nullptr ? wc->getBool("hide_empty_workspaces", false) : false,
         .workspaceGroupCapsule = wc != nullptr ? wc->getBool("workspace_group_capsule", true) : true,
-        .focusedOnly = wc != nullptr ? wc->getBool("focused_only", false) : false,
+        .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
         .groupSingleIconPerApp = wc != nullptr ? wc->getBool("group_single_icon_per_app", false) : false,
         .showActiveIndicator = wc != nullptr ? wc->getBool("show_active_indicator", true) : true,
         .activeOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("active_opacity", 1.0)) : 1.0f,
@@ -662,7 +662,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .activePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("active_pill_size", 2.2) : 2.2),
         .inactivePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("inactive_pill_size", 1.0) : 1.0),
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
-        .focusedOnly = wc != nullptr ? wc->getBool("focused_only", false) : false,
+        .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -526,6 +526,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .workspaceLabelPlacement = WorkspaceLabelPlacement::Corner,
         .hideEmptyWorkspaces = wc != nullptr ? wc->getBool("hide_empty_workspaces", false) : false,
         .workspaceGroupCapsule = wc != nullptr ? wc->getBool("workspace_group_capsule", true) : true,
+        .focusedOnly = wc != nullptr ? wc->getBool("focused_only", false) : false,
         .groupSingleIconPerApp = wc != nullptr ? wc->getBool("group_single_icon_per_app", false) : false,
         .showActiveIndicator = wc != nullptr ? wc->getBool("show_active_indicator", true) : true,
         .activeOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("active_opacity", 1.0)) : 1.0f,
@@ -661,6 +662,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .activePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("active_pill_size", 2.2) : 2.2),
         .inactivePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("inactive_pill_size", 1.0) : 1.0),
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
+        .focusedOnly = wc != nullptr ? wc->getBool("focused_only", false) : false,
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -350,6 +350,7 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
   if (m_taskStrip == nullptr) {
     return;
   }
+  m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   clearChildren(m_taskStrip);
   buildTaskButtons(renderer);
 }
@@ -2329,7 +2330,7 @@ wl_output* TaskbarWidget::workspaceHostOutput(const WorkspaceModel& model) const
 
 ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    if (!m_focusedOutputOnly || isFocusedOutput()) {
+    if (m_activeUsesFocusedColor) {
       return m_focusedColor;
     }
     return m_occupiedColor;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -165,7 +165,7 @@ TaskbarWidget::TaskbarWidget(
     CompositorPlatform& platform, ConfigService& config, wl_output* output, TaskbarWidgetOptions options
 )
     : m_platform(platform), m_configService(config), m_output(output), m_configOptions(std::move(options)),
-      m_showAllOutputs(m_configOptions.showAllOutputs), m_focusedOnly(m_configOptions.focusedOnly),
+      m_showAllOutputs(m_configOptions.showAllOutputs), m_focusedOutputOnly(m_configOptions.focusedOutputOnly),
       m_showActiveIndicator(m_configOptions.showActiveIndicator), m_activeOpacity(m_configOptions.activeOpacity),
       m_inactiveOpacity(m_configOptions.inactiveOpacity), m_focusedColor(m_configOptions.focusedColor),
       m_occupiedColor(m_configOptions.occupiedColor), m_emptyColor(m_configOptions.emptyColor),
@@ -334,7 +334,7 @@ void TaskbarWidget::doLayout(Renderer& renderer, float containerWidth, float con
 
 void TaskbarWidget::doUpdate(Renderer& /*renderer*/) {
   updateModels();
-  if (m_focusedOnly) {
+  if (m_focusedOutputOnly) {
     const bool isFocused = isFocusedOutput();
     if (isFocused != m_wasFocusedOutput) {
       m_wasFocusedOutput = isFocused;
@@ -2329,7 +2329,7 @@ wl_output* TaskbarWidget::workspaceHostOutput(const WorkspaceModel& model) const
 
 ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    if (!m_focusedOnly || isFocusedOutput()) {
+    if (!m_focusedOutputOnly || isFocusedOutput()) {
       return m_focusedColor;
     }
     return m_occupiedColor;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -165,12 +165,12 @@ TaskbarWidget::TaskbarWidget(
     CompositorPlatform& platform, ConfigService& config, wl_output* output, TaskbarWidgetOptions options
 )
     : m_platform(platform), m_configService(config), m_output(output), m_configOptions(std::move(options)),
-      m_showAllOutputs(m_configOptions.showAllOutputs), m_showActiveIndicator(m_configOptions.showActiveIndicator),
-      m_activeOpacity(m_configOptions.activeOpacity), m_inactiveOpacity(m_configOptions.inactiveOpacity),
-      m_focusedColor(m_configOptions.focusedColor), m_occupiedColor(m_configOptions.occupiedColor),
-      m_emptyColor(m_configOptions.emptyColor), m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth),
-      m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth), m_barPosition(std::move(m_configOptions.barPosition)),
-      m_shadowConfig(m_configOptions.shadowConfig) {
+      m_showAllOutputs(m_configOptions.showAllOutputs), m_focusedOnly(m_configOptions.focusedOnly),
+      m_showActiveIndicator(m_configOptions.showActiveIndicator), m_activeOpacity(m_configOptions.activeOpacity),
+      m_inactiveOpacity(m_configOptions.inactiveOpacity), m_focusedColor(m_configOptions.focusedColor),
+      m_occupiedColor(m_configOptions.occupiedColor), m_emptyColor(m_configOptions.emptyColor),
+      m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth), m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth),
+      m_barPosition(std::move(m_configOptions.barPosition)), m_shadowConfig(m_configOptions.shadowConfig) {
   syncWorkspaceGroupingCapability();
   buildDesktopIconIndex();
 }
@@ -332,9 +332,18 @@ void TaskbarWidget::doLayout(Renderer& renderer, float containerWidth, float con
   }
 }
 
-void TaskbarWidget::doUpdate(Renderer& renderer) {
-  (void)renderer;
+void TaskbarWidget::doUpdate(Renderer& /*renderer*/) {
   updateModels();
+  if (m_focusedOnly) {
+    const bool isFocused = isFocusedOutput();
+    if (isFocused != m_wasFocusedOutput) {
+      m_wasFocusedOutput = isFocused;
+      m_rebuildPending = true;
+      if (root() != nullptr) {
+        root()->markLayoutDirty();
+      }
+    }
+  }
 }
 
 void TaskbarWidget::rebuild(Renderer& renderer) {
@@ -2320,7 +2329,10 @@ wl_output* TaskbarWidget::workspaceHostOutput(const WorkspaceModel& model) const
 
 ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    return m_focusedColor;
+    if (!m_focusedOnly || isFocusedOutput()) {
+      return m_focusedColor;
+    }
+    return m_occupiedColor;
   }
   if (workspace.urgent) {
     return colorSpecFromRole(ColorRole::Error);
@@ -2332,6 +2344,8 @@ ColorSpec TaskbarWidget::workspaceFillColor(const Workspace& workspace) const {
   color.alpha *= 0.55f;
   return color;
 }
+
+bool TaskbarWidget::isFocusedOutput() const { return m_platform.preferredInteractiveOutput() == m_output; }
 
 ColorSpec TaskbarWidget::workspaceTextColor(const Workspace& workspace) const {
   if (workspace.urgent) {

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -34,6 +34,7 @@ struct TaskbarWidgetOptions {
   WorkspaceLabelPlacement workspaceLabelPlacement = WorkspaceLabelPlacement::Corner;
   bool hideEmptyWorkspaces = false;
   bool workspaceGroupCapsule = true;
+  bool focusedOnly = false;
   bool groupSingleIconPerApp = false;
   bool showActiveIndicator = true;
   float activeOpacity = 1.0f;
@@ -110,6 +111,7 @@ private:
   [[nodiscard]] wl_output* workspaceHostOutput(const WorkspaceModel& model) const noexcept;
   [[nodiscard]] ColorSpec workspaceFillColor(const Workspace& workspace) const;
   [[nodiscard]] ColorSpec workspaceTextColor(const Workspace& workspace) const;
+  [[nodiscard]] bool isFocusedOutput() const;
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
@@ -126,6 +128,8 @@ private:
   WorkspaceLabelPlacement m_workspaceLabelPlacement = WorkspaceLabelPlacement::Corner;
   bool m_hideEmptyWorkspaces = false;
   bool m_workspaceGroupCapsule = true;
+  bool m_focusedOnly = false;
+  bool m_wasFocusedOutput = true;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;
   float m_activeOpacity = 1.0f;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -34,7 +34,7 @@ struct TaskbarWidgetOptions {
   WorkspaceLabelPlacement workspaceLabelPlacement = WorkspaceLabelPlacement::Corner;
   bool hideEmptyWorkspaces = false;
   bool workspaceGroupCapsule = true;
-  bool focusedOnly = false;
+  bool focusedOutputOnly = false;
   bool groupSingleIconPerApp = false;
   bool showActiveIndicator = true;
   float activeOpacity = 1.0f;
@@ -128,7 +128,7 @@ private:
   WorkspaceLabelPlacement m_workspaceLabelPlacement = WorkspaceLabelPlacement::Corner;
   bool m_hideEmptyWorkspaces = false;
   bool m_workspaceGroupCapsule = true;
-  bool m_focusedOnly = false;
+  bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -130,6 +130,7 @@ private:
   bool m_workspaceGroupCapsule = true;
   bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
+  bool m_activeUsesFocusedColor = true;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;
   float m_activeOpacity = 1.0f;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -197,6 +197,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
 
 void WorkspacesWidget::rebuild(Renderer& renderer) {
   uiAssertNotRendering("WorkspacesWidget::rebuild");
+  m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   cancelAnimation();
   while (!m_container->children().empty()) {
     m_container->removeChild(m_container->children().back().get());
@@ -494,6 +495,7 @@ void WorkspacesWidget::updateAllItemMetrics(Renderer& renderer) {
 }
 
 void WorkspacesWidget::retarget(Renderer& renderer) {
+  m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   for (std::size_t i = 0; i < m_items.size(); ++i) {
     auto& it = m_items[i];
     const auto& ws = m_cachedState[i];
@@ -710,7 +712,7 @@ bool WorkspacesWidget::isFocusedOutput() const { return m_platform.preferredInte
 
 ColorSpec WorkspacesWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    if (!m_focusedOutputOnly || isFocusedOutput()) {
+    if (m_activeUsesFocusedColor) {
       return m_focusedColor;
     }
     return m_occupiedColor;
@@ -734,7 +736,7 @@ ColorSpec WorkspacesWidget::workspaceTextColor(const Workspace& workspace) const
     return readableColorForFill(workspaceFillColor(workspace));
   }
   if (workspace.active) {
-    if (!m_focusedOutputOnly || isFocusedOutput()) {
+    if (m_activeUsesFocusedColor) {
       return m_focusedColor;
     }
     return m_occupiedColor;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -46,7 +46,8 @@ WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* outp
       m_hideWhenEmpty(options.hideWhenEmpty), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
-      m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {}
+      m_focusedOnly(options.focusedOnly), m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor),
+      m_emptyColor(options.emptyColor) {}
 
 WorkspacesWidget::DisplayMode WorkspacesWidget::effectiveDisplayMode() const noexcept {
   if (m_minimal && m_displayMode == DisplayMode::None) {
@@ -158,6 +159,13 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
   }
 
   if (!structuralChange && !activeChange) {
+    if (m_focusedOnly) {
+      const bool isFocused = isFocusedOutput();
+      if (isFocused != m_wasFocusedOutput) {
+        m_wasFocusedOutput = isFocused;
+        retarget(renderer);
+      }
+    }
     return;
   }
 
@@ -698,9 +706,14 @@ std::optional<std::size_t> WorkspacesWidget::numericWorkspaceId(const Workspace&
   return std::nullopt;
 }
 
+bool WorkspacesWidget::isFocusedOutput() const { return m_platform.preferredInteractiveOutput() == m_output; }
+
 ColorSpec WorkspacesWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    return m_focusedColor;
+    if (!m_focusedOnly || isFocusedOutput()) {
+      return m_focusedColor;
+    }
+    return m_occupiedColor;
   }
   if (workspace.urgent) {
     return colorSpecFromRole(ColorRole::Error);
@@ -721,7 +734,10 @@ ColorSpec WorkspacesWidget::workspaceTextColor(const Workspace& workspace) const
     return readableColorForFill(workspaceFillColor(workspace));
   }
   if (workspace.active) {
-    return m_focusedColor;
+    if (!m_focusedOnly || isFocusedOutput()) {
+      return m_focusedColor;
+    }
+    return m_occupiedColor;
   }
   if (workspace.occupied) {
     return m_occupiedColor;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -46,8 +46,8 @@ WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* outp
       m_hideWhenEmpty(options.hideWhenEmpty), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
-      m_focusedOnly(options.focusedOnly), m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor),
-      m_emptyColor(options.emptyColor) {}
+      m_focusedOutputOnly(options.focusedOutputOnly), m_focusedColor(options.focusedColor),
+      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {}
 
 WorkspacesWidget::DisplayMode WorkspacesWidget::effectiveDisplayMode() const noexcept {
   if (m_minimal && m_displayMode == DisplayMode::None) {
@@ -159,7 +159,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
   }
 
   if (!structuralChange && !activeChange) {
-    if (m_focusedOnly) {
+    if (m_focusedOutputOnly) {
       const bool isFocused = isFocusedOutput();
       if (isFocused != m_wasFocusedOutput) {
         m_wasFocusedOutput = isFocused;
@@ -710,7 +710,7 @@ bool WorkspacesWidget::isFocusedOutput() const { return m_platform.preferredInte
 
 ColorSpec WorkspacesWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
-    if (!m_focusedOnly || isFocusedOutput()) {
+    if (!m_focusedOutputOnly || isFocusedOutput()) {
       return m_focusedColor;
     }
     return m_occupiedColor;
@@ -734,7 +734,7 @@ ColorSpec WorkspacesWidget::workspaceTextColor(const Workspace& workspace) const
     return readableColorForFill(workspaceFillColor(workspace));
   }
   if (workspace.active) {
-    if (!m_focusedOnly || isFocusedOutput()) {
+    if (!m_focusedOutputOnly || isFocusedOutput()) {
       return m_focusedColor;
     }
     return m_occupiedColor;

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -35,6 +35,7 @@ public:
     float activePillSize = 2.2f;
     float inactivePillSize = 1.0f;
     bool minimal = false;
+    bool focusedOnly = false;
   };
 
   WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options);
@@ -88,6 +89,7 @@ private:
   [[nodiscard]] ColorSpec workspaceTextColor(const Workspace& workspace) const;
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
+  [[nodiscard]] bool isFocusedOutput() const;
 
   CompositorPlatform& m_platform;
   wl_output* m_output = nullptr;
@@ -99,6 +101,8 @@ private:
   float m_activePillSize = 2.2f;
   float m_inactivePillSize = 1.0f;
   bool m_minimal = false;
+  bool m_focusedOnly = false;
+  bool m_wasFocusedOutput = true;
   Node* m_container = nullptr;
   std::vector<Workspace> m_cachedState;
   std::vector<Item> m_items;

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -35,7 +35,7 @@ public:
     float activePillSize = 2.2f;
     float inactivePillSize = 1.0f;
     bool minimal = false;
-    bool focusedOnly = false;
+    bool focusedOutputOnly = false;
   };
 
   WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options);
@@ -101,7 +101,7 @@ private:
   float m_activePillSize = 2.2f;
   float m_inactivePillSize = 1.0f;
   bool m_minimal = false;
-  bool m_focusedOnly = false;
+  bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
   Node* m_container = nullptr;
   std::vector<Workspace> m_cachedState;

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -103,6 +103,7 @@ private:
   bool m_minimal = false;
   bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
+  bool m_activeUsesFocusedColor = true;
   Node* m_container = nullptr;
   std::vector<Workspace> m_cachedState;
   std::vector<Item> m_items;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -826,11 +826,11 @@ namespace settings {
           add(std::move(groupCapsule));
         }
         {
-          auto focusedOnly = boolSpec("focused_only", false);
-          focusedOnly.descriptionKey = "settings.widgets.settings.focused-only.taskbar-description";
-          focusedOnly.visibleWhen =
+          auto focusedOutputOnly = boolSpec("focused_output_only", false);
+          focusedOutputOnly.descriptionKey = "settings.widgets.settings.focused-output-only.taskbar-description";
+          focusedOutputOnly.visibleWhen =
               WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_workspace_label", {"true"}}};
-          add(std::move(focusedOnly));
+          add(std::move(focusedOutputOnly));
         }
         {
           auto singleIconPerApp = boolSpec("group_single_icon_per_app", false);
@@ -943,9 +943,9 @@ namespace settings {
         add(std::move(minimal));
       }
       {
-        auto focusedOnly = boolSpec("focused_only", false);
-        focusedOnly.descriptionKey = "settings.widgets.settings.focused-only.workspaces-description";
-        add(std::move(focusedOnly));
+        auto focusedOutputOnly = boolSpec("focused_output_only", false);
+        focusedOutputOnly.descriptionKey = "settings.widgets.settings.focused-output-only.workspaces-description";
+        add(std::move(focusedOutputOnly));
       }
       add(segmentedSpec("display", "id", workspaceDisplay));
       {

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -826,6 +826,13 @@ namespace settings {
           add(std::move(groupCapsule));
         }
         {
+          auto focusedOnly = boolSpec("focused_only", false);
+          focusedOnly.descriptionKey = "settings.widgets.settings.focused-only.taskbar-description";
+          focusedOnly.visibleWhen =
+              WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_workspace_label", {"true"}}};
+          add(std::move(focusedOnly));
+        }
+        {
           auto singleIconPerApp = boolSpec("group_single_icon_per_app", false);
           singleIconPerApp.visibleWhen =
               WidgetSettingVisibility{WidgetSettingVisibilityCondition{"group_by_workspace", {"true"}}};
@@ -934,6 +941,11 @@ namespace settings {
         auto minimal = boolSpec("minimal", false);
         minimal.descriptionKey = "settings.widgets.settings.minimal.workspaces-description";
         add(std::move(minimal));
+      }
+      {
+        auto focusedOnly = boolSpec("focused_only", false);
+        focusedOnly.descriptionKey = "settings.widgets.settings.focused-only.workspaces-description";
+        add(std::move(focusedOnly));
       }
       add(segmentedSpec("display", "id", workspaceDisplay));
       {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

New config option `focused_only = false` (default) for the workspaces widget and taskbar widget. When enabled, only the monitor with keyboard or pointer focus shows the active workspace highlight color. Other monitors show their active workspace as occupied color instead.

## Motivation

In multi-monitor setups, every monitor simultaneously highlights its own active workspace, making it ambiguous which monitor actually has focus. This opt-in setting makes the focused monitor visually distinct from peripheral monitors.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- `clang-format --dry-run --Werror` passes
- Tested on Hyprland with two monitors. Verified that switching focus between monitors updates workspace colors live on both the workspaces widget (pill colors) and taskbar widget (disc labels).

## Manual Coverage

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Config example:

```toml
[widget.workspaces]
focused_only = true

[widget.taskbar]
focused_only = true
```

Implementation: `workspaceFillColor()` checks `isFocusedOutput()` when `focused_only` is enabled. The `doUpdate()` loop in both widgets tracks `m_wasFocusedOutput` and triggers a retarget/rebuild when focus changes, so colors update immediately when switching monitors. The taskbar setting is visible in the settings GUI when "Show Workspace Label" is enabled.