### PR TITLE
feat(ipc): add notification-invoke-latest command

### DIFF
--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -210,6 +210,30 @@ void Application::initIpc() {
   );
 
   m_ipcService.registerHandler(
+      "notification-invoke-latest",
+      [this](const std::string&) -> std::string {
+        // Mirror the toast left-click behaviour for the most recent active notification:
+        // invoke its "default" action so the source application raises/focuses its window.
+        // all() stores notifications oldest-first (push_back), so iterate in reverse for newest.
+        const auto& notifications = m_notificationManager.all();
+        for (auto it = notifications.rbegin(); it != notifications.rend(); ++it) {
+          const auto& actions = it->actions; // pairs: [key, label, ...]; "default" must be first.
+          if (actions.size() >= 2 && actions[0] == "default") {
+            if (!m_notificationManager.invokeAction(it->id, "default", true)) {
+              return "error: invokeAction failed\n";
+            }
+            if (m_panelManager.isOpenPanel("control-center")) {
+              m_panelManager.refresh();
+            }
+            return "ok\n";
+          }
+        }
+        return "ok\n"; // No active notification carries a default action; nothing to do.
+      },
+      "notification-invoke-latest", "Invoke the default action of the most recent active notification"
+  );
+
+  m_ipcService.registerHandler(
       "notification-clear-history",
       [this](const std::string&) -> std::string {
         m_notificationManager.clearHistory();


### PR DESCRIPTION
Expose NotificationManager::invokeAction over IPC so a compositor keybind can activate the default action of the most recent active notification (raising/focusing the source app's window), mirroring a toast left-click.

The UI already does this on BTN_LEFT when the notification has a 'default' action; this adds the missing IPC wrapper for tiling compositors (niri).

## Type of Change
- [x] New feature

## Manual Coverage

- [x] Tested on Niri

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
