### PR TITLE
fix(lockscreen): authenticate against login and let noctalia own the fingerprint reader

### DIFF
--- a/src/auth/pam_authenticator.cpp
+++ b/src/auth/pam_authenticator.cpp
@@ -8,7 +8,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
-#include <filesystem>
 #include <pwd.h>
 #include <security/pam_appl.h>
 #include <sys/types.h>
@@ -214,14 +213,6 @@ namespace {
   }
 
 } // namespace
-
-bool PamAuthenticator::pamServiceExists(std::string_view name) {
-  if (name.empty()) {
-    return false;
-  }
-  std::error_code ec;
-  return std::filesystem::exists(std::filesystem::path("/etc/pam.d") / name, ec) && !ec;
-}
 
 PamAuthenticator::Result
 PamAuthenticator::authenticateCurrentUser(std::string_view password, std::string_view service) const {

--- a/src/auth/pam_authenticator.h
+++ b/src/auth/pam_authenticator.h
@@ -11,6 +11,5 @@ public:
   };
 
   [[nodiscard]] Result authenticateCurrentUser(std::string_view password, std::string_view service = "login") const;
-  [[nodiscard]] static bool pamServiceExists(std::string_view name);
   [[nodiscard]] static std::string currentUsername();
 };

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -699,7 +699,10 @@ void LockScreen::tryAuthenticate() {
   updatePromptOnSurfaces();
 
   const PamAuthenticator authenticator = m_authenticator;
-  const std::string pamService = passwordPamService();
+  // Authenticate against the "login" stack. If fingerprint is enabled, strip
+  // pam_fprintd from it: noctalia drives the reader itself over D-Bus and the
+  // two can't share the sensor. See docs/fingerprint.md.
+  const std::string pamService = "login";
   std::thread([this, generation, password = std::move(password), authenticator, pamService]() mutable {
     const auto result = authenticator.authenticateCurrentUser(password, pamService);
     clearSensitiveString(password);
@@ -756,15 +759,6 @@ void LockScreen::handleFingerprintStatus(const std::string& message, bool isErro
   m_status = message.empty() ? i18n::tr("lockscreen.ready") : message;
   m_statusIsError = isError;
   updatePromptOnSurfaces();
-}
-
-std::string LockScreen::passwordPamService() const {
-  if (m_configService != nullptr
-      && m_configService->config().lockscreen.fingerprint
-      && PamAuthenticator::pamServiceExists("su")) {
-    return "su";
-  }
-  return "login";
 }
 
 void LockScreen::clearSensitiveString(std::string& value) {

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -97,7 +97,6 @@ private:
   void startFingerprint();
   void stopFingerprint();
   void handleFingerprintStatus(const std::string& message, bool isError);
-  [[nodiscard]] std::string passwordPamService() const;
   static void clearSensitiveString(std::string& value);
 
   WaylandConnection* m_wayland = nullptr;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

fingerprint auth: login against PAM "login" stack
if fingerprint auth is enabled in noctalia, the PAM login stack needs to not have fprintd auth

## Motivation


## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#2902

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
