### PR TITLE
fix(audio_osd): use percent to check volume icon

### DIFF
--- a/src/shell/osd/audio_osd.cpp
+++ b/src/shell/osd/audio_osd.cpp
@@ -15,11 +15,11 @@ namespace {
 
   [[nodiscard]] bool volumeChanged(float a, float b) { return std::abs(a - b) > kVolumeChangeEpsilon; }
 
-  const char* volumeIconName(float volume, bool muted) {
-    if (muted || volume <= 0.0f) {
+  const char* volumeIconName(int percent, bool muted) {
+    if (muted || percent <= 0) {
       return "volume-mute";
     }
-    if (volume < 0.4f) {
+    if (percent < 40) {
       return "volume-low";
     }
     return "volume-high";
@@ -29,7 +29,7 @@ namespace {
     const int percent = static_cast<int>(std::round(std::max(0.0f, volume) * 100.0f));
     return OsdContent{
         .kind = OsdKind::Volume,
-        .icon = volumeIconName(volume, muted),
+        .icon = volumeIconName(percent, muted),
         .value = std::to_string(percent) + "%",
         .progress = std::clamp(volume, 0.0f, 1.0f),
         .overLimit = percent > 100,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

<!-- This PR changed to use the direct comparison of the current and last volumes in the audio OSD without an epsilon value. This is the same comparison used in the volume widget ([commit](https://github.com/noctalia-dev/noctalia/blob/4dbd52489c7fc3d345a77320b9f49db778d874c4/src/shell/bar/widgets/volume_widget.cpp#L149)). -->

This PR changes to use the `percent` instead of `volume` to compute the volume icon.

Let me know if this is not the correct direction or any further changes are required.

## Motivation

<!-- What problem does this solve? -->

fix #3168 

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

From 5%:
<img width="289" height="110" alt="Screenshot from 2026-06-27 04-21-46" src="https://github.com/user-attachments/assets/98b5b629-fc8a-45e5-ac5d-8593d133e61a" />

To 0%:
<img width="289" height="110" alt="Screenshot from 2026-06-27 04-21-59" src="https://github.com/user-attachments/assets/fe2d9f03-8a58-4359-968e-67ea7ee4c164" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

Ly-sec added the epsilon change in this [commit](https://github.com/noctalia-dev/noctalia/commit/8530c77a06b4365a26f0642eb44e834dbf4a268a#diff-24b0b51e8d2393e40626e096ea1574726e6659343dab8b127ba9771fccaa84d0). However, I couldn't find any further context so maybe he could provide additional context about that change.