### PR TITLE
feat(widget): show spinner when ethernet is resolving

### DIFF
--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -38,7 +38,12 @@ namespace {
   constexpr std::string_view kNmWiredConnectionType = "802-3-ethernet";
 
   // NMDeviceType values from NetworkManager D-Bus API.
+  constexpr std::uint32_t kNmDeviceTypeEthernet = 1;
   constexpr std::uint32_t kNmDeviceTypeWifi = 2;
+
+  // NMDeviceState: a device between Prepare and Activated is mid-activation.
+  constexpr std::uint32_t kNmDeviceStatePrepare = 40;
+  constexpr std::uint32_t kNmDeviceStateActivated = 100;
 
   // NMActiveConnectionState
   constexpr std::uint32_t kNmActiveConnectionStateActivating = 1;
@@ -1422,6 +1427,36 @@ void NetworkManagerService::finishRefreshAccessPoints(
   onComplete();
 }
 
+std::string NetworkManagerService::physicalActivatingConnection() {
+  std::vector<sdbus::ObjectPath> devices;
+  try {
+    m_nm->callMethod("GetDevices").onInterface(kNmInterface).storeResultsTo(devices);
+  } catch (const sdbus::Error&) {
+    return {};
+  }
+
+  for (const auto& devicePath : devices) {
+    try {
+      auto device = sdbus::createProxy(m_bus.connection(), kNmBusName, devicePath);
+      const auto deviceType = getPropertyOr<std::uint32_t>(*device, kNmDeviceInterface, "DeviceType", 0U);
+      if (deviceType != kNmDeviceTypeEthernet && deviceType != kNmDeviceTypeWifi) {
+        continue;
+      }
+      const auto state = getPropertyOr<std::uint32_t>(*device, kNmDeviceInterface, "State", 0U);
+      if (state < kNmDeviceStatePrepare || state >= kNmDeviceStateActivated) {
+        continue;
+      }
+      const auto active =
+          getPropertyOr<sdbus::ObjectPath>(*device, kNmDeviceInterface, "ActiveConnection", sdbus::ObjectPath{"/"});
+      if (!active.empty() && active != "/") {
+        return active;
+      }
+    } catch (const sdbus::Error&) {
+    }
+  }
+  return {};
+}
+
 void NetworkManagerService::rebindActiveConnection() {
   std::string newPath;
   try {
@@ -1429,6 +1464,14 @@ void NetworkManagerService::rebindActiveConnection() {
     newPath = value.get<sdbus::ObjectPath>();
   } catch (const sdbus::Error& e) {
     kLog.debug("PrimaryConnection unavailable: {}", e.what());
+  }
+
+  // PrimaryConnection stays "/" until a connection finishes activating, and NM's
+  // ActivatingConnection property tracks loopback rather than the real link. Fall
+  // back to a physical ethernet/wifi device that is mid-activation so the resolving
+  // state is observable while virtual devices (loopback, bridge, vlan, …) are not.
+  if (newPath.empty() || newPath == "/") {
+    newPath = physicalActivatingConnection();
   }
 
   if (newPath != m_activeConnectionPath) {
@@ -1803,6 +1846,7 @@ void NetworkManagerService::readStateAsync(std::function<void(NetworkState)> onC
 
               next->vpnActive = (type == "vpn" || type == "wireguard");
               next->connected = state == kNmActiveConnectionStateActivated;
+              next->resolving = state == kNmActiveConnectionStateActivating;
             }
 
             readDeviceState();

--- a/src/dbus/network/network_manager_service.h
+++ b/src/dbus/network/network_manager_service.h
@@ -81,6 +81,7 @@ private:
   void persistConnectionToDisk(const std::string& connectionPath, const std::string& ssid);
   void deleteUnsavedConnection(const std::string& connectionPath, const std::string& ssid);
   void rebindActiveConnection();
+  [[nodiscard]] std::string physicalActivatingConnection();
   void rebindActiveDevice(const std::string& devicePath);
   void rebindActiveAccessPoint(const std::string& apPath);
   void ensureWifiDeviceSubscribed(const std::string& devicePath);

--- a/src/dbus/network/network_types.h
+++ b/src/dbus/network/network_types.h
@@ -32,6 +32,7 @@ enum class NetworkConnectivity {
 struct NetworkState {
   NetworkConnectivity kind = NetworkConnectivity::Unknown;
   bool connected = false;
+  bool resolving = false; // active connection is activating, not yet connected
   bool wirelessEnabled = false;
   bool scanning = false;
   bool vpnActive = false;          // true if a VPN is the active connection

--- a/src/shell/bar/widgets/network_widget.cpp
+++ b/src/shell/bar/widgets/network_widget.cpp
@@ -32,6 +32,8 @@ namespace {
 
   std::string onOffText(bool enabled) { return enabled ? "On" : "Off"; }
 
+  std::string disconnectedText(bool resolving) { return resolving ? "Connecting" : "Not connected"; }
+
   std::string yesNoText(bool enabled) { return enabled ? "Yes" : "No"; }
 
   std::string networkCountText(std::size_t count) {
@@ -68,6 +70,16 @@ void NetworkWidget::create() {
       })
   );
 
+  // Replaces the glyph while a wired link is activating.
+  area->addChild(
+      ui::spinner({
+          .out = &m_spinner,
+          .color = widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)),
+          .spinnerSize = Style::baseGlyphSize * 0.8f * m_contentScale,
+          .visible = false,
+      })
+  );
+
   // Always create the label node: horizontal bars honor m_showLabel, but
   // vertical bars always display a 3-char truncation under the glyph to match
   // volume/brightness.
@@ -96,18 +108,22 @@ void NetworkWidget::doLayout(Renderer& renderer, float containerWidth, float con
     m_label->measure(renderer);
   }
 
+  // Glyph and spinner share one slot; only one is visible.
+  Node* icon =
+      (m_spinner != nullptr && m_spinner->visible()) ? static_cast<Node*>(m_spinner) : static_cast<Node*>(m_glyph);
+
   const bool labelVisible = m_label != nullptr && m_label->width() > 0.0f && m_label->visible();
   if (m_isVertical && labelVisible) {
-    const float w = std::max(m_glyph->width(), m_label->width());
-    m_glyph->setPosition(std::round((w - m_glyph->width()) * 0.5f), 0.0f);
-    m_label->setPosition(std::round((w - m_label->width()) * 0.5f), m_glyph->height());
-    rootNode->setSize(w, m_glyph->height() + m_label->height());
+    const float w = std::max(icon->width(), m_label->width());
+    icon->setPosition(std::round((w - icon->width()) * 0.5f), 0.0f);
+    m_label->setPosition(std::round((w - m_label->width()) * 0.5f), icon->height());
+    rootNode->setSize(w, icon->height() + m_label->height());
   } else {
-    const float h = labelVisible ? std::max(m_glyph->height(), m_label->height()) : m_glyph->height();
-    m_glyph->setPosition(0.0f, std::round((h - m_glyph->height()) * 0.5f));
-    float totalWidth = m_glyph->width();
+    const float h = labelVisible ? std::max(icon->height(), m_label->height()) : icon->height();
+    icon->setPosition(0.0f, std::round((h - icon->height()) * 0.5f));
+    float totalWidth = icon->width();
     if (labelVisible) {
-      m_label->setPosition(m_glyph->width() + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
+      m_label->setPosition(icon->width() + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
       totalWidth = m_label->x() + m_label->width();
     }
     rootNode->setSize(totalWidth, h);
@@ -129,6 +145,9 @@ void NetworkWidget::syncState(Renderer& renderer) {
   m_haveLastState = true;
   m_lastVertical = m_isVertical;
 
+  const bool showSpinner = s.kind == NetworkConnectivity::Wired && s.resolving;
+
+  m_glyph->setVisible(!showSpinner);
   m_glyph->setGlyph(network_glyphs::glyphForState(s));
   m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
   m_glyph->setColor(
@@ -136,6 +155,16 @@ void NetworkWidget::syncState(Renderer& renderer) {
                   : colorSpecFromRole(ColorRole::OnSurfaceVariant)
   );
   m_glyph->measure(renderer);
+
+  if (m_spinner != nullptr) {
+    m_spinner->setVisible(showSpinner);
+    m_spinner->setSpinnerSize(Style::baseGlyphSize * 0.8f * m_contentScale);
+    if (showSpinner && !m_spinner->spinning()) {
+      m_spinner->start();
+    } else if (!showSpinner && m_spinner->spinning()) {
+      m_spinner->stop();
+    }
+  }
 
   if (m_label != nullptr) {
     const bool showLabel = m_showLabel;
@@ -216,7 +245,7 @@ std::vector<TooltipRow> NetworkWidget::buildTooltipRows() const {
     return rows;
   }
 
-  rows.push_back({"Network", "Not connected"});
+  rows.push_back({"Network", disconnectedText(s.resolving)});
   rows.push_back({"Wi-Fi", onOffText(s.wirelessEnabled)});
   if (s.scanning) {
     rows.push_back({"Scanning", yesNoText(s.scanning)});

--- a/src/shell/bar/widgets/network_widget.h
+++ b/src/shell/bar/widgets/network_widget.h
@@ -9,6 +9,7 @@
 
 class Glyph;
 class Label;
+class Spinner;
 class SystemMonitorService;
 struct wl_output;
 
@@ -28,6 +29,7 @@ private:
   SystemMonitorService* m_monitor = nullptr;
   bool m_showLabel = true;
   Glyph* m_glyph = nullptr;
+  Spinner* m_spinner = nullptr;
   Label* m_label = nullptr;
   NetworkState m_lastState;
   bool m_haveLastState = false;

--- a/src/ui/controls/spinner.cpp
+++ b/src/ui/controls/spinner.cpp
@@ -11,7 +11,7 @@ namespace {
 
   constexpr float kDefaultSize = 20.0f;
   constexpr float kDefaultThickness = 2.0f;
-  constexpr float kRevolutionMs = 800.0f;
+  constexpr float kRevolutionMs = 1200.0f;
   constexpr float kTwoPi = 2.0f * std::numbers::pi_v<float>;
 
 } // namespace


### PR DESCRIPTION
## Summary

The network bar widget now shows a spinner in place of its glyph while a wired (ethernet) link is activating, then resolves to the normal wired icon once connected. The tooltip reports "Connecting" during this phase.

## Motivation

On my office network, ethernet takes ~5s to resolve (DHCP / IP negotiation). During that window the widget just showed the default disconnected glyph, giving no indication that a connection was actually in progress. The spinner makes that resolving state visible.

## Type of Change

- [x] New feature

## Testing

- Verified live against NetworkManager over D-Bus (`busctl`): during an ethernet down/up cycle the physical device transitions `30 → 70 (IP_CONFIG) → 100`, with the device's active connection in `Activating` state during the resolving window — which is what now drives the spinner.

## Manual Coverage

- [x] Tested on another compositor: Niri (observed the spinner during a real ethernet reconnect)
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="243" height="102" alt="image" src="https://github.com/user-attachments/assets/f0187400-9b95-46b2-b196-ddc2ea7bf85c" />

https://github.com/user-attachments/assets/6394afd9-f4a8-4b1d-b865-9fcb339693c1



## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Detecting the resolving state is not as simple as reading NetworkManager's `ActivatingConnection` property: while a real link is activating, `PrimaryConnection` stays `/` and `ActivatingConnection` tracks the loopback connection rather than the physical link. Instead, `rebindActiveConnection()` falls back to scanning for a physical ethernet/wifi device whose `State` is between Prepare (40) and Activated (100), and uses that device's active connection. Virtual devices (loopback, bridge, vlan, …) are excluded by device type, so they never surface as a connection.
- The global spinner revolution was slowed from 800ms to 1200ms; at the previous speed the rotation outran the compositor's frame cadence and read as jitter (visible on the bluetooth/scan spinners too).
- Tooltip strings ("Connecting"/"Not connected") follow the existing hard-coded strings in this widget, which are not routed through `en.json`; no new translatable strings were introduced.
