### PR TITLE
feat(launcher): tab select in menus

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -2,6 +2,8 @@
 
 #include "config/config_service.h"
 #include "core/deferred_call.h"
+#include "core/key_modifiers.h"
+#include "core/key_symbols.h"
 #include "core/keybind_matcher.h"
 #include "core/log.h"
 #include "core/process.h"
@@ -1650,6 +1652,15 @@ bool ClipboardPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) 
     if (m_selectedIndex + 1 < m_filteredIndices.size()) {
       selectIndex(m_selectedIndex + 1);
     }
+    return true;
+  }
+
+  if (KeySymbol::isTab(sym) && (modifiers & ~(KeyMod::Shift)) == 0) {
+    const bool reverse = (modifiers & KeyMod::Shift) != 0 || sym == XKB_KEY_ISO_Left_Tab;
+    const std::size_t count = m_filteredIndices.size();
+    const std::size_t next = reverse ? (m_selectedIndex == 0 ? count - 1 : m_selectedIndex - 1)
+                                     : (m_selectedIndex + 1 < count ? m_selectedIndex + 1 : 0);
+    selectIndex(next);
     return true;
   }
 

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1252,6 +1252,23 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
     return cycleCategory((modifiers & KeyMod::Shift) != 0);
   }
 
+  if (KeySymbol::isTab(sym) && (modifiers & ~(KeyMod::Shift)) == 0) {
+    if (!m_results.empty()) {
+      const bool reverse = (modifiers & KeyMod::Shift) != 0 || sym == XKB_KEY_ISO_Left_Tab;
+      const int last = static_cast<int>(m_results.size() - 1);
+      const int current = static_cast<int>(m_selectedIndex);
+      // Reuse the arrow-key selection path, wrapping around the ends to cycle.
+      int delta = reverse ? -1 : 1;
+      if (reverse && current == 0) {
+        delta = last;
+      } else if (!reverse && current == last) {
+        delta = -last;
+      }
+      moveSelection(delta);
+    }
+    return true;
+  }
+
   if (KeySymbol::isPageUp(sym)) {
     const int stride = m_grid != nullptr ? static_cast<int>(m_grid->pageItemStride()) : 1;
     moveSelection(-stride);


### PR DESCRIPTION
## Summary

Add Tab / Shift+Tab navigation to the launcher and clipboard panels. Tab moves selection to the next entry, Shift+Tab (or `ISO_Left_Tab`) to the previous one. Both wrap around the ends.

## Motivation

Selection could only be moved with the arrow keys. Tab is a common expectation for cycling through list entries and keeps the hands on the home row.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

## Testing

Manually tested in the launcher and clipboard panels: Tab cycles forward, Shift+Tab cycles backward, both wrap at the ends. Tab combined with any modifier other than Shift is left untouched.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No new config keys or user-facing strings. Tab only triggers when no modifiers other than Shift are held, so existing keybinds are unaffected.
