### PR TITLE
widgets/volume: add glyph settings

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2807,7 +2807,8 @@
         "glyph": {
           "description": "Icon glyph name",
           "label": "Glyph",
-          "sysmon-description": "Custom icon glyph. Leave empty to use the icon for the selected stat."
+          "sysmon-description": "Custom icon glyph. Leave empty to use the icon for the selected stat.",
+          "volume-description": "Custom icon glyph. Leave empty to use the built-in dynamic icons."
         },
         "group-by-workspace": {
           "description": "Group taskbar icons into workspace capsules when compositor data is available",
@@ -2957,6 +2958,10 @@
         "mute-color": {
           "description": "Color role used for the icon and label when muted; fixed hex colors are also supported",
           "label": "Mute Color"
+        },
+        "mute-glyph": {
+          "description": "Icon glyph used when muted or at 0% volume. Leave empty to use the built-in mute icon.",
+          "label": "Mute Glyph"
         },
         "occupied-color": {
           "description": "Color role used for occupied workspaces; fixed hex colors are also supported",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -598,8 +598,11 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const ColorSpec muteColor = wc != nullptr
         ? wc->getColorSpec("mute_color", colorSpecFromRole(ColorRole::Error), "widget." + name + ".mute_color")
         : colorSpecFromRole(ColorRole::Error);
+    std::string glyphOverride = wc != nullptr ? wc->getString("glyph", "") : std::string{};
+    std::string muteGlyphOverride = wc != nullptr ? wc->getString("mute_glyph", "") : std::string{};
     auto widget = std::make_unique<VolumeWidget>(
-        m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep, muteColor
+        m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep, muteColor,
+        std::move(glyphOverride), std::move(muteGlyphOverride)
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <utility>
 
 namespace {
 
@@ -34,10 +35,12 @@ namespace {
 
 VolumeWidget::VolumeWidget(
     PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* /*output*/,
-    bool showLabel, VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor
+    bool showLabel, VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
+    std::string muteGlyphOverride
 )
     : m_audio(audio), m_easyEffects(easyEffects), m_config(config), m_showLabel(showLabel),
-      m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target), m_muteColor(muteColor) {}
+      m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target), m_muteColor(muteColor),
+      m_glyphOverride(std::move(glyphOverride)), m_muteGlyphOverride(std::move(muteGlyphOverride)) {}
 
 void VolumeWidget::create() {
   auto area = std::make_unique<InputArea>();
@@ -81,7 +84,7 @@ void VolumeWidget::create() {
   area->addChild(
       ui::glyph({
           .out = &m_glyph,
-          .glyph = "volume-high",
+          .glyph = glyphName(1.0f, false),
           .glyphSize = Style::baseGlyphSize * m_contentScale,
           .color = widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)),
       })
@@ -158,7 +161,7 @@ void VolumeWidget::syncState(Renderer& renderer) {
   m_lastVertical = m_isVertical;
   m_lastEffectsProfile = effectsProfile;
 
-  m_glyph->setGlyph(volumeGlyphName(volume, muted, m_target));
+  m_glyph->setGlyph(glyphName(volume, muted));
   m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
   m_glyph->setColor(muted ? m_muteColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
   m_glyph->measure(renderer);
@@ -194,4 +197,16 @@ void VolumeWidget::syncState(Renderer& renderer) {
   }
 
   requestRedraw();
+}
+
+std::string VolumeWidget::glyphName(float volume, bool muted) const {
+  if (muted || volume <= 0.0f) {
+    if (!m_muteGlyphOverride.empty()) {
+      return m_muteGlyphOverride;
+    }
+  } else if (!m_glyphOverride.empty()) {
+    return m_glyphOverride;
+  }
+
+  return volumeGlyphName(volume, muted, m_target);
 }

--- a/src/shell/bar/widgets/volume_widget.h
+++ b/src/shell/bar/widgets/volume_widget.h
@@ -21,7 +21,8 @@ class VolumeWidget : public Widget {
 public:
   VolumeWidget(
       PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* output, bool showLabel,
-      VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor
+      VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
+      std::string muteGlyphOverride
   );
 
   void create() override;
@@ -30,6 +31,7 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void syncState(Renderer& renderer);
+  [[nodiscard]] std::string glyphName(float volume, bool muted) const;
 
   PipeWireService* m_audio = nullptr;
   EasyEffectsService* m_easyEffects = nullptr;
@@ -38,6 +40,8 @@ private:
   float m_scrollStep = 0.05f;
   VolumeWidgetTarget m_target = VolumeWidgetTarget::Output;
   ColorSpec m_muteColor;
+  std::string m_glyphOverride;
+  std::string m_muteGlyphOverride;
   Glyph* m_glyph = nullptr;
   Label* m_label = nullptr;
   float m_lastVolume = -1.0f;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -167,8 +167,13 @@ namespace settings {
           return "upload";
         }
       }
-      if (type == "volume" && config->getString("device", "output") == "input") {
-        return "microphone";
+      if (type == "volume") {
+        if (const std::string custom = config->getString("glyph", ""); !custom.empty()) {
+          return custom;
+        }
+        if (config->getString("device", "output") == "input") {
+          return "microphone";
+        }
       }
       return defaultWidgetGlyph(type);
     }
@@ -905,6 +910,12 @@ namespace settings {
       }
     } else if (type == "volume") {
       add(segmentedSpec("device", "output", volumeDeviceOptions));
+      {
+        auto glyph = glyphSpec("glyph", "");
+        glyph.descriptionKey = "settings.widgets.settings.glyph.volume-description";
+        add(std::move(glyph));
+      }
+      add(glyphSpec("mute_glyph", ""));
       add(stepperIntSpec("scroll_step", 5, 1.0, 25.0, 1.0, "%"));
       add(boolSpec("show_label", true));
       add(colorSpec("mute_color", "error"));


### PR DESCRIPTION
Add glyph override settings for the volume bar widget. You can separately adjust both the base glyph and the mute glyph.

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
