### PR TITLE
idle: support fractional second behavior timeout

### DIFF
--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -504,7 +504,7 @@ namespace {
               }
               toml::table row;
               row.insert_or_assign("enabled", item.enabled);
-              row.insert_or_assign("timeout", static_cast<std::int64_t>(item.timeoutSeconds));
+              row.insert_or_assign("timeout", item.timeoutSeconds);
               if (!item.action.empty()) {
                 row.insert_or_assign("action", item.action);
               }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -221,7 +221,7 @@ struct ShellSessionConfig {
 struct IdleBehaviorConfig {
   std::string name;
   bool enabled = true;
-  std::int32_t timeoutSeconds = 0;
+  double timeoutSeconds = 0.0;
   /// lock | screen_off | suspend | lock_and_suspend | command (custom shell strings)
   std::string action;
   std::string command;

--- a/src/idle/idle_manager.cpp
+++ b/src/idle/idle_manager.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <utility>
 
 namespace {
@@ -16,6 +17,7 @@ namespace {
   constexpr Logger kLog("idle");
 
   constexpr std::uint32_t kHeartbeatTimeoutMs = 1000;
+  constexpr double kMaxIdleTimeoutMs = static_cast<double>(std::numeric_limits<std::uint32_t>::max());
 
   const ext_idle_notification_v1_listener kIdleNotificationListener = {
       .idled = &IdleManager::handleIdled,
@@ -26,6 +28,11 @@ namespace {
       .idled = &IdleManager::handleHeartbeatIdled,
       .resumed = &IdleManager::handleHeartbeatResumed,
   };
+
+  std::uint32_t timeoutSecondsToMilliseconds(double timeoutSeconds) {
+    const double timeoutMs = std::clamp(std::ceil(timeoutSeconds * 1000.0), 1.0, kMaxIdleTimeoutMs);
+    return static_cast<std::uint32_t>(timeoutMs);
+  }
 
 } // namespace
 
@@ -156,11 +163,13 @@ void IdleManager::recreateBehaviorNotification(BehaviorState& behavior) {
   }
   behavior.phase = BehaviorPhase::Waiting;
 
-  if (!behavior.config.enabled || behavior.config.timeoutSeconds <= 0) {
+  if (!behavior.config.enabled
+      || !std::isfinite(behavior.config.timeoutSeconds)
+      || behavior.config.timeoutSeconds <= 0.0) {
     return;
   }
 
-  const auto timeoutMs = static_cast<std::uint32_t>(behavior.config.timeoutSeconds) * 1000u;
+  const auto timeoutMs = timeoutSecondsToMilliseconds(behavior.config.timeoutSeconds);
   behavior.notification = m_wayland->createIdleNotification(timeoutMs);
   if (behavior.notification == nullptr) {
     kLog.warn("failed to re-register idle behavior '{}'", behavior.config.name);
@@ -185,11 +194,11 @@ void IdleManager::createBehavior(const IdleBehaviorConfig& config) {
   if (!config.enabled) {
     return;
   }
-  if (config.timeoutSeconds < 0) {
+  if (!std::isfinite(config.timeoutSeconds) || config.timeoutSeconds < 0.0) {
     kLog.warn("idle behavior '{}' ignored: timeout must be >= 0 seconds", config.name);
     return;
   }
-  if (config.timeoutSeconds == 0) {
+  if (config.timeoutSeconds == 0.0) {
     kLog.debug("idle behavior '{}' disabled by zero timeout", config.name);
     return;
   }
@@ -202,7 +211,7 @@ void IdleManager::createBehavior(const IdleBehaviorConfig& config) {
   auto behavior = std::make_unique<BehaviorState>();
   behavior->owner = this;
   behavior->config = config;
-  const auto timeoutMs = static_cast<std::uint32_t>(config.timeoutSeconds) * 1000u;
+  const auto timeoutMs = timeoutSecondsToMilliseconds(config.timeoutSeconds);
   behavior->notification = m_wayland->createIdleNotification(timeoutMs);
   if (behavior->notification == nullptr) {
     kLog.warn("failed to register idle behavior '{}'", config.name);

--- a/src/shell/settings/settings_content_common.cpp
+++ b/src/shell/settings/settings_content_common.cpp
@@ -321,7 +321,9 @@ namespace settings {
     if (row.timeoutSeconds <= 0) {
       return i18n::tr("settings.idle.behavior.summary-disabled-timeout", "name", name);
     }
-    return i18n::tr("settings.idle.behavior.summary", "name", name, "seconds", std::to_string(row.timeoutSeconds));
+    return i18n::tr(
+        "settings.idle.behavior.summary", "name", name, "seconds", StringUtils::formatDotDecimal(row.timeoutSeconds)
+    );
   }
 
   std::string notificationFilterRowSummary(const NotificationFilterConfig& filter) {

--- a/src/shell/settings/settings_content_idle_behavior.cpp
+++ b/src/shell/settings/settings_content_idle_behavior.cpp
@@ -12,13 +12,9 @@
 #include "ui/style.h"
 #include "util/string_utils.h"
 
-#include <cmath>
 #include <cstdint>
-#include <format>
 #include <functional>
 #include <limits>
-#include <memory>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -186,7 +182,7 @@ namespace settings {
     Input* timeoutPtr = nullptr;
     auto timeoutIn = ui::input({
         .out = &timeoutPtr,
-        .value = std::format("{}", row.timeoutSeconds),
+        .value = StringUtils::formatDotDecimal(row.timeoutSeconds),
         .placeholder = "660",
         .fontSize = Style::fontSizeBody * scale,
         .controlHeight = Style::controlHeight * scale,
@@ -194,15 +190,14 @@ namespace settings {
     });
     const auto commitTimeout = [&row, persist, timeoutPtr]() {
       const auto parsed = parseDoubleInput(timeoutPtr->value());
-      if (!parsed.has_value()
-          || *parsed < 0.0
-          || *parsed > static_cast<double>(std::numeric_limits<std::int32_t>::max())) {
+      constexpr double kMaxIdleTimeoutSeconds = static_cast<double>(std::numeric_limits<std::uint32_t>::max()) / 1000.0;
+      if (!parsed.has_value() || *parsed < 0.0 || *parsed > kMaxIdleTimeoutSeconds) {
         timeoutPtr->setInvalid(true);
         return;
       }
-      row.timeoutSeconds = static_cast<std::int32_t>(std::lround(*parsed));
+      row.timeoutSeconds = *parsed;
       timeoutPtr->setInvalid(false);
-      timeoutPtr->setValue(std::format("{}", row.timeoutSeconds));
+      timeoutPtr->setValue(StringUtils::formatDotDecimal(row.timeoutSeconds));
       persist();
     };
     timeoutIn->setOnChange([timeoutPtr](const std::string& /*t*/) { timeoutPtr->setInvalid(false); });


### PR DESCRIPTION
I needed to have an idle behavior with 300ms timeout, i.e. when not idle inhibited anymore.

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration or behavior.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
