### PR TITLE
fix(dock): correct auto-hide trigger zones

### DIFF
--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -241,13 +241,16 @@ namespace shell::dock {
   computeInputRegion(const DockConfig& cfg, const DockPanelGeometry& panel, int surfaceW, int surfaceH, bool hidden) {
     if (hidden) {
       const DockEdge edge = cfg.position;
-      if (!isVerticalEdge(edge)) {
+      if (edge == DockEdge::Bottom) {
         return {InputRect{0, surfaceH - kAutoHideTriggerPx, surfaceW, kAutoHideTriggerPx}};
       }
       if (edge == DockEdge::Left) {
+        return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+      }
+      if (edge == DockEdge::Right) {
         return {InputRect{surfaceW - kAutoHideTriggerPx, 0, kAutoHideTriggerPx, surfaceH}};
       }
-      return {InputRect{0, 0, kAutoHideTriggerPx, surfaceH}};
+      return {InputRect{0, 0, surfaceW, kAutoHideTriggerPx}};
     }
 
     return {InputRect{


### PR DESCRIPTION
## Summary

The dock's auto-hide trigger zone was incorrectly positioned on top and side edges.
Fix follows the same explicit four-edge pattern in [`bar.cpp`](https://github.com/noctalia-dev/noctalia/blob/main/src/shell/bar/bar.cpp#L145-L155)

## Motivation

#3159 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3159

## Testing

`just build`

Manual: `just run`, toggled dock to each edge position, verified auto-hide trigger works consistently on all four edges.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.