### PR TITLE
Fix window cycling when pressing the dock item icon

### DIFF
--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -112,11 +112,24 @@ namespace {
         || (compositors::isKde() && (!window.title.empty() || !window.appId.empty()));
   }
 
-  [[nodiscard]] bool matchesActiveWindow(const ToplevelInfo& window, const ActiveToplevel& active) {
+  [[nodiscard]] bool matchesActiveWindow(
+      const ToplevelInfo& window, const ActiveToplevel& active, const std::vector<ToplevelInfo>& windows
+  ) {
     if (active.handle != nullptr && window.handle == active.handle) {
       return true;
     }
-    return false;
+
+    if (active.identifier.empty() || window.identifier.empty() || active.identifier != window.identifier) {
+      return false;
+    }
+
+    int count = 0;
+    for (const auto& w : windows) {
+      if (w.identifier == active.identifier && ++count > 1) {
+        return false;
+      }
+    }
+    return true;
   }
 
   const ToplevelInfo* nextActivatableWindow(
@@ -129,7 +142,7 @@ namespace {
 
     if (active.has_value()) {
       for (std::size_t i = 0; i < windows.size(); ++i) {
-        if (!matchesActiveWindow(windows[i], *active)) {
+        if (!matchesActiveWindow(windows[i], *active, windows)) {
           continue;
         }
         for (std::size_t offset = 1; offset <= windows.size(); ++offset) {

--- a/src/shell/dock/dock.cpp
+++ b/src/shell/dock/dock.cpp
@@ -116,7 +116,7 @@ namespace {
     if (active.handle != nullptr && window.handle == active.handle) {
       return true;
     }
-    return !active.identifier.empty() && !window.identifier.empty() && active.identifier == window.identifier;
+    return false;
   }
 
   const ToplevelInfo* nextActivatableWindow(


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

When left clicking on a docker item icon with more than 1 window open, one would expect it to cycle between windows. There is a bug with the current code where the cycle gets stuck because some windows have the same identifier and are treated as one and the same window.

## Motivation

Makes cycling between windows work.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/477eb940-963a-489c-8553-9a339310f2e3

After:


https://github.com/user-attachments/assets/5570813e-2cc7-4f9b-858e-0c297c6b8110




## Checklist

- [ ] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [ ] I ran the relevant build or test commands, or explained why they were not run.
- [ ] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
