### PR TITLE
Fix next/prev month days color reset on unhover

### DIFF
--- a/src/shell/control_center/calendar_tab.cpp
+++ b/src/shell/control_center/calendar_tab.cpp
@@ -716,20 +716,26 @@ void CalendarTab::rebuild() {
     int cellMonthShift = 0;
     bool inMonth = false;
 
+    const auto mutedDayPalette = [] {
+      Button::ButtonPalette ghostPalette = Button::defaultPalette(ButtonVariant::Ghost);
+      ghostPalette.normal.label = colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.75f);
+      return ghostPalette;
+    }();
+
     if (index < firstWeekdayOffset) {
       cellDay = previousMonthDays - firstWeekdayOffset + index + 1;
       cellYear = previousMonthYear;
       cellMonth = previousMonth;
       cellMonthShift = -1;
       dayButton->setText(std::to_string(cellDay));
-      dayButton->label()->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.75f));
+      dayButton->setCustomPalette(mutedDayPalette);
     } else if (day > monthDays) {
       cellDay = trailingDay;
       cellYear = nextMonthYear;
       cellMonth = nextMonth;
       cellMonthShift = 1;
       dayButton->setText(std::to_string(trailingDay));
-      dayButton->label()->setColor(colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.75f));
+      dayButton->setCustomPalette(mutedDayPalette);
       ++trailingDay;
     } else {
       cellDay = day;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Instead of changing color spec of label, we change button's palette, this way color won't reset to default Ghost variant after `resolveVisualStateColors`

<!-- What changed and why? -->

## Motivation
Fix #3070 

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
Closes #3070 
<!-- Example: Closes #123 -->

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
# Before

https://github.com/user-attachments/assets/345eca07-1129-450f-a6bb-43db2f870f29

# After

https://github.com/user-attachments/assets/255e88bb-75b1-4b41-94c7-0714291cec36




<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
