### PR TITLE
fix(panel): restore window focus on Hyprland after panel close

### DIFF
--- a/Services/Compositor/CompositorService.qml
+++ b/Services/Compositor/CompositorService.qml
@@ -31,6 +31,10 @@ Singleton {
   // Overview state (Niri-specific, defaults to false for other compositors)
   property bool overviewActive: false
 
+  // Hyprland input:follow_mouse value (default 1, mirrored from the Hyprland backend).
+  // Lets panel logic decide whether it must explicitly restore focus when a panel closes.
+  property int hyprlandFollowMouse: 1
+
   // Global workspaces flag (workspaces shared across all outputs)
   // True for LabWC (stacking compositor), false for tiling WMs with per-output workspaces
   property bool globalWorkspaces: false
@@ -242,6 +246,13 @@ Singleton {
                                             });
     }
 
+    // Hyprland follow_mouse (only the Hyprland backend exposes this)
+    if (backend.followMouseChanged) {
+      backend.followMouseChanged.connect(() => {
+                                           hyprlandFollowMouse = backend.followMouse;
+                                         });
+    }
+
     // Initial sync
     syncWorkspaces();
     syncWindows();
@@ -251,6 +262,9 @@ Singleton {
     }
     if (backend.globalWorkspaces !== undefined) {
       globalWorkspaces = backend.globalWorkspaces;
+    }
+    if (backend.followMouse !== undefined) {
+      hyprlandFollowMouse = backend.followMouse;
     }
   }
 

--- a/Services/Compositor/HyprlandService.qml
+++ b/Services/Compositor/HyprlandService.qml
@@ -28,6 +28,11 @@ Item {
   property bool dispatchModeChecked: false
   property bool useLuaDispatch: false
 
+  // input:follow_mouse value (Hyprland default is 1). When follow_mouse != 1 the
+  // compositor does not reliably refocus the app after a still-mapped layer surface
+  // releases keyboard focus, so the shell restores focus explicitly on panel close.
+  property int followMouse: 1
+
   // Debounce timer for window updates
   Timer {
     id: updateTimer
@@ -57,6 +62,7 @@ Item {
                      safeUpdateWindows();
                      queryDisplayScales();
                      queryKeyboardLayout();
+                     queryFollowMouse();
                      // Detect Hyprland dispatch syntax once during startup
                      detectDispatchMode();
                    });
@@ -225,6 +231,48 @@ Item {
         Logger.e("HyprlandService", "Failed to parse devices:", e);
       } finally {
         // Clear accumulated output for next query
+        accumulatedOutput = "";
+      }
+    }
+  }
+
+  // Query input:follow_mouse so the shell knows whether it must explicitly restore
+  // window focus after a panel closes (only needed when follow_mouse != 1).
+  function queryFollowMouse() {
+    followMouseProcess.running = true;
+  }
+
+  Process {
+    id: followMouseProcess
+    running: false
+    command: ["hyprctl", "getoption", "input:follow_mouse", "-j"]
+
+    property string accumulatedOutput: ""
+
+    stdout: SplitParser {
+      onRead: function (line) {
+        followMouseProcess.accumulatedOutput += line;
+      }
+    }
+
+    onExited: function (exitCode) {
+      if (exitCode !== 0 || !accumulatedOutput) {
+        Logger.e("HyprlandService", "Failed to query follow_mouse, exit code:", exitCode);
+        accumulatedOutput = "";
+        return;
+      }
+
+      try {
+        const data = JSON.parse(accumulatedOutput);
+        if (typeof data.int === "number") {
+          root.followMouse = data.int;
+          Logger.d("HyprlandService", "follow_mouse =", root.followMouse);
+        } else {
+          Logger.w("HyprlandService", "follow_mouse: unexpected getoption payload, keeping default", root.followMouse, "-", accumulatedOutput);
+        }
+      } catch (e) {
+        Logger.e("HyprlandService", "Failed to parse follow_mouse:", e);
+      } finally {
         accumulatedOutput = "";
       }
     }
@@ -581,6 +629,10 @@ Item {
 
       if (monitorsEvents.includes(event.name)) {
         Qt.callLater(queryDisplayScales);
+      }
+
+      if (event.name === "configreloaded") {
+        Qt.callLater(queryFollowMouse);
       }
 
       if (event.name == "activelayout") {

--- a/Services/UI/PanelService.qml
+++ b/Services/UI/PanelService.qml
@@ -28,6 +28,15 @@ Singleton {
   // Global state for keybind recording components to block global shortcuts
   property bool isKeybindRecording: false
 
+  // Hyprland refocus workaround: id (address) of the toplevel that held keyboard
+  // focus before a panel opened. When the last panel closes, focus is handed back
+  // to it explicitly, because Hyprland (with follow_mouse != 1) leaves the app
+  // "active" but unable to receive keyboard input after a still-mapped layer
+  // surface releases keyboard focus. See Hyprland #14285 / #14730 and the
+  // DankMaterialShell fix (PR #2655); noctalia's persistent MainScreen surface
+  // can't release-on-unmap like a per-popout surface, so it nudges focus instead.
+  property string windowIdToRestoreFocus: ""
+
   signal willOpen
   signal didClose
 
@@ -235,8 +244,45 @@ Singleton {
     }
   }
 
+  // Remember the toplevel that currently holds focus, before any panel grabs the
+  // keyboard, so it can be refocused when panels fully close (Hyprland workaround).
+  function captureFocusForRestore() {
+    windowIdToRestoreFocus = "";
+    if (!CompositorService.isHyprland)
+      return;
+    var w = CompositorService.getFocusedWindow();
+    if (w && w.id)
+      windowIdToRestoreFocus = String(w.id);
+  }
+
+  // Hand keyboard focus back to the window that was focused before the panel opened.
+  // Only acts on Hyprland when follow_mouse != 1 (otherwise the compositor restores
+  // focus on its own, and forcing it would fight focus-follows-mouse). No-op elsewhere.
+  // (focusWindow also re-raises the window via alterzorder, which is fine: it was the
+  //  active/top window before the panel opened.)
+  function restoreFocusAfterClose() {
+    var id = windowIdToRestoreFocus;
+    windowIdToRestoreFocus = "";
+    if (!id)
+      return;
+    if (!CompositorService.isHyprland)
+      return;
+    if (CompositorService.hyprlandFollowMouse === 1)
+      return;
+    Logger.d("PanelService", "Restoring keyboard focus to window:", id);
+    CompositorService.focusWindow({
+                                    "id": id
+                                  });
+  }
+
   // Helper to keep only one panel open at any time
   function willOpenPanel(panel) {
+    // Capture pre-panel focus only when no panel is currently open (the first panel
+    // in a sequence); switching between panels keeps the originally focused window.
+    if (openedPanel === null) {
+      captureFocusForRestore();
+    }
+
     // Close overlay launcher if open
     if (overlayLauncherOpen) {
       overlayLauncherOpen = false;
@@ -389,7 +435,8 @@ Singleton {
   }
 
   function closedPanel(panel) {
-    if (openedPanel && openedPanel === panel) {
+    var wasActivePanel = (openedPanel && openedPanel === panel);
+    if (wasActivePanel) {
       openedPanel = null;
       assignToSlot(0, null);
     }
@@ -402,6 +449,13 @@ Singleton {
     // Reset keyboard init state
     isInitializingKeyboard = false;
     keyboardInitTimer.stop();
+
+    // When the active panel fully closes via a normal (animated) close, nudge
+    // Hyprland to refocus the window that was focused before it opened. Skipped for
+    // immediate closes (app launches) where the launched app should take focus.
+    if (wasActivePanel && !closedImmediately) {
+      restoreFocusAfterClose();
+    }
 
     // emit signal
     didClose();


### PR DESCRIPTION
## Problem

On Hyprland with `input:follow_mouse != 1`, closing a noctalia panel leaves the
previously-focused window reported as *active* but unable to receive keyboard
input until another focus transition occurs
(hyprwm/Hyprland#14285, hyprwm/Hyprland#14730).

Root cause for v4's architecture: panels live in a single **persistent**
per-screen `MainScreen` layer-shell surface that never unmaps — it only toggles
`WlrLayershell.keyboardFocus`. When the last panel closes, focus drops to `None`
on a still-mapped surface, which trips the Hyprland refocus issue.
DankMaterialShell fixed the same bug (AvengeMedia/DankMaterialShell#2655) by
holding keyboard focus until its **per-popout** surface unmaps — the unmap is
what makes the compositor refocus cleanly. noctalia's shared/persistent surface
can't release-on-unmap, so it nudges focus back explicitly instead.

## Fix

- Capture the toplevel that holds keyboard focus *before* the first panel grabs
  the keyboard (`PanelService.willOpenPanel`).
- When the active panel fully closes via a normal animated close, re-focus that
  window (`PanelService.closedPanel` → `restoreFocusAfterClose`).
- Gated to **Hyprland + `follow_mouse != 1`**, and skipped for immediate
  (app-launch) closes. The default `follow_mouse=1` and all non-Hyprland
  compositors see **no behavior change**.

Implementation:

- `HyprlandService`: query/expose `input:follow_mouse` (re-queried on `configreloaded`).
- `CompositorService`: mirror it on the facade as `hyprlandFollowMouse`.
- `PanelService`: capture-on-open / restore-on-close via the existing `focusWindow()` path.

## Testing

Set `input:follow_mouse` to `0` (or `2`/`3`), open a bar panel, close it (Escape
or click-out), and confirm keyboard input returns to the underlying app. With
`follow_mouse=1` (the Hyprland default) behavior is unchanged.

## Notes / limitations

- Uses capture-on-open (deterministic) rather than reading focus at close, since
  the cached focus model can be invalidated while the layer surface holds the
  keyboard grab.
- If focus is changed (e.g. alt-tab) *while a panel is open*, close restores the
  pre-panel window. The overview-launcher overlay path (a separate surface) is
  not covered.
