### PR TITLE
feat(build): Add system_md4c option

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ sudo xbps-install meson ninja pkg-config git \
 Vendored dependencies, with no system package needed: `Wuffs`,
 `nlohmann/json`, `Luau`, `dr_wav`, `fzy`, `stb_image_resize2`, and Material Color Utilities.
 
-Dependencies that are vendored by default, with a meson option to instead use the system package: `tomlplusplus`
+Dependencies that are vendored by default, with a meson option to instead use the system package: `md4c`,
+`tomlplusplus`
 
 System packages required beyond the Wayland/GL stack: `libwebp` handles WebP decoding and thumbnail encoding. Wuffs
 handles the other supported raster image formats. `libqalculate` powers the launcher calculator (arithmetic, unit and

--- a/meson.build
+++ b/meson.build
@@ -187,14 +187,18 @@ else
 endif
 
 # ── Vendored: md4c (CommonMark parser) ───────────────────────────────────────
-_md4c_lib = static_library('md4c',
-  'third_party/md4c/md4c.c',
-  override_options: ['warning_level=0'],
-)
-md4c_dep = declare_dependency(
-  link_whole: _md4c_lib,
-  include_directories: include_directories('third_party/md4c', is_system: true),
-)
+if get_option('system_md4c')
+  md4c_dep = dependency('md4c')
+else
+  _md4c_lib = static_library('md4c',
+    'third_party/md4c/md4c.c',
+    override_options: ['warning_level=0'],
+  )
+  md4c_dep = declare_dependency(
+    link_whole: _md4c_lib,
+    include_directories: include_directories('third_party/md4c', is_system: true),
+  )
+endif
 
 # ── System: libwebp (WebP decode and thumbnail encode) ───────────────────────
 libwebp_dep = dependency('libwebp', required: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('jemalloc', type: 'feature', value: 'auto', description: 'Use jemalloc on glibc builds')
 option('tests', type: 'feature', value: 'auto', description: 'Build unit tests (auto: on for unsanitized debug builds)')
+option('system_md4c', type: 'boolean', value: false, description: 'Use system md4c instead of vendored')
 option('system_tomlplusplus', type: 'boolean', value: false, description: 'Use system tomlplusplus instead of vendored')


### PR DESCRIPTION
## Summary

Add system_md4c option to allow building against the system md4c library instead of the vendored one.  The option is disabled by default to retain the current vendored behavior.

## Motivation

Many distributions have guidelines/policies recommending the usage of system copies of shared libraries whenever possible.

* [Fedora packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling)
* [Debian policy manual](https://www.debian.org/doc/debian-policy/ch-source.html#embedded-code-copies)
* [openSUSE bundled software policy](https://en.opensuse.org/openSUSE:Bundled_software_policy)

Introducing an optional flag to build against the system shared library allows distros to use it if desired, while preserving the vendored approach otherwise.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Testing

I'm running a local build including this change as a patch, built against the shared md4c library in Fedora.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.