### PR TITLE
config: move privacy capture filters to shell settings

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2319,6 +2319,14 @@
           "description": "Enable the built-in authentication agent",
           "label": "Polkit Agent"
         },
+        "privacy-cam-filter-regex": {
+          "description": "Regex for camera apps to ignore in privacy indicators and OSDs",
+          "label": "Camera Filter Regex"
+        },
+        "privacy-mic-filter-regex": {
+          "description": "Regex for microphone apps to ignore in privacy indicators and OSDs",
+          "label": "Microphone Filter Regex"
+        },
         "screen-time-enabled": {
           "description": "Track per-app usage and show it in Control Center",
           "label": "Screen Time"

--- a/example.toml
+++ b/example.toml
@@ -30,6 +30,10 @@ shared_gl_context     = true         # startup-only; false isolates GPU contexts
 # lang                = "en"
 # avatar_path         = "~/Pictures/avatar.png"
 
+[shell.privacy]
+mic_filter_regex = ""                # microphone app names to ignore in privacy indicators and OSD
+cam_filter_regex = ""                # camera app names to ignore in privacy indicators and OSD
+
 [shell.animation]
 enabled = true
 speed   = 1.0                       # 0.5 = 2× slower, 2.0 = 2× faster

--- a/meson.build
+++ b/meson.build
@@ -449,6 +449,7 @@ _noctalia_sources = files(
   'src/notification/notification_display_name.cpp',
   'src/notification/notification_history_store.cpp',
   'src/pipewire/pipewire_service.cpp',
+  'src/pipewire/privacy_filter.cpp',
   'src/pipewire/pipewire_spectrum.cpp',
   'src/pipewire/sound_player.cpp',
   'src/render/animation/animation.cpp',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1724,6 +1724,16 @@ void Application::initUi() {
   m_keyboardLayoutOsd.prime(m_compositorPlatform);
   m_mediaOsd.bindOverlay(m_osdOverlay);
   m_privacyOsd.bindOverlay(m_osdOverlay);
+  m_privacyOsd.configure(m_configService.config());
+  m_configService.addReloadCallback(
+      [this]() {
+        if (m_configService.lastChange().shell) {
+          m_privacyOsd.onConfigReload(m_configService.config(), m_pipewireService.get());
+          m_bar.refresh();
+        }
+      },
+      "privacy-filters"
+  );
   m_screenCorners.initialize(m_wayland, &m_configService, &m_renderContext);
   m_screenCorners.onConfigReload();
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -843,6 +843,13 @@ struct ShellConfig {
     bool operator==(const ScreenshotConfig&) const = default;
   };
 
+  struct PrivacyConfig {
+    std::string micFilterRegex;
+    std::string camFilterRegex;
+
+    bool operator==(const PrivacyConfig&) const = default;
+  };
+
   float uiScale = 1.0f;
   float cornerRadiusScale = 1.0f;
   std::string fontFamily = "sans-serif";
@@ -880,6 +887,7 @@ struct ShellConfig {
   ScreenCornersConfig screenCorners;
   MprisConfig mpris;
   ScreenshotConfig screenshot;
+  PrivacyConfig privacy;
   ShellSessionConfig session;
 
   bool operator==(const ShellConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1175,6 +1175,14 @@ namespace noctalia::config::schema {
       return s;
     }
 
+    const Schema<ShellConfig::PrivacyConfig>& shellPrivacySchema() {
+      static const Schema<ShellConfig::PrivacyConfig> s = {
+          field(&ShellConfig::PrivacyConfig::micFilterRegex, "mic_filter_regex"),
+          field(&ShellConfig::PrivacyConfig::camFilterRegex, "cam_filter_regex"),
+      };
+      return s;
+    }
+
     // command/label/glyph are stored trimmed-or-nullopt but always emitted (value_or("")).
     Field<SessionPanelActionConfig>
     sessionOptionalString(std::optional<std::string> SessionPanelActionConfig::* member, std::string_view key) {
@@ -1291,6 +1299,7 @@ namespace noctalia::config::schema {
         subTable(&ShellConfig::screenCorners, "screen_corners", shellScreenCornersSchema()),
         subTable(&ShellConfig::mpris, "mpris", shellMprisSchema()),
         subTable(&ShellConfig::screenshot, "screenshot", shellScreenshotSchema()),
+        subTable(&ShellConfig::privacy, "privacy", shellPrivacySchema()),
         subTable(&ShellConfig::session, "session", shellSessionSchema()),
     };
     return s;

--- a/src/pipewire/privacy_filter.cpp
+++ b/src/pipewire/privacy_filter.cpp
@@ -1,0 +1,28 @@
+#include "pipewire/privacy_filter.h"
+
+#include "core/log.h"
+
+namespace {
+  constexpr Logger kLog("privacy");
+}
+
+void PrivacyFilter::update(std::string_view key, const std::string& pattern) {
+  if (pattern == m_pattern) {
+    return;
+  }
+  m_pattern = pattern;
+  if (pattern.empty()) {
+    m_regex.reset();
+    return;
+  }
+  try {
+    m_regex = std::regex(pattern);
+  } catch (const std::regex_error& e) {
+    kLog.warn("invalid {} '{}': {}", key, pattern, e.what());
+    m_regex.reset();
+  }
+}
+
+bool PrivacyFilter::matches(const std::string& value) const {
+  return m_regex.has_value() && std::regex_search(value, *m_regex);
+}

--- a/src/pipewire/privacy_filter.h
+++ b/src/pipewire/privacy_filter.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <optional>
+#include <regex>
+#include <string>
+#include <string_view>
+
+// Capture-name regex filter shared by the privacy bar widget and the privacy
+// OSD. Recompiles only when the pattern string actually changes; an empty
+// pattern matches nothing.
+class PrivacyFilter {
+public:
+  // Recompiles the regex if pattern differs from the current one. key names the
+  // config field for diagnostics on an invalid pattern.
+  void update(std::string_view key, const std::string& pattern);
+  [[nodiscard]] bool matches(const std::string& value) const;
+
+private:
+  std::string m_pattern;
+  std::optional<std::regex> m_regex;
+};

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -376,11 +376,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
       config.activeColor = wc->getColorSpec("active_color", config.activeColor, "widget." + name + ".active_color");
       config.inactiveColor =
           wc->getColorSpec("inactive_color", config.inactiveColor, "widget." + name + ".inactive_color");
-      config.micFilterRegex = wc->getString("mic_filter_regex", "");
-      config.camFilterRegex = wc->getString("cam_filter_regex", "");
     }
 
-    auto widget = std::make_unique<PrivacyWidget>(m_audio, std::move(config));
+    auto widget = std::make_unique<PrivacyWidget>(m_audio, &m_configService, config);
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/privacy_widget.cpp
+++ b/src/shell/bar/widgets/privacy_widget.cpp
@@ -1,7 +1,6 @@
 #include "shell/bar/widgets/privacy_widget.h"
 
 #include "config/config_service.h"
-#include "core/log.h"
 #include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
 #include "render/core/renderer.h"
@@ -19,20 +18,6 @@
 #include <utility>
 
 namespace {
-
-  constexpr Logger kLog("shell");
-
-  [[nodiscard]] std::optional<std::regex> compileFilter(std::string_view key, const std::string& pattern) {
-    if (pattern.empty()) {
-      return std::nullopt;
-    }
-    try {
-      return std::regex(pattern);
-    } catch (const std::regex_error& e) {
-      kLog.warn("privacy widget: invalid {} '{}': {}", key, pattern, e.what());
-      return std::nullopt;
-    }
-  }
 
   void addNonEmpty(std::vector<std::string>& values, std::string value) {
     if (value.empty()) {
@@ -196,19 +181,12 @@ void PrivacyWidget::syncState() {
 }
 
 void PrivacyWidget::refreshFilters() const {
-  const std::string micPattern =
-      m_configService != nullptr ? m_configService->config().shell.privacy.micFilterRegex : std::string{};
-  const std::string camPattern =
-      m_configService != nullptr ? m_configService->config().shell.privacy.camFilterRegex : std::string{};
-
-  if (micPattern != m_micFilterPattern) {
-    m_micFilterPattern = micPattern;
-    m_micFilter = compileFilter("shell.privacy.mic_filter_regex", m_micFilterPattern);
+  if (m_configService == nullptr) {
+    return;
   }
-  if (camPattern != m_camFilterPattern) {
-    m_camFilterPattern = camPattern;
-    m_camFilter = compileFilter("shell.privacy.cam_filter_regex", m_camFilterPattern);
-  }
+  const ShellConfig::PrivacyConfig& privacy = m_configService->config().shell.privacy;
+  m_micFilter.update("shell.privacy.mic_filter_regex", privacy.micFilterRegex);
+  m_camFilter.update("shell.privacy.cam_filter_regex", privacy.camFilterRegex);
 }
 
 PrivacyWidget::Snapshot PrivacyWidget::snapshot() const {
@@ -219,11 +197,11 @@ PrivacyWidget::Snapshot PrivacyWidget::snapshot() const {
     const PrivacyState& state = m_pipewire->privacyState();
     for (const auto& capture : state.captures) {
       if (capture.kind == PrivacyCaptureKind::Microphone) {
-        if (!matchesFilter(m_micFilter, capture.appName)) {
+        if (!m_micFilter.matches(capture.appName)) {
           addNonEmpty(out.micApps, capture.appName);
         }
       } else if (capture.kind == PrivacyCaptureKind::Camera) {
-        if (!matchesFilter(m_camFilter, capture.appName)) {
+        if (!m_camFilter.matches(capture.appName)) {
           addNonEmpty(out.cameraApps, capture.appName);
         }
       } else if (capture.kind == PrivacyCaptureKind::Screen) {
@@ -251,8 +229,4 @@ std::vector<TooltipRow> PrivacyWidget::buildTooltipRows() const {
     rows.push_back({i18n::tr("bar.widgets.privacy.screen-sharing"), joinApps(current.screenApps)});
   }
   return rows;
-}
-
-bool PrivacyWidget::matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const {
-  return filter.has_value() && std::regex_search(value, *filter);
 }

--- a/src/shell/bar/widgets/privacy_widget.cpp
+++ b/src/shell/bar/widgets/privacy_widget.cpp
@@ -1,5 +1,6 @@
 #include "shell/bar/widgets/privacy_widget.h"
 
+#include "config/config_service.h"
 #include "core/log.h"
 #include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
@@ -53,10 +54,8 @@ namespace {
 
 } // namespace
 
-PrivacyWidget::PrivacyWidget(PipeWireService* pipewire, PrivacyWidgetConfig config)
-    : m_pipewire(pipewire), m_config(std::move(config)),
-      m_micFilter(compileFilter("mic_filter_regex", m_config.micFilterRegex)),
-      m_camFilter(compileFilter("cam_filter_regex", m_config.camFilterRegex)) {
+PrivacyWidget::PrivacyWidget(PipeWireService* pipewire, ConfigService* configService, PrivacyWidgetConfig config)
+    : m_pipewire(pipewire), m_configService(configService), m_config(config) {
   m_config.iconSpacing = std::clamp(m_config.iconSpacing, 0, 48);
 }
 
@@ -196,8 +195,25 @@ void PrivacyWidget::syncState() {
   requestRedraw();
 }
 
+void PrivacyWidget::refreshFilters() const {
+  const std::string micPattern =
+      m_configService != nullptr ? m_configService->config().shell.privacy.micFilterRegex : std::string{};
+  const std::string camPattern =
+      m_configService != nullptr ? m_configService->config().shell.privacy.camFilterRegex : std::string{};
+
+  if (micPattern != m_micFilterPattern) {
+    m_micFilterPattern = micPattern;
+    m_micFilter = compileFilter("shell.privacy.mic_filter_regex", m_micFilterPattern);
+  }
+  if (camPattern != m_camFilterPattern) {
+    m_camFilterPattern = camPattern;
+    m_camFilter = compileFilter("shell.privacy.cam_filter_regex", m_camFilterPattern);
+  }
+}
+
 PrivacyWidget::Snapshot PrivacyWidget::snapshot() const {
   Snapshot out;
+  refreshFilters();
 
   if (m_pipewire != nullptr) {
     const PrivacyState& state = m_pipewire->privacyState();

--- a/src/shell/bar/widgets/privacy_widget.h
+++ b/src/shell/bar/widgets/privacy_widget.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include "pipewire/privacy_filter.h"
 #include "shell/bar/widget.h"
 #include "shell/tooltip/tooltip_content.h"
 #include "ui/palette.h"
 
-#include <optional>
-#include <regex>
 #include <string>
 #include <vector>
 
@@ -50,15 +49,12 @@ private:
   void refreshFilters() const;
   [[nodiscard]] Snapshot snapshot() const;
   [[nodiscard]] std::vector<TooltipRow> buildTooltipRows() const;
-  [[nodiscard]] bool matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const;
 
   PipeWireService* m_pipewire = nullptr;
   ConfigService* m_configService = nullptr;
   PrivacyWidgetConfig m_config;
-  mutable std::string m_micFilterPattern;
-  mutable std::string m_camFilterPattern;
-  mutable std::optional<std::regex> m_micFilter;
-  mutable std::optional<std::regex> m_camFilter;
+  mutable PrivacyFilter m_micFilter;
+  mutable PrivacyFilter m_camFilter;
 
   InputArea* m_area = nullptr;
   Glyph* m_micGlyph = nullptr;

--- a/src/shell/bar/widgets/privacy_widget.h
+++ b/src/shell/bar/widgets/privacy_widget.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 class Glyph;
+class ConfigService;
 class InputArea;
 class PipeWireService;
 class Renderer;
@@ -19,13 +20,11 @@ struct PrivacyWidgetConfig {
   int iconSpacing = 4;
   ColorSpec activeColor = colorSpecFromRole(ColorRole::Primary);
   ColorSpec inactiveColor = colorSpecFromRole(ColorRole::Outline);
-  std::string micFilterRegex;
-  std::string camFilterRegex;
 };
 
 class PrivacyWidget : public Widget {
 public:
-  PrivacyWidget(PipeWireService* pipewire, PrivacyWidgetConfig config);
+  PrivacyWidget(PipeWireService* pipewire, ConfigService* configService, PrivacyWidgetConfig config);
 
   void create() override;
 
@@ -48,14 +47,18 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void syncState();
+  void refreshFilters() const;
   [[nodiscard]] Snapshot snapshot() const;
   [[nodiscard]] std::vector<TooltipRow> buildTooltipRows() const;
   [[nodiscard]] bool matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const;
 
   PipeWireService* m_pipewire = nullptr;
+  ConfigService* m_configService = nullptr;
   PrivacyWidgetConfig m_config;
-  std::optional<std::regex> m_micFilter;
-  std::optional<std::regex> m_camFilter;
+  mutable std::string m_micFilterPattern;
+  mutable std::string m_camFilterPattern;
+  mutable std::optional<std::regex> m_micFilter;
+  mutable std::optional<std::regex> m_camFilter;
 
   InputArea* m_area = nullptr;
   Glyph* m_micGlyph = nullptr;

--- a/src/shell/osd/privacy_osd.cpp
+++ b/src/shell/osd/privacy_osd.cpp
@@ -1,15 +1,11 @@
 #include "shell/osd/privacy_osd.h"
 
 #include "config/config_types.h"
-#include "core/log.h"
 #include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
 #include "shell/osd/osd_overlay.h"
 
-#include <string_view>
-
 namespace {
-  constexpr Logger kLog("osd");
 
   enum class PrivacyKind {
     Mic,
@@ -45,18 +41,6 @@ namespace {
     return OsdContent{};
   }
 
-  [[nodiscard]] std::optional<std::regex> compileFilter(std::string_view key, const std::string& pattern) {
-    if (pattern.empty()) {
-      return std::nullopt;
-    }
-    try {
-      return std::regex(pattern);
-    } catch (const std::regex_error& e) {
-      kLog.warn("privacy osd: invalid {} '{}': {}", key, pattern, e.what());
-      return std::nullopt;
-    }
-  }
-
 } // namespace
 
 PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState) const {
@@ -64,12 +48,12 @@ PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState
   for (const auto& capture : privacyState.captures) {
     switch (capture.kind) {
     case PrivacyCaptureKind::Microphone:
-      if (!matchesFilter(m_micFilter, capture.appName)) {
+      if (!m_micFilter.matches(capture.appName)) {
         out.mic = true;
       }
       break;
     case PrivacyCaptureKind::Camera:
-      if (!matchesFilter(m_camFilter, capture.appName)) {
+      if (!m_camFilter.matches(capture.appName)) {
         out.camera = true;
       }
       break;
@@ -84,17 +68,8 @@ PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState
 void PrivacyOsd::bindOverlay(OsdOverlay& overlay) { m_overlay = &overlay; }
 
 void PrivacyOsd::configure(const Config& config) {
-  const std::string& micPattern = config.shell.privacy.micFilterRegex;
-  const std::string& camPattern = config.shell.privacy.camFilterRegex;
-
-  if (micPattern != m_micFilterPattern) {
-    m_micFilterPattern = micPattern;
-    m_micFilter = compileFilter("shell.privacy.mic_filter_regex", m_micFilterPattern);
-  }
-  if (camPattern != m_camFilterPattern) {
-    m_camFilterPattern = camPattern;
-    m_camFilter = compileFilter("shell.privacy.cam_filter_regex", m_camFilterPattern);
-  }
+  m_micFilter.update("shell.privacy.mic_filter_regex", config.shell.privacy.micFilterRegex);
+  m_camFilter.update("shell.privacy.cam_filter_regex", config.shell.privacy.camFilterRegex);
 }
 
 void PrivacyOsd::onConfigReload(const Config& config, const PipeWireService* service) {
@@ -125,8 +100,4 @@ void PrivacyOsd::onPrivacyStateChanged(const PipeWireService& service) {
   }
 
   m_lastState = current;
-}
-
-bool PrivacyOsd::matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const {
-  return filter.has_value() && std::regex_search(value, *filter);
 }

--- a/src/shell/osd/privacy_osd.cpp
+++ b/src/shell/osd/privacy_osd.cpp
@@ -1,10 +1,15 @@
 #include "shell/osd/privacy_osd.h"
 
+#include "config/config_types.h"
+#include "core/log.h"
 #include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
 #include "shell/osd/osd_overlay.h"
 
+#include <string_view>
+
 namespace {
+  constexpr Logger kLog("osd");
 
   enum class PrivacyKind {
     Mic,
@@ -40,17 +45,33 @@ namespace {
     return OsdContent{};
   }
 
+  [[nodiscard]] std::optional<std::regex> compileFilter(std::string_view key, const std::string& pattern) {
+    if (pattern.empty()) {
+      return std::nullopt;
+    }
+    try {
+      return std::regex(pattern);
+    } catch (const std::regex_error& e) {
+      kLog.warn("privacy osd: invalid {} '{}': {}", key, pattern, e.what());
+      return std::nullopt;
+    }
+  }
+
 } // namespace
 
-PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState) {
+PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState) const {
   State out;
   for (const auto& capture : privacyState.captures) {
     switch (capture.kind) {
     case PrivacyCaptureKind::Microphone:
-      out.mic = true;
+      if (!matchesFilter(m_micFilter, capture.appName)) {
+        out.mic = true;
+      }
       break;
     case PrivacyCaptureKind::Camera:
-      out.camera = true;
+      if (!matchesFilter(m_camFilter, capture.appName)) {
+        out.camera = true;
+      }
       break;
     case PrivacyCaptureKind::Screen:
       out.screen = true;
@@ -61,6 +82,27 @@ PrivacyOsd::State PrivacyOsd::fromPipewireState(const PrivacyState& privacyState
 }
 
 void PrivacyOsd::bindOverlay(OsdOverlay& overlay) { m_overlay = &overlay; }
+
+void PrivacyOsd::configure(const Config& config) {
+  const std::string& micPattern = config.shell.privacy.micFilterRegex;
+  const std::string& camPattern = config.shell.privacy.camFilterRegex;
+
+  if (micPattern != m_micFilterPattern) {
+    m_micFilterPattern = micPattern;
+    m_micFilter = compileFilter("shell.privacy.mic_filter_regex", m_micFilterPattern);
+  }
+  if (camPattern != m_camFilterPattern) {
+    m_camFilterPattern = camPattern;
+    m_camFilter = compileFilter("shell.privacy.cam_filter_regex", m_camFilterPattern);
+  }
+}
+
+void PrivacyOsd::onConfigReload(const Config& config, const PipeWireService* service) {
+  configure(config);
+  if (service != nullptr) {
+    m_lastState = fromPipewireState(service->privacyState());
+  }
+}
 
 void PrivacyOsd::onPrivacyStateChanged(const PipeWireService& service) {
   const State current = fromPipewireState(service.privacyState());
@@ -83,4 +125,8 @@ void PrivacyOsd::onPrivacyStateChanged(const PipeWireService& service) {
   }
 
   m_lastState = current;
+}
+
+bool PrivacyOsd::matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const {
+  return filter.has_value() && std::regex_search(value, *filter);
 }

--- a/src/shell/osd/privacy_osd.h
+++ b/src/shell/osd/privacy_osd.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <optional>
-#include <regex>
-#include <string>
+#include "pipewire/privacy_filter.h"
 
 struct Config;
 class OsdOverlay;
@@ -26,13 +24,10 @@ private:
   };
 
   [[nodiscard]] State fromPipewireState(const PrivacyState& privacyState) const;
-  [[nodiscard]] bool matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const;
 
   OsdOverlay* m_overlay = nullptr;
-  std::string m_micFilterPattern;
-  std::string m_camFilterPattern;
-  std::optional<std::regex> m_micFilter;
-  std::optional<std::regex> m_camFilter;
+  PrivacyFilter m_micFilter;
+  PrivacyFilter m_camFilter;
   // Baseline starts empty by contract: the first PipeWire enumeration announces
   // any capture already active at launch as an on-transition. Do not prime from
   // live state or these startup notifications are lost.

--- a/src/shell/osd/privacy_osd.h
+++ b/src/shell/osd/privacy_osd.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <optional>
+#include <regex>
+#include <string>
+
+struct Config;
 class OsdOverlay;
 class PipeWireService;
 struct PrivacyState;
@@ -7,6 +12,8 @@ struct PrivacyState;
 class PrivacyOsd {
 public:
   void bindOverlay(OsdOverlay& overlay);
+  void configure(const Config& config);
+  void onConfigReload(const Config& config, const PipeWireService* service);
   void onPrivacyStateChanged(const PipeWireService& service);
 
 private:
@@ -18,9 +25,14 @@ private:
     bool operator==(const State&) const = default;
   };
 
-  [[nodiscard]] static State fromPipewireState(const PrivacyState& privacyState);
+  [[nodiscard]] State fromPipewireState(const PrivacyState& privacyState) const;
+  [[nodiscard]] bool matchesFilter(const std::optional<std::regex>& filter, const std::string& value) const;
 
   OsdOverlay* m_overlay = nullptr;
+  std::string m_micFilterPattern;
+  std::string m_camFilterPattern;
+  std::optional<std::regex> m_micFilter;
+  std::optional<std::regex> m_camFilter;
   // Baseline starts empty by contract: the first PipeWire enumeration announces
   // any capture already active at launch as an on-transition. Do not prime from
   // live state or these startup notifications are lost.

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1112,6 +1112,18 @@ namespace settings {
     ));
     // Security
     entries.push_back(makeEntry(
+        SettingsSection::Security, "privacy-security", tr("settings.schema.shell.privacy-mic-filter-regex.label"),
+        tr("settings.schema.shell.privacy-mic-filter-regex.description"), {"shell", "privacy", "mic_filter_regex"},
+        TextSetting{.value = cfg.shell.privacy.micFilterRegex, .placeholder = "", .browseFileExtensions = {}},
+        "privacy microphone mic app process regex filter ignore"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Security, "privacy-security", tr("settings.schema.shell.privacy-cam-filter-regex.label"),
+        tr("settings.schema.shell.privacy-cam-filter-regex.description"), {"shell", "privacy", "cam_filter_regex"},
+        TextSetting{.value = cfg.shell.privacy.camFilterRegex, .placeholder = "", .browseFileExtensions = {}},
+        "privacy camera webcam app process regex filter ignore"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Security, "privacy-security", tr("settings.schema.shell.offline-mode.label"),
         tr("settings.schema.shell.offline-mode.description"), {"shell", "offline_mode"},
         ToggleSetting{cfg.shell.offlineMode}, "network http fetch download"

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -756,8 +756,6 @@ namespace settings {
       add(intSpec("icon_spacing", 4, 0.0, 48.0, 1.0));
       add(colorSpec("active_color", "primary"));
       add(colorSpec("inactive_color", "outline"));
-      add(stringSpec("mic_filter_regex"));
-      add(stringSpec("cam_filter_regex"));
     } else if (type == "session") {
       add(glyphSpec("glyph", "shutdown"));
     } else if (type == "settings") {


### PR DESCRIPTION
The centralized filter settings are now also used for the privacy OSD.

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed..
- [x] I ran the relevant build or test command.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.