### PR TITLE
feat(workspace): add workspace alert IPC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -753,6 +753,7 @@ _noctalia_sources = files(
   'src/wayland/text_input_service.cpp',
   'src/wayland/virtual_keyboard_service.cpp',
   'src/compositors/compositor_platform.cpp',
+  'src/compositors/workspace_alert_service.cpp',
   'src/compositors/compositor_detect.cpp',
   'src/compositors/compositor_runtime.cpp',
   'src/compositors/dwl/dwl_workspace_backend.cpp',
@@ -938,6 +939,16 @@ notification_filter_test = executable('notification_filter_test',
 )
 
 test('notification_filter', notification_filter_test)
+
+workspace_alert_service_test = executable('workspace_alert_service_test',
+  sources: files(
+    'tests/workspace_alert_service_test.cpp',
+    'src/compositors/workspace_alert_service.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('workspace_alert_service', workspace_alert_service_test)
 
 animation_manager_test = executable('animation_manager_test',
   sources: files(

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -717,7 +717,16 @@ void Application::initServices() {
       m_panelManager.refresh();
     }
   });
+  m_compositorPlatform.setWorkspaceAlertService(&m_workspaceAlertService);
   m_compositorPlatform.setWorkspaceChangeCallback([this]() {
+    // Clear alerts for the workspace the user just switched to. Limit to the
+    // focused output so activity on one monitor doesn't dismiss alerts on
+    // another; fall back to all outputs when no focused output is known.
+    if (wl_output* output = m_compositorPlatform.preferredInteractiveOutput(); output != nullptr) {
+      (void)m_compositorPlatform.clearActiveWorkspaceAlerts(output);
+    } else {
+      (void)m_compositorPlatform.clearActiveWorkspaceAlerts();
+    }
     m_bar.refresh();
     m_windowSwitcher.onToplevelChange();
   });
@@ -2191,6 +2200,87 @@ void Application::initIpc() {
         return "ok\n";
       },
       "dpms-off", "Turn monitors off"
+  );
+
+  auto workspaceAlertStatus = [this]() {
+    const auto tokens = m_workspaceAlertService.tokens();
+    if (tokens.empty()) {
+      return std::string{"(no workspace alerts)\n"};
+    }
+    return StringUtils::join(tokens, "\n") + "\n";
+  };
+
+  m_ipcService.registerHandler(
+      "workspace-alert-add",
+      [this](const std::string& args) -> std::string {
+        const std::string workspace = StringUtils::trim(args);
+        if (workspace.empty()) {
+          return "error: workspace-alert-add requires <workspace>\n";
+        }
+        if (!m_compositorPlatform.isKnownWorkspaceAlertKey(workspace)) {
+          return "error: unknown workspace '" + workspace + "'\n";
+        }
+        // Store unconditionally. The overlay only marks inactive rows, so
+        // alerting the active workspace simply shows once the user leaves it and
+        // auto-clears on return; on per-output compositors this also lets an
+        // inactive duplicate alert even when the same workspace is active elsewhere.
+        (void)m_workspaceAlertService.add(workspace);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-add <workspace>", "Add a workspace alert (by number, name, or id)"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-add-window",
+      [this](const std::string& args) -> std::string {
+        const auto parts = noctalia::ipc::splitWords(args);
+        if (parts.size() != 1) {
+          return "error: workspace-alert-add-window requires <window-id>\n";
+        }
+        const auto workspace = m_compositorPlatform.workspaceAlertKeyForWindow(parts[0]);
+        if (!workspace.has_value()) {
+          return "error: could not resolve workspace for window id '" + parts[0] + "'\n";
+        }
+        (void)m_workspaceAlertService.add(*workspace);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-add-window <window-id>", "Add a workspace alert for a window"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-clear",
+      [this](const std::string& args) -> std::string {
+        const std::string workspace = StringUtils::trim(args);
+        if (workspace.empty()) {
+          return "error: workspace-alert-clear requires <workspace>\n";
+        }
+        (void)m_workspaceAlertService.clear(workspace);
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-clear <workspace>", "Clear a workspace alert"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-clear-all",
+      [this](const std::string& args) -> std::string {
+        if (!noctalia::ipc::splitWords(args).empty()) {
+          return "error: workspace-alert-clear-all takes no arguments\n";
+        }
+        m_workspaceAlertService.clearAll();
+        m_bar.refresh();
+        return "ok\n";
+      },
+      "workspace-alert-clear-all", "Clear all workspace alerts"
+  );
+  m_ipcService.registerHandler(
+      "workspace-alert-status",
+      [workspaceAlertStatus](const std::string& args) -> std::string {
+        if (!noctalia::ipc::splitWords(args).empty()) {
+          return "error: workspace-alert-status takes no arguments\n";
+        }
+        return workspaceAlertStatus();
+      },
+      "workspace-alert-status", "Print workspace alerts"
   );
 
   registerSessionIpc(m_ipcService, m_sessionActionRunner, m_lockScreen, m_configService);

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -7,6 +7,7 @@
 #include "calendar/calendar_service.h"
 #include "capture/screenshot_service.h"
 #include "compositors/compositor_platform.h"
+#include "compositors/workspace_alert_service.h"
 #include "config/config_poll_source.h"
 #include "config/config_service.h"
 #include "core/file_watcher.h"
@@ -168,6 +169,7 @@ private:
   [[nodiscard]] std::vector<PollSource*> buildPollSources();
 
   WaylandConnection m_wayland;
+  WorkspaceAlertService m_workspaceAlertService;
   CompositorPlatform m_compositorPlatform{m_wayland};
   ClipboardService m_clipboardService;
   TextInputService m_textInputService;

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -22,6 +22,7 @@
 #include "compositors/triad/triad_output_backend.h"
 #include "compositors/triad/triad_runtime.h"
 #include "compositors/triad/triad_workspace_backend.h"
+#include "compositors/workspace_alert_service.h"
 #include "core/log.h"
 #include "core/process.h"
 #include "dbus/session_bus.h"
@@ -1042,6 +1043,9 @@ std::vector<Workspace> CompositorPlatform::workspaces() const {
   if (compositors::isKde() && m_kwinActiveWindow != nullptr && m_kwinActiveWindow->isAvailable()) {
     applyKdeWorkspaceOccupancy(current, m_kwinActiveWindow->trackedWorkspaceWindows(), {});
   }
+  if (m_workspaceAlertService != nullptr) {
+    m_workspaceAlertService->applyOverlay(current);
+  }
   return current;
 }
 
@@ -1053,7 +1057,79 @@ std::vector<Workspace> CompositorPlatform::workspaces(wl_output* output) const {
   if (compositors::isKde() && m_kwinActiveWindow != nullptr && m_kwinActiveWindow->isAvailable()) {
     applyKdeWorkspaceOccupancy(current, m_kwinActiveWindow->trackedWorkspaceWindows(), connectorNameForOutput(output));
   }
+  if (m_workspaceAlertService != nullptr) {
+    m_workspaceAlertService->applyOverlay(current);
+  }
   return current;
+}
+
+void CompositorPlatform::setWorkspaceAlertService(WorkspaceAlertService* service) noexcept {
+  m_workspaceAlertService = service;
+}
+
+bool CompositorPlatform::isKnownWorkspaceAlertKey(std::string_view workspaceId) const {
+  if (workspaceId.empty()) {
+    return false;
+  }
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return WorkspaceAlertService::isKnownWorkspaceToken(workspaceId, workspaces());
+  }
+  for (const auto& output : outputs) {
+    if (WorkspaceAlertService::isKnownWorkspaceToken(workspaceId, workspaces(output.output))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<std::string> CompositorPlatform::workspaceAlertKeyForWindow(std::string_view windowId) const {
+  if (windowId.empty()) {
+    return std::nullopt;
+  }
+  // The assignment key is the backend's own workspace handle; the alert overlay
+  // matches it against a workspace's id/name/index, so store it directly once
+  // it resolves to a current workspace.
+  const auto resolveForOutput = [this, windowId](wl_output* output) -> std::optional<std::string> {
+    const auto token = WorkspaceAlertService::workspaceTokenForWindow(windowId, workspaceWindowAssignments(output));
+    if (token.has_value() && WorkspaceAlertService::isKnownWorkspaceToken(*token, workspaces(output))) {
+      return token;
+    }
+    return std::nullopt;
+  };
+
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return resolveForOutput(nullptr);
+  }
+  for (const auto& output : outputs) {
+    if (auto token = resolveForOutput(output.output); token.has_value()) {
+      return token;
+    }
+  }
+  return std::nullopt;
+}
+
+std::size_t CompositorPlatform::clearActiveWorkspaceAlerts(wl_output* output) {
+  if (m_workspaceAlertService == nullptr || m_workspaceAlertService->empty()) {
+    return 0;
+  }
+  return m_workspaceAlertService->clearActive(workspaces(output));
+}
+
+std::size_t CompositorPlatform::clearActiveWorkspaceAlerts() {
+  if (m_workspaceAlertService == nullptr || m_workspaceAlertService->empty()) {
+    return 0;
+  }
+  std::size_t cleared = 0;
+  const auto& outputs = m_wayland.outputs();
+  if (outputs.empty()) {
+    return m_workspaceAlertService->clearActive(workspaces());
+  }
+  for (const auto& output : outputs) {
+    cleared += m_workspaceAlertService->clearActive(workspaces(output.output));
+  }
+  return cleared;
 }
 
 std::unordered_map<std::string, std::vector<std::string>>

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <poll.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -42,14 +43,7 @@ namespace compositors {
   }
 } // namespace compositors
 
-struct WorkspaceWindowAssignment {
-  std::string windowId;
-  std::string workspaceKey;
-  std::string appId;
-  std::string title;
-  std::int32_t x = 0;
-  std::int32_t y = 0;
-};
+class WorkspaceAlertService;
 
 class CompositorPlatform {
 public:
@@ -127,6 +121,14 @@ public:
   [[nodiscard]] std::vector<std::string> workspaceDisplayKeys(wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<WorkspaceWindowAssignment>
   workspaceWindowAssignments(wl_output* outputFilter = nullptr) const;
+
+  // Workspace alerts: user-requested "attention" markers overlaid onto the
+  // workspace model by reusing Workspace::id (no new per-backend identifier).
+  void setWorkspaceAlertService(WorkspaceAlertService* service) noexcept;
+  [[nodiscard]] bool isKnownWorkspaceAlertKey(std::string_view workspaceId) const;
+  [[nodiscard]] std::optional<std::string> workspaceAlertKeyForWindow(std::string_view windowId) const;
+  [[nodiscard]] std::size_t clearActiveWorkspaceAlerts(wl_output* output);
+  [[nodiscard]] std::size_t clearActiveWorkspaceAlerts();
   [[nodiscard]] TaskbarAssignmentMode taskbarAssignmentMode() const noexcept;
   [[nodiscard]] bool supportsTaskbarWorkspaceGrouping() const noexcept;
   [[nodiscard]] std::unordered_map<std::uintptr_t, WorkspaceWindow>
@@ -174,6 +176,7 @@ private:
   );
 
   WaylandConnection& m_wayland;
+  WorkspaceAlertService* m_workspaceAlertService = nullptr;
   std::unique_ptr<compositors::CompositorRuntimeRegistry> m_runtimeRegistry;
   std::unique_ptr<WaylandWorkspaces> m_workspaces;
   std::unique_ptr<compositors::WorkspaceMetadataBackend> m_workspaceMetadataBackend;

--- a/src/compositors/workspace_alert_service.cpp
+++ b/src/compositors/workspace_alert_service.cpp
@@ -1,0 +1,113 @@
+#include "compositors/workspace_alert_service.h"
+
+#include <algorithm>
+#include <string>
+
+namespace {
+
+  // A token matches a workspace if it equals any of the workspace's
+  // user-addressable identifiers. Backends populate different ones, so all
+  // three are considered (empty/zero values never match).
+  bool identifierMatches(const Workspace& workspace, std::string_view token) {
+    return (!workspace.id.empty() && workspace.id == token)
+        || (!workspace.name.empty() && workspace.name == token)
+        || (workspace.index > 0 && std::to_string(workspace.index) == token);
+  }
+
+} // namespace
+
+bool WorkspaceAlertService::add(std::string_view token) {
+  if (token.empty()) {
+    return false;
+  }
+  return m_alerts.emplace(std::string{token}).second;
+}
+
+bool WorkspaceAlertService::clear(std::string_view token) {
+  if (token.empty()) {
+    return false;
+  }
+  const auto it = m_alerts.find(token);
+  if (it == m_alerts.end()) {
+    return false;
+  }
+  m_alerts.erase(it);
+  return true;
+}
+
+void WorkspaceAlertService::clearAll() { m_alerts.clear(); }
+
+bool WorkspaceAlertService::contains(std::string_view token) const {
+  return !token.empty() && m_alerts.contains(token);
+}
+
+bool WorkspaceAlertService::empty() const noexcept { return m_alerts.empty(); }
+
+std::vector<std::string> WorkspaceAlertService::tokens() const {
+  return {m_alerts.begin(), m_alerts.end()};
+}
+
+bool WorkspaceAlertService::isAlerted(const Workspace& workspace) const {
+  return (!workspace.id.empty() && m_alerts.contains(workspace.id))
+      || (!workspace.name.empty() && m_alerts.contains(workspace.name))
+      || (workspace.index > 0 && m_alerts.contains(std::to_string(workspace.index)));
+}
+
+void WorkspaceAlertService::applyOverlay(std::vector<Workspace>& workspaces) const {
+  if (m_alerts.empty()) {
+    return;
+  }
+  for (auto& workspace : workspaces) {
+    if (!workspace.active && isAlerted(workspace)) {
+      workspace.urgent = true;
+    }
+  }
+}
+
+std::size_t WorkspaceAlertService::clearActive(const std::vector<Workspace>& workspaces) {
+  if (m_alerts.empty()) {
+    return 0;
+  }
+  std::size_t cleared = 0;
+  for (const auto& workspace : workspaces) {
+    if (!workspace.active) {
+      continue;
+    }
+    // Remove whichever token form the user supplied for this workspace.
+    if (!workspace.id.empty() && clear(workspace.id)) {
+      ++cleared;
+    }
+    if (!workspace.name.empty() && clear(workspace.name)) {
+      ++cleared;
+    }
+    if (workspace.index > 0 && clear(std::to_string(workspace.index))) {
+      ++cleared;
+    }
+  }
+  return cleared;
+}
+
+bool WorkspaceAlertService::isKnownWorkspaceToken(
+    std::string_view token, const std::vector<Workspace>& workspaces
+) {
+  if (token.empty()) {
+    return false;
+  }
+  return std::any_of(workspaces.begin(), workspaces.end(), [&](const Workspace& workspace) {
+    return identifierMatches(workspace, token);
+  });
+}
+
+std::optional<std::string> WorkspaceAlertService::workspaceTokenForWindow(
+    std::string_view windowId, const std::vector<WorkspaceWindowAssignment>& assignments
+) {
+  if (windowId.empty()) {
+    return std::nullopt;
+  }
+  for (const auto& assignment : assignments) {
+    if (assignment.windowId == windowId && !assignment.workspaceKey.empty()) {
+      return assignment.workspaceKey;
+    }
+  }
+  return std::nullopt;
+}

--- a/src/compositors/workspace_alert_service.h
+++ b/src/compositors/workspace_alert_service.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "compositors/workspace_backend.h"
+
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Tracks user-requested "alert" markers for workspaces. An alert is stored as
+// the token the user supplied and matched against a workspace's user-
+// addressable identifiers -- its id, its name, or its visible index -- because
+// different compositors populate different ones (niri only sets the visible
+// index; Sway uses the name as the id; tag compositors use the numeric id).
+// Alerts are surfaced by reusing the workspace urgent flag, so the feature
+// needs no new per-backend identifier.
+//
+// Note: none of these identifiers is guaranteed unique across outputs on
+// compositors that number workspaces per monitor (niri index, mango/dwl tags),
+// so an alert there applies to the matching workspace on every output.
+class WorkspaceAlertService {
+public:
+  [[nodiscard]] bool add(std::string_view token);
+  [[nodiscard]] bool clear(std::string_view token);
+  void clearAll();
+
+  [[nodiscard]] bool contains(std::string_view token) const;
+  [[nodiscard]] bool empty() const noexcept;
+  [[nodiscard]] std::vector<std::string> tokens() const;
+
+  void applyOverlay(std::vector<Workspace>& workspaces) const;
+  [[nodiscard]] std::size_t clearActive(const std::vector<Workspace>& workspaces);
+
+  [[nodiscard]] static bool isKnownWorkspaceToken(
+      std::string_view token, const std::vector<Workspace>& workspaces
+  );
+  [[nodiscard]] static std::optional<std::string> workspaceTokenForWindow(
+      std::string_view windowId, const std::vector<WorkspaceWindowAssignment>& assignments
+  );
+
+private:
+  [[nodiscard]] bool isAlerted(const Workspace& workspace) const;
+
+  std::set<std::string, std::less<>> m_alerts;
+};

--- a/src/compositors/workspace_backend.h
+++ b/src/compositors/workspace_backend.h
@@ -32,6 +32,15 @@ struct WorkspaceWindow {
   std::string outputName;
 };
 
+struct WorkspaceWindowAssignment {
+  std::string windowId;
+  std::string workspaceKey;
+  std::string appId;
+  std::string title;
+  std::int32_t x = 0;
+  std::int32_t y = 0;
+};
+
 struct TaskbarWindowCandidate {
   std::uintptr_t handleKey = 0;
   std::vector<std::string> appIds;

--- a/tests/workspace_alert_service_test.cpp
+++ b/tests/workspace_alert_service_test.cpp
@@ -1,0 +1,120 @@
+#include "compositors/workspace_alert_service.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+  bool check(bool cond, const char* msg) {
+    if (!cond) {
+      std::cerr << "FAIL: " << msg << '\n';
+    }
+    return cond;
+  }
+
+  // Mixed identifier shapes: numbered rows (id == name == index), a Sway-style
+  // named row (id == name, no numeric index), and a niri-style row that only
+  // carries a visible index (id and name empty).
+  std::vector<Workspace> sampleWorkspaces() {
+    return {
+        Workspace{.id = "1", .name = "1", .index = 1, .active = false, .urgent = false, .occupied = true},
+        Workspace{.id = "2", .name = "2", .index = 2, .active = false, .urgent = false, .occupied = true},
+        Workspace{.id = "3", .name = "3", .index = 3, .active = true, .urgent = false, .occupied = true},
+        Workspace{.id = "web", .name = "web", .index = 0, .active = false, .urgent = true, .occupied = true},
+        Workspace{.id = "", .name = "", .index = 5, .active = false, .urgent = false, .occupied = true},
+    };
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  WorkspaceAlertService service;
+  ok &= check(service.empty(), "new service is empty");
+  ok &= check(service.clearActive(sampleWorkspaces()) == 0, "empty service clearActive is a no-op");
+  ok &= check(service.add("2"), "add returns true for new token");
+  ok &= check(!service.add("2"), "duplicate add returns false");
+  ok &= check(!service.add(""), "empty add is rejected");
+  ok &= check(service.contains("2"), "contains added token");
+
+  auto overlaid = sampleWorkspaces();
+  service.applyOverlay(overlaid);
+  ok &= check(overlaid[1].urgent, "overlay marks non-active alerted workspace urgent");
+  ok &= check(!overlaid[2].urgent, "overlay does not mark unrelated active workspace urgent");
+  ok &= check(overlaid[3].urgent, "overlay preserves compositor urgent state");
+  ok &= check(!overlaid[4].urgent, "overlay leaves unmatched workspaces alone");
+  ok &= check(service.contains("2"), "overlay is pure read and keeps alert");
+
+  // niri-style: a workspace with empty id/name is alertable by its visible index.
+  WorkspaceAlertService indexService;
+  ok &= check(indexService.add("5"), "index-only token add succeeds");
+  auto indexRows = sampleWorkspaces();
+  indexService.applyOverlay(indexRows);
+  ok &= check(indexRows[4].urgent, "overlay matches workspace by visible index");
+
+  // Sway-style: a named workspace is alertable by its name/id.
+  WorkspaceAlertService nameService;
+  ok &= check(nameService.add("web"), "name token add succeeds");
+  auto nameRows = sampleWorkspaces();
+  nameService.applyOverlay(nameRows);
+  ok &= check(nameRows[3].urgent, "overlay matches workspace by name/id");
+
+  // The overlay must never mark the active workspace, even if alerted directly.
+  WorkspaceAlertService activeService;
+  ok &= check(activeService.add("3"), "add active token at service level");
+  auto activeOverlay = sampleWorkspaces();
+  activeService.applyOverlay(activeOverlay);
+  ok &= check(!activeOverlay[2].urgent, "overlay never marks active workspace urgent");
+
+  // Per-output duplicate indexes (e.g. niri/mango/dwl): the same alert token must
+  // mark the inactive copy on one output while leaving the active copy alone.
+  WorkspaceAlertService dupService;
+  ok &= check(dupService.add("2"), "duplicate-index alert add succeeds");
+  std::vector<Workspace> outputA{Workspace{.id = "", .name = "", .index = 2, .active = true, .occupied = true}};
+  std::vector<Workspace> outputB{Workspace{.id = "", .name = "", .index = 2, .active = false, .occupied = true}};
+  dupService.applyOverlay(outputA);
+  dupService.applyOverlay(outputB);
+  ok &= check(!outputA[0].urgent, "active duplicate index stays unmarked");
+  ok &= check(outputB[0].urgent, "inactive duplicate index is alerted");
+
+  // clearActive removes whichever token form named the now-active workspace.
+  ok &= check(service.add("3"), "active token add succeeds");
+  auto activeRows = sampleWorkspaces();
+  const std::size_t cleared = service.clearActive(activeRows);
+  ok &= check(cleared == 1, "clearActive clears alert on active workspace");
+  ok &= check(!service.contains("3"), "active token removed");
+  ok &= check(service.contains("2"), "inactive token remains");
+
+  std::vector<WorkspaceWindowAssignment> assignments{
+      WorkspaceWindowAssignment{.windowId = "10", .workspaceKey = "1", .appId = "kitty", .title = "shell"},
+      WorkspaceWindowAssignment{.windowId = "20", .workspaceKey = "2", .appId = "code", .title = "editor"},
+      WorkspaceWindowAssignment{.windowId = "30", .workspaceKey = "", .appId = "empty", .title = "empty"},
+  };
+  ok &= check(WorkspaceAlertService::workspaceTokenForWindow("20", assignments) == "2", "resolves window id");
+  ok &= check(
+      !WorkspaceAlertService::workspaceTokenForWindow("30", assignments).has_value(), "rejects empty assignment key"
+  );
+  ok &= check(
+      !WorkspaceAlertService::workspaceTokenForWindow("99", assignments).has_value(), "rejects unknown window id"
+  );
+
+  const auto rows = sampleWorkspaces();
+  ok &= check(WorkspaceAlertService::isKnownWorkspaceToken("2", rows), "known token by id/index validates");
+  ok &= check(WorkspaceAlertService::isKnownWorkspaceToken("5", rows), "known token by index-only validates");
+  ok &= check(WorkspaceAlertService::isKnownWorkspaceToken("web", rows), "known token by name validates");
+  ok &= check(!WorkspaceAlertService::isKnownWorkspaceToken("9", rows), "unknown token rejects");
+  ok &= check(!WorkspaceAlertService::isKnownWorkspaceToken("0", rows), "zero index never matches");
+  ok &= check(!WorkspaceAlertService::isKnownWorkspaceToken("", rows), "empty token rejects");
+
+  ok &= check(service.add("1"), "sort token add succeeds");
+  const auto tokens = service.tokens();
+  ok &= check(tokens.size() == 2 && tokens[0] == "1" && tokens[1] == "2", "tokens are sorted");
+  ok &= check(service.clear("1"), "clear returns true for present token");
+  ok &= check(!service.contains("1"), "clear removes token");
+  service.clearAll();
+  ok &= check(service.empty(), "clearAll empties service");
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What this does

Adds a workspace-alert feature. Over IPC, a user can flag a workspace — or the workspace containing a given window — so it renders with the existing `urgent` style until they switch to it. The alert auto-clears when the user activates that workspace.

IPC commands:
- `workspace-alert-add <workspace-id>`
- `workspace-alert-add-window <window-id>`
- `workspace-alert-clear <workspace-id>`
- `workspace-alert-clear-all`
- `workspace-alert-status`

## Why this is a rewrite of #3025

The original PR (#3025) was declined on scope: it introduced a new canonical `Workspace.key` field and threaded it through all seven compositor backends — the highest-maintenance surface in the project — plus output-name-resolver plumbing and widget/snapshot changes.

This version reuses the compositor's **existing workspace identifiers** as the alert token, so the feature collapses to a self-contained unit:
- a `WorkspaceAlertService` (set of tokens + overlay logic),
- the five IPC handlers,
- one overlay hook in each `CompositorPlatform::workspaces()` overload,
- the focused-output auto-clear wiring.

An alert token is matched against a workspace's **id, name, or visible index**, because backends populate different ones (niri only sets the visible index; Sway uses the name as the id; tag compositors use the numeric id). This keeps the feature usable across compositors without threading a new canonical key through every backend. **No per-backend changes.** The only cross-cutting edit is relocating the plain `WorkspaceWindowAssignment` struct between two headers.

## Known limitation

None of these identifiers is guaranteed unique across outputs on compositors that number workspaces per monitor (niri index, mango/dwl tags), so an alert there applies to the matching workspace on every monitor (and activating it on any monitor clears it). This is the accepted per-output trade-off for not introducing a per-backend canonical key; it's documented in the service header.

## Notes

- The overlay reuses the `urgent` flag and only marks **inactive** rows, so alerting the active workspace simply shows once you leave it and clears on return; on per-output compositors this also lets an inactive duplicate alert even when the same workspace is active on another monitor.
- The id/name/index matching runs *after* the metadata backend's `apply()` in `workspaces()`, so the visible index is populated at match time (this is what makes niri — which doesn't expose a usable `id` — work).
- `m_workspaceAlertService` is declared before `m_compositorPlatform` so the raw pointer handed to the platform outlives it.

## Testing

- `just build` passes.
- `workspace_alert_service` unit test: 31/31 (covers overlay suppression of active rows, matching by index/name/id, per-output duplicate-index handling, window→workspace resolution, and validation).
- Verified live on niri: `workspace-alert-add <n>` by visible number, `add-window <id>`, `clear`, `clear-all`, and `status` all behave as expected.
- `git diff --check` clean.