### PR TITLE
fix(session): wait for lock screen to render before suspending

### DIFF
--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -457,6 +457,9 @@ bool LockScreen::shouldUseBlurredDesktop() const {
 }
 
 bool LockScreen::allSurfacesReady() const {
+  if (m_instances.empty()) {
+    return false;
+  }
   for (const auto& instance : m_instances) {
     if (instance.surface != nullptr && !instance.surface->firstFrameRendered()) {
       return false;

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -152,6 +152,7 @@ void LockScreen::unlock() {
   }
 
   m_pendingAfterLocked = {};
+  m_suspendTimeoutTimer.stop();
   invalidatePendingAuthentication();
   stopFingerprint();
 
@@ -350,15 +351,25 @@ bool LockScreen::isActive() const noexcept { return m_lockPending || m_locked; }
 
 bool LockScreen::isSessionLocked() const noexcept { return m_locked; }
 
+bool LockScreen::tryFlushPendingAfterLocked() {
+  if (m_locked && m_pendingAfterLocked && allSurfacesReady()) {
+    auto pending = std::move(m_pendingAfterLocked);
+    m_pendingAfterLocked = {};
+    m_suspendTimeoutTimer.stop();
+    DeferredCall::callLater(std::move(pending));
+    return true;
+  }
+  return false;
+}
+
 void LockScreen::runAfterSessionLocked(std::function<void()> fn) {
   if (fn == nullptr) {
     return;
   }
-  if (m_locked && allSurfacesReady()) {
-    DeferredCall::callLater(std::move(fn));
+  m_pendingAfterLocked = std::move(fn);
+  if (tryFlushPendingAfterLocked()) {
     return;
   }
-  m_pendingAfterLocked = std::move(fn);
   if (isActive()) {
     return;
   }
@@ -382,17 +393,24 @@ void LockScreen::handleLocked(void* data, ext_session_lock_v1* /*lock*/) {
     instance.surface->setLockedState(true);
     instance.surface->setOnLogin([self]() { self->tryAuthenticate(); });
   }
+
+  // Start the fallback timer (3 seconds) to trigger suspend anyway if surfaces take too long to render
+  self->m_suspendTimeoutTimer.start(std::chrono::seconds(3), [self]() {
+    if (self->m_pendingAfterLocked) {
+      kLog.warn("Lock screen surfaces took too long to render; suspending fallback triggered");
+      auto pending = std::move(self->m_pendingAfterLocked);
+      self->m_pendingAfterLocked = {};
+      DeferredCall::callLater(std::move(pending));
+    }
+  });
+
   self->updatePromptOnSurfaces();
   self->startFingerprint();
   kLog.info("session is locked");
   if (self->m_onSessionLocked) {
     self->m_onSessionLocked();
   }
-  if (self->m_pendingAfterLocked && self->allSurfacesReady()) {
-    auto pending = std::move(self->m_pendingAfterLocked);
-    self->m_pendingAfterLocked = {};
-    DeferredCall::callLater(std::move(pending));
-  }
+  self->tryFlushPendingAfterLocked();
 }
 
 void LockScreen::handleFinished(void* data, ext_session_lock_v1* /*lock*/) {
@@ -621,13 +639,7 @@ void LockScreen::createInstance(const WaylandOutput& output) {
     surface->setDesktopCapture(std::move(captureIt->second));
     m_desktopCaptures.erase(captureIt);
   }
-  surface->setRenderCallback([this]() {
-    if (m_locked && m_pendingAfterLocked && allSurfacesReady()) {
-      auto pending = std::move(m_pendingAfterLocked);
-      m_pendingAfterLocked = {};
-      DeferredCall::callLater(std::move(pending));
-    }
-  });
+  surface->setRenderCallback([this]() { tryFlushPendingAfterLocked(); });
   surface->setOnLogin([this]() { tryAuthenticate(); });
   surface->setOnPasswordChanged([this](const std::string& value) { handlePasswordEdited(value); });
   surface->setPromptState(m_user, m_password, m_status, m_statusIsError, m_authenticating);
@@ -651,6 +663,7 @@ void LockScreen::createInstance(const WaylandOutput& output) {
 
 void LockScreen::resetLockState() {
   m_pendingAfterLocked = {};
+  m_suspendTimeoutTimer.stop();
   m_lockDeferred = false;
   if (m_lock == nullptr) {
     m_lockPending = false;

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -354,7 +354,7 @@ void LockScreen::runAfterSessionLocked(std::function<void()> fn) {
   if (fn == nullptr) {
     return;
   }
-  if (m_locked) {
+  if (m_locked && allSurfacesReady()) {
     DeferredCall::callLater(std::move(fn));
     return;
   }
@@ -388,7 +388,7 @@ void LockScreen::handleLocked(void* data, ext_session_lock_v1* /*lock*/) {
   if (self->m_onSessionLocked) {
     self->m_onSessionLocked();
   }
-  if (self->m_pendingAfterLocked) {
+  if (self->m_pendingAfterLocked && self->allSurfacesReady()) {
     auto pending = std::move(self->m_pendingAfterLocked);
     self->m_pendingAfterLocked = {};
     DeferredCall::callLater(std::move(pending));
@@ -454,6 +454,15 @@ bool LockScreen::shouldUseBlurredDesktop() const {
       && m_configService->config().lockscreen.blurredDesktop
       && m_wayland != nullptr
       && m_wayland->hasScreencopy();
+}
+
+bool LockScreen::allSurfacesReady() const {
+  for (const auto& instance : m_instances) {
+    if (instance.surface != nullptr && !instance.surface->firstFrameRendered()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 void LockScreen::primeDesktopCaptures() {
@@ -609,6 +618,13 @@ void LockScreen::createInstance(const WaylandOutput& output) {
     surface->setDesktopCapture(std::move(captureIt->second));
     m_desktopCaptures.erase(captureIt);
   }
+  surface->setRenderCallback([this]() {
+    if (m_locked && m_pendingAfterLocked && allSurfacesReady()) {
+      auto pending = std::move(m_pendingAfterLocked);
+      m_pendingAfterLocked = {};
+      DeferredCall::callLater(std::move(pending));
+    }
+  });
   surface->setOnLogin([this]() { tryAuthenticate(); });
   surface->setOnPasswordChanged([this](const std::string& value) { handlePasswordEdited(value); });
   surface->setPromptState(m_user, m_password, m_status, m_statusIsError, m_authenticating);

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -2,6 +2,7 @@
 
 #include "auth/pam_authenticator.h"
 #include "capture/screencopy_capture.h"
+#include "core/timer_manager.h"
 
 #include <cstdint>
 #include <functional>
@@ -82,6 +83,7 @@ private:
   void captureDesktopSnapshots();
   [[nodiscard]] bool shouldUseBlurredDesktop() const;
   [[nodiscard]] bool allSurfacesReady() const;
+  bool tryFlushPendingAfterLocked();
   void applyLockscreenStyle(LockSurface& surface) const;
   void applyOutputRestriction();
   void applyWallpaperStyleToSurfaces();
@@ -125,4 +127,5 @@ private:
   std::function<void()> m_onSessionLocked;
   std::function<void()> m_onSessionUnlocked;
   std::function<void()> m_onLockEngaged;
+  Timer m_suspendTimeoutTimer;
 };

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -81,6 +81,7 @@ private:
   void syncInstances();
   void captureDesktopSnapshots();
   [[nodiscard]] bool shouldUseBlurredDesktop() const;
+  [[nodiscard]] bool allSurfacesReady() const;
   void applyLockscreenStyle(LockSurface& surface) const;
   void applyOutputRestriction();
   void applyWallpaperStyleToSurfaces();

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -406,7 +406,9 @@ void LockSurface::handleConfigure(
     std::uint32_t height
 ) {
   auto* self = static_cast<LockSurface*>(data);
-  self->m_firstFrameRendered = false;
+  if (self->width() != width || self->height() != height) {
+    self->m_firstFrameRendered = false;
+  }
   ext_session_lock_surface_v1_ack_configure(lockSurface, serial);
   self->Surface::onConfigure(width, height);
 }

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -833,8 +833,10 @@ void LockSurface::onGpuResourcesInvalidated() {
 
 void LockSurface::render() {
   Surface::render();
-  m_firstFrameRendered = true;
-  if (m_renderCallback) {
-    m_renderCallback();
+  if (!m_firstFrameRendered) {
+    m_firstFrameRendered = true;
+    if (m_renderCallback) {
+      m_renderCallback();
+    }
   }
 }

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -830,3 +830,11 @@ void LockSurface::onGpuResourcesInvalidated() {
   m_wallpaperDirty = true;
   requestLayout();
 }
+
+void LockSurface::render() {
+  Surface::render();
+  m_firstFrameRendered = true;
+  if (m_renderCallback) {
+    m_renderCallback();
+  }
+}

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -406,6 +406,7 @@ void LockSurface::handleConfigure(
     std::uint32_t height
 ) {
   auto* self = static_cast<LockSurface*>(data);
+  self->m_firstFrameRendered = false;
   ext_session_lock_surface_v1_ack_configure(lockSurface, serial);
   self->Surface::onConfigure(width, height);
 }

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -70,9 +70,11 @@ public:
       std::uint32_t height
   );
 
+protected:
+  void render() override;
+
 private:
   void prepareFrame(bool needsUpdate, bool needsLayout);
-  void render() override;
   void applyWallpaperTexture();
   void applyBlurredDesktopTexture();
   void releaseWallpaperTextureRef(const std::string& path);

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -62,6 +62,9 @@ public:
   void setOutputKey(std::string outputKey) { m_outputKey = std::move(outputKey); }
   void setWidgetsHost(LockscreenWidgetsHost* host) noexcept { m_widgetsHost = host; }
 
+  [[nodiscard]] bool firstFrameRendered() const noexcept { return m_firstFrameRendered; }
+  void setRenderCallback(std::function<void()> callback) { m_renderCallback = std::move(callback); }
+
   static void handleConfigure(
       void* data, ext_session_lock_surface_v1* lockSurface, std::uint32_t serial, std::uint32_t width,
       std::uint32_t height
@@ -69,6 +72,7 @@ public:
 
 private:
   void prepareFrame(bool needsUpdate, bool needsLayout);
+  void render() override;
   void applyWallpaperTexture();
   void applyBlurredDesktopTexture();
   void releaseWallpaperTextureRef(const std::string& path);
@@ -119,4 +123,6 @@ private:
   bool m_authenticating = false;
   std::string m_outputKey;
   LockscreenWidgetsHost* m_widgetsHost = nullptr;
+  bool m_firstFrameRendered = false;
+  std::function<void()> m_renderCallback;
 };


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This PR ensures that the deferred suspend command is executed only after all active lock screen surfaces have successfully drawn and committed their first frame. 

- Overrode `render()` in `LockSurface` to track when `m_firstFrameRendered` is set to `true` and trigger a render callback.
- Added `allSurfacesReady()` in `LockScreen` to verify if all output surfaces have completed their first render.
- Updated `runAfterSessionLocked` and `handleLocked` to defer execution of the pending suspend callback until `allSurfacesReady()` is true.

## Motivation

This resolves a race condition where the system suspends before the lock screen has finished rendering. When resuming, the unlocked desktop could briefly flash or remain visible, presenting a security vulnerability and visual glitch.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #2962

## Testing

Built the daemon and ran the entire test suite:
meson compile -C build
meson test -C build
All tests pass successfully.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

If a lock surface fails to configure or render due to driver glitches or compositor-specific edge cases, the suspend sequence could get indefinitely postponed. I sugest adding a 2-3 second fallback timer to trigger suspend regardless of render status.