### PR TITLE
feat(workspaces): add labels option for custom workspace labels

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3029,6 +3029,11 @@
         "workspace-label-placement": {
           "description": "Corner, centered on the edge, or inside the pill.",
           "label": "Workspace Label Placement"
+        },
+        "labels": {
+          "description": "Custom labels for workspaces, indexed by workspace number",
+          "label": "Workspace Labels",
+          "workspaces-description": "Override numeric workspace labels with custom labels. The first entry will be the label for workspace 1, the second entry for workspace 2, and so on."
         }
       },
       "types": {

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -663,6 +663,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     if (wc != nullptr && wc->hasSetting("max_label_chars")) {
       maxLabelChars = static_cast<std::size_t>(wc->getInt("max_label_chars", 1));
     }
+    const std::vector<std::string> labels = wc != nullptr ? wc->getStringList("labels") : std::vector<std::string>{};
     WorkspacesWidget::Options options{
         .displayMode = displayMode,
         .focusedColor = focusedColor,
@@ -675,6 +676,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .activePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("active_pill_size", 2.2) : 2.2),
         .inactivePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("inactive_pill_size", 1.0) : 1.0),
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
+        .labels = labels,
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -46,7 +46,8 @@ WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* outp
       m_hideWhenEmpty(options.hideWhenEmpty), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
-      m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {}
+      m_labels(std::move(options.labels)), m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor),
+      m_emptyColor(options.emptyColor) {}
 
 WorkspacesWidget::DisplayMode WorkspacesWidget::effectiveDisplayMode() const noexcept {
   if (m_minimal && m_displayMode == DisplayMode::None) {
@@ -654,13 +655,18 @@ void WorkspacesWidget::activateAdjacentWorkspace(int direction) {
 std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::size_t displayIndex) const {
   const DisplayMode displayMode = effectiveDisplayMode();
   if (displayMode == DisplayMode::Id) {
+    std::size_t numericIdx = 0;
     if (workspace.index > 0) {
-      return std::to_string(workspace.index);
+      numericIdx = workspace.index;
+    } else if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {
+      numericIdx = *numericId;
+    } else {
+      numericIdx = displayIndex + 1;
     }
-    if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {
-      return std::to_string(*numericId);
+    if (!m_labels.empty() && numericIdx > 0 && numericIdx <= m_labels.size()) {
+      return m_labels[numericIdx - 1];
     }
-    return std::to_string(displayIndex + 1);
+    return std::to_string(numericIdx);
   }
   if (displayMode == DisplayMode::Name) {
     std::string label = !workspace.name.empty() ? workspace.name : workspace.id;

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -35,6 +35,7 @@ public:
     float activePillSize = 2.2f;
     float inactivePillSize = 1.0f;
     bool minimal = false;
+    std::vector<std::string> labels;
   };
 
   WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options);
@@ -99,6 +100,7 @@ private:
   float m_activePillSize = 2.2f;
   float m_inactivePillSize = 1.0f;
   bool m_minimal = false;
+  std::vector<std::string> m_labels;
   Node* m_container = nullptr;
   std::vector<Workspace> m_cachedState;
   std::vector<Item> m_items;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -946,6 +946,12 @@ namespace settings {
         add(std::move(maxLabelChars));
       }
       {
+        auto labels = stringListSpec("labels");
+        labels.descriptionKey = "settings.widgets.settings.labels.workspaces-description";
+        labels.visibleWhen = WidgetSettingVisibility{{"display", {"id"}}};
+        add(std::move(labels));
+      }
+      {
         auto pillScale = doubleSpec("pill_scale", 1.0, 0.1, 1.0, 0.05);
         pillScale.descriptionKey = "settings.widgets.settings.pill-scale.workspaces-description";
         pillScale.visibleWhen = pillStyleOnly;


### PR DESCRIPTION
## Summary

Add a `labels` configuration option to the workspaces widget that maps workspace numbers to custom label strings. When set, the first entry overrides the label for workspace 1, the second for workspace 2, and so on. Workspaces beyond the length of the array fall back to the default display behavior.

The setting is exposed in the noctalia settings UI as an ordered string list, visible when display mode is "id".

## Motivation

This is inspired by waybar's per-workspace icon/name mapping via the `format-icons` map in the Workspaces module, which lets users replace numbered workspace IDs with arbitrary strings such as kanji numerals or application glyphs.

This is not necessary for most window managers, but useful for WMs like mango that don't let the user set workspace names.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

## Testing

I ran noctalia with the commit and tested applying some mappings via settings UI. Everything works as expected. I also ran the test suite, all pass.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Mango
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/7c0ac396-b749-4c15-904b-f7e964e3c43b" />
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/36bde2a0-f64a-40ea-909a-24c2ee9c68ee" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
