### PR TITLE
Improve media ipc

### DIFF
--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -708,7 +708,7 @@ void MprisService::registerIpc(IpcService& ipc) {
           return playActive() ? "ok\n" : "error: no active player or Play unsupported\n";
         }
         if (action == "stop") {
-          return stopActive() ? "ok\n" : "error: no active player or Stop unsupported\n";
+          return stopActive() ? "ok\n" : "error: no active player or Pause/Stop unsupported\n";
         }
 
         return "error: invalid media action (use next, previous, toggle, play, stop)\n";
@@ -791,12 +791,26 @@ bool MprisService::stop(const std::string& busName) {
   if (it == m_players.end()) {
     return false;
   }
+
+  if (it->second.playbackStatus != "Playing") {
+    return true;
+  }
+
+  if (it->second.canPause) {
+    if (!callPlayerMethod(busName, "Pause")) {
+      return false;
+    }
+    dismissPlayer(busName);
+    return true;
+  }
+
   if (!canInvoke(it->second, "Stop")) {
     return false;
   }
   if (!callPlayerMethod(busName, "Stop")) {
     return false;
   }
+
   dismissPlayer(busName);
   return true;
 }

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -556,7 +556,6 @@ void MprisService::applyPositionSample(const std::string& busName, int64_t rawPo
       } else if (pausedJumpUs < kPauseRecoveryMinJumpUs) {
         return;
       } else {
-        playerIt->second.playbackStatus = "Playing";
         m_recentNoSignalPauseAt.erase(pauseIt);
       }
     } else if (!recentLocalSeek && pausedJumpUs < kPausedSameTrackPositionJumpToleranceUs) {
@@ -1638,7 +1637,6 @@ void MprisService::addOrRefreshPlayer(const std::string& busName) {
             seekCommandIt != m_lastSeekCommandAt.end() && now - seekCommandIt->second <= kSeekPauseGraceWindow;
         const std::int64_t pausedJumpUs = std::llabs(normalizedUs - previousPosUs);
         if (recoveringRecentPause && !recentLocalSeek && pausedJumpUs >= kPauseRecoveryMinJumpUs) {
-          playerIt->second.playbackStatus = "Playing";
           m_recentNoSignalPauseAt.erase(pauseIt);
         }
       }

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -800,7 +800,6 @@ bool MprisService::stop(const std::string& busName) {
     if (!callPlayerMethod(busName, "Pause")) {
       return false;
     }
-    dismissPlayer(busName);
     return true;
   }
 
@@ -811,7 +810,6 @@ bool MprisService::stop(const std::string& busName) {
     return false;
   }
 
-  dismissPlayer(busName);
   return true;
 }
 

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -691,7 +691,7 @@ void MprisService::registerIpc(IpcService& ipc) {
       [this](const std::string& args) -> std::string {
         const auto parts = noctalia::ipc::splitWords(args);
         if (parts.size() != 1) {
-          return "error: media requires exactly one action <next|previous|toggle|stop>\n";
+          return "error: media requires exactly one action <next|previous|toggle|play|stop>\n";
         }
 
         const std::string& action = parts[0];
@@ -704,13 +704,16 @@ void MprisService::registerIpc(IpcService& ipc) {
         if (action == "toggle" || action == "playPause" || action == "play-pause") {
           return playPauseActive() ? "ok\n" : "error: no active player or PlayPause unsupported\n";
         }
+        if (action == "play") {
+          return playActive() ? "ok\n" : "error: no active player or Play unsupported\n";
+        }
         if (action == "stop") {
           return stopActive() ? "ok\n" : "error: no active player or Stop unsupported\n";
         }
 
-        return "error: invalid media action (use next, previous, toggle, stop)\n";
+        return "error: invalid media action (use next, previous, toggle, play, stop)\n";
       },
-      "media <next|previous|toggle|stop>", "Control active media playback"
+      "media <next|previous|toggle|play|stop>", "Control active media playback"
   );
 }
 
@@ -771,6 +774,18 @@ bool MprisService::playPause(const std::string& busName) {
   return callPlayerMethod(busName, "PlayPause");
 }
 
+bool MprisService::play(const std::string& busName) {
+  const auto it = m_players.find(busName);
+  if (it == m_players.end()) {
+    return false;
+  }
+  if (!canInvoke(it->second, "Play")) {
+    return false;
+  }
+  m_stoppedPlayers.erase(busName);
+  return callPlayerMethod(busName, "Play");
+}
+
 bool MprisService::stop(const std::string& busName) {
   const auto it = m_players.find(busName);
   if (it == m_players.end()) {
@@ -814,6 +829,14 @@ bool MprisService::playPauseActive() {
     return false;
   }
   return playPause(*active);
+}
+
+bool MprisService::playActive() {
+  const auto active = chooseActivePlayer();
+  if (!active.has_value()) {
+    return false;
+  }
+  return play(*active);
 }
 
 bool MprisService::stopActive() {
@@ -2164,6 +2187,9 @@ bool MprisService::callPlayerMethod(const std::string& busName, const char* meth
 
 bool MprisService::canInvoke(const MprisPlayerInfo& player, const char* methodName) const {
   const std::string_view method{methodName};
+  if (method == "Play") {
+    return player.canPlay;
+  }
   if (method == "PlayPause" || method == "Stop") {
     return player.canPlay || player.canPause;
   }

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -690,7 +690,8 @@ void MprisService::registerIpc(IpcService& ipc) {
       [this](const std::string& args) -> std::string {
         const auto parts = noctalia::ipc::splitWords(args);
         if (parts.size() != 1) {
-          return "error: media requires exactly one action <next|previous|toggle|play|stop>\n";
+          return "error: media requires exactly one action "
+                 "<next|previous|toggle|play|stop|next-player|previous-player>\n";
         }
 
         const std::string& action = parts[0];
@@ -709,10 +710,16 @@ void MprisService::registerIpc(IpcService& ipc) {
         if (action == "stop") {
           return stopActive() ? "ok\n" : "error: no active player or Pause/Stop unsupported\n";
         }
+        if (action == "next-player") {
+          return cycleActivePlayer(1) ? "ok\n" : "error: no media players available\n";
+        }
+        if (action == "previous-player") {
+          return cycleActivePlayer(-1) ? "ok\n" : "error: no media players available\n";
+        }
 
-        return "error: invalid media action (use next, previous, toggle, play, stop)\n";
+        return "error: invalid media action (use next, previous, toggle, play, stop, next-player, previous-player)\n";
       },
-      "media <next|previous|toggle|play|stop>", "Control active media playback"
+      "media <next|previous|toggle|play|stop|next-player|previous-player>", "Control active media playback"
   );
 }
 
@@ -2181,6 +2188,27 @@ std::optional<std::string> MprisService::chooseActivePlayer() const {
 
   // kLog.debug("choose active player source=none");
   return std::nullopt;
+}
+
+bool MprisService::cycleActivePlayer(int direction) {
+  const std::vector<MprisPlayerInfo> players = listPlayers();
+  if (players.empty()) {
+    return false;
+  }
+
+  const auto active = chooseActivePlayer();
+  std::size_t targetIndex = direction >= 0 ? 0 : players.size() - 1;
+  if (active.has_value()) {
+    for (std::size_t i = 0; i < players.size(); ++i) {
+      if (players[i].busName != *active) {
+        continue;
+      }
+      targetIndex = direction >= 0 ? (i + 1) % players.size() : (i + players.size() - 1) % players.size();
+      break;
+    }
+  }
+
+  return setPinnedPlayerPreference(players[targetIndex].busName);
 }
 
 bool MprisService::isBlacklisted(const MprisPlayerInfo& player) const {

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -1774,17 +1774,45 @@ void MprisService::applyPlayerSnapshot(
   }
   const auto previousActive = activePlayer();
   const auto now = std::chrono::steady_clock::now();
+  bool clearedPinnedPlayerPreference = false;
+  const auto existing = m_players.find(busName);
+  const bool becamePlaying =
+      info.playbackStatus == "Playing" && (existing == m_players.end() || existing->second.playbackStatus != "Playing");
+  const bool transitionedFromPlaying =
+      info.playbackStatus != "Playing" && existing != m_players.end() && existing->second.playbackStatus == "Playing";
+  const auto hasOtherPlayingPlayer = [this, &busName]() {
+    for (const auto& [otherBusName, player] : m_players) {
+      if (otherBusName != busName && !isBlacklisted(player) && player.playbackStatus == "Playing") {
+        return true;
+      }
+    }
+    return false;
+  };
 
   if (info.playbackStatus == "Playing") {
+    if (becamePlaying && m_pinnedPlayerPreference.has_value() && *m_pinnedPlayerPreference != busName) {
+      const auto pinnedIt = m_players.find(*m_pinnedPlayerPreference);
+      if (pinnedIt != m_players.end() && pinnedIt->second.playbackStatus != "Playing") {
+        m_pinnedPlayerPreference.reset();
+        clearedPinnedPlayerPreference = true;
+      }
+    }
     m_stoppedPlayers.erase(busName);
+    if (becamePlaying) {
+      m_lastActivePlayer = busName;
+      m_lastPlayingUpdate[busName] = now;
+    }
+  } else if (transitionedFromPlaying) {
     m_lastActivePlayer = busName;
-    m_lastPlayingUpdate[busName] = now;
+    if (m_pinnedPlayerPreference.has_value() && *m_pinnedPlayerPreference == busName && hasOtherPlayingPlayer()) {
+      m_pinnedPlayerPreference.reset();
+      clearedPinnedPlayerPreference = true;
+    }
   }
   if (hasStrongNowPlayingMetadata(info)) {
     m_lastStrongMetadataUpdate[busName] = now;
   }
 
-  const auto existing = m_players.find(busName);
   if (existing == m_players.end()) {
     MprisPlayerInfo initial = info;
     if (!hadPositionSignal) {
@@ -2015,7 +2043,7 @@ void MprisService::applyPlayerSnapshot(
     }
 
     syncSignals(previousActive);
-    if (significantChanged && m_changeCallback) {
+    if ((significantChanged || clearedPinnedPlayerPreference) && m_changeCallback) {
       m_changeCallback();
     }
   }

--- a/src/dbus/mpris/mpris_service.cpp
+++ b/src/dbus/mpris/mpris_service.cpp
@@ -776,7 +776,6 @@ bool MprisService::playPause(const std::string& busName) {
   if (!canInvoke(it->second, "PlayPause")) {
     return false;
   }
-  m_stoppedPlayers.erase(busName);
   return callPlayerMethod(busName, "PlayPause");
 }
 
@@ -788,7 +787,6 @@ bool MprisService::play(const std::string& busName) {
   if (!canInvoke(it->second, "Play")) {
     return false;
   }
-  m_stoppedPlayers.erase(busName);
   return callPlayerMethod(busName, "Play");
 }
 
@@ -1804,7 +1802,6 @@ void MprisService::applyPlayerSnapshot(
         clearedPinnedPlayerPreference = true;
       }
     }
-    m_stoppedPlayers.erase(busName);
     if (becamePlaying) {
       m_lastActivePlayer = busName;
       m_lastPlayingUpdate[busName] = now;
@@ -2099,7 +2096,6 @@ void MprisService::clearPlayerState(const std::string& busName) {
   if (m_lastActivePlayer == busName) {
     m_lastActivePlayer.clear();
   }
-  m_stoppedPlayers.erase(busName);
 }
 
 void MprisService::removePlayer(const std::string& busName) {
@@ -2123,11 +2119,9 @@ void MprisService::removePlayer(const std::string& busName) {
 }
 
 std::optional<std::string> MprisService::chooseActivePlayer() const {
-  const auto isDismissed = [this](const std::string& busName) { return m_stoppedPlayers.contains(busName); };
-
   if (m_pinnedPlayerPreference.has_value()) {
     const auto it = m_players.find(*m_pinnedPlayerPreference);
-    if (it != m_players.end() && !isBlacklisted(it->second) && !isDismissed(*m_pinnedPlayerPreference)) {
+    if (it != m_players.end() && !isBlacklisted(it->second)) {
       // kLog.debug("choose active player source=pinned name={}", *m_pinnedPlayerPreference);
       return m_pinnedPlayerPreference;
     }
@@ -2136,7 +2130,7 @@ std::optional<std::string> MprisService::chooseActivePlayer() const {
   std::optional<std::string> mostRecentPlaying;
   std::chrono::steady_clock::time_point mostRecentPlayingAt{};
   for (const auto& [busName, player] : m_players) {
-    if (isBlacklisted(player) || isDismissed(busName) || player.playbackStatus != "Playing") {
+    if (isBlacklisted(player) || player.playbackStatus != "Playing") {
       continue;
     }
     const auto playingIt = m_lastPlayingUpdate.find(busName);
@@ -2154,10 +2148,7 @@ std::optional<std::string> MprisService::chooseActivePlayer() const {
 
   for (const auto& busName : m_preferredPlayers) {
     const auto it = m_players.find(busName);
-    if (it != m_players.end()
-        && !isBlacklisted(it->second)
-        && !isDismissed(busName)
-        && it->second.playbackStatus == "Playing") {
+    if (it != m_players.end() && !isBlacklisted(it->second) && it->second.playbackStatus == "Playing") {
       // kLog.debug("choose active player source=preferred_playing name={}", busName);
       return busName;
     }
@@ -2165,7 +2156,7 @@ std::optional<std::string> MprisService::chooseActivePlayer() const {
 
   for (const auto& busName : m_preferredPlayers) {
     const auto it = m_players.find(busName);
-    if (it != m_players.end() && !isBlacklisted(it->second) && !isDismissed(busName)) {
+    if (it != m_players.end() && !isBlacklisted(it->second)) {
       // kLog.debug("choose active player source=preferred_any name={}", busName);
       return busName;
     }
@@ -2173,14 +2164,14 @@ std::optional<std::string> MprisService::chooseActivePlayer() const {
 
   if (!m_lastActivePlayer.empty()) {
     const auto it = m_players.find(m_lastActivePlayer);
-    if (it != m_players.end() && !isBlacklisted(it->second) && !isDismissed(m_lastActivePlayer)) {
+    if (it != m_players.end() && !isBlacklisted(it->second)) {
       // kLog.debug("choose active player source=last_active name={}", m_lastActivePlayer);
       return m_lastActivePlayer;
     }
   }
 
   for (const auto& [busName, player] : m_players) {
-    if (!isBlacklisted(player) && !isDismissed(busName)) {
+    if (!isBlacklisted(player)) {
       // kLog.debug("choose active player source=first_cached name={}", busName);
       return busName;
     }
@@ -2266,27 +2257,6 @@ bool MprisService::canInvoke(const MprisPlayerInfo& player, const char* methodNa
     return player.canGoPrevious;
   }
   return false;
-}
-
-void MprisService::dismissPlayer(const std::string& busName) {
-  if (busName.empty()) {
-    return;
-  }
-
-  const auto previousActive = chooseActivePlayer();
-  m_stoppedPlayers.insert(busName);
-  if (m_lastActivePlayer == busName) {
-    m_lastActivePlayer.clear();
-  }
-
-  if (!previousActive.has_value() || *previousActive != busName) {
-    return;
-  }
-
-  emitActivePlayerChanged();
-  if (m_changeCallback) {
-    m_changeCallback();
-  }
 }
 
 bool MprisService::onPlayPausePlayer(const std::string& busName) {

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -135,6 +135,7 @@ private:
   [[nodiscard]] MprisPlayerInfo projectedPlayerInfo(const MprisPlayerInfo& player) const;
   [[nodiscard]] std::int64_t projectedPositionUs(const MprisPlayerInfo& player) const;
   [[nodiscard]] std::optional<std::string> chooseActivePlayer() const;
+  bool cycleActivePlayer(int direction);
   [[nodiscard]] bool isBlacklisted(const MprisPlayerInfo& player) const;
   std::function<void(std::optional<sdbus::Error>)> makeAsyncReplyHandler(std::string op, std::string busName);
   std::function<void(std::optional<sdbus::Error>)>

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -64,10 +64,12 @@ public:
   void registerIpc(IpcService& ipc);
 
   bool playPause(const std::string& busName);
+  bool play(const std::string& busName);
   bool stop(const std::string& busName);
   bool next(const std::string& busName);
   bool previous(const std::string& busName);
   bool playPauseActive();
+  bool playActive();
   bool stopActive();
   bool nextActive();
   bool previousActive();

--- a/src/dbus/mpris/mpris_service.h
+++ b/src/dbus/mpris/mpris_service.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 class SessionBus;
@@ -142,7 +141,6 @@ private:
   makeAsyncReplyHandler(std::string op, std::string busName, std::string_view method);
   [[nodiscard]] bool callPlayerMethod(const std::string& busName, const char* methodName);
   [[nodiscard]] bool canInvoke(const MprisPlayerInfo& player, const char* methodName) const;
-  void dismissPlayer(const std::string& busName);
 
   bool onPlayPausePlayer(const std::string& busName);
   bool onStopPlayer(const std::string& busName);
@@ -200,7 +198,6 @@ private:
   std::unordered_map<std::string, int> m_playerPropertiesFailures;
   std::unordered_map<std::string, std::chrono::milliseconds> m_playerPropertiesRefreshBackoffMs;
   std::deque<std::string> m_pendingDiscoveryBusNames;
-  std::unordered_set<std::string> m_stoppedPlayers;
   std::string m_lastActivePlayer;
   std::string m_lastEmittedActivePlayer;
   std::optional<std::string> m_pinnedPlayerPreference;


### PR DESCRIPTION
This adds
```
media <..|play|next-player|previous-player>
```
and changes some logic in the mpris service so that it's a lot more convenient and behaves the way I would expect.

## Type of Change
- [x] Bug fix
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.