### PR TITLE
fix wrong default value of session lock integration state

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -12,6 +12,7 @@ pkgs.mkShell {
 
     # Formatting (required by justfile)
     llvmPackages_22.clang-tools
+    llvmPackages_22.libclang
     gnugrep
     gnused
     findutils

--- a/src/dbus/logind/logind_service.h
+++ b/src/dbus/logind/logind_service.h
@@ -36,7 +36,7 @@ private:
   SystemBus& m_bus;
   std::unique_ptr<sdbus::IProxy> m_managerProxy;
   std::unique_ptr<sdbus::IProxy> m_sessionProxy;
-  bool m_sessionLockIntegrationEnabled = true;
+  bool m_sessionLockIntegrationEnabled = false;
   PrepareForSleepCallback m_prepareForSleepCallback;
   SessionLockCallback m_lockCallback;
   SessionLockCallback m_unlockCallback;

--- a/src/shell/desktop/editor/desktop_widgets_editor.cpp
+++ b/src/shell/desktop/editor/desktop_widgets_editor.cpp
@@ -606,7 +606,7 @@ void DesktopWidgetsEditor::prepareFrame(OverlaySurface& surface, bool needsUpdat
     updateWallpaperPreview(surface);
   }
 
-  const bool needsFrameTick = std::any_of(surface.views.begin(), surface.views.end(), [](const auto& entry) {
+  const bool needsFrameTick = std::ranges::any_of(surface.views, [](const auto& entry) {
     return entry.second.widget != nullptr && entry.second.widget->needsFrameTick();
   });
   if (needsFrameTick) {


### PR DESCRIPTION
## Summary

since integration checks the state of the integration when setting it enabled or disabled. it doesnt enable it if it is defaulted to true since applicaion tries to set it to enabled but since value is already set to enabled it ignores it.

so before this commit you need to enable than disable the lockscreen to get lockscreen integration working

<!-- If this PR is not ready for review yet, please mark it as Draft. -->



<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
