### PR TITLE
Feat/dock concave side corners

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1710,19 +1710,19 @@
           "description": "Background opacity of the dock"
         },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the dock"
+          "description": "Bottom left corner radius for the dock; negative values carve a concave corner"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the dock"
+          "description": "Bottom right corner radius for the dock; negative values carve a concave corner"
         },
         "corner-radius": {
-          "description": "Corner radius of the dock"
+          "description": "Corner radius of the dock; negative values carve a concave corner"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the dock"
+          "description": "Top left corner radius for the dock; negative values carve a concave corner"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the dock"
+          "description": "Top right corner radius for the dock; negative values carve a concave corner"
         },
         "cross-axis-padding": {
           "description": "Inner padding along the dock's cross axis (between icons and the screen edge)"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1710,19 +1710,19 @@
           "description": "Background opacity of the dock"
         },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the dock; negative values carve a concave corner"
+          "description": "Bottom left corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the dock; negative values carve a concave corner"
+          "description": "Bottom right corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
         },
         "corner-radius": {
-          "description": "Corner radius of the dock; negative values carve a concave corner"
+          "description": "Corner radius of the dock; negative values carve a concave corner when this corner faces the screen edge"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the dock; negative values carve a concave corner"
+          "description": "Top left corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the dock; negative values carve a concave corner"
+          "description": "Top right corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
         },
         "cross-axis-padding": {
           "description": "Inner padding along the dock's cross axis (between icons and the screen edge)"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1709,20 +1709,24 @@
         "background-opacity": {
           "description": "Background opacity of the dock"
         },
+        "concave-edge-corners": {
+          "description": "Carve inward corners on the side that touches the screen edge",
+          "label": "Concave Edge Corners"
+        },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
+          "description": "Bottom left corner radius for the dock"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
+          "description": "Bottom right corner radius for the dock"
         },
         "corner-radius": {
-          "description": "Corner radius of the dock; negative values carve a concave corner when this corner faces the screen edge"
+          "description": "Corner radius of the dock"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
+          "description": "Top left corner radius for the dock"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the dock; negative values carve a concave corner when this corner faces the screen edge"
+          "description": "Top right corner radius for the dock"
         },
         "cross-axis-padding": {
           "description": "Inner padding along the dock's cross axis (between icons and the screen edge)"

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -544,6 +544,7 @@ struct DockConfig {
   std::int32_t radiusTopRight = 16;    // dock background top-right corner radius
   std::int32_t radiusBottomLeft = 16;  // dock background bottom-left corner radius
   std::int32_t radiusBottomRight = 16; // dock background bottom-right corner radius
+  bool concaveEdgeCorners = false;     // carve concave corners on the side that touches the screen edge
   std::int32_t marginEnds = 0;         // inset from each end of the dock along its main axis
   std::int32_t marginEdge = 8;         // distance from the nearest screen edge (floats the dock when > 0)
   bool shadow = true;                  // use the global shell shadow

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -377,6 +377,7 @@ namespace noctalia::config::schema {
         field(&DockConfig::radiusTopRight, "radius_top_right", kDockRadiusRange),
         field(&DockConfig::radiusBottomLeft, "radius_bottom_left", kDockRadiusRange),
         field(&DockConfig::radiusBottomRight, "radius_bottom_right", kDockRadiusRange),
+        field(&DockConfig::concaveEdgeCorners, "concave_edge_corners"),
         field(&DockConfig::marginEnds, "margin_ends", kDockMarginEndsRange),
         field(&DockConfig::marginEdge, "margin_edge", kDockMarginEdgeRange),
         field(&DockConfig::shadow, "shadow"),

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -36,7 +36,7 @@ namespace noctalia::config::schema {
   inline constexpr Range<std::int64_t> kDockItemSpacingRange{0, 100, 1};
   inline constexpr Range<std::int64_t> kDockMarginEndsRange{0, 500, 1};
   inline constexpr Range<std::int64_t> kDockMarginEdgeRange{0, 100, 1};
-  inline constexpr Range<std::int64_t> kDockRadiusRange{-80, 80, 1}; // radius + each corner
+  inline constexpr Range<std::int64_t> kDockRadiusRange{0, 80, 1}; // radius + each corner
   inline constexpr Range<float> kDockActiveScaleRange{0.1f, 1.75f, 0.05f};
   inline constexpr Range<float> kDockInactiveScaleRange{0.1f, 1.0f, 0.05f};
   inline constexpr Range<float> kDockMagnificationScaleRange{1.0f, 2.0f, 0.05f};

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -36,7 +36,7 @@ namespace noctalia::config::schema {
   inline constexpr Range<std::int64_t> kDockItemSpacingRange{0, 100, 1};
   inline constexpr Range<std::int64_t> kDockMarginEndsRange{0, 500, 1};
   inline constexpr Range<std::int64_t> kDockMarginEdgeRange{0, 100, 1};
-  inline constexpr Range<std::int64_t> kDockRadiusRange{0, 80, 1}; // radius + each corner
+  inline constexpr Range<std::int64_t> kDockRadiusRange{-80, 80, 1}; // radius + each corner
   inline constexpr Range<float> kDockActiveScaleRange{0.1f, 1.75f, 0.05f};
   inline constexpr Range<float> kDockInactiveScaleRange{0.1f, 1.0f, 0.05f};
   inline constexpr Range<float> kDockMagnificationScaleRange{1.0f, 2.0f, 0.05f};

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -125,6 +125,11 @@ namespace shell::dock {
     const DockEdge edge = cfg.position;
     const bool vertical = isVerticalEdge(edge);
     const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+    const auto concave = dockConcaveShape(cfg);
+    const int insetL = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.left)));
+    const int insetT = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.top)));
+    const int insetR = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.right)));
+    const int insetB = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.bottom)));
     const auto panelW = dockContentSize(cfg, itemCount);
     const auto panelH = dockThickness(cfg);
     const std::int32_t zoomPad = dockHoverZoomCrossPad(cfg);
@@ -135,7 +140,7 @@ namespace shell::dock {
 
     DockSurfaceGeometry geometry;
     if (!vertical) {
-      geometry.surfaceW = static_cast<std::uint32_t>(panelW + sb.left + sb.right);
+      geometry.surfaceW = static_cast<std::uint32_t>(panelW + sb.left + sb.right + insetL + insetR);
       geometry.marginLeft = cfg.marginEnds;
       geometry.marginRight = cfg.marginEnds;
       if (isBottom) {
@@ -160,7 +165,7 @@ namespace shell::dock {
 
     geometry.marginTop = cfg.marginEnds;
     geometry.marginBottom = cfg.marginEnds;
-    geometry.surfaceH = static_cast<std::uint32_t>(panelW + sb.up + sb.down);
+    geometry.surfaceH = static_cast<std::uint32_t>(panelW + sb.up + sb.down + insetT + insetB);
     if (isRight) {
       if (edgeGutter > 0) {
         geometry.surfaceW = static_cast<std::uint32_t>(sb.left + panelH + edgeGutter + zoomPad);
@@ -205,6 +210,11 @@ namespace shell::dock {
     const DockEdge edge = cfg.position;
     const bool vertical = isVerticalEdge(edge);
     const auto sb = shell::surface_shadow::bleed(cfg.shadow, shadow);
+    const auto concave = dockConcaveShape(cfg);
+    const float insetL = std::ceil(std::max(0.0f, concave.logicalInset.left));
+    const float insetT = std::ceil(std::max(0.0f, concave.logicalInset.top));
+    const float insetR = std::ceil(std::max(0.0f, concave.logicalInset.right));
+    const float insetB = std::ceil(std::max(0.0f, concave.logicalInset.bottom));
     const auto bleedL = static_cast<float>(sb.left);
     const auto bleedR = static_cast<float>(sb.right);
     const auto bleedU = static_cast<float>(sb.up);
@@ -224,9 +234,9 @@ namespace shell::dock {
         }
       }
       return DockPanelGeometry{
-          .panelX = bleedL,
+          .panelX = bleedL + insetL,
           .panelY = y,
-          .panelW = surfaceW - bleedL - bleedR,
+          .panelW = surfaceW - bleedL - bleedR - insetL - insetR,
           .panelH = panelThickness,
       };
     }
@@ -241,9 +251,9 @@ namespace shell::dock {
     }
     return DockPanelGeometry{
         .panelX = x,
-        .panelY = bleedU,
+        .panelY = bleedU + insetT,
         .panelW = panelThickness,
-        .panelH = surfaceH - bleedU - bleedD,
+        .panelH = surfaceH - bleedU - bleedD - insetT - insetB,
     };
   }
 

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -23,41 +23,46 @@ namespace shell::dock {
   } // namespace
 
   DockConcaveShape dockConcaveShape(const DockConfig& cfg) {
-    const auto shapeFor = [](std::int32_t v) { return v < 0 ? CornerShape::Concave : CornerShape::Convex; };
-    const auto mag = [](std::int32_t v) { return static_cast<float>(v < 0 ? -v : v); };
-
     DockConcaveShape g;
-    g.corners = CornerShapes{
-        .tl = shapeFor(cfg.radiusTopLeft),
-        .tr = shapeFor(cfg.radiusTopRight),
-        .br = shapeFor(cfg.radiusBottomRight),
-        .bl = shapeFor(cfg.radiusBottomLeft),
+    g.radii = Radii{
+        static_cast<float>(cfg.radiusTopLeft),
+        static_cast<float>(cfg.radiusTopRight),
+        static_cast<float>(cfg.radiusBottomRight),
+        static_cast<float>(cfg.radiusBottomLeft),
     };
-    g.radii =
-        Radii{mag(cfg.radiusTopLeft), mag(cfg.radiusTopRight), mag(cfg.radiusBottomRight), mag(cfg.radiusBottomLeft)};
 
-    const auto negMag = [&](std::int32_t v) { return v < 0 ? mag(v) : 0.0f; };
+    if (!cfg.concaveEdgeCorners || cfg.marginEdge > 0) {
+      return g;
+    }
+
     const float cap = static_cast<float>(dockThickness(cfg)) * 0.5f;
     const auto capped = [&](float v) { return std::min(cap, v); };
 
-    // Map concave insets to the two side edges for the current dock position.
-    // For a bottom dock, negative bottom-left/right carve inward on left/right.
+    // Carve concavity only on corners facing the screen edge.
     switch (cfg.position) {
     case DockEdge::Bottom:
-      g.logicalInset.left = capped(negMag(cfg.radiusBottomLeft));
-      g.logicalInset.right = capped(negMag(cfg.radiusBottomRight));
+      g.corners.bl = CornerShape::Concave;
+      g.corners.br = CornerShape::Concave;
+      g.logicalInset.left = capped(g.radii.bl);
+      g.logicalInset.right = capped(g.radii.br);
       break;
     case DockEdge::Top:
-      g.logicalInset.left = capped(negMag(cfg.radiusTopLeft));
-      g.logicalInset.right = capped(negMag(cfg.radiusTopRight));
+      g.corners.tl = CornerShape::Concave;
+      g.corners.tr = CornerShape::Concave;
+      g.logicalInset.left = capped(g.radii.tl);
+      g.logicalInset.right = capped(g.radii.tr);
       break;
     case DockEdge::Left:
-      g.logicalInset.top = capped(negMag(cfg.radiusTopLeft));
-      g.logicalInset.bottom = capped(negMag(cfg.radiusBottomLeft));
+      g.corners.tl = CornerShape::Concave;
+      g.corners.bl = CornerShape::Concave;
+      g.logicalInset.top = capped(g.radii.tl);
+      g.logicalInset.bottom = capped(g.radii.bl);
       break;
     case DockEdge::Right:
-      g.logicalInset.top = capped(negMag(cfg.radiusTopRight));
-      g.logicalInset.bottom = capped(negMag(cfg.radiusBottomRight));
+      g.corners.tr = CornerShape::Concave;
+      g.corners.br = CornerShape::Concave;
+      g.logicalInset.top = capped(g.radii.tr);
+      g.logicalInset.bottom = capped(g.radii.br);
       break;
     }
     return g;

--- a/src/shell/dock/dock_geometry.cpp
+++ b/src/shell/dock/dock_geometry.cpp
@@ -22,6 +22,47 @@ namespace shell::dock {
 
   } // namespace
 
+  DockConcaveShape dockConcaveShape(const DockConfig& cfg) {
+    const auto shapeFor = [](std::int32_t v) { return v < 0 ? CornerShape::Concave : CornerShape::Convex; };
+    const auto mag = [](std::int32_t v) { return static_cast<float>(v < 0 ? -v : v); };
+
+    DockConcaveShape g;
+    g.corners = CornerShapes{
+        .tl = shapeFor(cfg.radiusTopLeft),
+        .tr = shapeFor(cfg.radiusTopRight),
+        .br = shapeFor(cfg.radiusBottomRight),
+        .bl = shapeFor(cfg.radiusBottomLeft),
+    };
+    g.radii =
+        Radii{mag(cfg.radiusTopLeft), mag(cfg.radiusTopRight), mag(cfg.radiusBottomRight), mag(cfg.radiusBottomLeft)};
+
+    const auto negMag = [&](std::int32_t v) { return v < 0 ? mag(v) : 0.0f; };
+    const float cap = static_cast<float>(dockThickness(cfg)) * 0.5f;
+    const auto capped = [&](float v) { return std::min(cap, v); };
+
+    // Map concave insets to the two side edges for the current dock position.
+    // For a bottom dock, negative bottom-left/right carve inward on left/right.
+    switch (cfg.position) {
+    case DockEdge::Bottom:
+      g.logicalInset.left = capped(negMag(cfg.radiusBottomLeft));
+      g.logicalInset.right = capped(negMag(cfg.radiusBottomRight));
+      break;
+    case DockEdge::Top:
+      g.logicalInset.left = capped(negMag(cfg.radiusTopLeft));
+      g.logicalInset.right = capped(negMag(cfg.radiusTopRight));
+      break;
+    case DockEdge::Left:
+      g.logicalInset.top = capped(negMag(cfg.radiusTopLeft));
+      g.logicalInset.bottom = capped(negMag(cfg.radiusBottomLeft));
+      break;
+    case DockEdge::Right:
+      g.logicalInset.top = capped(negMag(cfg.radiusTopRight));
+      g.logicalInset.bottom = capped(negMag(cfg.radiusBottomRight));
+      break;
+    }
+    return g;
+  }
+
   std::uint32_t positionToAnchor(DockEdge edge) {
     if (edge == DockEdge::Top) {
       return LayerShellAnchor::Top;

--- a/src/shell/dock/dock_geometry.h
+++ b/src/shell/dock/dock_geometry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/config_types.h"
+#include "render/core/render_styles.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -28,6 +29,14 @@ namespace shell::dock {
     std::int32_t marginLeft = 0;
     std::int32_t exclusiveZone = 0;
   };
+
+  struct DockConcaveShape {
+    CornerShapes corners{};
+    Radii radii;
+    RectInsets logicalInset{};
+  };
+
+  [[nodiscard]] DockConcaveShape dockConcaveShape(const DockConfig& cfg);
 
   [[nodiscard]] std::uint32_t positionToAnchor(DockEdge edge);
   [[nodiscard]] bool isVerticalEdge(DockEdge edge);

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -194,8 +194,8 @@ namespace shell::dock {
     // Shadow follows the same shape as the background
     if (instance.shadow != nullptr) {
       const auto shadowOff = shadowDirectionOffset(shadowConfig.direction);
-      const float shadowOffsetX = static_cast<float>(shadowOff.x);
-      const float shadowOffsetY = static_cast<float>(shadowOff.y);
+      const auto shadowOffsetX = static_cast<float>(shadowOff.x);
+      const auto shadowOffsetY = static_cast<float>(shadowOff.y);
       const RoundedRectStyle shadowStyle = shell::surface_shadow::style(
           shadowConfig, cfg.backgroundOpacity,
           shell::surface_shadow::Shape{

--- a/src/shell/dock/dock_instance.cpp
+++ b/src/shell/dock/dock_instance.cpp
@@ -19,18 +19,6 @@
 #include <cmath>
 
 namespace shell::dock {
-  namespace {
-
-    Radii dockCornerRadii(const DockConfig& cfg) {
-      return Radii{
-          static_cast<float>(cfg.radiusTopLeft),
-          static_cast<float>(cfg.radiusTopRight),
-          static_cast<float>(cfg.radiusBottomRight),
-          static_cast<float>(cfg.radiusBottomLeft),
-      };
-    }
-
-  } // namespace
 
   void prepareFrame(
       DockInstance& instance, DockInstanceDependencies deps, const DockInstanceCallbacks& callbacks, bool needsUpdate,
@@ -96,15 +84,20 @@ namespace shell::dock {
     if (instance.panel == nullptr) {
       return;
     }
+    const auto concave = dockConcaveShape(cfg);
     float absX = 0.0f;
     float absY = 0.0f;
     Node::absolutePosition(instance.panel, absX, absY);
-    const int px = static_cast<int>(std::lround(absX));
-    const int py = static_cast<int>(std::lround(absY));
-    const int pw = static_cast<int>(std::lround(instance.panel->width()));
-    const int ph = static_cast<int>(std::lround(instance.panel->height()));
-    const Radii radii = dockCornerRadii(cfg);
-    auto blurStrips = Surface::tessellateRoundedRect(px, py, pw, ph, radii.tl, radii.tr, radii.br, radii.bl);
+
+    const float insetL = concave.logicalInset.left;
+    const float insetT = concave.logicalInset.top;
+    const float insetR = concave.logicalInset.right;
+    const float insetB = concave.logicalInset.bottom;
+    const int px = static_cast<int>(std::lround(absX + insetL));
+    const int py = static_cast<int>(std::lround(absY + insetT));
+    const int pw = static_cast<int>(std::lround(instance.panel->width() - insetL - insetR));
+    const int ph = static_cast<int>(std::lround(instance.panel->height() - insetT - insetB));
+    auto blurStrips = Surface::tessellateShape(px, py, pw, ph, concave.corners, concave.logicalInset, concave.radii);
     instance.surface->setBlurRegion(blurStrips);
   }
 
@@ -122,7 +115,7 @@ namespace shell::dock {
 
     const auto& shadowConfig = deps.config.config().shell.shadow;
     const auto panelGeometry = shell::dock::computePanelGeometry(cfg, shadowConfig, w, h);
-    const Radii radii = dockCornerRadii(cfg);
+    const auto concave = shell::dock::dockConcaveShape(cfg);
 
     if (instance.sceneRoot == nullptr) {
       instance.sceneRoot = std::make_unique<Node>();
@@ -142,8 +135,10 @@ namespace shell::dock {
       // Panel background (icons render as a sibling so magnification can extend past the capsule).
       instance.panel = static_cast<Box*>(instance.slideRoot->addChild(
           ui::box({
-              .configure = [radii](Box& box) {
-                box.setRadii(radii);
+              .configure = [concave](Box& box) {
+                box.setCornerShapes(concave.corners);
+                box.setLogicalInset(concave.logicalInset);
+                box.setRadii(concave.radii);
                 box.setClipChildren(false);
               },
           })
@@ -183,6 +178,11 @@ namespace shell::dock {
       }
 
       instance.surface->setSceneRoot(instance.sceneRoot.get());
+    } else {
+      // Update corner shapes/radii/inset on reconfigure.
+      instance.panel->setCornerShapes(concave.corners);
+      instance.panel->setLogicalInset(concave.logicalInset);
+      instance.panel->setRadii(concave.radii);
     }
 
     // Update root size on reconfigure.
@@ -191,24 +191,38 @@ namespace shell::dock {
       instance.slideRoot->setSize(w, h);
     }
 
-    // Shadow
+    // Shadow follows the same shape as the background
     if (instance.shadow != nullptr) {
       const auto shadowOff = shadowDirectionOffset(shadowConfig.direction);
-      const auto shadowOffsetX = static_cast<float>(shadowOff.x);
-      const auto shadowOffsetY = static_cast<float>(shadowOff.y);
+      const float shadowOffsetX = static_cast<float>(shadowOff.x);
+      const float shadowOffsetY = static_cast<float>(shadowOff.y);
       const RoundedRectStyle shadowStyle = shell::surface_shadow::style(
-          shadowConfig, cfg.backgroundOpacity, shell::surface_shadow::Shape{.radius = radii}
+          shadowConfig, cfg.backgroundOpacity,
+          shell::surface_shadow::Shape{
+              .corners = concave.corners, .logicalInset = concave.logicalInset, .radius = concave.radii
+          }
       );
       instance.shadow->setStyle(shadowStyle);
       instance.shadow->setZIndex(-1);
-      instance.shadow->setPosition(panelGeometry.panelX + shadowOffsetX, panelGeometry.panelY + shadowOffsetY);
-      instance.shadow->setSize(panelGeometry.panelW, panelGeometry.panelH);
+      instance.shadow->setPosition(
+          panelGeometry.panelX - concave.logicalInset.left + shadowOffsetX,
+          panelGeometry.panelY - concave.logicalInset.top + shadowOffsetY
+      );
+      instance.shadow->setSize(
+          panelGeometry.panelW + concave.logicalInset.left + concave.logicalInset.right,
+          panelGeometry.panelH + concave.logicalInset.top + concave.logicalInset.bottom
+      );
     }
 
     // Panel
     applyPanelPalette(instance, cfg);
-    instance.panel->setPosition(panelGeometry.panelX, panelGeometry.panelY);
-    instance.panel->setSize(panelGeometry.panelW, panelGeometry.panelH);
+    instance.panel->setPosition(
+        panelGeometry.panelX - concave.logicalInset.left, panelGeometry.panelY - concave.logicalInset.top
+    );
+    instance.panel->setSize(
+        panelGeometry.panelW + concave.logicalInset.left + concave.logicalInset.right,
+        panelGeometry.panelH + concave.logicalInset.top + concave.logicalInset.bottom
+    );
 
     // Row matches the pill; hover spread is clamped to stay inside the background.
     instance.row->setPosition(panelGeometry.panelX, panelGeometry.panelY);

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -937,6 +937,11 @@ namespace settings {
         sliderFor(cfg.dock.radiusBottomRight, noctalia::config::schema::kDockRadiusRange, true), "rounded corner", true
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Dock, "shape", tr("settings.schema.dock.concave-edge-corners.label"),
+        tr("settings.schema.dock.concave-edge-corners.description"), {"dock", "concave_edge_corners"},
+        ToggleSetting{cfg.dock.concaveEdgeCorners}, "rounded corner carve"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Dock, "effects", tr("settings.schema.shared.background-opacity.label"),
         tr("settings.schema.dock.background-opacity.description"), {"dock", "background_opacity"},
         sliderFor(cfg.dock.backgroundOpacity, noctalia::config::schema::kUnitRange, false), "alpha"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This PR adds concave (inverted) dock corner support using negative radius values, similar to bar corner behavior.

### Key Changes
- Allows negative dock radius values in config schema (kDockRadiusRange now supports -80..80)
- Implements dock concave shape mapping and geometry handling for all dock edges
- Updates dock rendering pipeline (panel, shadow, compositor blur tessellation) to use corner shape + logical inset data
- Keeps convex behavior unchanged for non-negative radius values
- Updates assets/translations/en.json descriptions for dock corner radius settings

## Summary

<!-- What changed and why? -->

## Motivation

Users can now create a dock shape that visually blends into edges/surfaces (e.g. concave side cuts for bottom docks), similar to V4..

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing
- just format
- ninja -C build-debug
- just lint
- just test
- python3 tools/i18n-check.py
- just configure release && just build release

## Manual Coverage

- Verified concave dock corners with negative radius values
- Confirmed expected behavior for bottom dock with side concave cuts:
  - radius_bottom_left = -12
  - radius_bottom_right = -12
- Confirmed normal convex corners still behave as before when values are non-negative

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/9b868dd3-c93e-4db7-8e28-3b8263291bcc

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
- Addressed clang-tidy findings after rebase (dock_instance + workspace_alert_service modernize warnings).
