### PR TITLE
fix(lockscreen): remove empty password check to let U2F through

### DIFF
--- a/src/auth/pam_authenticator.cpp
+++ b/src/auth/pam_authenticator.cpp
@@ -225,10 +225,6 @@ bool PamAuthenticator::pamServiceExists(std::string_view name) {
 
 PamAuthenticator::Result
 PamAuthenticator::authenticateCurrentUser(std::string_view password, std::string_view service) const {
-  if (password.empty()) {
-    return Result{.success = false, .message = i18n::tr("auth.pam.authentication-failed")};
-  }
-
   int pipeFds[2] = {-1, -1};
   if (::pipe2(pipeFds, O_CLOEXEC) != 0) {
     return Result{.success = false, .message = i18n::tr("auth.pam.start-failed")};


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary
Removed a redundant empty password check in `PamAuthenticator` that was overriding the `allowEmptyPassword` lockscreen config.
<!-- What changed and why? -->

## Motivation
The function `LockScreen::tryAuthenticate` already checks the `allowEmptyPassword` configuration. If an empty password is valid, it's passed to the authenticator. 

But `PamAuthenticator::authenticateCurrentUser` has a hardcoded check against empty passwords. Removing this lets the `allowEmptyPassword` config actually work as intended, allowing empty passwords to pass through to PAM for U2F and passwordless setups.

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing
Manually verified standard password authentication and U2F authentication, for success and failure, with and without `allowEmptyPassword`. 
<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
