### PR TITLE
feat(workspace-tray): add workspace tray bar widget with dropdown panel

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1151,7 +1151,8 @@
         "wallpaper": "Wallpaper",
         "weather": "Weather",
         "widget-list": "Widget List",
-        "widgets": "Widgets"
+        "widgets": "Widgets",
+        "workspace-tray": "Workspace Tray"
       },
       "sections": {
         "accessibility": "Accessibility",
@@ -2275,6 +2276,10 @@
           "description": "Position the session panel near the bar widget that opened it; openings without a bar trigger are centered",
           "label": "Along Bar"
         },
+        "open-near-click-workspace-tray": {
+          "description": "Position the workspace tray panel near the bar click instead of centering it along the bar",
+          "label": "Open Near Click"
+        },
         "open-near-click-wallpaper": {
           "description": "Position the wallpaper picker near the bar widget that opened it; openings without a bar trigger are centered",
           "label": "Along Bar"
@@ -2297,6 +2302,10 @@
         },
         "placement-session": {
           "description": "Choose whether the session panel attaches to the bar or floats at a chosen screen position",
+          "label": "Placement"
+        },
+        "placement-workspace-tray": {
+          "description": "Choose whether the workspace tray attaches to the bar, floats near it, or opens centered",
           "label": "Placement"
         },
         "placement-wallpaper": {
@@ -3166,7 +3175,8 @@
           "description": "Only highlight the active workspace on the focused monitor",
           "label": "Highlight Focused Monitor Only",
           "taskbar-description": "Only use the focused color for the active workspace on the monitor that has keyboard or pointer focus; other monitors use the occupied color",
-          "workspaces-description": "Only highlight the active workspace on the monitor that has keyboard or pointer focus; other monitors show their active workspace as occupied instead"
+          "workspaces-description": "Only highlight the active workspace on the monitor that has keyboard or pointer focus; other monitors show their active workspace as occupied instead",
+          "workspace-tray-description": "Only use the focused color on the monitor that has keyboard or pointer focus; other monitors use the occupied color"
         },
         "font-family": {
           "description": "Typeface for this widget; leave empty to inherit the bar font",
@@ -3221,7 +3231,8 @@
         "hide-when-empty": {
           "description": "Hide workspace pills when there are no open windows",
           "label": "Hide When Empty",
-          "workspaces-description": "Hide workspace pills that have no open windows"
+          "workspaces-description": "Hide workspace pills that have no open windows",
+          "workspace-tray-description": "Hide the widget when all workspaces on this monitor are empty"
         },
         "hide-when-full": {
           "description": "Hide the battery widget when fully charged",
@@ -3316,7 +3327,8 @@
         "max-label-chars": {
           "description": "Maximum number of characters to show for workspace names",
           "label": "Max Label Characters",
-          "workspaces-description": "Maximum characters for workspace name labels"
+          "workspaces-description": "Maximum characters for workspace name labels",
+          "workspace-tray-description": "Maximum characters for the workspace name shown on the bar pill"
         },
         "max-length": {
           "description": "Maximum widget length in pixels",
@@ -3366,6 +3378,14 @@
         "only-active-workspace": {
           "description": "Hide windows on inactive workspaces",
           "label": "Only Active Workspace"
+        },
+        "new-workspace-command": {
+          "description": "Shell command run when the new workspace button is clicked",
+          "label": "New Workspace Command"
+        },
+        "new-workspace-glyph": {
+          "description": "Icon shown on the new workspace button",
+          "label": "New Workspace Icon"
         },
         "path": {
           "description": "Path used by disk statistics",
@@ -3428,6 +3448,10 @@
           "description": "Show weather condition text",
           "label": "Show Condition"
         },
+        "show-chevron": {
+          "description": "Show a dropdown arrow next to the workspace label",
+          "label": "Show Chevron"
+        },
         "show-empty-label": {
           "description": "Show placeholder text when no window is focused instead of hiding the widget",
           "label": "Show Empty Label"
@@ -3443,6 +3467,10 @@
         "show-num-lock": {
           "description": "Show Num Lock state",
           "label": "Show Num Lock"
+        },
+        "show-new-workspace": {
+          "description": "Show a button at the bottom of the workspace list to create a new workspace",
+          "label": "Show New Workspace Button"
         },
         "show-scroll-lock": {
           "description": "Show Scroll Lock state",
@@ -3568,7 +3596,8 @@
         "volume": "Volume",
         "wallpaper": "Wallpaper",
         "weather": "Weather",
-        "workspaces": "Workspaces"
+        "workspaces": "Workspaces",
+        "workspace-tray": "Workspace Tray"
       }
     },
     "window": {

--- a/meson.build
+++ b/meson.build
@@ -729,6 +729,8 @@ _noctalia_sources = files(
   'src/shell/bar/widgets/wallpaper_widget.cpp',
   'src/shell/bar/widgets/weather_widget.cpp',
   'src/shell/bar/widgets/workspaces_widget.cpp',
+  'src/shell/bar/widgets/workspace_tray_widget.cpp',
+  'src/shell/workspace_tray/workspace_tray_panel.cpp',
   'src/system/dependency_service.cpp',
   'src/system/desktop_entry.cpp',
   'src/system/desktop_entry_launch.cpp',

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -76,6 +76,7 @@
 #include "shell/tray/tray_drawer_panel.h"
 #include "shell/wallpaper/panel/wallpaper_panel.h"
 #include "shell/wallpaper/wallpaper_paths.h"
+#include "shell/workspace_tray/workspace_tray_panel.h"
 #include "system/brightness_poll_source.h"
 #include "system/brightness_service.h"
 #include "system/distro_info.h"
@@ -666,6 +667,9 @@ void Application::initPanelManagerAndPanels() {
                                  return m_polkitAgent.get();
                                }));
   m_panelManager.registerPanel("setup-wizard", std::make_unique<SetupWizardPanel>(&m_configService, &m_wayland));
+  m_panelManager.registerPanel(
+      "workspace-tray", std::make_unique<WorkspaceTrayPanel>(&m_compositorPlatform, &m_configService)
+  );
 
   if (SetupWizardPanel::isFirstRun(m_configService)) {
     DeferredCall::callLater([]() { PanelManager::instance().togglePanel("setup-wizard"); });

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -890,6 +890,7 @@ struct ShellConfig {
     PanelPlacement wallpaperPlacement = PanelPlacement::Attached;
     PanelPlacement sessionPlacement = PanelPlacement::Attached;
     PanelPlacement polkitPlacement = PanelPlacement::Floating;
+    PanelPlacement workspaceTrayPlacement = PanelPlacement::Attached;
     // Floating screen position per panel (one of kPanelPositions). "auto" = bar-relative.
     // Launcher/clipboard default to "center" (the historical centered placement).
     std::string launcherPosition = "center";
@@ -898,12 +899,14 @@ struct ShellConfig {
     std::string wallpaperPosition = "auto";
     std::string sessionPosition = "auto";
     std::string polkitPosition = "center";
+    std::string workspaceTrayPosition = "auto";
     std::int32_t floatingOffset = 8; // logical px gap between a floating/detached panel and the bar edge
     bool openNearClickControlCenter = false;
     bool openNearClickLauncher = false;
     bool openNearClickClipboard = false;
     bool openNearClickWallpaper = false;
     bool openNearClickSession = false;
+    bool openNearClickWorkspaceTray = false;
 
     bool operator==(const PanelConfig&) const = default;
   };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1192,18 +1192,21 @@ namespace noctalia::config::schema {
           enumField(&ShellConfig::PanelConfig::wallpaperPlacement, "wallpaper_placement", kPanelPlacements),
           enumField(&ShellConfig::PanelConfig::sessionPlacement, "session_placement", kPanelPlacements),
           enumField(&ShellConfig::PanelConfig::polkitPlacement, "polkit_placement", kPanelPlacements),
+          enumField(&ShellConfig::PanelConfig::workspaceTrayPlacement, "workspace_tray_placement", kPanelPlacements),
           field(&ShellConfig::PanelConfig::launcherPosition, "launcher_position"),
           field(&ShellConfig::PanelConfig::clipboardPosition, "clipboard_position"),
           field(&ShellConfig::PanelConfig::controlCenterPosition, "control_center_position"),
           field(&ShellConfig::PanelConfig::wallpaperPosition, "wallpaper_position"),
           field(&ShellConfig::PanelConfig::sessionPosition, "session_position"),
           field(&ShellConfig::PanelConfig::polkitPosition, "polkit_position"),
+          field(&ShellConfig::PanelConfig::workspaceTrayPosition, "workspace_tray_position"),
           field(&ShellConfig::PanelConfig::floatingOffset, "floating_offset", Range<std::int64_t>{0, 100}),
           field(&ShellConfig::PanelConfig::openNearClickControlCenter, "open_near_click_control_center"),
           field(&ShellConfig::PanelConfig::openNearClickLauncher, "open_near_click_launcher"),
           field(&ShellConfig::PanelConfig::openNearClickClipboard, "open_near_click_clipboard"),
           field(&ShellConfig::PanelConfig::openNearClickWallpaper, "open_near_click_wallpaper"),
           field(&ShellConfig::PanelConfig::openNearClickSession, "open_near_click_session"),
+          field(&ShellConfig::PanelConfig::openNearClickWorkspaceTray, "open_near_click_workspace_tray"),
       };
       return s;
     }

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -44,6 +44,7 @@
 #include "shell/bar/widgets/volume_widget.h"
 #include "shell/bar/widgets/wallpaper_widget.h"
 #include "shell/bar/widgets/weather_widget.h"
+#include "shell/bar/widgets/workspace_tray_widget.h"
 #include "shell/bar/widgets/workspaces_widget.h"
 #include "system/format_units.h"
 #include "ui/style.h"
@@ -713,6 +714,35 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .enableScroll = wc != nullptr ? wc->getBool("enable_scroll", true) : true,
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, m_configService, output, options);
+    widget->setContentScale(contentScale);
+    return widget;
+  }
+
+  if (type == "workspace_tray") {
+    const std::string display = wc != nullptr ? wc->getString("display", "id") : std::string("id");
+    const ColorSpec focusedColor = wc != nullptr
+        ? wc->getColorSpec("focused_color", colorSpecFromRole(ColorRole::Primary), "widget." + name + ".focused_color")
+        : colorSpecFromRole(ColorRole::Primary);
+    const ColorSpec occupiedColor = wc != nullptr
+        ? wc->getColorSpec(
+              "occupied_color", colorSpecFromRole(ColorRole::Secondary), "widget." + name + ".occupied_color"
+          )
+        : colorSpecFromRole(ColorRole::Secondary);
+    WorkspaceTrayWidget::DisplayMode displayMode = WorkspaceTrayWidget::DisplayMode::Id;
+    if (display == "name") {
+      displayMode = WorkspaceTrayWidget::DisplayMode::Name;
+    }
+    std::size_t maxLabelChars = 3;
+    if (wc != nullptr && wc->hasSetting("max_label_chars")) {
+      maxLabelChars = static_cast<std::size_t>(wc->getInt("max_label_chars", 3));
+    }
+    const bool showChevron = wc != nullptr ? wc->getBool("show_chevron", true) : true;
+    const bool focusedOnly = wc != nullptr ? wc->getBool("focused_only", false) : false;
+    const bool hideWhenEmpty = wc != nullptr ? wc->getBool("hide_when_empty", false) : false;
+    auto widget = std::make_unique<WorkspaceTrayWidget>(
+        m_platform, output, displayMode, maxLabelChars, focusedColor, occupiedColor, showChevron, focusedOnly,
+        hideWhenEmpty
+    );
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/workspace_tray_widget.cpp
+++ b/src/shell/bar/widgets/workspace_tray_widget.cpp
@@ -1,0 +1,316 @@
+#include "shell/bar/widgets/workspace_tray_widget.h"
+
+#include "compositors/compositor_platform.h"
+#include "core/ui_phase.h"
+#include "render/core/renderer.h"
+#include "render/scene/input_area.h"
+#include "render/scene/node.h"
+#include "ui/builders.h"
+#include "ui/palette.h"
+#include "ui/style.h"
+#include "util/string_utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <linux/input-event-codes.h>
+#include <wayland-client-protocol.h>
+
+namespace {
+
+  constexpr float kWidgetHeight = Style::baseGlyphSize;
+  constexpr float kPaddingH = Style::spaceSm;
+  constexpr float kChevronGap = Style::spaceXs;
+  constexpr float kChevronSize = Style::fontSizeMini;
+
+} // namespace
+
+WorkspaceTrayWidget::WorkspaceTrayWidget(
+    CompositorPlatform& platform, wl_output* output, DisplayMode displayMode, std::size_t maxLabelChars,
+    ColorSpec focusedColor, ColorSpec occupiedColor, bool showChevron, bool focusedOnly, bool hideWhenEmpty
+)
+    : m_platform(platform), m_output(output), m_displayMode(displayMode), m_maxLabelChars(maxLabelChars),
+      m_focusedColor(focusedColor), m_occupiedColor(occupiedColor), m_showChevron(showChevron),
+      m_focusedOnly(focusedOnly), m_hideWhenEmpty(hideWhenEmpty) {}
+
+void WorkspaceTrayWidget::create() {
+  auto container = std::make_unique<InputArea>();
+  container->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT}));
+  container->setOnClick([this](const InputArea::PointerData& data) {
+    if (data.pressed) {
+      return;
+    }
+    if (data.button == BTN_LEFT) {
+      requestPanelToggle("workspace-tray", outputContext());
+    }
+  });
+  container->setOnAxis([this](const InputArea::PointerData& data) {
+    if (data.axis != WL_POINTER_AXIS_VERTICAL_SCROLL) {
+      return;
+    }
+    const float delta = data.scrollDelta(1.0f);
+    if (delta == 0.0f) {
+      return;
+    }
+    activateAdjacentWorkspace(delta > 0.0f ? 1 : -1);
+  });
+  m_container = container.get();
+  setRoot(std::move(container));
+}
+
+void WorkspaceTrayWidget::doLayout(Renderer& renderer, float /*containerWidth*/, float /*containerHeight*/) {
+  const std::uint64_t textMetricsGeneration = renderer.textMetricsGeneration();
+  if (m_textMetricsGeneration != textMetricsGeneration) {
+    m_textMetricsGeneration = textMetricsGeneration;
+    m_rebuildPending = true;
+  }
+  if (m_rebuildPending) {
+    rebuild(renderer);
+    m_rebuildPending = false;
+  }
+}
+
+void WorkspaceTrayWidget::syncWidgetVisibility(bool showWidget) {
+  if (Node* rootNode = root(); rootNode != nullptr) {
+    rootNode->setVisible(showWidget);
+    rootNode->setParticipatesInLayout(showWidget);
+  }
+}
+
+void WorkspaceTrayWidget::doUpdate(Renderer& /*renderer*/) {
+  auto current = m_platform.workspaces(m_output);
+
+  if (!m_cachedState.empty() && !current.empty() && !std::ranges::any_of(current, [](const Workspace& ws) {
+        return ws.active;
+      })) {
+    return;
+  }
+
+  const bool showWidget = !current.empty()
+      && (!m_hideWhenEmpty
+          || std::ranges::any_of(current, [](const Workspace& ws) { return ws.occupied || ws.active || ws.urgent; }));
+  syncWidgetVisibility(showWidget);
+  if (!showWidget) {
+    if (!m_cachedState.empty()) {
+      m_cachedState.clear();
+      m_rebuildPending = true;
+      if (root() != nullptr) {
+        root()->markLayoutDirty();
+      }
+    }
+    return;
+  }
+
+  bool structuralChange = current.size() != m_cachedState.size();
+  bool activeChange = false;
+  bool occupiedChange = false;
+  if (!structuralChange) {
+    for (std::size_t i = 0; i < current.size(); ++i) {
+      const auto& a = current[i];
+      const auto& b = m_cachedState[i];
+      if (a.id != b.id || a.name != b.name || a.index != b.index || a.coordinates != b.coordinates) {
+        structuralChange = true;
+        break;
+      }
+      if (a.active != b.active || a.urgent != b.urgent) {
+        activeChange = true;
+      }
+      if (a.occupied != b.occupied) {
+        occupiedChange = true;
+      }
+    }
+  }
+
+  if (!structuralChange && !activeChange && !occupiedChange) {
+    if (m_focusedOnly) {
+      const bool isFocused = isFocusedOutput();
+      if (isFocused != m_wasFocusedOutput) {
+        m_wasFocusedOutput = isFocused;
+        m_rebuildPending = true;
+        if (root() != nullptr) {
+          root()->markLayoutDirty();
+        }
+      }
+    }
+    return;
+  }
+
+  m_cachedState.clear();
+  m_cachedState.reserve(current.size());
+  for (const auto& ws : current) {
+    m_cachedState.push_back(
+        Workspace{
+            .id = ws.id,
+            .name = ws.name,
+            .coordinates = ws.coordinates,
+            .index = ws.index,
+            .active = ws.active,
+            .urgent = ws.urgent,
+            .occupied = ws.occupied
+        }
+    );
+  }
+
+  m_rebuildPending = true;
+  if (root() != nullptr) {
+    root()->markLayoutDirty();
+  }
+}
+
+void WorkspaceTrayWidget::rebuild(Renderer& renderer) {
+  uiAssertNotRendering("WorkspaceTrayWidget::rebuild");
+
+  while (!m_container->children().empty()) {
+    m_container->removeChild(m_container->children().back().get());
+  }
+  m_label = nullptr;
+  m_chevron = nullptr;
+
+  const auto active = activeWorkspaceIndex();
+  if (!active.has_value()) {
+    m_container->setFrameSize(0.0f, 0.0f);
+    return;
+  }
+
+  const std::string label = activeWorkspaceLabel();
+
+  const float widgetHeight = std::round(kWidgetHeight * m_contentScale);
+  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float paddingH = kPaddingH * m_contentScale;
+  const float chevronGlyphSize = kChevronSize * m_contentScale;
+  const float chevronGap = kChevronGap * m_contentScale;
+  const ColorSpec color = textColor();
+
+  float labelWidth = 0.0f;
+  float labelHeight = labelFontSize;
+  if (!label.empty()) {
+    const TextMetrics tm = renderer.measureText(label, labelFontSize, labelFontWeight());
+    labelWidth = std::max(tm.right - tm.left, tm.inkRight - tm.inkLeft);
+    labelHeight = std::max(labelHeight, tm.bottom - tm.top);
+  }
+
+  float chevronWidth = 0.0f;
+  if (m_showChevron) {
+    chevronWidth = chevronGlyphSize;
+  }
+
+  const float contentWidth = labelWidth + (m_showChevron ? chevronGap + chevronWidth : 0.0f);
+  const float widgetWidth = contentWidth + paddingH * 2.0f;
+
+  if (!label.empty()) {
+    m_label = static_cast<Label*>(m_container->addChild(
+        ui::label({
+            .text = label,
+            .fontSize = labelFontSize,
+            .fontWeight = labelFontWeight(),
+            .fontFamily = labelFontFamily(),
+            .color = color,
+            .baselineMode = LabelBaselineMode::TextFixedHeight,
+        })
+    ));
+    m_label->measure(renderer);
+  }
+
+  if (m_showChevron) {
+    m_chevron = static_cast<Glyph*>(m_container->addChild(
+        ui::glyph({
+            .glyph = "chevron-down",
+            .glyphSize = chevronGlyphSize,
+            .color = color,
+        })
+    ));
+    m_chevron->measure(renderer);
+  }
+
+  float cursorX = paddingH;
+  const float labelY = (widgetHeight - labelHeight) * 0.5f;
+
+  if (m_label != nullptr) {
+    m_label->setPosition(cursorX, labelY);
+    cursorX += labelWidth;
+  }
+
+  if (m_chevron != nullptr) {
+    cursorX += chevronGap;
+    const float chevronY = (widgetHeight - chevronGlyphSize) * 0.5f;
+    m_chevron->setPosition(cursorX, chevronY);
+  }
+
+  m_container->setFrameSize(widgetWidth, widgetHeight);
+
+  if (barCapsuleShell() != nullptr) {
+    barCapsuleShell()->markLayoutDirty();
+  }
+}
+
+std::optional<std::size_t> WorkspaceTrayWidget::activeWorkspaceIndex() const {
+  for (std::size_t i = 0; i < m_cachedState.size(); ++i) {
+    if (m_cachedState[i].active) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+void WorkspaceTrayWidget::activateAdjacentWorkspace(int direction) {
+  if (m_cachedState.empty() || direction == 0) {
+    return;
+  }
+
+  const auto active = activeWorkspaceIndex();
+  std::size_t targetIndex = 0;
+  if (!active.has_value()) {
+    targetIndex = direction > 0 ? 0 : (m_cachedState.size() - 1);
+  } else {
+    const std::size_t current = *active;
+    if (direction > 0) {
+      if (current + 1 >= m_cachedState.size()) {
+        return;
+      }
+      targetIndex = current + 1;
+    } else {
+      if (current == 0) {
+        return;
+      }
+      targetIndex = current - 1;
+    }
+  }
+
+  m_platform.activateWorkspace(m_output, m_cachedState[targetIndex]);
+}
+
+std::string WorkspaceTrayWidget::activeWorkspaceLabel() const {
+  const auto active = activeWorkspaceIndex();
+  if (!active.has_value()) {
+    return {};
+  }
+  const auto& ws = m_cachedState[*active];
+
+  if (m_displayMode == DisplayMode::Name) {
+    std::string label = !ws.name.empty() ? ws.name : ws.id;
+    if (m_maxLabelChars > 0) {
+      label = StringUtils::truncateUtf8CodePoints(label, m_maxLabelChars);
+    }
+    return label;
+  }
+
+  if (ws.index > 0) {
+    return std::to_string(ws.index);
+  }
+  return std::to_string(*active + 1);
+}
+
+bool WorkspaceTrayWidget::isFocusedOutput() const { return m_platform.preferredInteractiveOutput() == m_output; }
+
+ColorSpec WorkspaceTrayWidget::textColor() const {
+  if (!m_focusedOnly || isFocusedOutput()) {
+    return m_focusedColor;
+  }
+  return m_occupiedColor;
+}
+
+std::string WorkspaceTrayWidget::outputContext() const {
+  char buf[32];
+  std::snprintf(buf, sizeof(buf), "%p", static_cast<const void*>(m_output));
+  return buf;
+}

--- a/src/shell/bar/widgets/workspace_tray_widget.h
+++ b/src/shell/bar/widgets/workspace_tray_widget.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "compositors/compositor_platform.h"
+#include "config/config_types.h"
+#include "render/core/renderer.h"
+#include "shell/bar/widget.h"
+#include "ui/palette.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+class Glyph;
+class InputArea;
+class Label;
+struct wl_output;
+
+class WorkspaceTrayWidget : public Widget {
+public:
+  enum class DisplayMode : std::uint8_t {
+    Id,
+    Name,
+  };
+
+  WorkspaceTrayWidget(
+      CompositorPlatform& platform, wl_output* output, DisplayMode displayMode, std::size_t maxLabelChars,
+      ColorSpec focusedColor, ColorSpec occupiedColor, bool showChevron, bool focusedOnly, bool hideWhenEmpty
+  );
+  ~WorkspaceTrayWidget() override = default;
+
+  void create() override;
+
+private:
+  void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
+  void doUpdate(Renderer& renderer) override;
+  void rebuild(Renderer& renderer);
+  void syncWidgetVisibility(bool showWidget);
+
+  [[nodiscard]] std::optional<std::size_t> activeWorkspaceIndex() const;
+  void activateAdjacentWorkspace(int direction);
+
+  [[nodiscard]] std::string activeWorkspaceLabel() const;
+  [[nodiscard]] bool isFocusedOutput() const;
+  [[nodiscard]] ColorSpec textColor() const;
+  [[nodiscard]] std::string outputContext() const;
+
+  CompositorPlatform& m_platform;
+  wl_output* m_output = nullptr;
+  DisplayMode m_displayMode = DisplayMode::Id;
+  std::size_t m_maxLabelChars = 3;
+  ColorSpec m_focusedColor = colorSpecFromRole(ColorRole::Primary);
+  ColorSpec m_occupiedColor = colorSpecFromRole(ColorRole::Secondary);
+  bool m_showChevron = true;
+  bool m_focusedOnly = false;
+  bool m_hideWhenEmpty = false;
+  bool m_wasFocusedOutput = true;
+
+  std::vector<Workspace> m_cachedState;
+  bool m_rebuildPending = true;
+  std::uint64_t m_textMetricsGeneration = 0;
+
+  InputArea* m_container = nullptr;
+  Label* m_label = nullptr;
+  Glyph* m_chevron = nullptr;
+};

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -276,6 +276,9 @@ namespace {
     if (panelId == "session") {
       return !pinned(pc.sessionPlacement, pc.sessionPosition) && pc.openNearClickSession;
     }
+    if (panelId == "workspace-tray") {
+      return !pinned(pc.workspaceTrayPlacement, pc.workspaceTrayPosition) && pc.openNearClickWorkspaceTray;
+    }
     return false;
   }
 

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1315,6 +1315,19 @@ namespace settings {
         asSegmented(enumSelect(kPanelPlacements, cfg.shell.panel.controlCenterPlacement)),
         "attached floating bar panel position"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::Panels, "workspace-tray", tr("settings.schema.panels.placement-workspace-tray.label"),
+        tr("settings.schema.panels.placement-workspace-tray.description"),
+        {"shell", "panel", "workspace_tray_placement"},
+        asSegmented(enumSelect(kPanelPlacements, cfg.shell.panel.workspaceTrayPlacement)),
+        "attached floating centered bar panel workspace tray position"
+    ));
+    entries.push_back(panelBarAlignmentEntry(
+        SettingsSection::Panels, "workspace-tray", "workspace_tray",
+        "settings.schema.panels.open-near-click-workspace-tray.label",
+        "settings.schema.panels.open-near-click-workspace-tray.description", cfg.shell.panel.openNearClickWorkspaceTray,
+        &ShellConfig::PanelConfig::workspaceTrayPlacement, &ShellConfig::PanelConfig::workspaceTrayPosition
+    ));
     entries.push_back(panelPositionEntry(
         SettingsSection::ControlCenter, "general", "control_center",
         "settings.schema.panels.position-control-center.label",

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -90,6 +90,7 @@ namespace settings {
         {.type = "wallpaper", .labelKey = "settings.widgets.types.wallpaper", .glyph = "wallpaper-selector"},
         {.type = "weather", .labelKey = "settings.widgets.types.weather", .glyph = "weather-cloud"},
         {.type = "workspaces", .labelKey = "settings.widgets.types.workspaces", .glyph = "layout-grid"},
+        {.type = "workspace_tray", .labelKey = "settings.widgets.types.workspace-tray", .glyph = "selector"},
     };
 
     const WidgetTypeSpec* findWidgetTypeSpec(std::string_view type) {
@@ -1134,6 +1135,37 @@ namespace settings {
       add(withGroup(colorSpec("occupied_color", "secondary"), "workspaces.colors"));
       add(withGroup(colorSpec("empty_color", "secondary"), "workspaces.colors"));
       add(withGroup(colorSpec("urgent_color", "error"), "workspaces.colors"));
+    } else if (type == "workspace_tray") {
+      const std::vector<WidgetSettingSelectOption> trayDisplay = {
+          {"id", "settings.widgets.options.id"},
+          {"name", "settings.widgets.options.name"},
+      };
+      add(segmentedSpec("display", "id", trayDisplay));
+      {
+        auto maxLabelChars = intSpec("max_label_chars", 3, 1.0, 20.0, 1.0);
+        maxLabelChars.descriptionKey = "settings.widgets.settings.max-label-chars.workspace-tray-description";
+        add(std::move(maxLabelChars));
+      }
+      add(boolSpec("show_chevron", true));
+      {
+        auto focusedOnly = boolSpec("focused_only", false);
+        focusedOnly.descriptionKey = "settings.widgets.settings.focused-only.workspace-tray-description";
+        add(std::move(focusedOnly));
+      }
+      add(boolSpec("hide_when_empty", false));
+      add(boolSpec("show_new_workspace", false));
+      {
+        auto cmd = stringSpec("new_workspace_command", "");
+        cmd.visibleWhen = WidgetSettingVisibility{{"show_new_workspace", {"true"}}};
+        add(std::move(cmd));
+      }
+      {
+        auto glyph = glyphSpec("new_workspace_glyph", "plus");
+        glyph.visibleWhen = WidgetSettingVisibility{{"show_new_workspace", {"true"}}};
+        add(std::move(glyph));
+      }
+      add(colorSpec("focused_color", "primary"));
+      add(colorSpec("occupied_color", "secondary"));
     }
 
     specs.insert(specs.end(), std::make_move_iterator(commonSpecs.begin()), std::make_move_iterator(commonSpecs.end()));

--- a/src/shell/workspace_tray/workspace_tray_panel.cpp
+++ b/src/shell/workspace_tray/workspace_tray_panel.cpp
@@ -1,0 +1,274 @@
+#include "shell/workspace_tray/workspace_tray_panel.h"
+
+#include "config/config_service.h"
+#include "core/process/process.h"
+#include "render/core/renderer.h"
+#include "render/scene/input_area.h"
+#include "render/scene/node.h"
+#include "shell/panel/panel_manager.h"
+#include "ui/builders.h"
+#include "ui/palette.h"
+#include "ui/style.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+  constexpr float kRowHeight = 24.0f;
+
+} // namespace
+
+WorkspaceTrayPanel::WorkspaceTrayPanel(CompositorPlatform* platform, ConfigService* config)
+    : m_platform(platform), m_config(config) {}
+
+void WorkspaceTrayPanel::create() {
+  loadConfig();
+  auto container = std::make_unique<Node>();
+  m_container = container.get();
+  setRoot(std::move(container));
+}
+
+void WorkspaceTrayPanel::onOpen(std::string_view context) {
+  parseOutput(context);
+  loadConfig();
+  if (m_platform != nullptr && m_output != nullptr) {
+    m_workspaces = m_platform->workspaces(m_output);
+  }
+  m_needsRebuild = true;
+}
+
+void WorkspaceTrayPanel::onClose() {
+  if (m_container != nullptr) {
+    while (!m_container->children().empty()) {
+      m_container->removeChild(m_container->children().back().get());
+    }
+  }
+  m_workspaces.clear();
+}
+
+PanelPlacement WorkspaceTrayPanel::panelPlacement() const noexcept {
+  if (m_config == nullptr) {
+    return PanelPlacement::Attached;
+  }
+  return m_config->config().shell.panel.workspaceTrayPlacement;
+}
+
+float WorkspaceTrayPanel::preferredWidth() const {
+  ensureDataLoaded();
+  const float charWidth = scaled(Style::fontSizeBody * 0.65f);
+  const float padding = scaled(Style::spaceSm) * 2.0f;
+  const float minWidth = scaled(64.0f);
+  return std::max(static_cast<float>(m_maxLabelChars) * charWidth + padding, minWidth);
+}
+
+float WorkspaceTrayPanel::preferredHeight() const {
+  ensureDataLoaded();
+  const bool showPlus = m_showNewWorkspace && !m_newWorkspaceCommand.empty();
+  const std::size_t count = visibleCount() + (showPlus ? 1 : 0);
+  const float rows = static_cast<float>(std::max(count, static_cast<std::size_t>(1)));
+  const float gap = scaled(1.0f);
+  const float pad = scaled(Style::panelPadding) * 2.0f;
+  return rows * scaled(kRowHeight) + (rows > 1 ? (rows - 1) * gap : 0.0f) + pad;
+}
+
+void WorkspaceTrayPanel::doLayout(Renderer& renderer, float width, float /*height*/) {
+  m_actualWidth = width;
+  if (m_needsRebuild) {
+    rebuild(renderer);
+    m_needsRebuild = false;
+  }
+}
+
+void WorkspaceTrayPanel::doUpdate(Renderer& /*renderer*/) {
+  if (m_platform == nullptr || m_output == nullptr) {
+    return;
+  }
+
+  auto current = m_platform->workspaces(m_output);
+  bool changed = current.size() != m_workspaces.size();
+  if (!changed) {
+    for (std::size_t i = 0; i < current.size(); ++i) {
+      if (current[i].id != m_workspaces[i].id
+          || current[i].name != m_workspaces[i].name
+          || current[i].active != m_workspaces[i].active
+          || current[i].occupied != m_workspaces[i].occupied
+          || current[i].index != m_workspaces[i].index) {
+        changed = true;
+        break;
+      }
+    }
+  }
+
+  if (changed) {
+    m_workspaces = std::move(current);
+    m_needsRebuild = true;
+  }
+}
+
+void WorkspaceTrayPanel::rebuild(Renderer& renderer) {
+  if (m_container == nullptr) {
+    return;
+  }
+
+  while (!m_container->children().empty()) {
+    m_container->removeChild(m_container->children().back().get());
+  }
+
+  if (m_platform == nullptr) {
+    return;
+  }
+
+  if (m_workspaces.empty()) {
+    if (m_output != nullptr) {
+      m_workspaces = m_platform->workspaces(m_output);
+    } else {
+      m_workspaces = m_platform->workspaces();
+    }
+  }
+
+  const float rowHeight = scaled(kRowHeight);
+  const float fontSize = scaled(Style::fontSizeBody);
+  const float gap = scaled(1.0f);
+  const float totalWidth = m_actualWidth > 0.0f ? m_actualWidth : preferredWidth();
+  const float contentWidth = totalWidth;
+
+  float y = 0.0f;
+
+  for (std::size_t i = 0; i < m_workspaces.size(); ++i) {
+    const auto& ws = m_workspaces[i];
+    if (m_hideWhenEmpty && !ws.occupied && !ws.active && !ws.urgent) {
+      continue;
+    }
+    const std::string label = m_displayModeName ? (!ws.name.empty() ? ws.name : ws.id)
+                                                : (ws.index > 0 ? std::to_string(ws.index) : std::to_string(i + 1));
+
+    const ColorSpec color = ws.active ? m_focusedColor : m_occupiedColor;
+
+    auto area = std::make_unique<InputArea>();
+    area->setFrameSize(contentWidth, rowHeight);
+    area->setPosition(0.0f, y);
+    area->setOnClick([this, ws](const InputArea::PointerData& data) {
+      if (data.pressed) {
+        return;
+      }
+      if (m_platform != nullptr && m_output != nullptr) {
+        m_platform->activateWorkspace(m_output, ws);
+      }
+      PanelManager::instance().close();
+    });
+
+    auto* labelNode = static_cast<Label*>(area->addChild(
+        ui::label({
+            .text = label,
+            .fontSize = fontSize,
+            .fontWeight = ws.active ? FontWeight::Medium : FontWeight::Normal,
+            .color = color,
+            .baselineMode = LabelBaselineMode::TextFixedHeight,
+        })
+    ));
+    labelNode->measure(renderer);
+
+    const float lx = (contentWidth - labelNode->width()) * 0.5f;
+    const float ly = (rowHeight - labelNode->height()) * 0.5f;
+    labelNode->setPosition(lx, ly);
+
+    m_container->addChild(std::move(area));
+
+    y += rowHeight + gap;
+  }
+
+  if (m_showNewWorkspace && !m_newWorkspaceCommand.empty()) {
+    auto area = std::make_unique<InputArea>();
+    area->setFrameSize(contentWidth, rowHeight);
+    area->setPosition(0.0f, y);
+    area->setOnClick([this](const InputArea::PointerData& data) {
+      if (data.pressed) {
+        return;
+      }
+      (void)process::runAsync(m_newWorkspaceCommand);
+      PanelManager::instance().close();
+    });
+
+    auto* glyphNode = static_cast<Glyph*>(area->addChild(
+        ui::glyph({
+            .glyph = m_newWorkspaceGlyph,
+            .glyphSize = fontSize,
+            .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+        })
+    ));
+    glyphNode->measure(renderer);
+
+    const float gx = (contentWidth - glyphNode->width()) * 0.5f;
+    const float gy = (rowHeight - glyphNode->height()) * 0.5f;
+    glyphNode->setPosition(gx, gy);
+
+    m_container->addChild(std::move(area));
+
+    y += rowHeight + gap;
+  }
+
+  m_container->setFrameSize(totalWidth, y - gap);
+
+  if (root() != nullptr) {
+    root()->markLayoutDirty();
+  }
+}
+
+void WorkspaceTrayPanel::loadConfig() const {
+  if (m_config == nullptr) {
+    return;
+  }
+  for (const auto& [name, widget] : m_config->config().widgets) {
+    const std::string effectiveType = widget.type.empty() ? name : widget.type;
+    if (effectiveType == "workspace_tray") {
+      m_maxLabelChars = static_cast<std::size_t>(widget.getInt("max_label_chars", 3));
+      m_displayModeName = widget.getString("display", "id") == "name";
+      m_focusedColor = widget.getColorSpec(
+          "focused_color", colorSpecFromRole(ColorRole::Primary), "widget." + name + ".focused_color"
+      );
+      m_occupiedColor = widget.getColorSpec(
+          "occupied_color", colorSpecFromRole(ColorRole::Secondary), "widget." + name + ".occupied_color"
+      );
+      m_showNewWorkspace = widget.getBool("show_new_workspace", false);
+      m_newWorkspaceCommand = widget.getString("new_workspace_command", "");
+      m_newWorkspaceGlyph = widget.getString("new_workspace_glyph", "plus");
+      m_hideWhenEmpty = widget.getBool("hide_when_empty", false);
+      return;
+    }
+  }
+}
+
+void WorkspaceTrayPanel::parseOutput(std::string_view context) const {
+  if (context.empty()) {
+    return;
+  }
+  try {
+    const std::string s(context);
+    char* end = nullptr;
+    const unsigned long addr = std::strtoul(s.c_str(), &end, 16);
+    if (end != s.c_str() && addr != 0) {
+      m_output = reinterpret_cast<wl_output*>(addr);
+    }
+  } catch (...) {
+  }
+}
+
+void WorkspaceTrayPanel::ensureDataLoaded() const {
+  loadConfig();
+  parseOutput(pendingOpenContext());
+  if (m_platform != nullptr && m_output != nullptr) {
+    m_workspaces = m_platform->workspaces(m_output);
+  }
+}
+
+std::size_t WorkspaceTrayPanel::visibleCount() const {
+  std::size_t count = 0;
+  for (const auto& ws : m_workspaces) {
+    if (!m_hideWhenEmpty || ws.occupied || ws.active || ws.urgent) {
+      ++count;
+    }
+  }
+  return count;
+}

--- a/src/shell/workspace_tray/workspace_tray_panel.h
+++ b/src/shell/workspace_tray/workspace_tray_panel.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "compositors/compositor_platform.h"
+#include "config/config_types.h"
+#include "shell/panel/panel.h"
+#include "ui/palette.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class ConfigService;
+class Glyph;
+class Node;
+
+class WorkspaceTrayPanel : public Panel {
+public:
+  WorkspaceTrayPanel(CompositorPlatform* platform, ConfigService* config);
+  ~WorkspaceTrayPanel() override = default;
+
+  void create() override;
+  void onOpen(std::string_view context) override;
+  void onClose() override;
+
+  [[nodiscard]] float preferredWidth() const override;
+  [[nodiscard]] float preferredHeight() const override;
+  [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;
+  [[nodiscard]] bool isContextActive(std::string_view /*context*/) const override { return true; }
+  [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::OnDemand; }
+
+private:
+  void doLayout(Renderer& renderer, float width, float height) override;
+  void doUpdate(Renderer& renderer) override;
+  void rebuild(Renderer& renderer);
+
+  void loadConfig() const;
+  void parseOutput(std::string_view context) const;
+  void ensureDataLoaded() const;
+  [[nodiscard]] std::size_t visibleCount() const;
+
+  CompositorPlatform* m_platform = nullptr;
+  ConfigService* m_config = nullptr;
+
+  mutable wl_output* m_output = nullptr;
+  mutable std::vector<Workspace> m_workspaces;
+  mutable bool m_needsRebuild = true;
+
+  mutable std::size_t m_maxLabelChars = 3;
+  mutable bool m_displayModeName = false;
+  mutable ColorSpec m_focusedColor = colorSpecFromRole(ColorRole::Primary);
+  mutable ColorSpec m_occupiedColor = colorSpecFromRole(ColorRole::Secondary);
+  mutable bool m_showNewWorkspace = false;
+  mutable std::string m_newWorkspaceCommand;
+  mutable std::string m_newWorkspaceGlyph = "plus";
+  mutable bool m_hideWhenEmpty = false;
+
+  Node* m_container = nullptr;
+  float m_actualWidth = 0.0f;
+};


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds a new bar widget (`workspace_tray`) that shows the active workspace name as colored text and opens a dropdown panel on click to switch workspaces. Intended as a minimal alternative to the workspaces widget for users who prefer less visual clutter.

## Motivation

The existing workspaces widget shows numbered pills for every workspace. Some users only want to see the current workspace name and switch via a dropdown, similar to workspace switchers in other desktop environments. This widget provides that with a small footprint and full compositor-agnostic workspace data via `CompositorPlatform`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- `clang-format --dry-run --Werror` passes
- Tested on Hyprland with two monitors. Verified workspace name display, dropdown panel open/close, workspace switching, scroll cycling, new-workspace button, and `hide_when_empty` behavior.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/93a484cc-1246-4b5c-80eb-88dc56e8f32b

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Config example:

```toml
[widget.workspace_tray]
type = "workspace_tray"
display = "name"
focused_only = true
max_label_chars = 3
show_new_workspace = true
new_workspace_command = "hyprctl dispatch workspace emptyw"
new_workspace_glyph = "plus"
```

Widget features:
- Text-only rendering, no pill background by default; capsule styling adds background when configured
- Active workspace colored with `focused_color`; unfocused monitors use `occupied_color` when `focused_only` is enabled
- Scroll to cycle adjacent workspaces
- Optional chevron indicator
- `hide_when_empty` to hide when all workspaces on the monitor are empty

Dropdown panel:
- Lists all workspaces for the monitor that opened it
- Active workspace highlighted in focused color
- Same placement system as other panels (attached / floating / centered with optional open-near-click)
- Optional new-workspace button with user-defined command and icon

Uses `CompositorPlatform` exclusively for workspace data and activation. Works across all supported compositors.