### PR TITLE
fix(tray): differentiate generic electron tray icons using tooltip title

### DIFF
--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -1988,6 +1988,10 @@ void TrayService::refreshItemMetadata(const std::string& itemId) {
           next.status = get_item_property_string_from(properties, "Status", cur.status);
           next.needsAttention = (next.status == "NeedsAttention");
 
+          if (next.itemName == "chrome_status_icon_1" && !next.statusNotifierTitle.empty()) {
+            next.itemName = next.itemName + "::" + next.statusNotifierTitle;
+          }
+
           const auto iconPixmaps = get_icon_pixmaps_from(properties, "IconPixmap", {});
           pickBestPixmap(iconPixmaps, next.iconArgb32, next.iconWidth, next.iconHeight);
 


### PR DESCRIPTION
## Summary

Fixed an issue where certain electron app sys tray icons can't be hidden because of them using all using ``chrome_status_icon_1`` as their ID. 

## Motivation

I wanted to hide Discord's sys tray icon but there was no option to do so in their settings and they used ``chrome_status_icon_1`` as their ID which meant that using that ID to hide the icon would also hide the icons of other electron apps using the same generic ID. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Added ``chrome_status_icon_1::Discord`` in the "Hidden Items" tray widget entry and verified that it hid Discord's tray app icon without affecting other electron apps.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/59888be6-9fcf-4a05-ae89-970b1288e214

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I don't know in what way the documentation should be edited or if it should be edited at all.