### PR TITLE
feat(workspace):color cycling

### DIFF
--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -646,12 +646,45 @@ std::unique_ptr<Widget> WidgetFactory::create(
     } else if (display == "none") {
       displayMode = WorkspacesWidget::DisplayMode::None;
     }
+
+    const std::string colorModeValue = wc != nullptr ? wc->getString("color_mode", "state") : std::string("state");
+
+    WorkspacesWidget::ColorMode colorMode = WorkspacesWidget::ColorMode::State;
+
+    if (colorModeValue == "cycle") {
+      colorMode = WorkspacesWidget::ColorMode::Cycle;
+    } else if (colorModeValue != "state") {
+      kLog.warn("invalid widget.{}.color_mode '{}'; expected state or cycle", name, colorModeValue);
+    }
+
+    std::vector<ColorSpec> cycleColors;
+
+    if (wc != nullptr) {
+      const auto configuredColors = wc->getStringList("cycle_colors");
+
+      cycleColors.reserve(configuredColors.size());
+
+      for (std::size_t i = 0; i < configuredColors.size(); ++i) {
+        cycleColors.push_back(colorSpecFromConfigString(
+            configuredColors[i], "widget." + name + ".cycle_colors[" + std::to_string(i) + "]"
+        ));
+      }
+    }
+
+    if (colorMode == WorkspacesWidget::ColorMode::Cycle && cycleColors.empty()) {
+      kLog.warn("widget.{}.color_mode is cycle but cycle_colors is empty; falling back to state", name);
+
+      colorMode = WorkspacesWidget::ColorMode::State;
+    }
+
     std::size_t maxLabelChars = 1; // Default: truncate names to 1 char (v4 behavior)
     if (wc != nullptr && wc->hasSetting("max_label_chars")) {
       maxLabelChars = static_cast<std::size_t>(wc->getInt("max_label_chars", 1));
     }
     WorkspacesWidget::Options options{
         .displayMode = displayMode,
+        .colorMode = colorMode,
+        .cycleColors = std::move(cycleColors),
         .focusedColor = focusedColor,
         .occupiedColor = occupiedColor,
         .emptyColor = emptyColor,
@@ -664,7 +697,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
     };
-    auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, options);
+    auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, std::move(options));
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -759,18 +759,31 @@ ColorSpec WorkspacesWidget::workspaceTextColor(const Workspace& workspace) const
   if (workspace.urgent) {
     return m_minimal ? colorSpecFromRole(ColorRole::Error) : colorSpecFromRole(ColorRole::OnError);
   }
+
   if (!m_minimal) {
     return readableColorForFill(workspaceFillColor(workspace));
   }
+
   if (workspace.active) {
+    if (m_colorMode == ColorMode::Cycle && !m_cycleColors.empty()) {
+      return workspaceCycleColor(workspace);
+    }
+
     if (m_activeUsesFocusedColor) {
       return m_focusedColor;
     }
+
     return m_occupiedColor;
   }
+
   if (workspace.occupied) {
+    if (m_colorMode == ColorMode::Cycle && !m_cycleColors.empty()) {
+      return workspaceCycleColor(workspace);
+    }
+
     return m_occupiedColor;
   }
+
   ColorSpec color = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurfaceVariant));
   color.alpha *= 0.55f;
   return color;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -41,10 +41,10 @@ namespace {
 } // namespace
 
 WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options)
-    : m_platform(platform), m_output(output), m_displayMode(options.displayMode),
-      m_maxLabelChars(options.maxLabelChars), m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied),
-      m_hideWhenEmpty(options.hideWhenEmpty), m_pillScale(options.pillScale),
-      m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
+    : m_platform(platform), m_output(output), m_displayMode(options.displayMode), m_colorMode(options.colorMode),
+      m_cycleColors(std::move(options.cycleColors)), m_maxLabelChars(options.maxLabelChars),
+      m_labelsOnlyWhenOccupied(options.labelsOnlyWhenOccupied), m_hideWhenEmpty(options.hideWhenEmpty),
+      m_pillScale(options.pillScale), m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
       m_focusedOutputOnly(options.focusedOutputOnly), m_focusedColor(options.focusedColor),
       m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {}
@@ -708,21 +708,48 @@ std::optional<std::size_t> WorkspacesWidget::numericWorkspaceId(const Workspace&
   return std::nullopt;
 }
 
+ColorSpec WorkspacesWidget::workspaceCycleColor(const Workspace& workspace) const {
+  if (m_cycleColors.empty()) {
+    return m_emptyColor;
+  }
+
+  std::size_t workspaceNumber = workspace.index;
+
+  if (workspaceNumber == 0) {
+    workspaceNumber = numericWorkspaceId(workspace).value_or(1);
+  }
+
+  const std::size_t colorIndex = (workspaceNumber - 1) % m_cycleColors.size();
+  return m_cycleColors[colorIndex];
+}
+
 bool WorkspacesWidget::isFocusedOutput() const { return m_platform.preferredInteractiveOutput() == m_output; }
 
 ColorSpec WorkspacesWidget::workspaceFillColor(const Workspace& workspace) const {
   if (workspace.active) {
+    if (m_colorMode == ColorMode::Cycle && !m_cycleColors.empty()) {
+      return workspaceCycleColor(workspace);
+    }
+
     if (m_activeUsesFocusedColor) {
       return m_focusedColor;
     }
+
     return m_occupiedColor;
   }
+
   if (workspace.urgent) {
     return colorSpecFromRole(ColorRole::Error);
   }
+
   if (workspace.occupied) {
+    if (m_colorMode == ColorMode::Cycle && !m_cycleColors.empty()) {
+      return workspaceCycleColor(workspace);
+    }
+
     return m_occupiedColor;
   }
+
   ColorSpec color = m_emptyColor;
   color.alpha *= 0.55f;
   return color;

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -23,8 +23,15 @@ public:
     Name,
   };
 
+  enum class ColorMode : std::uint8_t {
+    State,
+    Cycle,
+  };
+
   struct Options {
     DisplayMode displayMode = DisplayMode::Id;
+    ColorMode colorMode = ColorMode::State;
+    std::vector<ColorSpec> cycleColors;
     ColorSpec focusedColor = colorSpecFromRole(ColorRole::Primary);
     ColorSpec occupiedColor = colorSpecFromRole(ColorRole::Secondary);
     ColorSpec emptyColor = colorSpecFromRole(ColorRole::Secondary);
@@ -86,6 +93,7 @@ private:
   };
 
   [[nodiscard]] ColorSpec workspaceFillColor(const Workspace& workspace) const;
+  [[nodiscard]] ColorSpec workspaceCycleColor(const Workspace& workspace) const;
   [[nodiscard]] ColorSpec workspaceTextColor(const Workspace& workspace) const;
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
@@ -94,6 +102,8 @@ private:
   CompositorPlatform& m_platform;
   wl_output* m_output = nullptr;
   DisplayMode m_displayMode = DisplayMode::None;
+  ColorMode m_colorMode = ColorMode::State;
+  std::vector<ColorSpec> m_cycleColors;
   std::size_t m_maxLabelChars = 1;
   bool m_labelsOnlyWhenOccupied = false;
   bool m_hideWhenEmpty = false;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -949,6 +949,14 @@ namespace settings {
       }
       add(segmentedSpec("display", "id", workspaceDisplay));
       {
+        auto colorMode = stringSpec("color_mode", "state", true);
+        add(std::move(colorMode));
+      }
+      {
+        auto cycleColors = stringListSpec("cycle_colors", {}, true);
+        add(std::move(cycleColors));
+      }
+      {
         auto labelsOnlyWhenOccupied = boolSpec("labels_only_when_occupied", false);
         labelsOnlyWhenOccupied.descriptionKey =
             "settings.widgets.settings.labels-only-when-occupied.workspaces-description";


### PR DESCRIPTION
## Summary

Adds optional color cycling for the bar workspaces widget.

New workspace settings:

```toml
[widget.workspaces]
color_mode = "cycle"
cycle_colors = ["#5BCEFA", "#F5A9B8", "#FFFFFF"]
```

When `color_mode` is set to `cycle`, active and occupied workspaces use colors from `cycle_colors` based on the workspace number.

Empty workspaces keep the existing `empty_color` behavior, and urgent workspaces keep the existing error color.

The feature also works with `minimal = true`, where the workspace text color follows the same cycle.

## Motivation

This makes it possible to create repeating workspace color schemes without replacing the native workspaces widget or relying on plugin/external workarounds.

The default behavior is unchanged because `color_mode` defaults to `state`.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Refactoring
* [ ] Build / packaging

## Related Issue

N/A

## Testing

Ran:

```sh
just format
just build
just test
just lint
noctalia-dev-validate
python3 tools/i18n-check.py
```

Manual testing:

* Tested `color_mode = "cycle"` with hex colors.
* Tested normal workspace mode.
* Tested `minimal = true`.
* Verified empty workspaces keep the existing empty color behavior.
* Verified invalid `color_mode` values fall back to state mode with a warning.
* Verified `color_mode = "cycle"` with an empty `cycle_colors` list falls back to state mode with a warning.

## Manual Coverage

* [ ] Tested on Niri
* [x] Tested on Hyprland
* [ ] Tested on Sway
* [ ] Tested on another compositor:
* [ ] Tested with different bar positions and density settings
* [ ] Tested at different interface scaling values
* [ ] Tested with multiple monitors

## Screenshots / Videos

Example config:

```toml
[widget.workspaces]
color_mode = "cycle"
cycle_colors = ["#5BCEFA", "#F5A9B8", "#FFFFFF"]
```
<img width="3196" height="66" alt="image" src="https://github.com/user-attachments/assets/4d81c67b-20b1-46d1-a723-0e68f764eb5c" />


## Checklist

* [x] This PR is ready for review, or it is marked as Draft.
* [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
* [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
* [x] I ran the relevant build or test commands, or explained why they were not run.
* [x] I self-reviewed the changes.
* [x] I checked for new warnings or errors.
* [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
* [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
* [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
* [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This is intentionally opt-in. Existing workspace coloring remains unchanged unless `color_mode = "cycle"` is configured.

I kept `color_mode` registered as an advanced string setting for now to avoid adding new user-facing translation keys. Happy to adjust this to a segmented/select setting if preferred.
