### PR TITLE
fix(panel): improve fade in/out animation to fade entire scene (special handling for blur)

### DIFF
--- a/src/render/programs/effect_program.cpp
+++ b/src/render/programs/effect_program.cpp
@@ -147,7 +147,7 @@ void main() {
     resultRGB = mix(resultRGB, resultRGB * vec3(1.08, 1.04, 0.98), 0.15);
 
     float mask = cornerMask();
-    float finalAlpha = resultAlpha * mask;
+    float finalAlpha = resultAlpha * mask * u_bg_color.a;
     gl_FragColor = vec4(resultRGB * (finalAlpha / max(resultAlpha, 0.001)), finalAlpha);
 }
 )";
@@ -195,7 +195,7 @@ void main() {
     vec3 blended = mix(u_bg_color.rgb, snowColor, snowAlpha);
 
     float mask = cornerMask();
-    float finalAlpha = mask;
+    float finalAlpha = mask * u_bg_color.a;
     gl_FragColor = vec4(blended * finalAlpha, finalAlpha);
 }
 )";
@@ -293,7 +293,8 @@ void main() {
     vec3 resultRGB = mix(col, rainTint, rain * 0.45);
 
     float mask = cornerMask();
-    gl_FragColor = vec4(resultRGB * mask, mask);
+    float finalAlpha = mask * u_bg_color.a;
+    gl_FragColor = vec4(resultRGB * finalAlpha, finalAlpha);
 }
 )";
 
@@ -384,7 +385,7 @@ void main() {
     float resultAlpha = fogAlpha + col.a * (1.0 - fogAlpha);
 
     float mask = cornerMask();
-    float finalAlpha = resultAlpha * mask;
+    float finalAlpha = resultAlpha * mask * u_bg_color.a;
     gl_FragColor = vec4(resultRGB * (finalAlpha / max(resultAlpha, 0.001)), finalAlpha);
 }
 )";
@@ -475,7 +476,7 @@ void main() {
     float resultAlpha = starsAlpha + col.a * (1.0 - starsAlpha);
 
     float mask = cornerMask();
-    float finalAlpha = resultAlpha * mask;
+    float finalAlpha = resultAlpha * mask * u_bg_color.a;
     gl_FragColor = vec4(resultRGB * (finalAlpha / max(resultAlpha, 0.001)), finalAlpha);
 }
 )";

--- a/src/render/render_context.cpp
+++ b/src/render/render_context.cpp
@@ -455,6 +455,7 @@ void RenderContext::renderNode(
       auto style = graph->style();
       style.lineColor1.a *= effectiveOpacity;
       style.lineColor2.a *= effectiveOpacity;
+      style.lineColor3.a *= effectiveOpacity;
       style.graphFillOpacity *= effectiveOpacity;
       m_backend->drawGraph(
           graph->textureId(), graph->textureWidth(), sw, sh, node->width(), node->height(), style, worldTransform

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -972,7 +972,7 @@ void PanelManager::closePanel(bool animateClose) {
     } else {
       m_animations.cancelForOwner(m_sceneRoot.get());
       m_animations.animate(
-          m_detachedRevealProgress, 0.0f, Style::animFast, Easing::EaseInOutQuad,
+          m_detachedRevealProgress, 0.0f, Style::animNormal, Easing::EaseInOutCubic,
           [this](float v) { applyDetachedReveal(v); },
           [this, gen]() {
             DeferredCall::callLater([this, gen]() {
@@ -1462,14 +1462,12 @@ void PanelManager::applyDetachedReveal(float progress) {
     return;
   }
   // Scale the entire scene from 0.95 to 1.0 around the surface center.
-  // Opacity is not animated because the compositor blur region is not opacity-aware.
   const float s = 1.0f - 0.05f * (1.0f - m_detachedRevealProgress);
   m_sceneRoot->setScale(s);
-  // Fade only the content layer. The background must stay fully opaque so the
-  // compositor blur region is always covered by an opaque rect.
-  if (m_contentNode != nullptr) {
-    m_contentNode->setOpacity(m_detachedRevealProgress);
-  }
+  // Fade the whole panel (background + content) uniformly. The compositor blur region
+  // is not opacity-aware, so we gate it in applyPanelCompositorBlur() to stay cleared
+  // while the panel is mostly translucent.
+  m_sceneRoot->setOpacity(m_detachedRevealProgress);
   applyPanelCompositorBlur();
 }
 
@@ -1568,6 +1566,15 @@ void PanelManager::applyPanelCompositorBlur() {
   // The blur region is submitted on every panel surface.
   // As of niri 26.04, subsurfaces are ignored for ext-background-effect-v1.
   if (m_surface == nullptr || m_activePanel == nullptr) {
+    return;
+  }
+
+  // The blur region is not opacity-aware: while the panel is still mostly translucent a
+  // submitted region would show through as a blurred blob, so keep it cleared until the
+  // panel is opaque enough. This works the same during both fade in/out.
+  const float kBlurRevealThreshold = 0.6f;
+  if (m_detachedRevealProgress < kBlurRevealThreshold) {
+    m_surface->clearBlurRegion();
     return;
   }
 


### PR DESCRIPTION
## Summary

The detached panel animation currently does not animate opacity on the panel background (only content) because compositor blur cannot be simultaneously animated. The blur region becomes very obvious at low opacity (so the blur on/off is super obvious).

This PR animates the full scene opacity for much smoother fade in/out. To workaround the blur issue, I only enable blur when opacity passes a certain threshold. See the video below (you really can't see the blur turn on/off).

As a consequence, I noticed there was an opacity bug exposed in the weather shader (content didn't fade, but it wasn't obvious until now). The shader now applies the scene opacity. The third graph in system monitor had the same issue which I also fixed.

## Motivation

The abrupt transition when opening/closing panel has always bothered me. :stuck_out_tongue_closed_eyes: 

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

See the video.

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

You really can't see the discrete blur on/off point.

https://github.com/user-attachments/assets/aaafa260-552c-44ef-9ed2-e8557475e7ba


## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
