### PR TITLE
Add Niri workspace stack and focus tracking

### DIFF
--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -61,6 +61,19 @@ namespace {
 
   constexpr Logger kLog("compositor_platform");
 
+  [[nodiscard]] const char* metadataBackendName(const compositors::WorkspaceMetadataBackend* backend) {
+    if (backend == nullptr) {
+      return "none";
+    }
+    if (dynamic_cast<const NiriWorkspaceBackend*>(backend) != nullptr) {
+      return "niri";
+    }
+    if (dynamic_cast<const TriadWorkspaceBackend*>(backend) != nullptr) {
+      return "triad";
+    }
+    return "unknown";
+  }
+
   [[nodiscard]] const char* valueOrUnset(const char* value) {
     return value != nullptr && value[0] != '\0' ? value : "<unset>";
   }
@@ -572,6 +585,12 @@ void CompositorPlatform::initialize() {
   m_initialized = true;
 
   m_workspaces->initialize();
+  kLog.info(
+      "workspace stack: compositor={} base_backend={} metadata_backend={} niri_runtime_available={}",
+      compositors::name(compositors::detect()), m_workspaces != nullptr ? m_workspaces->backendName() : "none",
+      metadataBackendName(m_workspaceMetadataBackend.get()),
+      m_runtimeRegistry != nullptr ? m_runtimeRegistry->niri().available() : false
+  );
   for (const auto& output : m_wayland.outputs()) {
     if (output.output != nullptr) {
       m_workspaces->onOutputAdded(output.output);
@@ -968,10 +987,27 @@ bool CompositorPlatform::isCompositorWindowIdKnown(const std::string_view window
 }
 
 std::optional<std::string> CompositorPlatform::focusedCompositorWindowId() const {
-  if (m_workspaces == nullptr) {
-    return std::nullopt;
+  if (compositors::detect() == compositors::CompositorKind::Niri && m_workspaceMetadataBackend != nullptr) {
+    if (const auto focused = m_workspaceMetadataBackend->focusedWindowId(); focused.has_value()) {
+      return focused;
+    }
   }
-  return m_workspaces->focusedWindowId();
+  if (m_workspaces != nullptr) {
+    if (const auto focused = m_workspaces->focusedWindowId(); focused.has_value()) {
+      return focused;
+    }
+  }
+  if (m_workspaceMetadataBackend != nullptr) {
+    if (const auto focused = m_workspaceMetadataBackend->focusedWindowId(); focused.has_value()) {
+      return focused;
+    }
+  }
+  if (const auto active = activeToplevel(); active.has_value() && active->handle != nullptr) {
+    if (const auto mapped = compositorWindowIdForToplevel(active->handle); mapped.has_value() && !mapped->empty()) {
+      return mapped;
+    }
+  }
+  return std::nullopt;
 }
 
 void CompositorPlatform::setWorkspaceChangeCallback(ChangeCallback callback) {

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -12,7 +12,6 @@
 #include <utility>
 
 namespace {
-
   [[nodiscard]] std::optional<std::uint64_t> jsonUnsigned(const nlohmann::json& json) {
     if (json.is_number_unsigned()) {
       return json.get<std::uint64_t>();
@@ -311,12 +310,20 @@ bool NiriWorkspaceBackend::focusWindowById(const std::string& windowId) {
   );
 }
 
+std::optional<std::string> NiriWorkspaceBackend::focusedWindowId() const {
+  if (!m_focusedWindowId.has_value()) {
+    return std::nullopt;
+  }
+  return std::to_string(*m_focusedWindowId);
+}
+
 void NiriWorkspaceBackend::cleanup() { m_runtime.cleanup(); }
 
 void NiriWorkspaceBackend::handleStreamReset() {
   const bool overviewWasOpen = m_overviewKnown && m_overviewOpen;
   m_windows.clear();
   m_workspaces.clear();
+  m_focusedWindowId.reset();
   m_overviewKnown = false;
   m_overviewOpen = false;
   if (overviewWasOpen) {
@@ -347,6 +354,10 @@ void NiriWorkspaceBackend::handleEvent(std::string_view key, const nlohmann::jso
     return;
   } else if (key == "WindowOpenedOrChanged") {
     changed = handleWindowOpenedOrChanged(value);
+  } else if (key == "WindowFocusChanged") {
+    changed = handleWindowFocusChanged(value);
+  } else if (key == "WorkspaceActiveWindowChanged") {
+    changed = handleWorkspaceActiveWindowChanged(value);
   } else if (key == "WindowLayoutsChanged") {
     changed = handleWindowLayoutsChanged(value);
   } else if (key == "WindowClosed") {
@@ -396,12 +407,30 @@ bool NiriWorkspaceBackend::handleWindowsChanged(const nlohmann::json& payload) {
     return false;
   }
 
+  std::optional<std::uint64_t> nextFocusedWindowId;
+  for (const auto& [windowId, window] : next) {
+    if (!window.focused) {
+      continue;
+    }
+    if (nextFocusedWindowId.has_value()) {
+      nextFocusedWindowId.reset();
+      break;
+    }
+    nextFocusedWindowId = windowId;
+  }
+
   const bool membershipChanged = !sameWindowMembership(next, m_windows);
   m_windows = std::move(next);
+  if (nextFocusedWindowId.has_value()) {
+    clearFocusedFlagsExcept(nextFocusedWindowId);
+    m_focusedWindowId = nextFocusedWindowId;
+  } else {
+    recomputeFocusedWindow();
+  }
   if (membershipChanged) {
     recomputeOccupancy();
   }
-  return membershipChanged;
+  return true;
 }
 
 bool NiriWorkspaceBackend::handleOverviewChanged(const nlohmann::json& payload) {
@@ -458,10 +487,70 @@ bool NiriWorkspaceBackend::handleWindowOpenedOrChanged(const nlohmann::json& pay
   const bool membershipChanged = existing == m_windows.end() ? (state.workspaceId.has_value() || !state.appId.empty())
                                                              : !sameWindowMembership(existing->second, state);
   m_windows[*id] = state;
+  if (state.focused) {
+    clearFocusedFlagsExcept(*id);
+    m_focusedWindowId = *id;
+  } else if (m_focusedWindowId == *id) {
+    recomputeFocusedWindow();
+  }
   if (membershipChanged) {
     recomputeOccupancy();
   }
-  return membershipChanged;
+  return true;
+}
+
+bool NiriWorkspaceBackend::handleWindowFocusChanged(const nlohmann::json& payload) {
+  std::optional<std::uint64_t> windowId = jsonUnsigned(payload);
+  if (!windowId.has_value() && payload.is_object()) {
+    windowId = jsonOptionalUnsigned(payload, "id");
+  }
+  if (!windowId.has_value()) {
+    return false;
+  }
+
+  if (m_focusedWindowId == *windowId) {
+    const auto it = m_windows.find(*windowId);
+    if (it != m_windows.end() && it->second.focused) {
+      return false;
+    }
+  }
+
+  clearFocusedFlagsExcept(*windowId);
+  m_focusedWindowId = *windowId;
+  if (auto it = m_windows.find(*windowId); it != m_windows.end()) {
+    it->second.focused = true;
+  }
+  return true;
+}
+
+bool NiriWorkspaceBackend::handleWorkspaceActiveWindowChanged(const nlohmann::json& payload) {
+  if (!payload.is_object()) {
+    return false;
+  }
+
+  const auto windowId = jsonOptionalUnsigned(payload, "active_window_id");
+  if (!windowId.has_value()) {
+    if (!m_focusedWindowId.has_value()) {
+      return false;
+    }
+    clearFocusedFlagsExcept(std::nullopt);
+    m_focusedWindowId.reset();
+    return true;
+  }
+
+  if (m_focusedWindowId == *windowId) {
+    const auto it = m_windows.find(*windowId);
+    if (it != m_windows.end() && it->second.focused) {
+      return false;
+    }
+  }
+
+  clearFocusedFlagsExcept(*windowId);
+  m_focusedWindowId = *windowId;
+  if (auto it = m_windows.find(*windowId); it != m_windows.end()) {
+    it->second.focused = true;
+  }
+  return true;
 }
 
 bool NiriWorkspaceBackend::handleWindowLayoutsChanged(const nlohmann::json& payload) {
@@ -526,6 +615,9 @@ bool NiriWorkspaceBackend::handleWindowClosed(const nlohmann::json& payload) {
 
   if (m_windows.erase(*windowId) == 0) {
     return false;
+  }
+  if (m_focusedWindowId == *windowId) {
+    recomputeFocusedWindow();
   }
   recomputeOccupancy();
   return true;
@@ -595,6 +687,20 @@ bool NiriWorkspaceBackend::applyWindowFields(const nlohmann::json& json, WindowS
     changed = true;
   }
 
+  const auto focusedFlagSnake = jsonOptionalBool(json, "is_focused");
+  const auto focusedFlagCamel = jsonOptionalBool(json, "isFocused");
+  const auto focusedFlagPlain = jsonOptionalBool(json, "focused");
+  if (focusedFlagSnake.has_value()) {
+    state.focused = *focusedFlagSnake;
+    changed = true;
+  } else if (focusedFlagCamel.has_value()) {
+    state.focused = *focusedFlagCamel;
+    changed = true;
+  } else if (focusedFlagPlain.has_value()) {
+    state.focused = *focusedFlagPlain;
+    changed = true;
+  }
+
   if (json.contains("layout")) {
     const auto& layout = json["layout"];
     if (layout.contains("pos_in_scrolling_layout")) {
@@ -627,6 +733,28 @@ bool NiriWorkspaceBackend::sameWindowMembership(
     }
   }
   return true;
+}
+
+void NiriWorkspaceBackend::clearFocusedFlagsExcept(std::optional<std::uint64_t> focusedId) {
+  for (auto& [windowId, window] : m_windows) {
+    window.focused = focusedId.has_value() && windowId == *focusedId;
+  }
+}
+
+void NiriWorkspaceBackend::recomputeFocusedWindow() {
+  std::optional<std::uint64_t> focusedId;
+  for (const auto& [windowId, window] : m_windows) {
+    if (!window.focused) {
+      continue;
+    }
+    if (focusedId.has_value()) {
+      focusedId.reset();
+      break;
+    }
+    focusedId = windowId;
+  }
+  clearFocusedFlagsExcept(focusedId);
+  m_focusedWindowId = focusedId;
 }
 
 std::optional<std::uint64_t> NiriWorkspaceBackend::parseUnsigned(const std::string& value) {

--- a/src/compositors/niri/niri_workspace_backend.h
+++ b/src/compositors/niri/niri_workspace_backend.h
@@ -42,6 +42,7 @@ public:
   appIdsByWorkspace(const std::string& outputName = {}) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(const std::string& outputName = {}) const override;
   bool focusWindowById(const std::string& windowId) override;
+  [[nodiscard]] std::optional<std::string> focusedWindowId() const override;
   void cleanup() override;
 
 private:
@@ -51,6 +52,7 @@ private:
     std::string title;
     std::int32_t x = 0;
     std::int32_t y = 0;
+    bool focused = false;
 
     bool operator==(const WindowState&) const = default;
   };
@@ -68,6 +70,8 @@ private:
   [[nodiscard]] bool handleWindowsChanged(const nlohmann::json& payload);
   [[nodiscard]] bool handleOverviewChanged(const nlohmann::json& payload);
   [[nodiscard]] bool handleWindowOpenedOrChanged(const nlohmann::json& payload);
+  [[nodiscard]] bool handleWindowFocusChanged(const nlohmann::json& payload);
+  [[nodiscard]] bool handleWorkspaceActiveWindowChanged(const nlohmann::json& payload);
   [[nodiscard]] bool handleWindowLayoutsChanged(const nlohmann::json& payload);
   [[nodiscard]] bool handleWindowClosed(const nlohmann::json& payload);
   [[nodiscard]] static std::optional<WorkspaceState> parseWorkspace(const nlohmann::json& json);
@@ -78,6 +82,8 @@ private:
       const std::unordered_map<std::uint64_t, WindowState>& lhs,
       const std::unordered_map<std::uint64_t, WindowState>& rhs
   ) noexcept;
+  void clearFocusedFlagsExcept(std::optional<std::uint64_t> focusedId);
+  void recomputeFocusedWindow();
   [[nodiscard]] static std::optional<std::uint64_t> parseUnsigned(const std::string& value);
   [[nodiscard]] static std::optional<std::size_t> parseLeadingNumber(const std::string& value);
   [[nodiscard]] static std::string workspaceKey(const WorkspaceState& workspace);
@@ -90,6 +96,7 @@ private:
   std::unordered_map<std::uint64_t, WindowState> m_windows;
   std::unordered_map<std::uint64_t, std::size_t> m_occupancy;
   std::unordered_map<std::uint64_t, WorkspaceState> m_workspaces;
+  std::optional<std::uint64_t> m_focusedWindowId;
   bool m_overviewKnown = false;
   bool m_overviewOpen = false;
   ChangeCallback m_changeCallback;

--- a/src/compositors/workspace_backend.h
+++ b/src/compositors/workspace_backend.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <poll.h>
 #include <string>
 #include <unordered_map>
@@ -148,6 +149,7 @@ namespace compositors {
     // distinctly from WorkspaceBackend::focusWindow so backends that implement
     // both interfaces don't hit a conflicting-return-type override.
     virtual bool focusWindowById(const std::string& /*windowId*/) { return false; }
+    [[nodiscard]] virtual std::optional<std::string> focusedWindowId() const { return std::nullopt; }
     [[nodiscard]] virtual bool canTrackOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool hasOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool isOverviewOpen() const noexcept { return true; }

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -650,6 +650,11 @@ std::unique_ptr<Widget> WidgetFactory::create(
     if (wc != nullptr && wc->hasSetting("max_label_chars")) {
       maxLabelChars = static_cast<std::size_t>(wc->getInt("max_label_chars", 1));
     }
+    const bool niriStack = wc != nullptr ? wc->getBool("niri_stack", false) : false;
+    const std::size_t visibleWorkspaceCount =
+        wc != nullptr ? static_cast<std::size_t>(wc->getInt("visible_workspace_count", 3)) : 3;
+    const float dotSize = wc != nullptr ? static_cast<float>(wc->getDouble("dot_size", 6.0)) : 6.0f;
+    const bool showWindowChips = wc != nullptr ? wc->getBool("show_window_chips", true) : true;
     WorkspacesWidget::Options options{
         .displayMode = displayMode,
         .focusedColor = focusedColor,
@@ -663,6 +668,10 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .inactivePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("inactive_pill_size", 1.0) : 1.0),
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
+        .niriStack = niriStack,
+        .visibleWorkspaceCount = visibleWorkspaceCount,
+        .dotSize = dotSize,
+        .showWindowChips = showWindowChips,
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -6,6 +6,8 @@
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "system/app_identity.h"
+#include "system/desktop_entry.h"
 #include "ui/builders.h"
 #include "ui/style.h"
 #include "util/string_utils.h"
@@ -14,6 +16,7 @@
 #include <cctype>
 #include <cmath>
 #include <linux/input-event-codes.h>
+#include <numeric>
 #include <utility>
 #include <wayland-client-protocol.h>
 
@@ -38,6 +41,60 @@ namespace {
     return !label.empty()
         && std::ranges::all_of(label, [](char c) { return std::isdigit(static_cast<unsigned char>(c)); });
   }
+
+  [[nodiscard]] std::string resolveWindowChipLabel(const std::string& appId) {
+    if (appId.empty()) {
+      return {};
+    }
+
+    const DesktopEntry desktopEntry = app_identity::resolveRunningDesktopEntry(appId, desktopEntries());
+    if (!desktopEntry.name.empty()) {
+      return desktopEntry.name;
+    }
+
+    if (const auto slash = appId.find_last_of('/'); slash != std::string::npos && slash + 1 < appId.size()) {
+      return appId.substr(slash + 1);
+    }
+
+    return appId;
+  }
+
+  [[nodiscard]] std::optional<std::string>
+  inferFocusedWindowId(const CompositorPlatform& platform, const std::vector<WorkspaceWindowAssignment>& assignments) {
+    if (const auto direct = platform.focusedCompositorWindowId(); direct.has_value() && !direct->empty()) {
+      return direct;
+    }
+
+    const auto active = platform.activeToplevel();
+    if (active.has_value()) {
+      if (active->handle != nullptr) {
+        if (const auto mapped = platform.compositorWindowIdForToplevel(active->handle);
+            mapped.has_value() && !mapped->empty()) {
+          return mapped;
+        }
+      }
+
+      std::optional<std::string> uniqueMatch;
+      for (const auto& assignment : assignments) {
+        const bool appMatch = !active->appId.empty() && assignment.appId == active->appId;
+        const bool titleMatch = !active->title.empty() && assignment.title == active->title;
+        if (!appMatch && !titleMatch) {
+          continue;
+        }
+        if (uniqueMatch.has_value()) {
+          uniqueMatch.reset();
+          break;
+        }
+        uniqueMatch = assignment.windowId;
+      }
+      if (uniqueMatch.has_value()) {
+        return uniqueMatch;
+      }
+    }
+
+    return std::nullopt;
+  }
+
 } // namespace
 
 WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options)
@@ -47,7 +104,9 @@ WorkspacesWidget::WorkspacesWidget(CompositorPlatform& platform, wl_output* outp
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
       m_focusedOutputOnly(options.focusedOutputOnly), m_focusedColor(options.focusedColor),
-      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {}
+      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor), m_niriStack(options.niriStack),
+      m_visibleWorkspaceCount(options.visibleWorkspaceCount), m_dotSize(options.dotSize),
+      m_showWindowChips(options.showWindowChips) {}
 
 WorkspacesWidget::DisplayMode WorkspacesWidget::effectiveDisplayMode() const noexcept {
   if (m_minimal && m_displayMode == DisplayMode::None) {
@@ -94,6 +153,9 @@ void WorkspacesWidget::doLayout(Renderer& renderer, float containerWidth, float 
   if (wasVertical != m_isVertical) {
     m_rebuildPending = true;
   }
+  if (m_niriStack) {
+    m_containerHeight = containerHeight;
+  }
   const std::uint64_t textMetricsGeneration = renderer.textMetricsGeneration();
   if (m_textMetricsGeneration != textMetricsGeneration) {
     m_textMetricsGeneration = textMetricsGeneration;
@@ -112,8 +174,59 @@ void WorkspacesWidget::syncWidgetVisibility(bool showWidget) {
   }
 }
 
+void WorkspacesWidget::clearNiriStackItems() { m_niriChipItems.clear(); }
+
+ColorSpec WorkspacesWidget::activeWorkspaceChipFillColor() const {
+  const auto active = std::ranges::find_if(m_cachedState, [](const Workspace& ws) { return ws.active; });
+  if (active != m_cachedState.end()) {
+    return workspaceFillColor(*active);
+  }
+  return colorSpecFromRole(ColorRole::Primary);
+}
+
+void WorkspacesWidget::updateNiriChipFocusVisuals() {
+  const ColorSpec focusedFill = activeWorkspaceChipFillColor();
+  const ColorSpec unfocusedFill = colorSpecFromRole(ColorRole::SurfaceVariant, 0.30f);
+  const ColorSpec focusedText = readableColorForFill(focusedFill);
+  const ColorSpec unfocusedText = colorSpecFromRole(ColorRole::OnSurfaceVariant);
+
+  for (auto& chip : m_niriChipItems) {
+    const bool isFocused = !m_niriLastFocusedWindowId.empty() && chip.windowId == m_niriLastFocusedWindowId;
+    if (chip.background != nullptr) {
+      chip.background->setFill(isFocused ? focusedFill : unfocusedFill);
+      if (isFocused) {
+        chip.background->setBorder(colorSpecFromRole(ColorRole::Primary), Style::borderWidth * m_contentScale);
+      } else {
+        chip.background->clearBorder();
+      }
+    }
+    if (chip.label != nullptr) {
+      chip.label->setColor(isFocused ? focusedText : unfocusedText);
+      chip.label->setFontWeight(isFocused ? FontWeight::SemiBold : FontWeight::Normal);
+    }
+  }
+
+  if (root() != nullptr) {
+    root()->markPaintDirty();
+  }
+  if (Node* shell = barCapsuleShell(); shell != nullptr) {
+    shell->markPaintDirty();
+  }
+  requestFrameTick();
+  requestRedraw();
+}
+
 void WorkspacesWidget::doUpdate(Renderer& renderer) {
   auto current = m_platform.workspaces(m_output);
+
+  if (m_niriStack && !m_niriChipItems.empty()) {
+    const auto liveAssignments = m_platform.workspaceWindowAssignments(m_output);
+    const std::string liveFocusId = inferFocusedWindowId(m_platform, liveAssignments).value_or("");
+    if (liveFocusId != m_niriLastFocusedWindowId) {
+      m_niriLastFocusedWindowId = liveFocusId;
+      updateNiriChipFocusVisuals();
+    }
+  }
 
   if (!m_cachedState.empty() && !current.empty() && !std::ranges::any_of(current, [](const Workspace& ws) {
         return ws.active;
@@ -127,6 +240,7 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
   if (!showWidget) {
     if (!m_cachedState.empty() || !m_items.empty()) {
       m_cachedState.clear();
+      clearNiriStackItems();
       m_rebuildPending = true;
       if (root() != nullptr) {
         root()->markLayoutDirty();
@@ -166,6 +280,34 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
         retarget(renderer);
       }
     }
+    if (m_niriStack) {
+      const auto liveAssignments = m_platform.workspaceWindowAssignments(m_output);
+      auto newWindows = liveAssignments;
+      const bool windowsChanged = [&]() {
+        if (newWindows.size() != m_niriCachedWindows.size()) {
+          return true;
+        }
+        for (std::size_t i = 0; i < newWindows.size(); ++i) {
+          const auto& a = newWindows[i];
+          const auto& b = m_niriCachedWindows[i];
+          if (a.windowId != b.windowId
+              || a.workspaceKey != b.workspaceKey
+              || a.appId != b.appId
+              || a.title != b.title
+              || a.x != b.x
+              || a.y != b.y) {
+            return true;
+          }
+        }
+        return false;
+      }();
+      if (windowsChanged) {
+        m_niriCachedWindows = std::move(newWindows);
+        m_rebuildPending = true;
+        if (root() != nullptr)
+          root()->markLayoutDirty();
+      }
+    }
     return;
   }
 
@@ -185,13 +327,45 @@ void WorkspacesWidget::doUpdate(Renderer& renderer) {
     );
   }
 
-  if (structuralChange) {
+  if (structuralChange || (m_niriStack && activeChange)) {
+    if (m_niriStack && activeChange) {
+      m_niriLastFocusedWindowId =
+          inferFocusedWindowId(m_platform, m_platform.workspaceWindowAssignments(m_output)).value_or("");
+    }
     m_rebuildPending = true;
     if (root() != nullptr) {
       root()->markLayoutDirty();
     }
   } else {
     retarget(renderer);
+  }
+
+  if (m_niriStack) {
+    auto newWindows = m_platform.workspaceWindowAssignments(m_output);
+    const bool windowsChanged = [&]() {
+      if (newWindows.size() != m_niriCachedWindows.size()) {
+        return true;
+      }
+      for (std::size_t i = 0; i < newWindows.size(); ++i) {
+        const auto& a = newWindows[i];
+        const auto& b = m_niriCachedWindows[i];
+        if (a.windowId != b.windowId
+            || a.workspaceKey != b.workspaceKey
+            || a.appId != b.appId
+            || a.title != b.title
+            || a.x != b.x
+            || a.y != b.y) {
+          return true;
+        }
+      }
+      return false;
+    }();
+    if (windowsChanged) {
+      m_niriCachedWindows = std::move(newWindows);
+      m_rebuildPending = true;
+      if (root() != nullptr)
+        root()->markLayoutDirty();
+    }
   }
 }
 
@@ -203,6 +377,12 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
     m_container->removeChild(m_container->children().back().get());
   }
   m_items.clear();
+  clearNiriStackItems();
+
+  if (m_niriStack) {
+    rebuildNiriStack(renderer);
+    return;
+  }
 
   const auto& workspaces = m_cachedState;
   const float gap = kWorkspaceGap * m_contentScale;
@@ -356,6 +536,231 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
     m_container->setFrameSize(m_indicatorHeight, total);
   } else {
     m_container->setFrameSize(total, m_indicatorHeight);
+  }
+}
+
+void WorkspacesWidget::rebuildNiriStack(Renderer& renderer) {
+  const auto& workspaces = m_cachedState;
+  if (workspaces.empty()) {
+    m_container->setFrameSize(0.0f, m_containerHeight);
+    m_niriVisibleStart = 0;
+    return;
+  }
+
+  const float hPad = std::round(Style::spaceXs * m_contentScale);
+  const float midY = m_containerHeight * 0.5f;
+  const float barH = std::max(4.0f, std::round(m_dotSize * 0.62f * m_contentScale));
+  const float barInactiveW = std::max(8.0f, std::round(m_dotSize * 1.7f * m_contentScale));
+  const float barActiveW = std::max(barInactiveW + 4.0f, std::round(barInactiveW * 1.65f));
+  const float barSpacing = std::max(4.0f, std::round(barH * 1.15f));
+  const float slotW = barActiveW;
+
+  std::vector<std::size_t> ordered(workspaces.size());
+  std::iota(ordered.begin(), ordered.end(), 0);
+  std::ranges::stable_sort(ordered, [&](std::size_t lhs, std::size_t rhs) {
+    const auto sortKey = [&](const Workspace& ws, std::size_t originalIndex) {
+      if (ws.index > 0) {
+        return std::pair<int, std::size_t>{0, ws.index};
+      }
+      if (const auto numericId = numericWorkspaceId(ws); numericId.has_value()) {
+        return std::pair<int, std::size_t>{1, *numericId};
+      }
+      return std::pair<int, std::size_t>{2, originalIndex};
+    };
+    return sortKey(workspaces[lhs], lhs) < sortKey(workspaces[rhs], rhs);
+  });
+
+  std::size_t activeOrderedIdx = 0;
+  for (std::size_t i = 0; i < ordered.size(); ++i) {
+    if (workspaces[ordered[i]].active) {
+      activeOrderedIdx = i;
+      break;
+    }
+  }
+
+  const std::size_t nAll = ordered.size();
+  const std::size_t nVisible = std::min(m_visibleWorkspaceCount, nAll);
+  const std::size_t centerSlot = nVisible / 2;
+  std::size_t visibleStart = 0;
+  if (activeOrderedIdx > centerSlot) {
+    visibleStart = activeOrderedIdx - centerSlot;
+  }
+  if (visibleStart + nVisible > nAll) {
+    visibleStart = nAll - nVisible;
+  }
+  m_niriVisibleStart = visibleStart;
+  const float barColTotalH =
+      static_cast<float>(nVisible) * barH + static_cast<float>(nVisible > 1 ? nVisible - 1 : 0) * barSpacing;
+
+  float x = hPad;
+
+  // --- Workspace bars ---
+  for (std::size_t i = 0; i < nVisible; ++i) {
+    const float centerY = midY - barColTotalH * 0.5f + static_cast<float>(i) * (barH + barSpacing) + barH * 0.5f;
+    const std::size_t wsIdx = ordered[m_niriVisibleStart + i];
+    const auto& ws = workspaces[wsIdx];
+    const float thisBarW = ws.active ? barActiveW : barInactiveW;
+
+    // Make the click area larger than the visible bar so narrow indicators stay easy to hit.
+    const float slotH = barH + barSpacing;
+    auto hitArea = std::make_unique<InputArea>();
+    hitArea->setFrameSize(slotW, slotH);
+    hitArea->setPosition(x, std::round(centerY - slotH * 0.5f));
+
+    auto bar = ui::box({
+        .fill = workspaceFillColor(ws),
+        .radius = barH * 0.5f,
+        .width = thisBarW,
+        .height = barH,
+    });
+    bar->setOpacity(ws.active ? 1.0f : (ws.occupied || ws.urgent ? 0.82f : 0.32f));
+    bar->setPosition(0.0f, std::round((slotH - barH) * 0.5f));
+    hitArea->addChild(std::move(bar));
+
+    auto wsCopy = ws;
+    hitArea->setOnClick([this, wsCopy](const InputArea::PointerData& data) {
+      if (data.button == BTN_LEFT) {
+        m_platform.activateWorkspace(m_output, wsCopy);
+      }
+    });
+
+    m_container->addChild(std::move(hitArea));
+  }
+
+  x += slotW + hPad;
+
+  // --- Get active workspace windows ---
+  // Compute the key that niri assigns to this workspace: idx if available, else id.
+  std::string activeKey;
+  const std::size_t activeWsIdx = ordered[activeOrderedIdx];
+  if (activeWsIdx < workspaces.size()) {
+    const auto& activeWs = workspaces[activeWsIdx];
+    if (activeWs.index > 0) {
+      activeKey = std::to_string(activeWs.index);
+    } else if (!activeWs.id.empty()) {
+      activeKey = activeWs.id;
+    }
+  }
+
+  // Fetch fresh window assignments so the rebuild always reflects current state.
+  const auto allWindows = m_platform.workspaceWindowAssignments(m_output);
+  std::vector<WorkspaceWindowAssignment> filteredWindows;
+  for (const auto& win : allWindows) {
+    if (!activeKey.empty() && win.workspaceKey == activeKey) {
+      filteredWindows.push_back(win);
+    }
+  }
+  std::sort(
+      filteredWindows.begin(), filteredWindows.end(),
+      [](const WorkspaceWindowAssignment& a, const WorkspaceWindowAssignment& b) { return a.x < b.x; }
+  );
+  std::string focusedWindowId;
+  if (const auto inferred = inferFocusedWindowId(m_platform, allWindows); inferred.has_value()) {
+    const auto it =
+        std::find_if(filteredWindows.begin(), filteredWindows.end(), [&](const WorkspaceWindowAssignment& assignment) {
+          return assignment.windowId == *inferred;
+        });
+    if (it != filteredWindows.end()) {
+      focusedWindowId = *inferred;
+    }
+  }
+  m_niriLastFocusedWindowId = focusedWindowId;
+
+  // --- Separator ---
+  if (m_showWindowChips && !filteredWindows.empty()) {
+    const float sepH = std::round(barColTotalH * 0.85f);
+    auto sep = ui::box({
+        .fill = colorSpecFromRole(ColorRole::Outline),
+        .width = 1.0f,
+        .height = sepH,
+    });
+    sep->setOpacity(0.4f);
+    sep->setPosition(x, std::round(midY - sepH * 0.5f));
+    m_container->addChild(std::move(sep));
+    x += 1.0f + hPad;
+  }
+
+  // --- Window chips ---
+  if (m_showWindowChips) {
+    const float chipFontSize = Style::fontSizeMini * 0.92f * m_contentScale;
+    const float chipH = std::round(m_containerHeight * 0.65f);
+    const float chipPadH = std::round(Style::spaceXs * 0.85f * m_contentScale);
+    const float chipGap = std::round(Style::spaceXs * m_contentScale);
+    bool hadChips = false;
+
+    for (const auto& win : filteredWindows) {
+      std::string t = resolveWindowChipLabel(win.appId);
+      t = StringUtils::truncateUtf8CodePoints(t, 14);
+
+      const bool isFocused = !focusedWindowId.empty() && win.windowId == focusedWindowId;
+      const ColorSpec chipFill =
+          isFocused ? workspaceFillColor(workspaces[activeWsIdx]) : colorSpecFromRole(ColorRole::SurfaceVariant, 0.30f);
+      const ColorSpec chipTextColor =
+          isFocused ? readableColorForFill(chipFill) : colorSpecFromRole(ColorRole::OnSurfaceVariant);
+
+      auto chipArea = std::make_unique<InputArea>();
+      auto chipBg = ui::box({
+          .fill = chipFill,
+          .radius = chipH * 0.5f,
+      });
+      chipBg->setFrameSize(0.0f, chipH);
+      if (isFocused) {
+        chipBg->setBorder(colorSpecFromRole(ColorRole::Primary), Style::borderWidth * m_contentScale);
+      } else {
+        chipBg->clearBorder();
+      }
+
+      auto chipLabel = ui::label({
+          .text = t,
+          .fontSize = chipFontSize,
+          .fontFamily = labelFontFamily(),
+          .color = chipTextColor,
+          .fontWeight = isFocused ? FontWeight::SemiBold : FontWeight::Normal,
+      });
+      chipLabel->measure(renderer);
+      const float chipW = std::round(chipLabel->width() + chipPadH * 2.0f);
+
+      chipArea->setFrameSize(chipW, chipH);
+      chipArea->setPosition(x, std::round(midY - chipH * 0.5f));
+      chipBg->setFrameSize(chipW, chipH);
+      auto* chipBgPtr = chipBg.get();
+      chipArea->addChild(std::move(chipBg));
+      chipLabel->setPosition(chipPadH, std::round((chipH - chipLabel->height()) * 0.5f));
+      auto* chipLabelPtr = chipLabel.get();
+      chipArea->addChild(std::move(chipLabel));
+
+      const std::string windowId = win.windowId;
+      chipArea->setOnClick([this, windowId](const InputArea::PointerData& data) {
+        if (data.button == BTN_LEFT) {
+          m_niriLastFocusedWindowId = windowId;
+          m_platform.focusCompositorWindow(windowId);
+          updateNiriChipFocusVisuals();
+        }
+      });
+
+      auto* chipAreaPtr = static_cast<InputArea*>(m_container->addChild(std::move(chipArea)));
+      m_niriChipItems.push_back(
+          NiriChipItem{
+              .area = chipAreaPtr,
+              .background = chipBgPtr,
+              .label = chipLabelPtr,
+              .windowId = windowId,
+          }
+      );
+      x += chipW + chipGap;
+      hadChips = true;
+    }
+
+    if (hadChips) {
+      x -= chipGap;
+    }
+  }
+
+  // --- Finalize ---
+  x += hPad;
+  m_container->setFrameSize(x, m_containerHeight);
+  if (barCapsuleShell() != nullptr) {
+    barCapsuleShell()->markLayoutDirty();
   }
 }
 

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "compositors/compositor_platform.h"
+#include "compositors/workspace_backend.h"
 #include "render/animation/animation_manager.h"
 #include "shell/bar/widget.h"
 #include "ui/palette.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -36,6 +38,10 @@ public:
     float inactivePillSize = 1.0f;
     bool minimal = false;
     bool focusedOutputOnly = false;
+    bool niriStack = false;
+    std::size_t visibleWorkspaceCount = 3;
+    float dotSize = 6.0f;
+    bool showWindowChips = true;
   };
 
   WorkspacesWidget(CompositorPlatform& platform, wl_output* output, Options options);
@@ -47,6 +53,7 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void rebuild(Renderer& renderer);
+  void rebuildNiriStack(Renderer& renderer);
   void computeTargets();
   void retarget(Renderer& renderer);
   void updateContainerSize();
@@ -67,6 +74,8 @@ private:
   void recalculateItemMetrics(Renderer& renderer, std::size_t index);
   void updateAllItemMetrics(Renderer& renderer);
   void ensureItemLabel(Renderer& renderer, std::size_t index);
+  void clearNiriStackItems();
+  void updateNiriChipFocusVisuals();
 
   struct Item {
     InputArea* area = nullptr;
@@ -85,11 +94,19 @@ private:
     float currentWidth = 0.0f;
   };
 
+  struct NiriChipItem {
+    InputArea* area = nullptr;
+    Box* background = nullptr;
+    Label* label = nullptr;
+    std::string windowId;
+  };
+
   [[nodiscard]] ColorSpec workspaceFillColor(const Workspace& workspace) const;
   [[nodiscard]] ColorSpec workspaceTextColor(const Workspace& workspace) const;
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
   [[nodiscard]] bool isFocusedOutput() const;
+  [[nodiscard]] ColorSpec activeWorkspaceChipFillColor() const;
 
   CompositorPlatform& m_platform;
   wl_output* m_output = nullptr;
@@ -118,4 +135,14 @@ private:
   ColorSpec m_focusedColor = colorSpecFromRole(ColorRole::Primary);
   ColorSpec m_occupiedColor = colorSpecFromRole(ColorRole::Secondary);
   ColorSpec m_emptyColor = colorSpecFromRole(ColorRole::Secondary);
+
+  bool m_niriStack = false;
+  std::size_t m_visibleWorkspaceCount = 3;
+  float m_dotSize = 6.0f;
+  bool m_showWindowChips = true;
+  float m_containerHeight = 0.0f;
+  std::size_t m_niriVisibleStart = 0;
+  std::vector<WorkspaceWindowAssignment> m_niriCachedWindows;
+  std::string m_niriLastFocusedWindowId;
+  std::vector<NiriChipItem> m_niriChipItems;
 };

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -994,6 +994,23 @@ namespace settings {
         auto emptyColor = colorSpec("empty_color", "secondary");
         add(std::move(emptyColor));
       }
+      add(boolSpec("niri_stack", false));
+      const WidgetSettingVisibility niriOnly{{"niri_stack", {"true"}}};
+      {
+        auto v = intSpec("visible_workspace_count", 3, 1.0, 10.0, 1.0);
+        v.visibleWhen = niriOnly;
+        add(std::move(v));
+      }
+      {
+        auto v = doubleSpec("dot_size", 6.0, 3.0, 16.0, 0.5);
+        v.visibleWhen = niriOnly;
+        add(std::move(v));
+      }
+      {
+        auto v = boolSpec("show_window_chips", true);
+        v.visibleWhen = niriOnly;
+        add(std::move(v));
+      }
     }
 
     specs.insert(specs.end(), std::make_move_iterator(commonSpecs.begin()), std::make_move_iterator(commonSpecs.end()));


### PR DESCRIPTION
## Summary

This PR improves the Niri workspace widget by introducing a compact vertical workspace stack, surfacing active-workspace window chips, and preferring Niri metadata focus when resolving the focused compositor window.

## Included changes

- add `niri_stack` workspace rendering with compact vertical indicators
- center the visible workspace slice around the active workspace
- avoid empty leading and trailing slots in the compact view
- show active-workspace window chips next to the stack
- track focused compositor window via `NiriWorkspaceBackend`
- prefer Niri metadata focus over potentially stale `ext-workspace` focus in `CompositorPlatform`
- expose new widget settings for the Niri workspace stack mode

## Validation

- ran `clang-format` on the touched files
- built successfully with `ninja -C build-debug`

## Known issues / Open questions

- Active window highlighting is still slightly delayed compared to Niri's visible focus changes. The metadata backend already receives `WindowFocusChanged`, but there still appears to be additional latency somewhere in the update/render pipeline.
- Clicking the upper workspace indicator can still activate the wrong workspace in some situations. The visual ordering comes from Niri metadata, while activation currently follows a different path.
- Compact workspace labels are intentionally omitted for now. I'm considering a hover-reveal approach and would appreciate UX feedback.