### PR TITLE
refactor(settings): improve search performance to avoid keyboard input lag

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3290,6 +3290,7 @@
       "reset-page": "Reset Page",
       "reset-page-confirm": "Confirm Reset",
       "search-placeholder": "Search settings…",
+      "search-truncated": "Showing the first {count} matches. Refine your search to narrow results.",
       "support-report": "Support Report",
       "support-report-saved": "Support report saved.",
       "support-report-title": "Save Support Report",

--- a/src/shell/settings/settings_content.cpp
+++ b/src/shell/settings/settings_content.cpp
@@ -28,9 +28,11 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -1278,42 +1280,43 @@ namespace settings {
     Flex* activeKeybindRow = nullptr;
     std::size_t activeKeybindRowCount = 0;
     std::size_t visibleEntries = 0;
+    // Very short queries (one or two letters) match hundreds of entries and building the subtree for every match is
+    // costly. Cap how many results we render and hint that the list was truncated.
+    constexpr std::size_t kMaxSearchResults = 50;
+    bool truncated = false;
     const std::string normalizedSearchQuery = normalizedSettingQuery(ctx.searchQuery);
 
     BarWidgetEditorContext barWidgetEditorCtx = makeBarWidgetEditorContext(factory);
 
-    auto visibilityConditionMatches = [&](const SettingVisibilityCondition& cond) -> bool {
-      for (const auto& other : registry) {
-        if (other.path == cond.path) {
-          std::string currentValue;
-          if (const auto* toggle = std::get_if<ToggleSetting>(&other.control)) {
-            currentValue = toggle->checked ? "true" : "false";
-          } else if (const auto* select = std::get_if<SelectSetting>(&other.control)) {
-            currentValue = select->selectedValue;
-          } else if (const auto* text = std::get_if<TextSetting>(&other.control)) {
-            currentValue = text->value;
-          }
-          for (const auto& v : cond.values) {
-            if (v == currentValue) {
-              return true;
-            }
-          }
-          return false;
-        }
+    // Visibility conditions reference other settings by path. Build an index once so each
+    // visibility check is an O(1) lookup instead of full registry scan.
+    const auto joinPath = [](const std::vector<std::string>& path) {
+      return path | std::views::join_with('\x1f') | std::ranges::to<std::string>();
+    };
+    std::unordered_map<std::string, std::string> visibilityValues;
+    for (const auto& other : registry) {
+      if (const auto* toggle = std::get_if<ToggleSetting>(&other.control)) {
+        visibilityValues.emplace(joinPath(other.path), toggle->checked ? "true" : "false");
+      } else if (const auto* select = std::get_if<SelectSetting>(&other.control)) {
+        visibilityValues.emplace(joinPath(other.path), select->selectedValue);
+      } else if (const auto* text = std::get_if<TextSetting>(&other.control)) {
+        visibilityValues.emplace(joinPath(other.path), text->value);
       }
-      return true;
+    }
+
+    auto visibilityConditionMatches = [&](const SettingVisibilityCondition& cond) -> bool {
+      const auto it = visibilityValues.find(joinPath(cond.path));
+      if (it == visibilityValues.end()) {
+        return true;
+      }
+      return std::ranges::contains(cond.values, it->second);
     };
 
     auto isEntryVisible = [&](const SettingEntry& e) -> bool {
       if (!e.visibleWhen.has_value()) {
         return true;
       }
-      for (const auto& cond : e.visibleWhen->all) {
-        if (!visibilityConditionMatches(cond)) {
-          return false;
-        }
-      }
-      return true;
+      return std::ranges::all_of(e.visibleWhen->all, visibilityConditionMatches);
     };
 
     const std::string_view selectedBarName =
@@ -1332,6 +1335,10 @@ namespace settings {
 
     for (const std::size_t entryIndex : entryOrder) {
       const auto& entry = registry[entryIndex];
+      if (!ctx.searchQuery.empty() && visibleEntries >= kMaxSearchResults) {
+        truncated = true;
+        break;
+      }
       if (ctx.searchQuery.empty()
           && !ctx.selectedSection.empty()
           && ctx.selectedSection != "bar"
@@ -1465,6 +1472,18 @@ namespace settings {
           ui::row(
               {.align = FlexAlign::Center, .fillWidth = true}, ui::box({.flexGrow = 0.5f}), std::move(emptyState),
               ui::box({.flexGrow = 0.5f})
+          )
+      );
+    }
+
+    if (truncated) {
+      content.addChild(
+          ui::row(
+              {.align = FlexAlign::Center, .justify = FlexJustify::Center, .fillWidth = true},
+              makeLabel(
+                  i18n::tr("settings.window.search-truncated", "count", std::to_string(kMaxSearchResults)),
+                  Style::fontSizeBody * scale, colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal
+              )
           )
       );
     }


### PR DESCRIPTION
## Summary

The shell settings panel lags when typing the first few letters because there are so many matches to build in the node tree. This PR makes two changes:

1) Limit number of matches to 50 total and show message at the end of search results explaining the limit (new i18n key).
2) Optimize visibility check to use O(1) lookup so `addSettingsContentSections` goes from O(N^2) to O(N) in registry size.

## Motivation

The lag at beginning of search is mildly annoying. I don't have anymore lag after this PR (on my CPU at least).

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

I tested searching for settings keys that should be hidden and they don't appear. I also did the reverse.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Message when more than 50 results:

<img width="1116" height="1267" alt="Screenshot_on_06-27-2026_at_16-07-56" src="https://github.com/user-attachments/assets/54ee3ac1-4daf-419c-aeab-aa62c356a800" />

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
