### PR TITLE
fix(core): reject directories in commandExists

### DIFF
--- a/src/core/process.cpp
+++ b/src/core/process.cpp
@@ -713,7 +713,7 @@ namespace process {
     }
 
     if (std::strchr(name, '/') != nullptr) {
-      return ::access(name, X_OK) == 0;
+      return ::access(name, X_OK) == 0 && std::filesystem::is_regular_file(name);
     }
 
     const char* pathEnv = std::getenv("PATH");
@@ -728,7 +728,7 @@ namespace process {
       const std::string_view dir = end == std::string_view::npos ? path.substr(start) : path.substr(start, end - start);
       const std::filesystem::path candidate =
           dir.empty() ? std::filesystem::path(name) : (std::filesystem::path(dir) / name);
-      if (::access(candidate.c_str(), X_OK) == 0) {
+      if (::access(candidate.c_str(), X_OK) == 0 && std::filesystem::is_regular_file(candidate)) {
         return true;
       }
       if (end == std::string_view::npos) {

--- a/tests/process_test.cpp
+++ b/tests/process_test.cpp
@@ -122,6 +122,18 @@ namespace {
     return ok;
   }
 
+  bool commandExistsRejectsDirectories() {
+    bool ok = true;
+    ok =
+        expect(!process::commandExists("/usr/bin"), "commandExists should return false for /usr/bin (directory)") && ok;
+    ok = expect(!process::commandExists("/"), "commandExists should return false for / (directory)") && ok;
+    ok = expect(process::commandExists("true"), "commandExists should return true for 'true' on PATH") && ok;
+    ok = expect(!process::commandExists(""), "commandExists should return false for empty string") && ok;
+    ok =
+        expect(!process::commandExists("/nonexistent"), "commandExists should return false for nonexistent path") && ok;
+    return ok;
+  }
+
 } // namespace
 
 int main() {
@@ -130,5 +142,6 @@ int main() {
   ok = capturedAsyncDeliversCallbacksAndResult() && ok;
   ok = capturedAsyncDeliversCompletionOnly() && ok;
   ok = syncAppliesEnvOverrides() && ok;
+  ok = commandExistsRejectsDirectories() && ok;
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

`process::commandExists` uses `::access(path, X_OK)` which returns true for directories with search permission. Added `!std::filesystem::is_directory()` checks.

## Motivation

Fixes a validation bug where directory paths like `/usr/bin` or `/` are incorrectly reported as valid executables, affecting all callers, including the plugin API's `luau_commandExists`.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3167

## Testing

`just test` with added unit tests
`just build` gives no errors

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors
- [x] Not UI/visual change

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.