### PR TITLE
feat(nix): add CUDA package to Nix flake for Cachix

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           name: "${{ secrets.CACHIX_CACHE_NAME }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build . --fallback
+      - run: nix build . .#cuda --fallback
 
   push:
     needs: cache

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -13,10 +13,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  cache-default:
+  cache:
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
+        target: [default, cuda]
     runs-on: ${{ matrix.runner }}
     if: ${{ github.repository == 'noctalia-dev/noctalia' }}
     steps:
@@ -26,25 +27,10 @@ jobs:
         with:
           name: "${{ secrets.CACHIX_CACHE_NAME }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build .#default --fallback
-
-  cache-cuda:
-    strategy:
-      matrix:
-        runner: [ubuntu-latest, ubuntu-24.04-arm]
-    runs-on: ${{ matrix.runner }}
-    if: ${{ github.repository == 'noctalia-dev/noctalia' }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
-        with:
-          name: "${{ secrets.CACHIX_CACHE_NAME }}"
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build .#cuda --fallback
+      - run: nix build .#${{ matrix.target }} --fallback
 
   push:
-    needs: [cache-default, cache-cuda]
+    needs: cache
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cache:
+  cache-default:
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
@@ -26,10 +26,25 @@ jobs:
         with:
           name: "${{ secrets.CACHIX_CACHE_NAME }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build . .#cuda --fallback
+      - run: nix build .#default --fallback
+
+  cache-cuda:
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    if: ${{ github.repository == 'noctalia-dev/noctalia' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix build .#cuda --fallback
 
   push:
-    needs: cache
+    needs: [cache-default, cache-cuda]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         { pkgs, ... }:
         {
           default = pkgs.callPackage ./nix/package.nix { };
+          cuda = pkgs.callPackage ./nix/package.nix { config.cudaSupport = true; };
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
         { pkgs, ... }:
         {
           default = pkgs.callPackage ./nix/package.nix { };
-          cuda = pkgs.callPackage ./nix/package.nix { config.cudaSupport = true; };
+          cuda = pkgs.callPackage ./nix/package.nix { cudaSupport = true; };
         }
       );
 


### PR DESCRIPTION
## Summary

Adds a `cuda` package to the flake so it can be built and cached by Cachix.

## Motivation

GPU monitoring on NVIDIA GPUs requires enabling CUDA by overriding `cudaSupport = true`. This changes the package derivation, resulting in a cache miss and forcing users to build the package locally.

This PR exposes a dedicated `cuda` package and builds it in the `cachix/cachix-action` workflow, allowing users with `cudaSupport = true` to benefit from the Cachix cache.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Testing

I successfully built both the `default` and `cuda` packages locally. I was not able to test the GitHub Actions workflow.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
