### PR TITLE
feat(clipboard): add support for image/jxl MIME type

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -189,6 +189,7 @@ md4c_dep = declare_dependency(
 
 # ── System: libwebp (WebP decode and thumbnail encode) ───────────────────────
 libwebp_dep = dependency('libwebp', required: true)
+libjxl_dep = dependency('libjxl', required: true)
 
 # ── Vendored: Luau (Roblox's Lua fork) ────────────────────────────────────────
 # Built as a quiet static library; only VM + Compiler + Bytecode + Ast + Common are vendored.
@@ -919,6 +920,7 @@ noctalia_exe = executable('noctalia',
     stb_dep,
     md4c_dep,
     libwebp_dep,
+    libjxl_dep,
     luau_dep,
   ] + jemalloc_deps + (dl_dep.found() ? [dl_dep] : []),
   include_directories: _noctalia_inc,
@@ -958,6 +960,7 @@ notification_history_utf8_test = executable('notification_history_utf8_test',
   ),
   dependencies: [
     libwebp_dep,
+    libjxl_dep,
   ],
   include_directories: _noctalia_inc,
 )
@@ -1248,6 +1251,7 @@ ui_tree_reconciler_test = executable('ui_tree_reconciler_test',
     egl_dep,
     librsvg_dep,
     libwebp_dep,
+    libjxl_dep,
     stb_dep,
     xkbcommon_dep,
   ],
@@ -1397,6 +1401,7 @@ image_file_loader_data_uri_test = executable('image_file_loader_data_uri_test',
     cairo_dep,
     librsvg_dep,
     libwebp_dep,
+    libjxl_dep,
     stb_dep,
   ],
   include_directories: _noctalia_inc,
@@ -1411,6 +1416,7 @@ ico_decoder_test = executable('ico_decoder_test',
   ),
   dependencies: [
     libwebp_dep,
+    libjxl_dep,
   ],
   include_directories: _noctalia_inc,
 )

--- a/src/render/core/image_decoder.cpp
+++ b/src/render/core/image_decoder.cpp
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <expected>
+#include <jxl/decode.h>
+#include <jxl/decode_cxx.h>
 #include <utility>
 #include <vector>
 #include <webp/decode.h>
@@ -229,6 +231,92 @@ namespace {
     return decoded;
   }
 
+  bool isJxl(const std::uint8_t* data, std::size_t size) {
+    if (!data || size == 0) {
+      return false;
+    }
+    if (size >= 2 && data[0] == 0xFF && data[1] == 0x0A) {
+      return true;
+    }
+    if (size >= 12
+        && data[0] == 0x00
+        && data[1] == 0x00
+        && data[2] == 0x00
+        && data[3] == 0x0C
+        && data[4] == 0x4A // 'J'
+        && data[5] == 0x58 // 'X'
+        && data[6] == 0x4C // 'L'
+        && data[7] == 0x20 // ' '
+        && data[8] == 0x0D // '\r'
+        && data[9] == 0x0A // '\n'
+        && data[10] == 0x87
+        && data[11] == 0x0A) {
+      return true;
+    }
+    return false;
+  }
+
+  std::expected<DecodedRasterImage, std::string> decodeJxl(const std::uint8_t* data, std::size_t size) {
+    JxlDecoderPtr dec = JxlDecoderMake(nullptr);
+    if (!dec) {
+      return std::unexpected("libjxl: failed to create decoder");
+    }
+
+    if (JXL_DEC_SUCCESS != JxlDecoderSubscribeEvents(dec.get(), JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE)) {
+      return std::unexpected("libjxl: JxlDecoderSubscribeEvents failed");
+    }
+
+    if (JXL_DEC_SUCCESS != JxlDecoderSetInput(dec.get(), data, size)) {
+      return std::unexpected("libjxl: JxlDecoderSetInput failed");
+    }
+    JxlDecoderCloseInput(dec.get());
+
+    DecodedRasterImage decoded;
+    const JxlPixelFormat format = {4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
+
+    for (;;) {
+      JxlDecoderStatus status = JxlDecoderProcessInput(dec.get());
+
+      if (status == JXL_DEC_ERROR) {
+        return std::unexpected("libjxl: decoder error (status=" + std::to_string(status) + ")");
+      } else if (status == JXL_DEC_NEED_MORE_INPUT) {
+        return std::unexpected("libjxl: unexpected need for more input (status=" + std::to_string(status) + ")");
+      } else if (status == JXL_DEC_BASIC_INFO) {
+        JxlBasicInfo info;
+        if (JXL_DEC_SUCCESS != JxlDecoderGetBasicInfo(dec.get(), &info)) {
+          return std::unexpected("libjxl: JxlDecoderGetBasicInfo failed");
+        }
+        decoded.width = static_cast<int>(info.xsize);
+        decoded.height = static_cast<int>(info.ysize);
+      } else if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
+        if (decoded.width <= 0 || decoded.height <= 0) {
+          return std::unexpected("libjxl: basic info was not processed before out buffer request");
+        }
+        size_t bufferSize = 0;
+        if (JXL_DEC_SUCCESS != JxlDecoderImageOutBufferSize(dec.get(), &format, &bufferSize)) {
+          return std::unexpected("libjxl: JxlDecoderImageOutBufferSize failed");
+        }
+        decoded.pixels.resize(bufferSize);
+        if (JXL_DEC_SUCCESS
+            != JxlDecoderSetImageOutBuffer(dec.get(), &format, decoded.pixels.data(), decoded.pixels.size())) {
+          return std::unexpected("libjxl: JxlDecoderSetImageOutBuffer failed");
+        }
+      } else if (status == JXL_DEC_FULL_IMAGE) {
+        // Frame finished decoding
+      } else if (status == JXL_DEC_SUCCESS) {
+        break;
+      } else {
+        return std::unexpected("libjxl: unexpected decoder status (status=" + std::to_string(status) + ")");
+      }
+    }
+
+    if (decoded.pixels.empty() || decoded.width <= 0 || decoded.height <= 0) {
+      return std::unexpected("libjxl: decoding did not produce valid pixels");
+    }
+
+    return decoded;
+  }
+
 } // namespace
 
 std::expected<DecodedRasterImage, std::string> decodeRasterImage(const std::uint8_t* data, std::size_t size) {
@@ -241,6 +329,9 @@ std::expected<DecodedRasterImage, std::string> decodeRasterImage(const std::uint
 
   if (isIco(data, size))
     return decodeIco(data, size);
+
+  if (isJxl(data, size))
+    return decodeJxl(data, size);
 
   auto input = wuffs_aux::sync_io::MemoryInput(data, size);
   auto callbacks = RgbaDecodeCallbacks();

--- a/src/wayland/clipboard_service.cpp
+++ b/src/wayland/clipboard_service.cpp
@@ -38,6 +38,7 @@ namespace {
   constexpr std::array kImageMimeTypes = {
       std::string_view{"image/png"},
       std::string_view{"image/jpeg"},
+      std::string_view{"image/jxl"},
   };
 
   constexpr std::array kPasswordHintMimeTypes = {
@@ -77,6 +78,8 @@ namespace {
       return ".avif";
     if (mimeType == "image/heic")
       return ".heic";
+    if (mimeType == "image/jxl")
+      return ".jxl";
     return ".img";
   }
 


### PR DESCRIPTION
## Summary

Add support for jxl in clipboard 

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#3192

## Testing

compile and tested with meson test -C build

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and 

<!-- Add follow-up notes, reviewer context, or known limitations. -->
