### PR TITLE
fix(hyprland): resolve workspace for ext-only toplevels

### DIFF
--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1171,12 +1171,14 @@ void TaskbarWidget::updateModels() {
         if (const auto mappedId = m_platform.compositorWindowIdForToplevel(task.firstHandle); mappedId.has_value()) {
           task.workspaceWindowId = *mappedId;
         }
-      } else if (task.workspaceWindowId.empty()) {
+      } else {
         const auto mappedId = m_platform.compositorWindowIdForExtToplevel(
             reinterpret_cast<ext_foreign_toplevel_handle_v1*>(task.handleKey)
         );
         if (mappedId.has_value()) {
           task.workspaceWindowId = *mappedId;
+        } else {
+          task.workspaceWindowId.clear();
         }
       }
       if (!task.active


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

On Hyprland, tasks for windows that only expose an `ext-foreign-toplevel-handle-v1` (no usable wlr foreign toplevel handle with output association) disappear from the taskbar when `hide_empty_workspaces` is enabled together with `group_by_workspace`. The workspace group they sit in is erased because the task ends up with an empty `workspaceKey`.

## Motivation

This is most visible for apps that are the only occupant of a workspace (kitty is a common case). Workspaces that also host other apps stay afloat through those other apps, which is why the bug looks app-specific at first glance but is really global to any ext-only toplevel.

In `TaskbarWidget::updateModels`, tasks built from `ToplevelInfo` pick up `task.workspaceWindowId` from the ext identifier, which on Hyprland is not a window address. The Hyprland block right after skips the compositor mapping (`else if (task.workspaceWindowId.empty())` is false), so the task never gets its real Hyprland window address. A second knock-on effect in the generic assignment pass skips tasks whose `workspaceWindowId` is set but absent from the current assignment window IDs, so even the app/title fallback cannot rescue it.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- `clang-format --dry-run --Werror` passes
- Tested on Hyprland with two outputs, taskbar with `group_by_workspace = true` and `hide_empty_workspaces = true`. Opened kitty on an otherwise empty workspace and confirmed the workspace group stays visible. Verified window activation targets the correct window across multiple kitty instances on different workspaces.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

For ext-only windows, always run `compositorWindowIdForExtToplevel` regardless of the current `workspaceWindowId`, and clear the field when no mapping has landed yet. When the async mapping resolves, `workspaceWindowId` becomes the real Hyprland address and assignment matches normally. While the mapping is still pending, `workspaceWindowId` is empty so the app/title fallback in the generic assignment pass can still place the task in a workspace group.

The wlr path is untouched, and the KDE path is untouched (KDE windows arrive through `KwinActiveWindow` and use their own assignment block further down).