### PR TITLE
refactor: remove redundant dead assignments

### DIFF
--- a/src/app/main_loop.cpp
+++ b/src/app/main_loop.cpp
@@ -322,8 +322,6 @@ void MainLoop::run() {
       const float ms = elapsedSince(opStart);
       logSlowMainLoopOperation(ms, "wl_display_dispatch_pending took {:.1f}ms before poll", ms);
     }
-    bool waylandReadPrepared = true;
-
     // Try to flush queued requests. If the kernel send buffer is full we get
     // EAGAIN; that is the standard Wayland backpressure signal, not a fatal
     // error. In that case ask poll() to also wake us when the fd is writable
@@ -349,7 +347,6 @@ void MainLoop::run() {
       const int flushErrno = errno;
       if (flushErrno != EAGAIN) {
         wl_display_cancel_read(m_wayland.display());
-        waylandReadPrepared = false;
         throwWaylandFailure(m_wayland, "failed to flush Wayland display before poll", flushErrno);
       }
       waylandPollEvents |= POLLOUT;
@@ -495,10 +492,7 @@ void MainLoop::run() {
       }
     }
     if (pollResult < 0) {
-      if (waylandReadPrepared) {
-        wl_display_cancel_read(m_wayland.display());
-        waylandReadPrepared = false;
-      }
+      wl_display_cancel_read(m_wayland.display());
       if (errno == EINTR) {
         continue;
       }
@@ -521,10 +515,7 @@ void MainLoop::run() {
       logSlowMainLoopOperation(ms, "wl_display_flush took {:.1f}ms after POLLOUT", ms);
       const int flushErrno = errno;
       if (flushRet < 0 && flushErrno != EAGAIN) {
-        if (waylandReadPrepared) {
-          wl_display_cancel_read(m_wayland.display());
-          waylandReadPrepared = false;
-        }
+        wl_display_cancel_read(m_wayland.display());
         throwWaylandFailure(m_wayland, "failed to flush Wayland display after POLLOUT", flushErrno);
       }
     }
@@ -536,7 +527,6 @@ void MainLoop::run() {
       opStart = std::chrono::steady_clock::now();
       if (wl_display_read_events(m_wayland.display()) < 0) {
         const int readErrno = errno;
-        waylandReadPrepared = false;
         throwWaylandFailure(m_wayland, "failed to read Wayland events", readErrno);
       }
       ms = elapsedSince(opStart);
@@ -546,10 +536,8 @@ void MainLoop::run() {
         profile.waylandReadMs += ms;
       }
       logSlowMainLoopOperation(ms, "wl_display_read_events took {:.1f}ms", ms);
-      waylandReadPrepared = false;
     } else {
       wl_display_cancel_read(m_wayland.display());
-      waylandReadPrepared = false;
     }
 
     opStart = std::chrono::steady_clock::now();

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -494,7 +494,6 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       && offsetUs > 0
       && rawPositionUs + kStaleRebaseClearSlackUs < offsetUs) {
     offsetIt->second = 0;
-    offsetUs = 0;
     normalizedUs = rawPositionUs;
   }
 

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -687,8 +687,8 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
     // Convert panel screen coords to bar-surface-local coords for shadow exclusion.
     // Bar surface origin sits one shadow bleed inset from the visible bar top-left.
     const auto barShadowBleed = shell::surface_shadow::bleed(barConfig.shadow, shadowConfig);
-    std::int32_t barSurfaceLocalVisualX = visualX;
-    std::int32_t barSurfaceLocalVisualY = visualY;
+    std::int32_t barSurfaceLocalVisualX;
+    std::int32_t barSurfaceLocalVisualY;
     if (barIsVertical) {
       barSurfaceLocalVisualY = visualY - (barTop - std::min(mEnds, barShadowBleed.up));
       const std::int32_t barSurfaceOriginX =

--- a/src/shell/tooltip/tooltip_manager.cpp
+++ b/src/shell/tooltip/tooltip_manager.cpp
@@ -71,7 +71,6 @@ namespace {
     const float valueDelta = std::min(valueNeed, remainingW);
     widths.value += valueDelta;
     remainingW -= valueDelta;
-    valueNeed -= valueDelta;
 
     if (remainingW > 0.0f && keyNeed > 0.0f) {
       widths.key += std::min(keyNeed, remainingW);

--- a/src/system/brightness_service.cpp
+++ b/src/system/brightness_service.cpp
@@ -512,7 +512,6 @@ namespace {
         result.timedOut = true;
         ::kill(pid, SIGKILL);
         ::waitpid(pid, &status, 0);
-        childExited = true;
         break;
       }
 

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -1095,7 +1095,6 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
     }
     if (hasSelection()) {
       deleteSelection();
-      changed = true;
     }
     const auto bytes = utf32ToUtf8(utf32);
     m_value.insert(m_cursorPos, bytes);


### PR DESCRIPTION
These don't affect anything. I found them with `clang-analyzer-deadcode.DeadStores`.

## Type of Change
- [x] Refactoring