### PR TITLE
feat(taskbar): add minimal style option for workspace labels

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3087,7 +3087,8 @@
         "minimal": {
           "description": "Show workspace id or name labels only, without animated pills",
           "label": "Minimal Style",
-          "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation"
+          "workspaces-description": "Text-only workspace labels without pill backgrounds or slide animation",
+          "taskbar-description": "Text-only workspace labels without colored disc backgrounds"
         },
         "mirrored": {
           "description": "Mirror the visualizer around its center",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -533,6 +533,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .hideEmptyWorkspaces = wc != nullptr ? wc->getBool("hide_empty_workspaces", false) : false,
         .workspaceGroupCapsule = wc != nullptr ? wc->getBool("workspace_group_capsule", true) : true,
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
+        .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
         .groupSingleIconPerApp = wc != nullptr ? wc->getBool("group_single_icon_per_app", false) : false,
         .showActiveIndicator = wc != nullptr ? wc->getBool("show_active_indicator", true) : true,
         .activeOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("active_opacity", 1.0)) : 1.0f,

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -648,7 +648,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           .fontSize = badgeFontSize,
           .fontWeight = fontWeight,
           .fontFamily = fontFamily,
-          .color = m_minimal ? workspaceFillColor(ws.workspace) : workspaceTextColor(ws.workspace),
+          .color = workspaceTextColor(ws.workspace),
       });
       badgeText->measure(renderer);
       badgeText->setPosition(
@@ -694,7 +694,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           .fontSize = badgeFontSize,
           .fontWeight = fontWeight,
           .fontFamily = fontFamily,
-          .color = m_minimal ? workspaceFillColor(ws.workspace) : workspaceTextColor(ws.workspace),
+          .color = workspaceTextColor(ws.workspace),
       });
       badgeText->measure(renderer);
       badgeText->setPosition(
@@ -2357,9 +2357,23 @@ bool TaskbarWidget::isFocusedOutput() const { return m_platform.preferredInterac
 
 ColorSpec TaskbarWidget::workspaceTextColor(const Workspace& workspace) const {
   if (workspace.urgent) {
-    return colorSpecFromRole(ColorRole::OnError);
+    return m_minimal ? colorSpecFromRole(ColorRole::Error) : colorSpecFromRole(ColorRole::OnError);
   }
-  return readableColorForFill(workspaceFillColor(workspace));
+  if (!m_minimal) {
+    return readableColorForFill(workspaceFillColor(workspace));
+  }
+  if (workspace.active) {
+    if (m_activeUsesFocusedColor) {
+      return m_focusedColor;
+    }
+    return m_occupiedColor;
+  }
+  if (workspace.occupied) {
+    return m_occupiedColor;
+  }
+  ColorSpec color = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurfaceVariant));
+  color.alpha *= 0.55f;
+  return color;
 }
 
 ColorRole TaskbarWidget::onRoleForFill(ColorRole fill) {

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -166,11 +166,12 @@ TaskbarWidget::TaskbarWidget(
 )
     : m_platform(platform), m_configService(config), m_output(output), m_configOptions(std::move(options)),
       m_showAllOutputs(m_configOptions.showAllOutputs), m_focusedOutputOnly(m_configOptions.focusedOutputOnly),
-      m_showActiveIndicator(m_configOptions.showActiveIndicator), m_activeOpacity(m_configOptions.activeOpacity),
-      m_inactiveOpacity(m_configOptions.inactiveOpacity), m_focusedColor(m_configOptions.focusedColor),
-      m_occupiedColor(m_configOptions.occupiedColor), m_emptyColor(m_configOptions.emptyColor),
-      m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth), m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth),
-      m_barPosition(std::move(m_configOptions.barPosition)), m_shadowConfig(m_configOptions.shadowConfig) {
+      m_minimal(m_configOptions.minimal), m_showActiveIndicator(m_configOptions.showActiveIndicator),
+      m_activeOpacity(m_configOptions.activeOpacity), m_inactiveOpacity(m_configOptions.inactiveOpacity),
+      m_focusedColor(m_configOptions.focusedColor), m_occupiedColor(m_configOptions.occupiedColor),
+      m_emptyColor(m_configOptions.emptyColor), m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth),
+      m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth), m_barPosition(std::move(m_configOptions.barPosition)),
+      m_shadowConfig(m_configOptions.shadowConfig) {
   syncWorkspaceGroupingCapability();
   buildDesktopIconIndex();
 }
@@ -607,7 +608,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     const auto styleWorkspaceDisc = [this](Box& badge, float width, float height, const Workspace& workspace) {
       badge.setFrameSize(width, height);
       badge.setRadius(resolvedBarCapsuleRadius(width, height));
-      badge.setFill(workspaceFillColor(workspace));
+      badge.setFill(m_minimal ? clearColorSpec() : workspaceFillColor(workspace));
       badge.clearBorder();
     };
 
@@ -647,7 +648,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           .fontSize = badgeFontSize,
           .fontWeight = fontWeight,
           .fontFamily = fontFamily,
-          .color = workspaceTextColor(ws.workspace),
+          .color = m_minimal ? workspaceFillColor(ws.workspace) : workspaceTextColor(ws.workspace),
       });
       badgeText->measure(renderer);
       badgeText->setPosition(
@@ -693,7 +694,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           .fontSize = badgeFontSize,
           .fontWeight = fontWeight,
           .fontFamily = fontFamily,
-          .color = workspaceTextColor(ws.workspace),
+          .color = m_minimal ? workspaceFillColor(ws.workspace) : workspaceTextColor(ws.workspace),
       });
       badgeText->measure(renderer);
       badgeText->setPosition(

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -35,6 +35,7 @@ struct TaskbarWidgetOptions {
   bool hideEmptyWorkspaces = false;
   bool workspaceGroupCapsule = true;
   bool focusedOutputOnly = false;
+  bool minimal = false;
   bool groupSingleIconPerApp = false;
   bool showActiveIndicator = true;
   float activeOpacity = 1.0f;
@@ -131,6 +132,7 @@ private:
   bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;
   bool m_activeUsesFocusedColor = true;
+  bool m_minimal = false;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;
   float m_activeOpacity = 1.0f;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -851,6 +851,11 @@ namespace settings {
           focusedOutputOnly.visibleWhen =
               WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_workspace_label", {"true"}}};
           add(std::move(focusedOutputOnly));
+          auto minimal = boolSpec("minimal", false);
+          minimal.descriptionKey = "settings.widgets.settings.minimal.taskbar-description";
+          minimal.visibleWhen =
+              WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_workspace_label", {"true"}}};
+          add(std::move(minimal));
         }
         {
           auto singleIconPerApp = boolSpec("group_single_icon_per_app", false);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds a `minimal` setting to the taskbar widget. When enabled, workspace labels render as colored text without the colored disc background, using the workspace fill color (primary for active, secondary for occupied) as the text color.

## Motivation

This mirrors the minimal style option already available in the workspaces widget, providing visual consistency between the two workspace-related widgets. Some users prefer the cleaner look of text-only workspace labels without a filled disc background.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A.

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- `clang-format --dry-run --Werror` passes
- Tested on Hyprland. Verified workspace disc labels show as colored text without background when enabled, and revert to normal styling when disabled.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

Off:
<img width="86" height="38" alt="taskbar-minimal-before" src="https://github.com/user-attachments/assets/1d4bd644-5bce-4167-a730-5fd0841bc5c2" />

On:
<img width="85" height="42" alt="taskbar-minimal-after" src="https://github.com/user-attachments/assets/84f2b67b-1208-4b3c-b9c8-6e04122fdc4a" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Config example:

```toml
[widget.taskbar]
minimal = true
```

Three changes in `taskbar_widget.cpp`:
- `styleWorkspaceDisc`: sets transparent fill instead of workspace fill color when minimal is on
- Inline badge text color: uses `workspaceFillColor` instead of `workspaceTextColor` when minimal is on
- External badge text color: same swap

No structural changes to the rendering pipeline. The disc Box remains in the scene graph but is transparent, keeping layout and hit-testing unchanged. The setting is visible in the taskbar widget settings when "Show Workspace Label" is enabled.