### PR TITLE
notification_toast: fix subsecond progress bar timing

### DIFF
--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -91,7 +91,7 @@ namespace {
     if (timeout <= 0) {
       return -1;
     }
-    return std::max(1000, static_cast<int>(timeout));
+    return static_cast<int>(timeout);
   }
   constexpr int kProgressHeight = 3;
   constexpr int kContentSlideOffset = 12; // subtle foreground slide during reveal/retract


### PR DESCRIPTION
The toast progress bar was clamping all positive timeouts to at least 1000ms, while the actual notification expiry used the original timeout.