### PR TITLE
feat(templates): add velo launcher palette template

### DIFF
--- a/assets/templates/builtin.toml
+++ b/assets/templates/builtin.toml
@@ -80,6 +80,10 @@ category = "terminal"
 name = "Wezterm"
 category = "terminal"
 
+[catalog.velo]
+name = "velo"
+category = "misc"
+
 [templates.alacritty]
 input_path = "./alacritty/alacritty.toml"
 output_path = "$XDG_CONFIG_HOME/alacritty/themes/noctalia.toml"
@@ -177,3 +181,8 @@ post_hook = "bash '{{ config_dir }}/starship/apply.sh'"
 input_path = "./wezterm/wezterm.toml"
 output_path = "$XDG_CONFIG_HOME/wezterm/colors/Noctalia.toml"
 post_hook = "bash '{{ config_dir }}/wezterm/apply.sh'"
+
+[templates.velo]
+input_path = "./velo/palette.json"
+output_path = "$XDG_CONFIG_HOME/velo/palettes/current-noctalia-override.json"
+post_hook = "bash '{{ config_dir }}/velo/apply.sh' {{ mode }}"

--- a/assets/templates/velo/apply.sh
+++ b/assets/templates/velo/apply.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/velo"
+config_file="$config_dir/config"
+palette_name="current-noctalia-override"
+
+darkmode="true"
+[ "${1:-}" = "light" ] && darkmode="false"
+
+mkdir -p "$config_dir"
+
+if [ ! -f "$config_file" ]; then
+    printf 'palette = "%s"\ndarkmode = %s\n' "$palette_name" "$darkmode" > "$config_file"
+    exit 0
+fi
+
+if grep -q '^palette[[:space:]]*=' "$config_file"; then
+    sed -i 's|^palette[[:space:]]*=.*|palette = "'"$palette_name"'"|' "$config_file"
+else
+    printf 'palette = "%s"\n' "$palette_name" >> "$config_file"
+fi
+
+if grep -q '^darkmode[[:space:]]*=' "$config_file"; then
+    sed -i 's|^darkmode[[:space:]]*=.*|darkmode = '"$darkmode"'|' "$config_file"
+else
+    printf 'darkmode = %s\n' "$darkmode" >> "$config_file"
+fi

--- a/assets/templates/velo/palette.json
+++ b/assets/templates/velo/palette.json
@@ -1,0 +1,18 @@
+{
+  "dark": {
+    "surface": "{{colors.surface.dark.hex}}",
+    "onSurface": "{{colors.on_surface.dark.hex}}",
+    "primary": "{{colors.primary.dark.hex}}",
+    "onPrimary": "{{colors.on_primary.dark.hex}}",
+    "secondary": "{{colors.secondary.dark.hex}}",
+    "outline": "{{colors.outline.dark.hex}}"
+  },
+  "light": {
+    "surface": "{{colors.surface.light.hex}}",
+    "onSurface": "{{colors.on_surface.light.hex}}",
+    "primary": "{{colors.primary.light.hex}}",
+    "onPrimary": "{{colors.on_primary.light.hex}}",
+    "secondary": "{{colors.secondary.light.hex}}",
+    "outline": "{{colors.outline.light.hex}}"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a built-in theme template for velo, a Wayland launcher (C fork of tofi). When enabled, noctalia keeps velo's palette in sync with the active noctalia theme.

## Motivation

velo already speaks noctalia's native palette format: its loader accepts both unprefixed keys (`primary`) and m-prefixed keys (`mPrimary`), and ignores unknown keys. This template bridges the two so a velo install automatically tracks noctalia's active theme without manual palette editing.

## Type of Change

- [x] New feature

## Related Issue

N/A

## Testing

- `ninja -C build` clean build
- `python3 tools/i18n-check.py` passes
- Verified `apply.sh` correctly rewrites `palette =` and `darkmode =` lines in velo config format while preserving comments and other settings
- Verified template syntax matches existing templates (alacritty, ghostty)

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Template output is compositor-agnostic (file-based palette sync); tested on Hyprland where velo runs.

## Screenshots / Videos

N/A. No visual UI changes in noctalia; palette sync is file-based.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Three files, no C++ changes:

- `assets/templates/velo/palette.json` renders six noctalia color tokens (surface, onSurface, primary, onPrimary, secondary, outline) in both dark and light variants into velo's JSON palette format
- `assets/templates/velo/apply.sh` is a post-hook that sets `palette = "current-noctalia-override"` and `darkmode = true|false` in `~/.config/velo/config`, preserving the rest of the file. Creates the config if missing, appends lines if absent
- `assets/templates/builtin.toml` adds the catalog entry (category `misc`) and template entry

Design: only one override palette file is written (`current-noctalia-override.json`); velo's vendored palettes are untouched. No runtime signal is needed: velo reads its config at startup, so the theme applies on next launch.