### PR TITLE
Add clipboard color previews

### DIFF
--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -2,9 +2,12 @@
 
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 #include <cmath>
 #include <cstdio>
+#include <numbers>
 #include <string>
+#include <system_error>
 
 namespace {
 
@@ -57,6 +60,44 @@ Color hsv(float h, float s, float v, float a) {
   }
 
   const float m = value - chroma;
+  return rgba(rp + m, gp + m, bp + m, std::clamp(a, 0.0f, 1.0f));
+}
+
+Color hsl(float h, float s, float l, float a) {
+  h = std::fmod(h, 360.0f);
+  if (h < 0.0f) {
+    h += 360.0f;
+  }
+  s = std::clamp(s, 0.0f, 1.0f);
+  l = std::clamp(l, 0.0f, 1.0f);
+
+  const float chroma = (1.0f - std::fabs(2.0f * l - 1.0f)) * s;
+  const float x = chroma * (1.0f - std::fabs(std::fmod(h / 60.0f, 2.0f) - 1.0f));
+  const float m = l - chroma / 2.0f;
+
+  float rp = 0.0f;
+  float gp = 0.0f;
+  float bp = 0.0f;
+  if (h < 60.0f) {
+    rp = chroma;
+    gp = x;
+  } else if (h < 120.0f) {
+    rp = x;
+    gp = chroma;
+  } else if (h < 180.0f) {
+    gp = chroma;
+    bp = x;
+  } else if (h < 240.0f) {
+    gp = x;
+    bp = chroma;
+  } else if (h < 300.0f) {
+    rp = x;
+    bp = chroma;
+  } else {
+    rp = chroma;
+    bp = x;
+  }
+
   return rgba(rp + m, gp + m, bp + m, std::clamp(a, 0.0f, 1.0f));
 }
 
@@ -130,4 +171,212 @@ bool tryParseHexColor(std::string_view input, Color& out) {
   } catch (...) {
     return false;
   }
+}
+
+bool tryParseCssColor(std::string_view text, Color& out) {
+  while (!text.empty() && static_cast<unsigned char>(text.front()) <= ' ') {
+    text.remove_prefix(1);
+  }
+  while (!text.empty() && static_cast<unsigned char>(text.back()) <= ' ') {
+    text.remove_suffix(1);
+  }
+  if (text.empty()) {
+    return false;
+  }
+
+  // Hex requires a literal '#'. Use hex() rather than tryParseHexColor(): the latter
+  // inserts a missing '#', which would treat plain words like "facade" as colors.
+  if (text.front() == '#') {
+    try {
+      out = hex(text);
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+
+  std::string lower;
+  lower.reserve(text.size());
+  for (char c : text) {
+    lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  const std::string_view lv(lower);
+
+  const bool isRgba = lv.starts_with("rgba(") && lv.back() == ')';
+  const bool isRgb = !isRgba && lv.starts_with("rgb(") && lv.back() == ')';
+  const bool isHsla = lv.starts_with("hsla(") && lv.back() == ')';
+  const bool isHsl = !isHsla && lv.starts_with("hsl(") && lv.back() == ')';
+
+  auto skipSpaces = [](std::string_view& sv) {
+    while (!sv.empty() && sv.front() == ' ') {
+      sv.remove_prefix(1);
+    }
+  };
+  // Between components: an optional comma (legacy) or just whitespace (CSS Color 4).
+  auto consumeSeparator = [&](std::string_view& sv) {
+    skipSpaces(sv);
+    if (!sv.empty() && sv.front() == ',') {
+      sv.remove_prefix(1);
+    }
+    skipSpaces(sv);
+  };
+  // Before alpha: a comma (legacy) or a slash (CSS Color 4) is required.
+  auto consumeAlphaSeparator = [&](std::string_view& sv) -> bool {
+    skipSpaces(sv);
+    if (!sv.empty() && (sv.front() == ',' || sv.front() == '/')) {
+      sv.remove_prefix(1);
+      skipSpaces(sv);
+      return true;
+    }
+    return false;
+  };
+  // Alpha: number in [0,1] or percentage in [0,100]%.
+  auto parseAlpha = [&](std::string_view& sv, float& result) -> bool {
+    skipSpaces(sv);
+    float v = 0.0f;
+    const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+    if (ec != std::errc{}) {
+      return false;
+    }
+    sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+    if (!sv.empty() && sv.front() == '%') {
+      sv.remove_prefix(1);
+      v /= 100.0f;
+    }
+    if (v < 0.0f || v > 1.0f) {
+      return false;
+    }
+    result = v;
+    skipSpaces(sv);
+    return true;
+  };
+
+  if (isRgb || isRgba) {
+    const std::size_t prefixLen = isRgba ? 5 : 4;
+    std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
+    // Channel: number in [0,255] or percentage in [0,100]%, normalized to [0,1].
+    auto parseChannel = [&](std::string_view& sv, float& result) -> bool {
+      skipSpaces(sv);
+      float v = 0.0f;
+      const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+      if (ec != std::errc{}) {
+        return false;
+      }
+      sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+      if (!sv.empty() && sv.front() == '%') {
+        sv.remove_prefix(1);
+        if (v < 0.0f || v > 100.0f) {
+          return false;
+        }
+        result = v / 100.0f;
+      } else {
+        if (v < 0.0f || v > 255.0f) {
+          return false;
+        }
+        result = v / 255.0f;
+      }
+      skipSpaces(sv);
+      return true;
+    };
+
+    Color color;
+    if (!parseChannel(inner, color.r)) {
+      return false;
+    }
+    consumeSeparator(inner);
+    if (!parseChannel(inner, color.g)) {
+      return false;
+    }
+    consumeSeparator(inner);
+    if (!parseChannel(inner, color.b)) {
+      return false;
+    }
+    skipSpaces(inner);
+    if (!inner.empty()) {
+      if (!consumeAlphaSeparator(inner) || !parseAlpha(inner, color.a)) {
+        return false;
+      }
+    }
+    if (!inner.empty()) {
+      return false;
+    }
+    out = color;
+    return true;
+  }
+
+  if (isHsl || isHsla) {
+    const std::size_t prefixLen = isHsla ? 5 : 4;
+    std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
+    // Hue: number with an optional angle unit; result in degrees (hsl() wraps the range).
+    auto parseHue = [&](std::string_view& sv, float& result) -> bool {
+      skipSpaces(sv);
+      float v = 0.0f;
+      const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+      if (ec != std::errc{}) {
+        return false;
+      }
+      sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+      if (sv.starts_with("deg")) {
+        sv.remove_prefix(3);
+      } else if (sv.starts_with("grad")) {
+        v *= 360.0f / 400.0f;
+        sv.remove_prefix(4);
+      } else if (sv.starts_with("rad")) {
+        v *= 180.0f / std::numbers::pi_v<float>;
+        sv.remove_prefix(3);
+      } else if (sv.starts_with("turn")) {
+        v *= 360.0f;
+        sv.remove_prefix(4);
+      }
+      result = v;
+      skipSpaces(sv);
+      return true;
+    };
+    // Saturation/lightness: percentage in [0,100]%, normalized to [0,1].
+    auto parsePercent = [&](std::string_view& sv, float& result) -> bool {
+      skipSpaces(sv);
+      float v = 0.0f;
+      const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+      if (ec != std::errc{}) {
+        return false;
+      }
+      sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+      if (sv.empty() || sv.front() != '%' || v < 0.0f || v > 100.0f) {
+        return false;
+      }
+      sv.remove_prefix(1);
+      result = v / 100.0f;
+      skipSpaces(sv);
+      return true;
+    };
+
+    float h = 0.0f;
+    float s = 0.0f;
+    float l = 0.0f;
+    float a = 1.0f;
+    if (!parseHue(inner, h)) {
+      return false;
+    }
+    consumeSeparator(inner);
+    if (!parsePercent(inner, s)) {
+      return false;
+    }
+    consumeSeparator(inner);
+    if (!parsePercent(inner, l)) {
+      return false;
+    }
+    skipSpaces(inner);
+    if (!inner.empty()) {
+      if (!consumeAlphaSeparator(inner) || !parseAlpha(inner, a)) {
+        return false;
+      }
+    }
+    if (!inner.empty()) {
+      return false;
+    }
+    out = hsl(h, s, l, a);
+    return true;
+  }
+
+  return false;
 }

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <string_view>
 
+// RGBA color; every channel is a float in [0,1].
 struct Color {
   float r = 0.0f;
   float g = 0.0f;
@@ -18,8 +19,10 @@ constexpr bool operator==(const Color& lhs, const Color& rhs) noexcept {
 
 constexpr Color rgba(float r, float g, float b, float a = 1.0f) { return Color{r, g, b, a}; }
 
+// Maps a 0-255 channel byte to a [0,1] float.
 constexpr float colorByte(std::uint32_t value) { return static_cast<float>(value) / 255.0f; }
 
+// Builds a Color from a packed 0xRRGGBB integer (alpha = 1).
 constexpr Color rgbHex(std::uint32_t value) {
   return Color{
       .r = colorByte((value >> 16U) & 0xFFU),
@@ -29,6 +32,7 @@ constexpr Color rgbHex(std::uint32_t value) {
   };
 }
 
+// Builds a Color from a packed 0xRRGGBBAA integer.
 constexpr Color rgbaHex(std::uint32_t value) {
   return Color{
       .r = colorByte((value >> 24U) & 0xFFU),
@@ -38,6 +42,7 @@ constexpr Color rgbaHex(std::uint32_t value) {
   };
 }
 
+// One hex digit ('0'-'9', 'a'-'f', 'A'-'F') to its value; throws on anything else.
 constexpr std::uint32_t hexDigit(char c) {
   if (c >= '0' && c <= '9') {
     return static_cast<std::uint32_t>(c - '0');
@@ -53,6 +58,7 @@ constexpr std::uint32_t hexDigit(char c) {
 
 constexpr std::uint32_t hexByte(char high, char low) { return (hexDigit(high) << 4U) | hexDigit(low); }
 
+// Parses "#rgb", "#rgba", "#rrggbb", or "#rrggbbaa" (literal '#' required); throws otherwise.
 constexpr Color hex(std::string_view value) {
   if (value.empty() || value.front() != '#') {
     throw std::invalid_argument("hex color must start with '#'");
@@ -102,6 +108,7 @@ constexpr Color withAlpha(const Color& color, float alpha) {
   return rgba(color.r, color.g, color.b, clamp(alpha));
 }
 
+// Scales rgb by amount (1 = unchanged, >1 brighter), clamped to [0,1]; alpha unchanged.
 constexpr Color brighten(const Color& color, float amount) {
   auto clamp = [](float v) constexpr { return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); };
   return Color{
@@ -112,6 +119,7 @@ constexpr Color brighten(const Color& color, float amount) {
   };
 }
 
+// Linear blend from a to b; t in [0,1].
 constexpr Color lerpColor(const Color& a, const Color& b, float t) {
   return Color{
       .r = a.r + (b.r - a.r) * t,
@@ -121,9 +129,22 @@ constexpr Color lerpColor(const Color& a, const Color& b, float t) {
   };
 }
 
+// Hue in turns ([0,1), wrapped); saturation/value/alpha in [0,1].
 [[nodiscard]] Color hsv(float h, float s, float v, float a = 1.0f);
+// Hue in degrees (wrapped to [0,360)); saturation/lightness/alpha in [0,1].
+[[nodiscard]] Color hsl(float h, float s, float l, float a = 1.0f);
+// Decomposes rgb into hue (turns, [0,1)), saturation, and value (each [0,1]).
 void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
+// WCAG relative luminance of color, in [0,1].
 [[nodiscard]] float relativeLuminance(const Color& color);
+// Returns opaque black or white, whichever reads better on background.
 [[nodiscard]] Color readableTextColorForBackground(const Color& background);
+// Formats as "#RRGGBB" (alpha dropped).
 [[nodiscard]] std::string formatRgbHex(const Color& color);
+// Like hex() but non-throwing, trims whitespace, and tolerates a missing '#'.
 [[nodiscard]] bool tryParseHexColor(std::string_view input, Color& out);
+// Parses a CSS-style color string into out, returning false if it is not a color.
+// Accepts "#rgb[a]"/"#rrggbb[aa]" (literal '#' required), plus rgb()/rgba()/hsl()/hsla()
+// in either comma-separated (legacy) or space-separated (CSS Color 4, with '/' alpha) form.
+// Channels take number or percentage; hue takes an optional deg/grad/rad/turn unit.
+[[nodiscard]] bool tryParseCssColor(std::string_view text, Color& out);

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -20,6 +20,9 @@
 #include "wayland/clipboard_service.h"
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <charconv>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -196,6 +199,222 @@ namespace {
     return ui::button(std::move(props));
   }
 
+  struct ParsedColor {
+    float r = 0.0f, g = 0.0f, b = 0.0f, a = 1.0f;
+  };
+
+  static std::array<float, 3> hslToRgb(float h, float s, float l) {
+    const float c = (1.0f - std::abs(2.0f * l - 1.0f)) * s;
+    const float x = c * (1.0f - std::abs(std::fmod(h / 60.0f, 2.0f) - 1.0f));
+    const float m = l - c / 2.0f;
+    float r = 0.0f, g = 0.0f, b = 0.0f;
+    if (h < 60.0f) {
+      r = c;
+      g = x;
+    } else if (h < 120.0f) {
+      r = x;
+      g = c;
+    } else if (h < 180.0f) {
+      g = c;
+      b = x;
+    } else if (h < 240.0f) {
+      g = x;
+      b = c;
+    } else if (h < 300.0f) {
+      r = x;
+      b = c;
+    } else {
+      r = c;
+      b = x;
+    }
+    return {r + m, g + m, b + m};
+  }
+
+  std::optional<ParsedColor> tryParseColor(std::string_view text) {
+    while (!text.empty() && static_cast<unsigned char>(text.front()) <= ' ') {
+      text.remove_prefix(1);
+    }
+    while (!text.empty() && static_cast<unsigned char>(text.back()) <= ' ') {
+      text.remove_suffix(1);
+    }
+    if (text.empty()) {
+      return std::nullopt;
+    }
+
+    auto toLower = [](char c) -> char { return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); };
+
+    if (text[0] == '#') {
+      const std::size_t len = text.size() - 1;
+      if (len != 3 && len != 4 && len != 6 && len != 8) {
+        return std::nullopt;
+      }
+      for (std::size_t i = 1; i < text.size(); ++i) {
+        const char c = text[i];
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+          return std::nullopt;
+        }
+      }
+      auto hexVal = [](char c) -> std::uint32_t {
+        if (c >= '0' && c <= '9')
+          return static_cast<std::uint32_t>(c - '0');
+        if (c >= 'a' && c <= 'f')
+          return static_cast<std::uint32_t>(10 + (c - 'a'));
+        return static_cast<std::uint32_t>(10 + (c - 'A'));
+      };
+      auto byteF = [](std::uint32_t v) -> float { return static_cast<float>(v) / 255.0f; };
+      if (len == 3) {
+        const std::uint32_t r = hexVal(text[1]);
+        const std::uint32_t g = hexVal(text[2]);
+        const std::uint32_t b = hexVal(text[3]);
+        return ParsedColor{byteF(r * 17U), byteF(g * 17U), byteF(b * 17U), 1.0f};
+      }
+      if (len == 4) {
+        const std::uint32_t r = hexVal(text[1]);
+        const std::uint32_t g = hexVal(text[2]);
+        const std::uint32_t b = hexVal(text[3]);
+        const std::uint32_t a = hexVal(text[4]);
+        return ParsedColor{byteF(r * 17U), byteF(g * 17U), byteF(b * 17U), byteF(a * 17U)};
+      }
+      if (len == 6) {
+        const std::uint32_t r = (hexVal(text[1]) << 4U) | hexVal(text[2]);
+        const std::uint32_t g = (hexVal(text[3]) << 4U) | hexVal(text[4]);
+        const std::uint32_t b = (hexVal(text[5]) << 4U) | hexVal(text[6]);
+        return ParsedColor{byteF(r), byteF(g), byteF(b), 1.0f};
+      }
+      {
+        const std::uint32_t r = (hexVal(text[1]) << 4U) | hexVal(text[2]);
+        const std::uint32_t g = (hexVal(text[3]) << 4U) | hexVal(text[4]);
+        const std::uint32_t b = (hexVal(text[5]) << 4U) | hexVal(text[6]);
+        const std::uint32_t a = (hexVal(text[7]) << 4U) | hexVal(text[8]);
+        return ParsedColor{byteF(r), byteF(g), byteF(b), byteF(a)};
+      }
+    }
+
+    std::string lower;
+    lower.reserve(text.size());
+    for (char c : text) {
+      lower.push_back(toLower(c));
+    }
+    std::string_view lv(lower);
+
+    const bool isRgba = lv.starts_with("rgba(") && lv.back() == ')';
+    const bool isRgb = !isRgba && lv.starts_with("rgb(") && lv.back() == ')';
+    const bool isHsla = lv.starts_with("hsla(") && lv.back() == ')';
+    const bool isHsl = !isHsla && lv.starts_with("hsl(") && lv.back() == ')';
+
+    if (isRgb || isRgba) {
+      const std::size_t prefixLen = isRgba ? 5 : 4;
+      std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
+      auto parseNext = [&](std::string_view& sv, float& out) -> bool {
+        while (!sv.empty() && sv.front() == ' ')
+          sv.remove_prefix(1);
+        int v = 0;
+        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+        if (ec != std::errc{} || v < 0 || v > 255)
+          return false;
+        out = static_cast<float>(v) / 255.0f;
+        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+        while (!sv.empty() && sv.front() == ' ')
+          sv.remove_prefix(1);
+        return true;
+      };
+      auto parseAlpha = [&](std::string_view& sv, float& out) -> bool {
+        while (!sv.empty() && sv.front() == ' ')
+          sv.remove_prefix(1);
+        float v = 0.0f;
+        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
+        if (ec != std::errc{} || v < 0.0f || v > 1.0f)
+          return false;
+        out = v;
+        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+        while (!sv.empty() && sv.front() == ' ')
+          sv.remove_prefix(1);
+        return true;
+      };
+      ParsedColor pc;
+      if (!parseNext(inner, pc.r))
+        return std::nullopt;
+      if (inner.empty() || inner.front() != ',')
+        return std::nullopt;
+      inner.remove_prefix(1);
+      if (!parseNext(inner, pc.g))
+        return std::nullopt;
+      if (inner.empty() || inner.front() != ',')
+        return std::nullopt;
+      inner.remove_prefix(1);
+      if (!parseNext(inner, pc.b))
+        return std::nullopt;
+      if (isRgba) {
+        if (inner.empty() || inner.front() != ',')
+          return std::nullopt;
+        inner.remove_prefix(1);
+        if (!parseAlpha(inner, pc.a))
+          return std::nullopt;
+      }
+      if (!inner.empty())
+        return std::nullopt;
+      return pc;
+    }
+
+    if (isHsl || isHsla) {
+      const std::size_t prefixLen = isHsla ? 5 : 4;
+      std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
+      auto skipSpaces = [](std::string_view& sv) {
+        while (!sv.empty() && sv.front() == ' ')
+          sv.remove_prefix(1);
+      };
+      auto parseFloatVal = [&](std::string_view& sv, float& out) -> bool {
+        skipSpaces(sv);
+        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out);
+        if (ec != std::errc{})
+          return false;
+        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
+        skipSpaces(sv);
+        return true;
+      };
+      auto parsePercent = [&](std::string_view& sv, float& out) -> bool {
+        if (!parseFloatVal(sv, out))
+          return false;
+        if (sv.empty() || sv.front() != '%')
+          return false;
+        sv.remove_prefix(1);
+        out /= 100.0f;
+        skipSpaces(sv);
+        return true;
+      };
+      float h = 0.0f, s = 0.0f, l = 0.0f, a = 1.0f;
+      if (!parseFloatVal(inner, h))
+        return std::nullopt;
+      if (h < 0.0f || h > 360.0f)
+        return std::nullopt;
+      if (inner.empty() || inner.front() != ',')
+        return std::nullopt;
+      inner.remove_prefix(1);
+      if (!parsePercent(inner, s))
+        return std::nullopt;
+      if (inner.empty() || inner.front() != ',')
+        return std::nullopt;
+      inner.remove_prefix(1);
+      if (!parsePercent(inner, l))
+        return std::nullopt;
+      if (isHsla) {
+        if (inner.empty() || inner.front() != ',')
+          return std::nullopt;
+        inner.remove_prefix(1);
+        if (!parseFloatVal(inner, a))
+          return std::nullopt;
+        if (a < 0.0f || a > 1.0f)
+          return std::nullopt;
+      }
+      if (!inner.empty())
+        return std::nullopt;
+      const auto rgb = hslToRgb(h, s, l);
+      return ParsedColor{rgb[0], rgb[1], rgb[2], a};
+    }
+
+    return std::nullopt;
+  }
+
   class ClipboardListRow final : public InputArea {
   public:
     ClipboardListRow(float scale, ThumbnailService* thumbnails) : m_scale(scale), m_thumbnails(thumbnails) {
@@ -238,6 +457,15 @@ namespace {
           ui::glyph({
               .out = &m_glyph,
               .glyphSize = kListGlyphSize * scale,
+          })
+      );
+
+      m_lead->addChild(
+          ui::box({
+              .out = &m_colorSwatch,
+              .radius = Style::scaledRadiusSm(scale),
+              .visible = false,
+              .participatesInLayout = false,
           })
       );
 
@@ -322,19 +550,38 @@ namespace {
       if (m_glyph != nullptr) {
         m_glyph->setGlyph(m_isImage ? "photo" : "file-text");
       }
+
+      const auto parsedColor = tryParseColor(entry.textPreview);
+      const bool isColor = !m_isImage && parsedColor.has_value();
+
+      if (m_colorSwatch != nullptr) {
+        if (isColor) {
+          const auto& pc = *parsedColor;
+          m_colorSwatch->setFill(fixedColorSpec(rgba(pc.r, pc.g, pc.b, pc.a)));
+        }
+        m_colorSwatch->setVisible(isColor);
+        m_colorSwatch->setParticipatesInLayout(isColor);
+      }
+      if (m_glyph != nullptr) {
+        m_glyph->setVisible(!isColor);
+        m_glyph->setParticipatesInLayout(!isColor);
+      }
+
       refreshThumbnail(renderer);
       applyVisualState();
       layout(renderer);
     }
 
     void refreshThumbnail(Renderer& renderer) {
-      if (m_image == nullptr || m_glyph == nullptr) {
+      if (m_image == nullptr || m_glyph == nullptr || m_colorSwatch == nullptr) {
         return;
       }
       if (!m_isImage || m_thumbnailPath.empty() || m_thumbnails == nullptr) {
         m_image->clear(renderer);
         m_image->setVisible(false);
-        m_glyph->setVisible(true);
+        const bool showGlyph = !m_colorSwatch->visible();
+        m_glyph->setVisible(showGlyph);
+        m_glyph->setParticipatesInLayout(showGlyph);
         return;
       }
 
@@ -343,12 +590,14 @@ namespace {
         m_image->clear(renderer);
         m_image->setVisible(false);
         m_glyph->setVisible(true);
+        m_glyph->setParticipatesInLayout(true);
         return;
       }
 
       m_image->setExternalTexture(renderer, handle);
       m_image->setVisible(true);
       m_glyph->setVisible(false);
+      m_glyph->setParticipatesInLayout(false);
     }
 
   private:
@@ -371,6 +620,10 @@ namespace {
       }
       if (m_image != nullptr) {
         m_image->setSize(thumbPx, thumbPx);
+      }
+      if (m_colorSwatch != nullptr && m_colorSwatch->visible()) {
+        const float swatchPx = std::round(thumbPx * 0.82f);
+        m_colorSwatch->setSize(swatchPx, swatchPx);
       }
       if (m_title != nullptr && m_meta != nullptr) {
         const float pinW = m_pinned ? kListPinGlyphSize * m_scale + Style::spaceMd * m_scale : 0.0f;
@@ -425,6 +678,7 @@ namespace {
     Flex* m_lead = nullptr;
     Image* m_image = nullptr;
     Glyph* m_glyph = nullptr;
+    Box* m_colorSwatch = nullptr;
     Glyph* m_pinGlyph = nullptr;
     Flex* m_textColumn = nullptr;
     Label* m_title = nullptr;
@@ -1193,6 +1447,21 @@ void ClipboardPanel::rebuildPreview(Renderer& renderer, float width, float heigh
     m_previewImage = image.get();
     m_previewContent->addChild(std::move(image));
   } else {
+    const auto previewColor = tryParseColor(entry.textPreview);
+    if (previewColor.has_value()) {
+      const auto& pc = *previewColor;
+      const float scale = contentScale();
+      const float swatchH = std::round(80.0f * scale);
+      m_previewContent->addChild(
+          ui::box({
+              .fill = fixedColorSpec(rgba(pc.r, pc.g, pc.b, pc.a)),
+              .radius = Style::scaledRadiusMd(scale),
+              .width = width,
+              .height = swatchH,
+          })
+      );
+    }
+
     if (m_clipboard != nullptr) {
       (void)m_clipboard->ensureEntryLoaded(historyIndex);
     }

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -8,6 +8,7 @@
 #include "core/ui_phase.h"
 #include "i18n/i18n.h"
 #include "render/core/async_texture_cache.h"
+#include "render/core/color.h"
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "shell/control_center/tab.h"
@@ -20,9 +21,7 @@
 #include "wayland/clipboard_service.h"
 
 #include <algorithm>
-#include <array>
 #include <cctype>
-#include <charconv>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -199,222 +198,6 @@ namespace {
     return ui::button(std::move(props));
   }
 
-  struct ParsedColor {
-    float r = 0.0f, g = 0.0f, b = 0.0f, a = 1.0f;
-  };
-
-  static std::array<float, 3> hslToRgb(float h, float s, float l) {
-    const float c = (1.0f - std::abs(2.0f * l - 1.0f)) * s;
-    const float x = c * (1.0f - std::abs(std::fmod(h / 60.0f, 2.0f) - 1.0f));
-    const float m = l - c / 2.0f;
-    float r = 0.0f, g = 0.0f, b = 0.0f;
-    if (h < 60.0f) {
-      r = c;
-      g = x;
-    } else if (h < 120.0f) {
-      r = x;
-      g = c;
-    } else if (h < 180.0f) {
-      g = c;
-      b = x;
-    } else if (h < 240.0f) {
-      g = x;
-      b = c;
-    } else if (h < 300.0f) {
-      r = x;
-      b = c;
-    } else {
-      r = c;
-      b = x;
-    }
-    return {r + m, g + m, b + m};
-  }
-
-  std::optional<ParsedColor> tryParseColor(std::string_view text) {
-    while (!text.empty() && static_cast<unsigned char>(text.front()) <= ' ') {
-      text.remove_prefix(1);
-    }
-    while (!text.empty() && static_cast<unsigned char>(text.back()) <= ' ') {
-      text.remove_suffix(1);
-    }
-    if (text.empty()) {
-      return std::nullopt;
-    }
-
-    auto toLower = [](char c) -> char { return static_cast<char>(std::tolower(static_cast<unsigned char>(c))); };
-
-    if (text[0] == '#') {
-      const std::size_t len = text.size() - 1;
-      if (len != 3 && len != 4 && len != 6 && len != 8) {
-        return std::nullopt;
-      }
-      for (std::size_t i = 1; i < text.size(); ++i) {
-        const char c = text[i];
-        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
-          return std::nullopt;
-        }
-      }
-      auto hexVal = [](char c) -> std::uint32_t {
-        if (c >= '0' && c <= '9')
-          return static_cast<std::uint32_t>(c - '0');
-        if (c >= 'a' && c <= 'f')
-          return static_cast<std::uint32_t>(10 + (c - 'a'));
-        return static_cast<std::uint32_t>(10 + (c - 'A'));
-      };
-      auto byteF = [](std::uint32_t v) -> float { return static_cast<float>(v) / 255.0f; };
-      if (len == 3) {
-        const std::uint32_t r = hexVal(text[1]);
-        const std::uint32_t g = hexVal(text[2]);
-        const std::uint32_t b = hexVal(text[3]);
-        return ParsedColor{byteF(r * 17U), byteF(g * 17U), byteF(b * 17U), 1.0f};
-      }
-      if (len == 4) {
-        const std::uint32_t r = hexVal(text[1]);
-        const std::uint32_t g = hexVal(text[2]);
-        const std::uint32_t b = hexVal(text[3]);
-        const std::uint32_t a = hexVal(text[4]);
-        return ParsedColor{byteF(r * 17U), byteF(g * 17U), byteF(b * 17U), byteF(a * 17U)};
-      }
-      if (len == 6) {
-        const std::uint32_t r = (hexVal(text[1]) << 4U) | hexVal(text[2]);
-        const std::uint32_t g = (hexVal(text[3]) << 4U) | hexVal(text[4]);
-        const std::uint32_t b = (hexVal(text[5]) << 4U) | hexVal(text[6]);
-        return ParsedColor{byteF(r), byteF(g), byteF(b), 1.0f};
-      }
-      {
-        const std::uint32_t r = (hexVal(text[1]) << 4U) | hexVal(text[2]);
-        const std::uint32_t g = (hexVal(text[3]) << 4U) | hexVal(text[4]);
-        const std::uint32_t b = (hexVal(text[5]) << 4U) | hexVal(text[6]);
-        const std::uint32_t a = (hexVal(text[7]) << 4U) | hexVal(text[8]);
-        return ParsedColor{byteF(r), byteF(g), byteF(b), byteF(a)};
-      }
-    }
-
-    std::string lower;
-    lower.reserve(text.size());
-    for (char c : text) {
-      lower.push_back(toLower(c));
-    }
-    std::string_view lv(lower);
-
-    const bool isRgba = lv.starts_with("rgba(") && lv.back() == ')';
-    const bool isRgb = !isRgba && lv.starts_with("rgb(") && lv.back() == ')';
-    const bool isHsla = lv.starts_with("hsla(") && lv.back() == ')';
-    const bool isHsl = !isHsla && lv.starts_with("hsl(") && lv.back() == ')';
-
-    if (isRgb || isRgba) {
-      const std::size_t prefixLen = isRgba ? 5 : 4;
-      std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
-      auto parseNext = [&](std::string_view& sv, float& out) -> bool {
-        while (!sv.empty() && sv.front() == ' ')
-          sv.remove_prefix(1);
-        int v = 0;
-        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
-        if (ec != std::errc{} || v < 0 || v > 255)
-          return false;
-        out = static_cast<float>(v) / 255.0f;
-        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
-        while (!sv.empty() && sv.front() == ' ')
-          sv.remove_prefix(1);
-        return true;
-      };
-      auto parseAlpha = [&](std::string_view& sv, float& out) -> bool {
-        while (!sv.empty() && sv.front() == ' ')
-          sv.remove_prefix(1);
-        float v = 0.0f;
-        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), v);
-        if (ec != std::errc{} || v < 0.0f || v > 1.0f)
-          return false;
-        out = v;
-        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
-        while (!sv.empty() && sv.front() == ' ')
-          sv.remove_prefix(1);
-        return true;
-      };
-      ParsedColor pc;
-      if (!parseNext(inner, pc.r))
-        return std::nullopt;
-      if (inner.empty() || inner.front() != ',')
-        return std::nullopt;
-      inner.remove_prefix(1);
-      if (!parseNext(inner, pc.g))
-        return std::nullopt;
-      if (inner.empty() || inner.front() != ',')
-        return std::nullopt;
-      inner.remove_prefix(1);
-      if (!parseNext(inner, pc.b))
-        return std::nullopt;
-      if (isRgba) {
-        if (inner.empty() || inner.front() != ',')
-          return std::nullopt;
-        inner.remove_prefix(1);
-        if (!parseAlpha(inner, pc.a))
-          return std::nullopt;
-      }
-      if (!inner.empty())
-        return std::nullopt;
-      return pc;
-    }
-
-    if (isHsl || isHsla) {
-      const std::size_t prefixLen = isHsla ? 5 : 4;
-      std::string_view inner = lv.substr(prefixLen, lv.size() - prefixLen - 1);
-      auto skipSpaces = [](std::string_view& sv) {
-        while (!sv.empty() && sv.front() == ' ')
-          sv.remove_prefix(1);
-      };
-      auto parseFloatVal = [&](std::string_view& sv, float& out) -> bool {
-        skipSpaces(sv);
-        const auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out);
-        if (ec != std::errc{})
-          return false;
-        sv.remove_prefix(static_cast<std::size_t>(ptr - sv.data()));
-        skipSpaces(sv);
-        return true;
-      };
-      auto parsePercent = [&](std::string_view& sv, float& out) -> bool {
-        if (!parseFloatVal(sv, out))
-          return false;
-        if (sv.empty() || sv.front() != '%')
-          return false;
-        sv.remove_prefix(1);
-        out /= 100.0f;
-        skipSpaces(sv);
-        return true;
-      };
-      float h = 0.0f, s = 0.0f, l = 0.0f, a = 1.0f;
-      if (!parseFloatVal(inner, h))
-        return std::nullopt;
-      if (h < 0.0f || h > 360.0f)
-        return std::nullopt;
-      if (inner.empty() || inner.front() != ',')
-        return std::nullopt;
-      inner.remove_prefix(1);
-      if (!parsePercent(inner, s))
-        return std::nullopt;
-      if (inner.empty() || inner.front() != ',')
-        return std::nullopt;
-      inner.remove_prefix(1);
-      if (!parsePercent(inner, l))
-        return std::nullopt;
-      if (isHsla) {
-        if (inner.empty() || inner.front() != ',')
-          return std::nullopt;
-        inner.remove_prefix(1);
-        if (!parseFloatVal(inner, a))
-          return std::nullopt;
-        if (a < 0.0f || a > 1.0f)
-          return std::nullopt;
-      }
-      if (!inner.empty())
-        return std::nullopt;
-      const auto rgb = hslToRgb(h, s, l);
-      return ParsedColor{rgb[0], rgb[1], rgb[2], a};
-    }
-
-    return std::nullopt;
-  }
-
   class ClipboardListRow final : public InputArea {
   public:
     ClipboardListRow(float scale, ThumbnailService* thumbnails) : m_scale(scale), m_thumbnails(thumbnails) {
@@ -551,13 +334,12 @@ namespace {
         m_glyph->setGlyph(m_isImage ? "photo" : "file-text");
       }
 
-      const auto parsedColor = tryParseColor(entry.textPreview);
-      const bool isColor = !m_isImage && parsedColor.has_value();
+      Color parsedColor;
+      const bool isColor = !m_isImage && tryParseCssColor(entry.textPreview, parsedColor);
 
       if (m_colorSwatch != nullptr) {
         if (isColor) {
-          const auto& pc = *parsedColor;
-          m_colorSwatch->setFill(fixedColorSpec(rgba(pc.r, pc.g, pc.b, pc.a)));
+          m_colorSwatch->setFill(fixedColorSpec(parsedColor));
         }
         m_colorSwatch->setVisible(isColor);
         m_colorSwatch->setParticipatesInLayout(isColor);
@@ -1447,14 +1229,13 @@ void ClipboardPanel::rebuildPreview(Renderer& renderer, float width, float heigh
     m_previewImage = image.get();
     m_previewContent->addChild(std::move(image));
   } else {
-    const auto previewColor = tryParseColor(entry.textPreview);
-    if (previewColor.has_value()) {
-      const auto& pc = *previewColor;
+    Color previewColor;
+    if (tryParseCssColor(entry.textPreview, previewColor)) {
       const float scale = contentScale();
       const float swatchH = std::round(80.0f * scale);
       m_previewContent->addChild(
           ui::box({
-              .fill = fixedColorSpec(rgba(pc.r, pc.g, pc.b, pc.a)),
+              .fill = fixedColorSpec(previewColor),
               .radius = Style::scaledRadiusMd(scale),
               .width = width,
               .height = swatchH,

--- a/src/wayland/clipboard_service.cpp
+++ b/src/wayland/clipboard_service.cpp
@@ -1488,8 +1488,27 @@ void ClipboardService::closeActiveWrite(std::size_t index) {
 }
 
 std::string ClipboardService::buildTextPreview(const std::vector<std::uint8_t>& data) {
-  const std::size_t previewSize = std::min<std::size_t>(data.size(), kPreviewBytes);
-  std::string preview(reinterpret_cast<const char*>(data.data()), previewSize);
+  const std::size_t limit = std::min<std::size_t>(data.size(), kPreviewBytes);
+  // Forward-scan to find the last complete UTF-8 sequence within the byte limit.
+  std::size_t safeSize = 0;
+  std::size_t i = 0;
+  while (i < limit) {
+    const auto b = static_cast<uint8_t>(data[i]);
+    int seqLen = 1;
+    if ((b & 0x80) == 0)
+      seqLen = 1;
+    else if ((b & 0xE0) == 0xC0)
+      seqLen = 2;
+    else if ((b & 0xF0) == 0xE0)
+      seqLen = 3;
+    else if ((b & 0xF8) == 0xF0)
+      seqLen = 4;
+    if (i + static_cast<std::size_t>(seqLen) > limit)
+      break;
+    safeSize = i + seqLen;
+    i += seqLen;
+  }
+  std::string preview(reinterpret_cast<const char*>(data.data()), safeSize);
   std::ranges::replace(preview, '\n', ' ');
   std::ranges::replace(preview, '\r', ' ');
   std::ranges::replace(preview, '\t', ' ');


### PR DESCRIPTION
## Summary

This PR adds color-aware previews to the clipboard panel.

Text clipboard entries that look like color values now show a swatch in the list and in the preview area instead of only a generic text icon. It also makes text preview truncation safer by avoiding cutting UTF-8 sequences in the middle.

## Included changes

- detect color-like clipboard text values
- support hex, `rgb(...)`, `rgba(...)`, `hsl(...)`, and `hsla(...)` parsing
- show a color swatch in clipboard list rows for parsed colors
- show a larger color preview in the clipboard preview pane
- keep normal image thumbnail behavior unchanged
- make `ClipboardService::buildTextPreview()` stop at a complete UTF-8 sequence within the preview byte limit

## Validation

- ran `clang-format` on the touched files
- built successfully with `ninja -C build-debug`

