### PR TITLE
Update ui.selection colors in helix.toml

### DIFF
--- a/assets/templates/helix/helix.toml
+++ b/assets/templates/helix/helix.toml
@@ -96,7 +96,7 @@
 "ui.menu" = { fg = "onSurface", bg = "surfaceContainer" }
 "ui.menu.selected" = { fg = "onPrimary", bg = "primary", modifiers = ["bold"] }
 
-"ui.selection" = { bg = "primary", fg = "onPrimary" }
+"ui.selection" = { bg = "primaryContainer", fg = "onPrimaryContainer" }
 
 "ui.highlight" = { bg = "primaryContainer", modifiers = ["bold"] }
 


### PR DESCRIPTION
## Summary

The selection color of the helix template overlaps with the cursor color which makes it impossible to see where the cursor is, for example if the cursor is at the start or at the end of the selection.

## Motivation

It makes it easier to see where the cursor is when moving around in helix. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

No related issue found. 

## Testing

Just run helix with the improved template.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before, where we can not see where the cursor is in the selection.

<img width="1663" height="586" alt="image" src="https://github.com/user-attachments/assets/c27a8962-2023-45ad-af3d-3f6408a078a7" />

After, where we can see where the cursor is in the selection.

<img width="1663" height="586" alt="image" src="https://github.com/user-attachments/assets/5aee56b3-cfbc-47b7-8d0d-bff6887694c6" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No additional notes are needed.
