### PR TITLE
feat(widget): volume and mic mute color

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2719,6 +2719,10 @@
           "description": "Mirror the visualizer around its center",
           "label": "Mirrored"
         },
+        "mute-color": {
+          "description": "Color role used for the icon and label when muted; fixed hex colors are also supported",
+          "label": "Mute Color"
+        },
         "occupied-color": {
           "description": "Color role used for occupied workspaces; fixed hex colors are also supported",
           "label": "Occupied Color"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -584,8 +584,12 @@ std::unique_ptr<Widget> WidgetFactory::create(
         static_cast<int>(std::clamp<std::int64_t>(wc != nullptr ? wc->getInt("scroll_step", 5) : 5, 1, 25));
     const std::string target = wc != nullptr ? wc->getString("device", "output") : std::string("output");
     const auto volumeTarget = target == "input" ? VolumeWidgetTarget::Input : VolumeWidgetTarget::Output;
-    auto widget =
-        std::make_unique<VolumeWidget>(m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep);
+    const ColorSpec muteColor = wc != nullptr
+        ? wc->getColorSpec("mute_color", colorSpecFromRole(ColorRole::Error), "widget." + name + ".mute_color")
+        : colorSpecFromRole(ColorRole::Error);
+    auto widget = std::make_unique<VolumeWidget>(
+        m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep, muteColor
+    );
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -35,10 +35,10 @@ namespace {
 
 VolumeWidget::VolumeWidget(
     PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* /*output*/,
-    bool showLabel, VolumeWidgetTarget target, int scrollStepPercent
+    bool showLabel, VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor
 )
     : m_audio(audio), m_easyEffects(easyEffects), m_config(config), m_showLabel(showLabel),
-      m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target) {}
+      m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target), m_muteColor(muteColor) {}
 
 void VolumeWidget::create() {
   auto area = std::make_unique<InputArea>();
@@ -161,10 +161,7 @@ void VolumeWidget::syncState(Renderer& renderer) {
 
   m_glyph->setGlyph(volumeGlyphName(volume, muted, m_target));
   m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
-  m_glyph->setColor(
-      muted ? colorSpecFromRole(ColorRole::OnSurfaceVariant)
-            : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface))
-  );
+  m_glyph->setColor(muted ? m_muteColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
   m_glyph->measure(renderer);
 
   m_label->setVisible(m_showLabel);
@@ -172,10 +169,7 @@ void VolumeWidget::syncState(Renderer& renderer) {
     int pct = static_cast<int>(std::round(volume * 100.0f));
     m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
     m_label->setText(m_isVertical ? std::to_string(pct) : std::to_string(pct) + "%");
-    m_label->setColor(
-        muted ? colorSpecFromRole(ColorRole::OnSurfaceVariant)
-              : widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface))
-    );
+    m_label->setColor(muted ? m_muteColor : widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
     m_label->measure(renderer);
   }
 

--- a/src/shell/bar/widgets/volume_widget.h
+++ b/src/shell/bar/widgets/volume_widget.h
@@ -21,7 +21,7 @@ class VolumeWidget : public Widget {
 public:
   VolumeWidget(
       PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* output, bool showLabel,
-      VolumeWidgetTarget target, int scrollStepPercent
+      VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor
   );
 
   void create() override;
@@ -37,6 +37,7 @@ private:
   bool m_showLabel = true;
   float m_scrollStep = 0.05f;
   VolumeWidgetTarget m_target = VolumeWidgetTarget::Output;
+  ColorSpec m_muteColor;
   Glyph* m_glyph = nullptr;
   Label* m_label = nullptr;
   float m_lastVolume = -1.0f;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -891,6 +891,7 @@ namespace settings {
       add(segmentedSpec("device", "output", volumeDeviceOptions));
       add(stepperIntSpec("scroll_step", 5, 1.0, 25.0, 1.0, "%"));
       add(boolSpec("show_label", true));
+      add(colorSpec("mute_color", "error"));
     } else if (type == "wallpaper") {
       add(glyphSpec("glyph", "wallpaper-selector"));
     } else if (type == "weather") {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds a configurable `mute_color` setting to the volume widget, applied to both the icon and the label when muted (covers both the volume and microphone targets). Defaults to the `error` color role and is settable from the GUI and config.

## Motivation

Easier to see if my mic is muted or not.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

`meson compile -C build-debug` — builds cleanly. Verified the mute color updates in the bar and the new setting appears in widget settings.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="252" height="44" alt="image" src="https://github.com/user-attachments/assets/18668c76-adc0-4f8e-8fcf-496d379c22fb" />

Settings:
<img width="897" height="539" alt="image" src="https://github.com/user-attachments/assets/36e874b6-1b43-495c-aea4-5d2ac906e862" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
