### PR TITLE
Add working left/right keybinds to launcher

### DIFF
--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1,8 +1,8 @@
 #include "shell/launcher/launcher_panel.h"
 
 #include "config/config_service.h"
+#include "config/config_types.h"
 #include "core/deferred_call.h"
-#include "core/key_modifiers.h"
 #include "core/key_symbols.h"
 #include "core/keybind_matcher.h"
 #include "core/ui_phase.h"
@@ -1250,10 +1250,6 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
     return true;
   };
 
-  if (sym == XKB_KEY_F6 && (modifiers & ~(KeyMod::Shift)) == 0) {
-    return cycleCategory((modifiers & KeyMod::Shift) != 0);
-  }
-
   if (KeySymbol::isPageUp(sym)) {
     const int stride = m_grid != nullptr ? static_cast<int>(m_grid->pageItemStride()) : 1;
     moveSelection(-stride);
@@ -1274,6 +1270,14 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
   if (KeybindMatcher::matches(KeybindAction::Down, sym, modifiers)) {
     moveSelection(1);
     return true;
+  }
+
+  if (KeybindMatcher::matches(KeybindAction::Left, sym, modifiers)) {
+    return cycleCategory(true);
+  }
+
+  if (KeybindMatcher::matches(KeybindAction::Right, sym, modifiers)) {
+    return cycleCategory(false);
   }
 
   if (KeybindMatcher::matches(KeybindAction::Validate, sym, modifiers)) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Removed hard coded `F6` and `SHIFT + F6` keybinds in launcher, now to scroll left/right we use keys from shell config

<!-- What changed and why? -->

## Motivation

Let user use their own keybinds for left and right instead of hard coded `F6` and `SHIFT + F6`

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
