### PR TITLE
docs(example): drop removed "centered" panel placement, document *_position

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -43,14 +43,22 @@ direction = "down"                  # center, up, down, left, right, up_left, up
 alpha     = 0.55                    # multiplied by each component's background opacity
 
 [shell.panel]
-transparency_mode     = "solid"     # solid | soft | glass; controls floating/centered opacity and card translucency
+transparency_mode     = "solid"     # solid | soft | glass; controls floating opacity and card translucency
 borders               = true        # panel shell outline and in-panel section cards
 shadow                = true        # cast the global [shell.shadow] from panel surfaces
-launcher_placement       = "centered" # attached | floating | centered
-clipboard_placement      = "centered" # attached | floating | centered
-control_center_placement = "attached" # attached | floating | centered
-wallpaper_placement      = "attached" # attached | floating | centered
-session_placement        = "attached" # attached | floating | centered
+launcher_placement       = "floating" # attached | floating
+clipboard_placement      = "floating" # attached | floating
+control_center_placement = "attached" # attached | floating
+wallpaper_placement      = "attached" # attached | floating
+session_placement        = "attached" # attached | floating
+# Floating-panel screen anchor, used when the matching *_placement = "floating".
+# "auto" keeps the panel bar-relative; the old "centered" placement is now floating + "center".
+# auto | center | top_left | top_center | top_right | center_left | center_right | bottom_left | bottom_center | bottom_right
+launcher_position        = "center"   # default for launcher and clipboard
+clipboard_position       = "center"
+control_center_position  = "auto"     # default for control center, wallpaper, session
+wallpaper_position       = "auto"
+session_position         = "auto"
 open_near_click_control_center = false # for attached/floating placement, follow the bar click instead of bar-center
 open_near_click_launcher       = false # for attached/floating placement, follow the bar click instead of bar-center
 open_near_click_clipboard      = false # for attached/floating placement, follow the bar click instead of bar-center


### PR DESCRIPTION
hey dusty, tiny docs thing i bumped into while updating my install.

after 7c50bbf84 dropped the Centered placement (it's `floating` + a per-panel `*_position` now), `example.toml` still lists "centered" in the `[shell.panel]` comments and uses it as the launcher/clipboard default. so if you copy the example as-is, `config validate` grumbles:

```
WARN  shell.panel.launcher_placement: unknown value "centered"
WARN  shell.panel.clipboard_placement: unknown value "centered"
```

this just syncs the example with the real schema defaults (launcher/clipboard default to `floating` + `center`, the rest to `attached` + `auto`) and documents the new `*_position` keys. `center` reproduces the old centered behavior, so nothing changes for anyone copying it.

before/after with `noctalia config validate example.toml`:

```
before: 8 warnings (the two above + unrelated illustrative keys)
after:  6 warnings, placement/position lines clean
```

docs only, no code touched. no rush at all on merging, just did it for fun while i had the schema open. cheers
