### PR TITLE
feat(weather): allow disabling temperature text in bar widget

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3109,6 +3109,10 @@
           "description": "Show Scroll Lock state",
           "label": "Show Scroll Lock"
         },
+        "show-temperature": {
+          "description": "Show current temperature text",
+          "label": "Show Temperature"
+        },
         "show-when-idle": {
           "description": "Keep the visualizer visible even when no media is playing",
           "label": "Show When Idle"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -619,7 +619,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "weather") {
     const float maxWidth = static_cast<float>(wc != nullptr ? wc->getDouble("max_length", 160.0) : 160.0);
     const bool showCondition = wc != nullptr ? wc->getBool("show_condition", true) : true;
-    auto widget = std::make_unique<WeatherWidget>(m_weather, output, maxWidth, showCondition);
+    const bool showTemperature = wc != nullptr ? wc->getBool("show_temperature", true) : true;
+    auto widget = std::make_unique<WeatherWidget>(m_weather, output, maxWidth, showCondition, showTemperature);
     widget->setContentScale(contentScale);
     return widget;
   }

--- a/src/shell/bar/widgets/weather_widget.cpp
+++ b/src/shell/bar/widgets/weather_widget.cpp
@@ -13,8 +13,10 @@
 #include <format>
 #include <memory>
 
-WeatherWidget::WeatherWidget(WeatherService* weather, wl_output* /*output*/, float maxWidth, bool showCondition)
-    : m_weather(weather), m_maxWidth(maxWidth), m_showCondition(showCondition) {}
+WeatherWidget::WeatherWidget(
+    WeatherService* weather, wl_output* /*output*/, float maxWidth, bool showCondition, bool showTemperature
+)
+    : m_weather(weather), m_maxWidth(maxWidth), m_showCondition(showCondition), m_showTemperature(showTemperature) {}
 
 void WeatherWidget::create() {
   auto area = std::make_unique<InputArea>();
@@ -99,13 +101,17 @@ void WeatherWidget::sync(Renderer& renderer) {
     glyph = WeatherService::glyphForCode(snapshot.current.weatherCode, snapshot.current.isDay);
     const int temp = static_cast<int>(std::lround(m_weather->displayTemperature(snapshot.current.temperatureC)));
     const std::string unit = m_weather->displayTemperatureUnit();
-    if (m_isVertical) {
-      text = verticalTemperature(temp);
+    if (m_showTemperature) {
+      if (m_isVertical) {
+        text = verticalTemperature(temp);
+      } else {
+        text = std::format("{}{}", temp, unit);
+      }
     } else {
-      text = std::format("{}{}", temp, unit);
+      text.clear();
     }
     if (m_showCondition && !m_isVertical) {
-      text += " ";
+      text += text.empty() ? "" : " ";
       text += WeatherService::shortDescriptionForCode(snapshot.current.weatherCode);
     }
   } else if (m_weather->loading()) {

--- a/src/shell/bar/widgets/weather_widget.h
+++ b/src/shell/bar/widgets/weather_widget.h
@@ -14,7 +14,7 @@ struct wl_output;
 
 class WeatherWidget : public Widget {
 public:
-  WeatherWidget(WeatherService* weather, wl_output* output, float maxWidth, bool showCondition);
+  WeatherWidget(WeatherService* weather, wl_output* output, float maxWidth, bool showCondition, bool showTemperature);
 
   void create() override;
 
@@ -26,6 +26,7 @@ private:
   WeatherService* m_weather = nullptr;
   float m_maxWidth = 160.0f;
   bool m_showCondition = true;
+  bool m_showTemperature = true;
   InputArea* m_area = nullptr;
   Glyph* m_glyph = nullptr;
   Label* m_label = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -921,6 +921,7 @@ namespace settings {
     } else if (type == "weather") {
       add(intSpec("max_length", 160, 40.0, 800.0, 1.0));
       add(boolSpec("show_condition", true));
+      add(boolSpec("show_temperature", true));
     } else if (type == "workspaces") {
       const WidgetSettingVisibility pillStyleOnly{{"minimal", {"false"}}};
       for (auto& spec : commonSpecs) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add new option to weather bar widget - toggle displayed weather temperature.
Together with "Show Condition" toggle it allows for weather widget to be only the glyph.

## Motivation

Allow making the weather bar widget to be "glyph only".

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

N/A

## Testing

Compiled and run locally, verified the new widget behavior "manually".

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Both options enabled:
<img width="243" height="63" alt="1 - All" src="https://github.com/user-attachments/assets/48df456f-8d95-4dac-a1ee-63c86561898d" />

Only temperature enabled:
<img width="243" height="63" alt="2 - Temp" src="https://github.com/user-attachments/assets/4d38f159-be52-44d4-a115-61c47fee863c" />

Only conditions enabled:
<img width="243" height="63" alt="3 - Condition" src="https://github.com/user-attachments/assets/6ae07bb1-7c7b-4b31-b24f-7668f0e7c576" />

Both options disabled - "glyph only":
<img width="243" height="63" alt="4 - Glyph" src="https://github.com/user-attachments/assets/a4dd28f3-d8d7-4be1-a9ff-7cbc28df0ea0" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I'll update the documentation after merge, weather widget is described in the documentation:
https://docs.noctalia.dev/v5/bar/widgets/#weather
