### PR TITLE
fix(hyprland): support named workspaces in taskbar

### DIFF
--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -135,7 +135,7 @@ HyprlandWorkspaceBackend::appIdsByWorkspace(wl_output* output) const {
     if (!seen.insert(toplevel.appId).second) {
       continue;
     }
-    byWorkspace[std::to_string(toplevel.workspaceId)].push_back(toplevel.appId);
+    byWorkspace[workspaceKeyForId(toplevel.workspaceId)].push_back(toplevel.appId);
   }
   return byWorkspace;
 }
@@ -152,15 +152,13 @@ std::vector<WorkspaceWindow> HyprlandWorkspaceBackend::workspaceWindows(wl_outpu
     if (filterByOutput && workspace.monitor != outputName) {
       continue;
     }
-    if (workspace.id >= 0) {
-      workspacesOnOutput.insert(workspace.id);
-    }
+    workspacesOnOutput.insert(workspace.id);
   }
 
   std::vector<WorkspaceWindow> result;
   result.reserve(m_toplevels.size());
   for (const auto& [address, toplevel] : m_toplevels) {
-    if (toplevel.appId.empty() || toplevel.workspaceId < 0) {
+    if (toplevel.appId.empty() || toplevel.workspaceId == -1) {
       continue;
     }
     if (filterByOutput && !m_workspaces.empty()) {
@@ -171,7 +169,7 @@ std::vector<WorkspaceWindow> HyprlandWorkspaceBackend::workspaceWindows(wl_outpu
     result.push_back(
         WorkspaceWindow{
             .windowId = compositors::hyprland::formatWindowAddress(address),
-            .workspaceKey = std::to_string(toplevel.workspaceId),
+            .workspaceKey = workspaceKeyForId(toplevel.workspaceId),
             .appId = toplevel.appId,
             .title = toplevel.title,
             .x = toplevel.x,
@@ -765,4 +763,16 @@ Workspace HyprlandWorkspaceBackend::toWorkspace(const WorkspaceState& state) {
       .urgent = state.urgent,
       .occupied = state.occupied,
   };
+}
+
+std::string HyprlandWorkspaceBackend::workspaceKeyForId(int workspaceId) const {
+  if (workspaceId >= 0) {
+    return std::to_string(workspaceId);
+  }
+  for (const auto& ws : m_workspaces) {
+    if (ws.id == workspaceId && !ws.name.empty()) {
+      return ws.name;
+    }
+  }
+  return std::to_string(workspaceId);
 }

--- a/src/compositors/hyprland/hyprland_workspace_backend.h
+++ b/src/compositors/hyprland/hyprland_workspace_backend.h
@@ -90,6 +90,7 @@ private:
   [[nodiscard]] static bool isSpecial(const WorkspaceState& state);
   [[nodiscard]] static bool workspaceOrderLess(const WorkspaceState* a, const WorkspaceState* b);
   [[nodiscard]] static Workspace toWorkspace(const WorkspaceState& state);
+  [[nodiscard]] std::string workspaceKeyForId(int workspaceId) const;
 
   OutputNameResolver m_outputNameResolver;
   std::vector<WorkspaceState> m_workspaces;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -2049,6 +2049,9 @@ std::string TaskbarWidget::workspaceLabel(const Workspace& workspace, std::size_
   if (const auto name = parseLeadingNumber(workspace.name); name.has_value()) {
     return std::to_string(*name);
   }
+  if (!workspace.name.empty()) {
+    return workspace.name;
+  }
   if (!workspace.id.empty()) {
     return workspace.id;
   }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Windows on Hyprland named workspaces (negative IDs like -1338) were invisible in the taskbar unless "Show All Monitors" was enabled. Group-by-workspace also showed empty entries with raw negative IDs like "-1340" instead of the workspace name.

## Motivation

Hyprland assigns negative integer IDs to named workspaces. Three separate code paths in the taskbar pipeline either filtered them out (`workspaceId < 0`), excluded them from per-output sets (`id >= 0` guard), or produced mismatched workspace keys between the model list and window assignment data. The result: named-workspace windows silently vanished from the taskbar.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- `clang-format --dry-run --Werror` passes
- Tested on Hyprland with mixed numeric (1, 2, 3) and named workspaces (M, P, S, T)

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

Before:
<img width="397" height="42" alt="named-workspaces-before" src="https://github.com/user-attachments/assets/35d3555f-89fd-43ea-81e3-5bc5bcbebcb0" />

After:
<img width="712" height="43" alt="named-workspaces-after" src="https://github.com/user-attachments/assets/48e96dea-5159-4ecc-b393-d7cac6d06a79" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Three targeted fixes:

1. `workspaceWindows()`: changed `workspaceId < 0` to `== -1` to only filter the unknown/fallback value, not named workspace IDs
2. `workspacesOnOutput`: removed `>= 0` guard so named workspaces are included in per-output filtering (they have valid monitor assignments)
3. Added `workspaceKeyForId(int)` helper used consistently in `appIdsByWorkspace()`, `workspaceWindows()`, and `workspaceLabel()` so all three paths produce matching keys (workspace name for named, numeric ID otherwise)