### PR TITLE
fix(tray): dedupe equivalent status notifier items

### DIFF
--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -1775,6 +1775,24 @@ void TrayService::requestProcessNameForItem(const std::string& itemId, const std
   }
 }
 
+std::uint32_t TrayService::connectionPidForBusName(const std::string& busName) const {
+  if (busName.empty() || m_dbusProxy == nullptr || !looks_like_dbus_name(busName)) {
+    return 0;
+  }
+
+  try {
+    std::uint32_t pid = 0;
+    m_dbusProxy->callMethod("GetConnectionUnixProcessID")
+        .onInterface(kDbusInterface)
+        .withArguments(busName)
+        .storeResultsTo(pid);
+    return pid;
+  } catch (const sdbus::Error& e) {
+    kLog.debug("pid lookup failed bus={} err={}", busName, e.what());
+    return 0;
+  }
+}
+
 std::string TrayService::busNameFromItemId(const std::string& itemId) {
   if (itemId.empty()) {
     return {};
@@ -1805,6 +1823,19 @@ void TrayService::registerOrRefreshItem(const std::string& busName, const std::s
   }
 
   if (!m_items.contains(itemId)) {
+    const auto pid = connectionPidForBusName(busName);
+    if (pid != 0) {
+      for (const auto& [existingId, existingItem] : m_items) {
+        if (existingItem.objectPath == objectPath && connectionPidForBusName(existingItem.busName) == pid) {
+          kLog.debug(
+              "tray item duplicate ignored id={} existing={} bus='{}' path='{}'", itemId, existingId, busName,
+              objectPath
+          );
+          return;
+        }
+      }
+    }
+
     kLog.debug("tray item registered id={} bus='{}' path='{}'", itemId, busName, objectPath);
     m_items.emplace(
         itemId,

--- a/src/dbus/tray/tray_service.h
+++ b/src/dbus/tray/tray_service.h
@@ -129,6 +129,7 @@ private:
   void attachItemProxySignals(const std::string& itemId, sdbus::IProxy& proxy);
   void resolvePathOnlyItemProxy(const std::string& itemId);
   void requestProcessNameForItem(const std::string& itemId, const std::string& busName);
+  [[nodiscard]] std::uint32_t connectionPidForBusName(const std::string& busName) const;
   void refreshItemMetadata(const std::string& itemId);
   void ensureMenuCache(const std::string& itemId, const std::string& busName, const std::string& menuPath);
   void dropMenuCache(const std::string& itemId);


### PR DESCRIPTION
Fixes #3194.

NordVPN can register the same StatusNotifier item under both its unique DBus name and a well-known `org.kde.StatusNotifierItem-*` name. Noctalia currently keys tray items by `busName + objectPath`, so both registrations are rendered as separate icons.

This dedupes new tray registrations when an existing item has the same object path and the same DBus connection process ID.

Tested locally with NordVPN 5.1.0 on Wayland/Niri. The duplicate NordVPN icon is gone, and unrelated tray items still show.
