### PR TITLE
Add network speed formatting settings

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -459,6 +459,10 @@
         "label-min-width": "Label Min Width",
         "layout": "Layout",
         "mirrored": "Mirrored",
+        "network-speed-unit": "Network Speed Unit",
+        "network-speed-unit-auto": "Auto",
+        "network-speed-unit-kilobytes": "kB/s",
+        "network-speed-unit-megabytes": "MB/s",
         "opacity": "Opacity",
         "primary-color": "Primary Color",
         "reset-defaults": "Reset to Defaults",
@@ -2623,6 +2627,7 @@
       },
       "options": {
         "always": "Always",
+        "auto": "Auto",
         "cpu-temp": "CPU Temperature",
         "cpu-usage": "CPU Usage",
         "disk-percent": "Disk Percent",
@@ -2639,6 +2644,8 @@
         "id": "ID",
         "input": "Input",
         "instance": "Per Placement",
+        "kilobytes": "kB/s",
+        "megabytes": "MB/s",
         "name": "Name",
         "net-rx": "Network RX",
         "net-tx": "Network TX",
@@ -2953,6 +2960,10 @@
         "mirrored": {
           "description": "Mirror the visualizer around its center",
           "label": "Mirrored"
+        },
+        "network-speed-unit": {
+          "description": "Unit used for network receive and transmit speeds; Auto switches between B/s, kB/s, MB/s, and GB/s",
+          "label": "Network Speed Unit"
         },
         "mute-color": {
           "description": "Color role used for the icon and label when muted; fixed hex colors are also supported",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -459,6 +459,7 @@
         "label-min-width": "Label Min Width",
         "layout": "Layout",
         "mirrored": "Mirrored",
+        "network-speed-compact": "Compact Network Speed",
         "network-speed-unit": "Network Speed Unit",
         "network-speed-unit-auto": "Auto",
         "network-speed-unit-kilobytes": "kB/s",
@@ -2960,6 +2961,10 @@
         "mirrored": {
           "description": "Mirror the visualizer around its center",
           "label": "Mirrored"
+        },
+        "network-speed-compact": {
+          "description": "Use short unit suffixes such as 1.2M instead of 1.2 MB/s",
+          "label": "Compact Network Speed"
         },
         "network-speed-unit": {
           "description": "Unit used for network receive and transmit speeds; Auto switches between B/s, kB/s, MB/s, and GB/s",

--- a/example.toml
+++ b/example.toml
@@ -434,9 +434,11 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 
 # [widget.network_rx]
 # network_speed_unit = "mb"          # auto | kb | mb
+# network_speed_compact = true       # show "1.2M" instead of "1.2 MB/s"
 #
 # [widget.network_tx]
 # network_speed_unit = "mb"          # auto | kb | mb
+# network_speed_compact = true       # show "1.2M" instead of "1.2 MB/s"
 
 # [widget.keyboard_layout]
 # display                 = "short"    # "short" (e.g. "DE") or "full" (full layout name)

--- a/example.toml
+++ b/example.toml
@@ -432,6 +432,12 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # [widget.notifications]
 # hide_when_no_unread = true
 
+# [widget.network_rx]
+# network_speed_unit = "mb"          # auto | kb | mb
+#
+# [widget.network_tx]
+# network_speed_unit = "mb"          # auto | kb | mb
+
 # [widget.keyboard_layout]
 # display                 = "short"    # "short" (e.g. "DE") or "full" (full layout name)
 # show_icon               = true

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -43,6 +43,7 @@
 #include "shell/bar/widgets/wallpaper_widget.h"
 #include "shell/bar/widgets/weather_widget.h"
 #include "shell/bar/widgets/workspaces_widget.h"
+#include "system/format_units.h"
 #include "ui/style.h"
 #include "util/string_utils.h"
 #include "wayland/wayland_connection.h"
@@ -486,6 +487,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     }
     const std::string display = wc != nullptr ? wc->getString("display", "gauge") : std::string("gauge");
     const std::string networkInterface = wc != nullptr ? wc->getString("interface", "") : std::string();
+    const std::string networkSpeedUnit = wc != nullptr ? wc->getString("network_speed_unit", "auto") : "auto";
     SysmonDisplayMode displayMode = SysmonDisplayMode::Gauge;
     if (display == "text")
       displayMode = SysmonDisplayMode::Text;
@@ -501,6 +503,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
               )
             : colorSpecFromRole(ColorRole::Error),
         .networkInterface = networkInterface,
+        .networkSpeedUnit = FormatUnits::decimalByteRateUnitFromString(networkSpeedUnit),
         .showLabel = wc != nullptr ? wc->getBool("show_label", true) : true,
         .labelMinWidth = static_cast<float>(wc != nullptr ? wc->getDouble("label_min_width", 0.0) : 0.0),
         .glyph = wc != nullptr ? wc->getString("glyph", "") : std::string{},

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -488,6 +488,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const std::string display = wc != nullptr ? wc->getString("display", "gauge") : std::string("gauge");
     const std::string networkInterface = wc != nullptr ? wc->getString("interface", "") : std::string();
     const std::string networkSpeedUnit = wc != nullptr ? wc->getString("network_speed_unit", "auto") : "auto";
+    const bool networkSpeedCompact = wc != nullptr ? wc->getBool("network_speed_compact", false) : false;
     SysmonDisplayMode displayMode = SysmonDisplayMode::Gauge;
     if (display == "text")
       displayMode = SysmonDisplayMode::Text;
@@ -504,6 +505,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
             : colorSpecFromRole(ColorRole::Error),
         .networkInterface = networkInterface,
         .networkSpeedUnit = FormatUnits::decimalByteRateUnitFromString(networkSpeedUnit),
+        .networkSpeedLabelStyle =
+            networkSpeedCompact ? FormatUnits::ByteRateLabelStyle::Compact : FormatUnits::ByteRateLabelStyle::Full,
         .showLabel = wc != nullptr ? wc->getBool("show_label", true) : true,
         .labelMinWidth = static_cast<float>(wc != nullptr ? wc->getDouble("label_min_width", 0.0) : 0.0),
         .glyph = wc != nullptr ? wc->getString("glyph", "") : std::string{},

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -136,7 +136,8 @@ SysmonWidget::SysmonWidget(SystemMonitorService* monitor, ConfigService& configS
     : m_monitor(monitor), m_stat(options.stat), m_displayMode(options.displayMode),
       m_highlightColor(options.highlightColor), m_configService(configService), m_showLabel(options.showLabel),
       m_labelMinWidth(options.labelMinWidth), m_diskPath(std::move(options.diskPath)),
-      m_networkInterface(std::move(options.networkInterface)), m_glyphOverride(std::move(options.glyph)) {
+      m_networkInterface(std::move(options.networkInterface)), m_networkSpeedUnit(options.networkSpeedUnit),
+      m_glyphOverride(std::move(options.glyph)) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat)) {
       m_monitor->retainCpuTemp();
@@ -808,10 +809,10 @@ std::optional<std::string> SysmonWidget::formatValueFor(SysmonStat stat, const S
     return std::nullopt;
 
   case SysmonStat::NetRx:
-    return FormatUnits::formatDecimalBytesPerSecond(netRxFromStats(stats, m_networkInterface));
+    return FormatUnits::formatDecimalBytesPerSecond(netRxFromStats(stats, m_networkInterface), m_networkSpeedUnit);
 
   case SysmonStat::NetTx:
-    return FormatUnits::formatDecimalBytesPerSecond(netTxFromStats(stats, m_networkInterface));
+    return FormatUnits::formatDecimalBytesPerSecond(netTxFromStats(stats, m_networkInterface), m_networkSpeedUnit);
 
   case SysmonStat::DiskPct:
     break; // handled above

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -137,7 +137,7 @@ SysmonWidget::SysmonWidget(SystemMonitorService* monitor, ConfigService& configS
       m_highlightColor(options.highlightColor), m_configService(configService), m_showLabel(options.showLabel),
       m_labelMinWidth(options.labelMinWidth), m_diskPath(std::move(options.diskPath)),
       m_networkInterface(std::move(options.networkInterface)), m_networkSpeedUnit(options.networkSpeedUnit),
-      m_glyphOverride(std::move(options.glyph)) {
+      m_networkSpeedLabelStyle(options.networkSpeedLabelStyle), m_glyphOverride(std::move(options.glyph)) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat)) {
       m_monitor->retainCpuTemp();
@@ -809,10 +809,14 @@ std::optional<std::string> SysmonWidget::formatValueFor(SysmonStat stat, const S
     return std::nullopt;
 
   case SysmonStat::NetRx:
-    return FormatUnits::formatDecimalBytesPerSecond(netRxFromStats(stats, m_networkInterface), m_networkSpeedUnit);
+    return FormatUnits::formatDecimalBytesPerSecond(
+        netRxFromStats(stats, m_networkInterface), m_networkSpeedUnit, m_networkSpeedLabelStyle
+    );
 
   case SysmonStat::NetTx:
-    return FormatUnits::formatDecimalBytesPerSecond(netTxFromStats(stats, m_networkInterface), m_networkSpeedUnit);
+    return FormatUnits::formatDecimalBytesPerSecond(
+        netTxFromStats(stats, m_networkInterface), m_networkSpeedUnit, m_networkSpeedLabelStyle
+    );
 
   case SysmonStat::DiskPct:
     break; // handled above

--- a/src/shell/bar/widgets/sysmon_widget.h
+++ b/src/shell/bar/widgets/sysmon_widget.h
@@ -4,6 +4,7 @@
 #include "core/timer_manager.h"
 #include "shell/bar/widget.h"
 #include "shell/tooltip/tooltip_content.h"
+#include "system/format_units.h"
 #include "ui/palette.h"
 #include "ui/signal.h"
 
@@ -44,6 +45,7 @@ struct SysmonWidgetOptions {
   SysmonDisplayMode displayMode = SysmonDisplayMode::Gauge;
   ColorSpec highlightColor = colorSpecFromRole(ColorRole::Error);
   std::string networkInterface;
+  FormatUnits::DecimalByteRateUnit networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
   bool showLabel = true;
   float labelMinWidth = 0.0f;
   std::string glyph;
@@ -91,6 +93,7 @@ private:
   float m_labelMinWidth = 0.0f;
   std::string m_diskPath;
   std::string m_networkInterface;
+  FormatUnits::DecimalByteRateUnit m_networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
   std::string m_glyphOverride;
   std::string m_lastRawValue;
   bool m_isVerticalBar = false;

--- a/src/shell/bar/widgets/sysmon_widget.h
+++ b/src/shell/bar/widgets/sysmon_widget.h
@@ -46,6 +46,7 @@ struct SysmonWidgetOptions {
   ColorSpec highlightColor = colorSpecFromRole(ColorRole::Error);
   std::string networkInterface;
   FormatUnits::DecimalByteRateUnit networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
+  FormatUnits::ByteRateLabelStyle networkSpeedLabelStyle = FormatUnits::ByteRateLabelStyle::Full;
   bool showLabel = true;
   float labelMinWidth = 0.0f;
   std::string glyph;
@@ -94,6 +95,7 @@ private:
   std::string m_diskPath;
   std::string m_networkInterface;
   FormatUnits::DecimalByteRateUnit m_networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
+  FormatUnits::ByteRateLabelStyle m_networkSpeedLabelStyle = FormatUnits::ByteRateLabelStyle::Full;
   std::string m_glyphOverride;
   std::string m_lastRawValue;
   bool m_isVerticalBar = false;

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -381,6 +381,9 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
             .networkInterface = getStringSetting(settings, "interface"),
             .networkSpeedUnit =
                 FormatUnits::decimalByteRateUnitFromString(getStringSetting(settings, "network_speed_unit", "auto")),
+            .networkSpeedLabelStyle = getBoolSetting(settings, "network_speed_compact", false)
+                ? FormatUnits::ByteRateLabelStyle::Compact
+                : FormatUnits::ByteRateLabelStyle::Full,
             .showLabel = getBoolSetting(settings, "show_label", true),
             .labelMinWidth = getFloatSetting(settings, "label_min_width", 0.0f),
             .shadow = getBoolSetting(settings, "shadow", true),

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -15,6 +15,7 @@
 #include "shell/desktop/widgets/desktop_sysmon_widget.h"
 #include "shell/desktop/widgets/desktop_weather_widget.h"
 #include "shell/desktop/widgets/plugin_desktop_widget.h"
+#include "system/format_units.h"
 #include "ui/controls/button.h"
 
 #include <algorithm>
@@ -378,6 +379,8 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
             .lineColor2 = getColorSpecSetting(settings, "color2", colorSpecFromRole(ColorRole::Secondary)),
             .highlightColor = getColorSpecSetting(settings, "highlight_color", colorSpecFromRole(ColorRole::Error)),
             .networkInterface = getStringSetting(settings, "interface"),
+            .networkSpeedUnit =
+                FormatUnits::decimalByteRateUnitFromString(getStringSetting(settings, "network_speed_unit", "auto")),
             .showLabel = getBoolSetting(settings, "show_label", true),
             .labelMinWidth = getFloatSetting(settings, "label_min_width", 0.0f),
             .shadow = getBoolSetting(settings, "shadow", true),

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -228,6 +228,12 @@ namespace desktop_settings {
     };
     sysmonStatsWithNone.insert(sysmonStatsWithNone.end(), sysmonStats.begin(), sysmonStats.end());
 
+    const std::vector<WidgetSettingSelectOption> networkSpeedUnits = {
+        {"auto", "desktop-widgets.editor.settings.network-speed-unit-auto"},
+        {"kb", "desktop-widgets.editor.settings.network-speed-unit-kilobytes"},
+        {"mb", "desktop-widgets.editor.settings.network-speed-unit-megabytes"},
+    };
+
     std::vector<WidgetSettingSpec> specs;
     auto add = [&](WidgetSettingSpec spec) { specs.push_back(std::move(spec)); };
 
@@ -355,6 +361,11 @@ namespace desktop_settings {
         interface.visibleWhen =
             WidgetSettingVisibility{{{"stat", {"net_rx", "net_tx"}}, {"stat2", {"net_rx", "net_tx"}}}};
         add(std::move(interface));
+      }
+      {
+        auto unit = selectSpec("network_speed_unit", "auto", networkSpeedUnits);
+        unit.visibleWhen = WidgetSettingVisibility{{{"stat", {"net_rx", "net_tx"}}, {"stat2", {"net_rx", "net_tx"}}}};
+        add(std::move(unit));
       }
       add(segmentedSpec("display", "graph", sysmonDisplay));
       {

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -367,6 +367,12 @@ namespace desktop_settings {
         unit.visibleWhen = WidgetSettingVisibility{{{"stat", {"net_rx", "net_tx"}}, {"stat2", {"net_rx", "net_tx"}}}};
         add(std::move(unit));
       }
+      {
+        auto compact = boolSpec("network_speed_compact", false);
+        compact.visibleWhen =
+            WidgetSettingVisibility{{{"stat", {"net_rx", "net_tx"}}, {"stat2", {"net_rx", "net_tx"}}}};
+        add(std::move(compact));
+      }
       add(segmentedSpec("display", "graph", sysmonDisplay));
       {
         auto gaugeLayout = segmentedSpec(

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -82,8 +82,8 @@ DesktopSysmonWidget::DesktopSysmonWidget(SystemMonitorService* monitor, Options 
     : m_monitor(monitor), m_config(options.config), m_stat(options.stat), m_stat2(options.stat2),
       m_displayMode(options.displayMode), m_gaugeLayout(options.gaugeLayout), m_lineColor(options.lineColor),
       m_lineColor2(options.lineColor2), m_highlightColor(options.highlightColor),
-      m_networkInterface(std::move(options.networkInterface)), m_showLabel(options.showLabel),
-      m_labelMinWidth(options.labelMinWidth), m_shadow(options.shadow) {
+      m_networkInterface(std::move(options.networkInterface)), m_networkSpeedUnit(options.networkSpeedUnit),
+      m_showLabel(options.showLabel), m_labelMinWidth(options.labelMinWidth), m_shadow(options.shadow) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat))
       m_monitor->retainCpuTemp();
@@ -263,6 +263,15 @@ bool DesktopSysmonWidget::applySetting(
         m_label->setMinWidth(m_labelMinWidth > 0.0f ? m_labelMinWidth * m_contentScale : 0.0f);
       }
       requestLayout();
+      return true;
+    }
+    return false;
+  }
+  if (key == "network_speed_unit") {
+    if (const auto* v = std::get_if<std::string>(&value)) {
+      m_networkSpeedUnit = FormatUnits::decimalByteRateUnitFromString(*v);
+      syncLabel();
+      requestRedraw();
       return true;
     }
     return false;
@@ -771,10 +780,14 @@ std::string DesktopSysmonWidget::formatValueFor(DesktopSysmonStat stat) const {
     return "--";
 
   case DesktopSysmonStat::NetRx:
-    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netRxBytesPerSec(m_networkInterface));
+    return FormatUnits::formatDecimalBytesPerSecond(
+        m_monitor->netRxBytesPerSec(m_networkInterface), m_networkSpeedUnit
+    );
 
   case DesktopSysmonStat::NetTx:
-    return FormatUnits::formatDecimalBytesPerSecond(m_monitor->netTxBytesPerSec(m_networkInterface));
+    return FormatUnits::formatDecimalBytesPerSecond(
+        m_monitor->netTxBytesPerSec(m_networkInterface), m_networkSpeedUnit
+    );
   }
 
   return "--";

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -83,7 +83,8 @@ DesktopSysmonWidget::DesktopSysmonWidget(SystemMonitorService* monitor, Options 
       m_displayMode(options.displayMode), m_gaugeLayout(options.gaugeLayout), m_lineColor(options.lineColor),
       m_lineColor2(options.lineColor2), m_highlightColor(options.highlightColor),
       m_networkInterface(std::move(options.networkInterface)), m_networkSpeedUnit(options.networkSpeedUnit),
-      m_showLabel(options.showLabel), m_labelMinWidth(options.labelMinWidth), m_shadow(options.shadow) {
+      m_networkSpeedLabelStyle(options.networkSpeedLabelStyle), m_showLabel(options.showLabel),
+      m_labelMinWidth(options.labelMinWidth), m_shadow(options.shadow) {
   if (m_monitor != nullptr) {
     if (needsCpuTemp(m_stat))
       m_monitor->retainCpuTemp();
@@ -270,6 +271,15 @@ bool DesktopSysmonWidget::applySetting(
   if (key == "network_speed_unit") {
     if (const auto* v = std::get_if<std::string>(&value)) {
       m_networkSpeedUnit = FormatUnits::decimalByteRateUnitFromString(*v);
+      syncLabel();
+      requestRedraw();
+      return true;
+    }
+    return false;
+  }
+  if (key == "network_speed_compact") {
+    if (const auto* v = std::get_if<bool>(&value)) {
+      m_networkSpeedLabelStyle = *v ? FormatUnits::ByteRateLabelStyle::Compact : FormatUnits::ByteRateLabelStyle::Full;
       syncLabel();
       requestRedraw();
       return true;
@@ -781,12 +791,12 @@ std::string DesktopSysmonWidget::formatValueFor(DesktopSysmonStat stat) const {
 
   case DesktopSysmonStat::NetRx:
     return FormatUnits::formatDecimalBytesPerSecond(
-        m_monitor->netRxBytesPerSec(m_networkInterface), m_networkSpeedUnit
+        m_monitor->netRxBytesPerSec(m_networkInterface), m_networkSpeedUnit, m_networkSpeedLabelStyle
     );
 
   case DesktopSysmonStat::NetTx:
     return FormatUnits::formatDecimalBytesPerSecond(
-        m_monitor->netTxBytesPerSec(m_networkInterface), m_networkSpeedUnit
+        m_monitor->netTxBytesPerSec(m_networkInterface), m_networkSpeedUnit, m_networkSpeedLabelStyle
     );
   }
 

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.h
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.h
@@ -2,6 +2,7 @@
 
 #include "core/frame_rate_limiter.h"
 #include "shell/desktop/desktop_widget.h"
+#include "system/format_units.h"
 #include "ui/palette.h"
 
 #include <chrono>
@@ -46,6 +47,7 @@ public:
     ColorSpec lineColor2 = colorSpecFromRole(ColorRole::Secondary);
     ColorSpec highlightColor = colorSpecFromRole(ColorRole::Error);
     std::string networkInterface;
+    FormatUnits::DecimalByteRateUnit networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
     bool showLabel = true;
     float labelMinWidth = 0.0f;
     bool shadow = true;
@@ -97,6 +99,7 @@ private:
   ColorSpec m_lineColor2;
   ColorSpec m_highlightColor;
   std::string m_networkInterface;
+  FormatUnits::DecimalByteRateUnit m_networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
   bool m_showLabel;
   float m_labelMinWidth;
   bool m_shadow;

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.h
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.h
@@ -48,6 +48,7 @@ public:
     ColorSpec highlightColor = colorSpecFromRole(ColorRole::Error);
     std::string networkInterface;
     FormatUnits::DecimalByteRateUnit networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
+    FormatUnits::ByteRateLabelStyle networkSpeedLabelStyle = FormatUnits::ByteRateLabelStyle::Full;
     bool showLabel = true;
     float labelMinWidth = 0.0f;
     bool shadow = true;
@@ -100,6 +101,7 @@ private:
   ColorSpec m_highlightColor;
   std::string m_networkInterface;
   FormatUnits::DecimalByteRateUnit m_networkSpeedUnit = FormatUnits::DecimalByteRateUnit::Auto;
+  FormatUnits::ByteRateLabelStyle m_networkSpeedLabelStyle = FormatUnits::ByteRateLabelStyle::Full;
   bool m_showLabel;
   float m_labelMinWidth;
   bool m_shadow;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -597,6 +597,11 @@ namespace settings {
         {"graph", "settings.widgets.options.graph"},
         {"text", "settings.widgets.options.text"},
     };
+    const std::vector<WidgetSettingSelectOption> networkSpeedUnits = {
+        {"auto", "settings.widgets.options.auto"},
+        {"kb", "settings.widgets.options.kilobytes"},
+        {"mb", "settings.widgets.options.megabytes"},
+    };
     const std::vector<WidgetSettingSelectOption> workspaceDisplay = {
         {"id", "settings.widgets.options.id"},
         {"name", "settings.widgets.options.name"},
@@ -778,6 +783,11 @@ namespace settings {
         auto interface = stringSpec("interface");
         interface.visibleWhen = WidgetSettingVisibility{"stat", {"net_rx", "net_tx"}};
         add(std::move(interface));
+      }
+      {
+        auto unit = selectSpec("network_speed_unit", "auto", networkSpeedUnits);
+        unit.visibleWhen = WidgetSettingVisibility{"stat", {"net_rx", "net_tx"}};
+        add(std::move(unit));
       }
       add(segmentedSpec("display", "gauge", sysmonDisplay));
       add(colorSpec("highlight_color", "error"));

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -789,6 +789,11 @@ namespace settings {
         unit.visibleWhen = WidgetSettingVisibility{"stat", {"net_rx", "net_tx"}};
         add(std::move(unit));
       }
+      {
+        auto compact = boolSpec("network_speed_compact", false);
+        compact.visibleWhen = WidgetSettingVisibility{"stat", {"net_rx", "net_tx"}};
+        add(std::move(compact));
+      }
       add(segmentedSpec("display", "gauge", sysmonDisplay));
       add(colorSpec("highlight_color", "error"));
       add(boolSpec("show_label", true));

--- a/src/system/format_units.cpp
+++ b/src/system/format_units.cpp
@@ -12,6 +12,22 @@ namespace FormatUnits {
     constexpr double kBytesPerGb = 1000.0 * 1000.0 * 1000.0;
     constexpr double kBytesPerTb = 1000.0 * 1000.0 * 1000.0 * 1000.0;
 
+    [[nodiscard]] std::string formatByteRateValue(
+        double value, std::string_view fullSuffix, std::string_view compactSuffix, ByteRateLabelStyle labelStyle
+    ) {
+      if (labelStyle == ByteRateLabelStyle::Compact) {
+        return std::format("{:.1f}{}", value, compactSuffix);
+      }
+      return std::format("{:.1f} {}", value, fullSuffix);
+    }
+
+    [[nodiscard]] std::string formatByteRateBytes(double bytesPerSec, ByteRateLabelStyle labelStyle) {
+      if (labelStyle == ByteRateLabelStyle::Compact) {
+        return std::format("{:.0f}B", bytesPerSec);
+      }
+      return std::format("{:.0f} B/s", bytesPerSec);
+    }
+
   } // namespace
 
   std::string formatBinaryMib(std::uint64_t mib) {
@@ -56,26 +72,26 @@ namespace FormatUnits {
     return DecimalByteRateUnit::Auto;
   }
 
-  std::string formatDecimalBytesPerSecond(double bytesPerSec, DecimalByteRateUnit unit) {
+  std::string formatDecimalBytesPerSecond(double bytesPerSec, DecimalByteRateUnit unit, ByteRateLabelStyle labelStyle) {
     switch (unit) {
     case DecimalByteRateUnit::Kilobytes:
-      return std::format("{:.1f} kB/s", bytesPerSec / kBytesPerKb);
+      return formatByteRateValue(bytesPerSec / kBytesPerKb, "kB/s", "k", labelStyle);
     case DecimalByteRateUnit::Megabytes:
-      return std::format("{:.1f} MB/s", bytesPerSec / kBytesPerMb);
+      return formatByteRateValue(bytesPerSec / kBytesPerMb, "MB/s", "M", labelStyle);
     case DecimalByteRateUnit::Auto:
       break;
     }
 
     if (bytesPerSec >= kBytesPerGb) {
-      return std::format("{:.1f} GB/s", bytesPerSec / kBytesPerGb);
+      return formatByteRateValue(bytesPerSec / kBytesPerGb, "GB/s", "G", labelStyle);
     }
     if (bytesPerSec >= kBytesPerMb) {
-      return std::format("{:.1f} MB/s", bytesPerSec / kBytesPerMb);
+      return formatByteRateValue(bytesPerSec / kBytesPerMb, "MB/s", "M", labelStyle);
     }
     if (bytesPerSec >= kBytesPerKb) {
-      return std::format("{:.1f} kB/s", bytesPerSec / kBytesPerKb);
+      return formatByteRateValue(bytesPerSec / kBytesPerKb, "kB/s", "k", labelStyle);
     }
-    return std::format("{:.0f} B/s", bytesPerSec);
+    return formatByteRateBytes(bytesPerSec, labelStyle);
   }
 
 } // namespace FormatUnits

--- a/src/system/format_units.cpp
+++ b/src/system/format_units.cpp
@@ -46,7 +46,26 @@ namespace FormatUnits {
 
   std::string formatDecimalBytesAsGb(double bytes) { return std::format("{:.1f} GB", bytes / kBytesPerGb); }
 
-  std::string formatDecimalBytesPerSecond(double bytesPerSec) {
+  DecimalByteRateUnit decimalByteRateUnitFromString(std::string_view value) {
+    if (value == "kb") {
+      return DecimalByteRateUnit::Kilobytes;
+    }
+    if (value == "mb") {
+      return DecimalByteRateUnit::Megabytes;
+    }
+    return DecimalByteRateUnit::Auto;
+  }
+
+  std::string formatDecimalBytesPerSecond(double bytesPerSec, DecimalByteRateUnit unit) {
+    switch (unit) {
+    case DecimalByteRateUnit::Kilobytes:
+      return std::format("{:.1f} kB/s", bytesPerSec / kBytesPerKb);
+    case DecimalByteRateUnit::Megabytes:
+      return std::format("{:.1f} MB/s", bytesPerSec / kBytesPerMb);
+    case DecimalByteRateUnit::Auto:
+      break;
+    }
+
     if (bytesPerSec >= kBytesPerGb) {
       return std::format("{:.1f} GB/s", bytesPerSec / kBytesPerGb);
     }

--- a/src/system/format_units.h
+++ b/src/system/format_units.h
@@ -11,6 +11,10 @@ namespace FormatUnits {
     Kilobytes,
     Megabytes,
   };
+  enum class ByteRateLabelStyle {
+    Full,
+    Compact,
+  };
 
   [[nodiscard]] std::string formatBinaryMib(std::uint64_t mib);
   [[nodiscard]] std::string formatBinaryMibAsGib(std::uint64_t mib);
@@ -19,7 +23,9 @@ namespace FormatUnits {
   [[nodiscard]] std::string formatDecimalBytesUsage(double usedBytes, double totalBytes);
   [[nodiscard]] std::string formatDecimalBytesAsGb(double bytes);
   [[nodiscard]] DecimalByteRateUnit decimalByteRateUnitFromString(std::string_view value);
-  [[nodiscard]] std::string
-  formatDecimalBytesPerSecond(double bytesPerSec, DecimalByteRateUnit unit = DecimalByteRateUnit::Auto);
+  [[nodiscard]] std::string formatDecimalBytesPerSecond(
+      double bytesPerSec, DecimalByteRateUnit unit = DecimalByteRateUnit::Auto,
+      ByteRateLabelStyle labelStyle = ByteRateLabelStyle::Full
+  );
 
 } // namespace FormatUnits

--- a/src/system/format_units.h
+++ b/src/system/format_units.h
@@ -2,8 +2,15 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 namespace FormatUnits {
+
+  enum class DecimalByteRateUnit {
+    Auto,
+    Kilobytes,
+    Megabytes,
+  };
 
   [[nodiscard]] std::string formatBinaryMib(std::uint64_t mib);
   [[nodiscard]] std::string formatBinaryMibAsGib(std::uint64_t mib);
@@ -11,6 +18,8 @@ namespace FormatUnits {
   [[nodiscard]] std::string formatBinaryBytesAsGib(std::uint64_t bytes);
   [[nodiscard]] std::string formatDecimalBytesUsage(double usedBytes, double totalBytes);
   [[nodiscard]] std::string formatDecimalBytesAsGb(double bytes);
-  [[nodiscard]] std::string formatDecimalBytesPerSecond(double bytesPerSec);
+  [[nodiscard]] DecimalByteRateUnit decimalByteRateUnitFromString(std::string_view value);
+  [[nodiscard]] std::string
+  formatDecimalBytesPerSecond(double bytesPerSec, DecimalByteRateUnit unit = DecimalByteRateUnit::Auto);
 
 } // namespace FormatUnits


### PR DESCRIPTION
This PR adds two formatting settings for network speed values:
- unit: auto (current), always kB/s, always MB/s
- compact: e.g. `1.2M` instead of `1.2 MB/s`

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
