### PR TITLE
bar: add 'bar-layer-set' ipc

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1817,6 +1817,9 @@ void Application::initUi() {
   m_panelManager.setAttachedPanelAvailabilityCallback([this](wl_output* output, std::string_view barName) {
     return m_bar.canAttachPanelToBar(output, barName);
   });
+  m_panelManager.setAttachedPanelLayerProvider([this](wl_output* output, std::string_view barName) {
+    return m_bar.layerForBar(output, barName);
+  });
   m_panelManager.setAttachedPanelBarSettledCallback([this](wl_output* output, std::string_view barName) {
     return m_bar.isAttachedPanelBarSettled(output, barName);
   });

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1500,6 +1500,14 @@ bool Bar::canAttachPanelToBar(wl_output* output, std::string_view barName) const
   return instance->barConfig.autoHide || instanceEffectivelyVisible(*instance);
 }
 
+std::optional<std::string> Bar::layerForBar(wl_output* output, std::string_view barName) const noexcept {
+  const BarInstance* instance = instanceForBar(output, barName);
+  if (instance == nullptr || instance->surface == nullptr || !instance->barConfig.enabled) {
+    return std::nullopt;
+  }
+  return instance->barConfig.layer;
+}
+
 bool Bar::isAttachedPanelBarSettled(wl_output* output, std::string_view barName) const noexcept {
   const BarInstance* instance = instanceForBar(output, barName);
   if (instance == nullptr || !instance->barConfig.autoHide) {
@@ -3051,6 +3059,43 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
   return "ok\n";
 }
 
+std::string Bar::setBarLayerIpc(std::string_view args) {
+  const auto parts = StringUtils::splitWhitespace(StringUtils::trim(args));
+  if (parts.empty() || parts.size() > 3) {
+    return "error: usage: bar-layer-set <top|overlay> [bar-name] [monitor-selector]\n";
+  }
+
+  const std::string& layer = parts[0];
+  if (layer != "top" && layer != "overlay") {
+    return "error: invalid layer (use top or overlay)\n";
+  }
+
+  std::optional<std::string_view> barName;
+  std::optional<std::string_view> monitorSelector;
+  if (parts.size() >= 2) {
+    barName = parts[1];
+  }
+  if (parts.size() >= 3) {
+    monitorSelector = parts[2];
+  }
+
+  std::vector<BarInstance*> targets;
+  if (const auto collectError = collectBarIpcInstances(barName, monitorSelector, targets)) {
+    return *collectError;
+  }
+
+  const LayerShellLayer shellLayer = layerShellLayerFromConfig(layer);
+  for (BarInstance* instance : targets) {
+    if (instance == nullptr || instance->surface == nullptr) {
+      continue;
+    }
+    instance->surface->setLayer(shellLayer);
+    instance->barConfig.layer = layer;
+  }
+
+  return "ok\n";
+}
+
 void Bar::registerIpc(IpcService& ipc) {
   ipc.registerHandler(
       "bar-show", [this](const std::string& args) -> std::string { return showBarIpc(args); },
@@ -3070,5 +3115,10 @@ void Bar::registerIpc(IpcService& ipc) {
   ipc.registerHandler(
       "bar-auto-hide-set", [this](const std::string& args) -> std::string { return setBarAutoHideIpc(args); },
       "bar-auto-hide-set <on|off|true|false|1|0> [bar-name] [monitor-selector]", "Set auto-hide state for a bar"
+  );
+
+  ipc.registerHandler(
+      "bar-layer-set", [this](const std::string& args) -> std::string { return setBarLayerIpc(args); },
+      "bar-layer-set <top|overlay> [bar-name] [monitor-selector]", "Set one or all bar layers"
   );
 }

--- a/src/shell/bar/bar.h
+++ b/src/shell/bar/bar.h
@@ -89,6 +89,7 @@ public:
   void
   setAttachedPanelGeometry(wl_output* output, std::string_view barName, std::optional<AttachedPanelGeometry> geometry);
   [[nodiscard]] bool canAttachPanelToBar(wl_output* output, std::string_view barName) const noexcept;
+  [[nodiscard]] std::optional<std::string> layerForBar(wl_output* output, std::string_view barName) const noexcept;
   // True when an attached panel may start its reveal animation: non-autohide bars, or autohide
   // bars that have finished sliding into their resting position.
   [[nodiscard]] bool isAttachedPanelBarSettled(wl_output* output, std::string_view barName) const noexcept;
@@ -132,6 +133,7 @@ private:
   [[nodiscard]] std::string hideBarIpc(std::string_view args);
   [[nodiscard]] std::string toggleBarIpc(std::string_view args);
   [[nodiscard]] std::string setBarAutoHideIpc(std::string_view args);
+  [[nodiscard]] std::string setBarLayerIpc(std::string_view args);
   [[nodiscard]] std::optional<std::string> collectBarIpcInstances(
       std::optional<std::string_view> barName, std::optional<std::string_view> monitorSelector,
       std::vector<BarInstance*>& instancesOut

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -300,6 +300,12 @@ void PanelManager::setAttachedPanelAvailabilityCallback(std::function<bool(wl_ou
   m_attachedPanelAvailabilityCallback = std::move(callback);
 }
 
+void PanelManager::setAttachedPanelLayerProvider(
+    std::function<std::optional<std::string>(wl_output*, std::string_view)> provider
+) {
+  m_attachedPanelLayerProvider = std::move(provider);
+}
+
 void PanelManager::setAttachedPanelBarSettledCallback(std::function<bool(wl_output*, std::string_view)> callback) {
   m_attachedPanelBarSettledCallback = std::move(callback);
 }
@@ -350,8 +356,13 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
 
   const auto panelWidth = static_cast<std::uint32_t>(m_activePanel->preferredWidth());
   const auto panelHeight = static_cast<std::uint32_t>(m_activePanel->preferredHeight());
-  const auto barConfig = resolvePanelBarConfig(m_config, m_platform, request.output, request.sourceBarName);
+  auto barConfig = resolvePanelBarConfig(m_config, m_platform, request.output, request.sourceBarName);
   m_sourceBarName = request.sourceBarName.empty() ? barConfig.name : std::string(request.sourceBarName);
+  if (m_attachedPanelLayerProvider != nullptr) {
+    if (auto layer = m_attachedPanelLayerProvider(request.output, m_sourceBarName); layer.has_value()) {
+      barConfig.layer = *layer;
+    }
+  }
   const bool isBottom = barConfig.position == "bottom";
   const bool isLeft = barConfig.position == "left";
   const bool isRight = barConfig.position == "right";

--- a/src/shell/panel/panel_manager.h
+++ b/src/shell/panel/panel_manager.h
@@ -79,6 +79,7 @@ public:
   void setPanelClosedCallback(std::function<void()> callback);
   void setPanelOpenedCallback(std::function<void()> callback);
   void setAttachedPanelAvailabilityCallback(std::function<bool(wl_output*, std::string_view)> callback);
+  void setAttachedPanelLayerProvider(std::function<std::optional<std::string>(wl_output*, std::string_view)> provider);
   void setAttachedPanelBarSettledCallback(std::function<bool(wl_output*, std::string_view)> callback);
   // Called when an auto-hide bar finishes revealing for an attached panel open.
   void onAttachedBarRevealSettled(wl_output* output, std::string_view barName);
@@ -180,6 +181,7 @@ private:
   std::function<void()> m_panelClosedCallback;
   std::function<void()> m_panelOpenedCallback;
   std::function<bool(wl_output*, std::string_view)> m_attachedPanelAvailabilityCallback;
+  std::function<std::optional<std::string>(wl_output*, std::string_view)> m_attachedPanelLayerProvider;
   std::function<bool(wl_output*, std::string_view)> m_attachedPanelBarSettledCallback;
   PanelClickShield m_clickShield;
   std::unique_ptr<FocusGrab> m_focusGrab;

--- a/src/wayland/layer_surface.cpp
+++ b/src/wayland/layer_surface.cpp
@@ -164,6 +164,18 @@ void LayerSurface::requestSize(std::uint32_t width, std::uint32_t height) {
   wl_surface_commit(m_surface);
 }
 
+void LayerSurface::setLayer(LayerShellLayer layer) {
+  if (m_config.layer == layer) {
+    return;
+  }
+  m_config.layer = layer;
+  if (m_layerSurface == nullptr || m_surface == nullptr) {
+    return;
+  }
+  zwlr_layer_surface_v1_set_layer(m_layerSurface, static_cast<std::uint32_t>(layer));
+  wl_surface_commit(m_surface);
+}
+
 void LayerSurface::setMargins(std::int32_t top, std::int32_t right, std::int32_t bottom, std::int32_t left) {
   m_config.marginTop = top;
   m_config.marginRight = right;

--- a/src/wayland/layer_surface.h
+++ b/src/wayland/layer_surface.h
@@ -60,6 +60,7 @@ public:
   // Requests a new surface size from the compositor. The compositor will
   // respond with a configure event, which triggers the configure callback.
   void requestSize(std::uint32_t width, std::uint32_t height);
+  void setLayer(LayerShellLayer layer);
   void setMargins(std::int32_t top, std::int32_t right, std::int32_t bottom, std::int32_t left);
   void setExclusiveZone(std::int32_t exclusiveZone);
   void setClickThrough(bool clickThrough);


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland
- [x] Tested with multiple bars

## Checklist
- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional notes
You may find this hyprland config for peeking a bar behind a fullscreen window useful:
```lua
hl.bind("SUPER_L", hl.dsp.exec_cmd("noctalia msg bar-layer-set overlay"))
hl.bind("SUPER + SUPER_L", hl.dsp.exec_cmd("noctalia msg bar-layer-set top"), { release = true, transparent = true })
```