### PR TITLE
feat(launcher): add support for OnlyShowIn and NotShowIn keys

### DIFF
--- a/src/notification/notification_display_name.cpp
+++ b/src/notification/notification_display_name.cpp
@@ -15,6 +15,7 @@ namespace {
   constexpr app_identity::DesktopEntryLookupOptions kLookupOptions{
       .includeHidden = true,
       .includeNoDisplay = true,
+      .includeHiddenOnCurrentDesktop = true,
   };
 
   std::string normalizeDesktopKey(std::string_view key) {

--- a/src/shell/bar/widgets/active_window_widget.cpp
+++ b/src/shell/bar/widgets/active_window_widget.cpp
@@ -264,7 +264,8 @@ std::string ActiveWindowWidget::resolveIconPath(const std::string& appId) {
   }
 
   const app_identity::DesktopEntryLookupOptions lookupOptions = appId.starts_with("steam_app_")
-      ? app_identity::DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true}
+      ? app_identity::
+            DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true, .includeHiddenOnCurrentDesktop = true}
       : app_identity::DesktopEntryLookupOptions{};
   if (const auto entry = app_identity::findDesktopEntry(appId, desktopEntries(), lookupOptions);
       entry.has_value() && !entry->icon.empty()) {

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -2192,6 +2192,7 @@ std::string TaskbarWidget::resolveIconPath(const std::string& appId, const std::
     const app_identity::DesktopEntryLookupOptions steamLookup{
         .includeHidden = true,
         .includeNoDisplay = true,
+        .includeHiddenOnCurrentDesktop = true,
     };
     if (const auto entry = app_identity::findDesktopEntry(appId, desktopEntries(), steamLookup);
         entry.has_value() && !entry->icon.empty()) {

--- a/src/shell/control_center/tabs/screen_time_tab.cpp
+++ b/src/shell/control_center/tabs/screen_time_tab.cpp
@@ -1070,7 +1070,8 @@ std::string ScreenTimeTab::resolveIconPath(const std::string& appKey) const {
 
   const int targetPx = static_cast<int>(std::round(kAppIconSize * contentScale()));
   const auto lookupOptions = baseKey.starts_with("steam_app_")
-      ? app_identity::DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true}
+      ? app_identity::
+            DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true, .includeHiddenOnCurrentDesktop = true}
       : app_identity::DesktopEntryLookupOptions{};
   std::string iconName;
   if (const auto entry = app_identity::findDesktopEntry(baseKey, desktopEntries(), lookupOptions);

--- a/src/shell/dock/pinned_apps.cpp
+++ b/src/shell/dock/pinned_apps.cpp
@@ -62,7 +62,7 @@ namespace shell::dock::pinned_apps {
     for (const auto& pinnedId : pinned) {
       const std::string pinnedLower = StringUtils::toLower(pinnedId);
       const auto match = std::ranges::find_if(entries, [&](const DesktopEntry& entry) {
-        return !entry.hidden && !entry.noDisplay && matchesEntryLower(entry, pinnedLower);
+        return !entry.hidden && !entry.noDisplay && entry.showOnCurrentDesktop && matchesEntryLower(entry, pinnedLower);
       });
 
       DesktopEntry entry = match != entries.end() ? *match : [&]() {

--- a/src/system/app_identity.cpp
+++ b/src/system/app_identity.cpp
@@ -58,6 +58,9 @@ namespace app_identity {
         if (!options.includeNoDisplay && entry.noDisplay) {
           continue;
         }
+        if (!options.includeHiddenOnCurrentDesktop && !entry.showOnCurrentDesktop) {
+          continue;
+        }
         if (StringUtils::toLower(std::string(appIdTail(entry.id))) == tailLower) {
           candidates.push_back(&entry);
         }
@@ -94,7 +97,7 @@ namespace app_identity {
       const std::string runningLower = StringUtils::toLower(std::string(runningAppId));
 
       for (const auto& entry : allEntries) {
-        if (entry.hidden || entry.noDisplay) {
+        if (entry.hidden || entry.noDisplay || !entry.showOnCurrentDesktop) {
           continue;
         }
         if (desktopEntryMatchesLower(entry, runningLower)) {
@@ -109,6 +112,7 @@ namespace app_identity {
       if (runningAppId.starts_with("steam_app_")) {
         extendedLookup.includeHidden = true;
         extendedLookup.includeNoDisplay = true;
+        extendedLookup.includeHiddenOnCurrentDesktop = true;
       }
       if (auto matched = findDesktopEntry(runningAppId, allEntries, extendedLookup)) {
         if (runningAppId.starts_with("steam_app_") && matched->startupWmClass.empty()) {
@@ -170,6 +174,9 @@ namespace app_identity {
       if (!options.includeNoDisplay && entry.noDisplay) {
         continue;
       }
+      if (!options.includeHiddenOnCurrentDesktop && !entry.showOnCurrentDesktop) {
+        continue;
+      }
       if (desktopEntryMatchesLower(entry, appLower)) {
         return entry;
       }
@@ -194,6 +201,9 @@ namespace app_identity {
         continue;
       }
       if (!options.includeNoDisplay && entry.noDisplay) {
+        continue;
+      }
+      if (!options.includeHiddenOnCurrentDesktop && !entry.showOnCurrentDesktop) {
         continue;
       }
       if (StringUtils::toLower(entry.startupWmClass) == appLower) {

--- a/src/system/app_identity.h
+++ b/src/system/app_identity.h
@@ -25,10 +25,11 @@ namespace app_identity {
   struct DesktopEntryLookupOptions {
     bool includeHidden = false;
     bool includeNoDisplay = false;
+    bool includeHiddenOnCurrentDesktop = false;
   };
 
-  // Best-effort lookup by app id / StartupWMClass. Set includeHidden/includeNoDisplay for
-  // Steam shortcuts and other entries that are not shown in launchers.
+  // Best-effort lookup by app id / StartupWMClass. Set includeHidden/includeNoDisplay/includeHiddenOnCurrentDesktop
+  // for Steam shortcuts and other entries that are not shown in launchers.
   [[nodiscard]] std::optional<DesktopEntry> findDesktopEntry(
       std::string_view appKey, const std::vector<DesktopEntry>& allEntries, DesktopEntryLookupOptions options = {}
   );

--- a/src/system/desktop_entry.cpp
+++ b/src/system/desktop_entry.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <ranges>
 #include <string_view>
 #include <sys/inotify.h>
 #include <sys/stat.h>
@@ -23,6 +24,49 @@ namespace {
   bool parseDesktopBool(std::string_view value) {
     const std::string lower = StringUtils::toLower(value);
     return lower == "true" || lower == "1" || lower == "yes";
+  }
+
+  void splitMultipleDesktopStrings(std::vector<std::string>& parsedValues, std::string_view fullValue) {
+    std::size_t start = 0;
+    while (start < fullValue.size()) {
+      const auto delimiter = fullValue.find(';', start);
+      const auto token =
+          (delimiter == std::string_view::npos) ? fullValue.substr(start) : fullValue.substr(start, delimiter - start);
+      if (!token.empty()) {
+        parsedValues.emplace_back(token);
+      }
+      if (delimiter == std::string_view::npos) {
+        break;
+      }
+      start = delimiter + 1;
+    }
+  }
+
+  bool shouldShowOnCurrentDesktop(const DesktopEntry& entry) {
+    const auto visibleByDefault = entry.onlyShowIn.empty();
+    const char* currentDesktop = std::getenv("XDG_CURRENT_DESKTOP");
+    if (currentDesktop == nullptr || currentDesktop[0] == '\0') {
+      return visibleByDefault;
+    }
+    std::string_view desktops(currentDesktop);
+    std::size_t start = 0;
+    while (start <= desktops.size()) {
+      const auto delimiter = desktops.find(':', start);
+      const auto token =
+          (delimiter == std::string_view::npos) ? desktops.substr(start) : desktops.substr(start, delimiter - start);
+      if (!token.empty()) {
+        if (std::ranges::find(entry.onlyShowIn, token) != entry.onlyShowIn.end()) {
+          return true;
+        } else if (std::ranges::find(entry.notShowIn, token) != entry.notShowIn.end()) {
+          return false;
+        }
+      }
+      if (delimiter == std::string_view::npos) {
+        break;
+      }
+      start = delimiter + 1;
+    }
+    return visibleByDefault;
   }
 
   struct LocaleInfo {
@@ -225,26 +269,22 @@ namespace {
         entry.workingDir = std::string(value);
       } else if (key == "Terminal") {
         entry.terminal = parseDesktopBool(value);
+      } else if (key == "OnlyShowIn") {
+        splitMultipleDesktopStrings(entry.onlyShowIn, value);
+      } else if (key == "NotShowIn") {
+        splitMultipleDesktopStrings(entry.notShowIn, value);
       } else if (key == "Actions") {
-        // Semicolon-separated list of action IDs, e.g. "NewWindow;NewPrivateWindow;"
-        std::size_t start = 0;
-        while (start < value.size()) {
-          auto semi = value.find(';', start);
-          auto id = (semi == std::string_view::npos) ? value.substr(start) : value.substr(start, semi - start);
-          if (!id.empty()) {
-            actionOrder.emplace_back(id);
-          }
-          if (semi == std::string_view::npos)
-            break;
-          start = semi + 1;
-        }
+        splitMultipleDesktopStrings(actionOrder, value);
       }
     }
 
     // Flush any trailing action section.
     flushCurrentAction();
 
-    if (type != "Application" || entry.noDisplay || entry.hidden || entry.name.empty()) {
+    // Pre-calculate for caching
+    entry.showOnCurrentDesktop = shouldShowOnCurrentDesktop(entry);
+
+    if (type != "Application" || entry.noDisplay || entry.hidden || !entry.showOnCurrentDesktop || entry.name.empty()) {
       return;
     }
 
@@ -415,6 +455,11 @@ namespace {
     // are added or removed in place.
     std::string computeSourceSignature() const {
       std::string sig;
+      const char* currentDesktop = std::getenv("XDG_CURRENT_DESKTOP");
+      sig += "xdg_current_desktop=";
+      sig += (currentDesktop != nullptr && currentDesktop[0] != '\0') ? currentDesktop : "<unset>";
+      sig += '\n';
+
       for (const auto& dataDir : xdgDataDirs()) {
         const fs::path appDir = fs::path(dataDir) / "applications";
         std::error_code ec;

--- a/src/system/desktop_entry.h
+++ b/src/system/desktop_entry.h
@@ -25,6 +25,8 @@ struct DesktopEntry {
   bool noDisplay = false;
   bool hidden = false;
   bool terminal = false;
+  std::vector<std::string> onlyShowIn;
+  std::vector<std::string> notShowIn;
 
   // Pre-lowercased for matching
   std::string nameLower;
@@ -34,6 +36,9 @@ struct DesktopEntry {
   std::string startupWmClassLower;
   std::string idLower;
   std::string execLower;
+
+  // Pre-calculated for caching, based on XDG_CURRENT_DESKTOP and OnlyShowIn/NotShowIn
+  bool showOnCurrentDesktop = true;
 
   // Desktop file actions (e.g. "New Window", "New Private Window")
   std::vector<DesktopAction> actions;

--- a/src/system/screen_time_service.cpp
+++ b/src/system/screen_time_service.cpp
@@ -127,7 +127,9 @@ namespace {
 
     const auto entry = app_identity::findDesktopEntry(
         baseKey, desktopEntries(),
-        app_identity::DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true}
+        app_identity::DesktopEntryLookupOptions{
+            .includeHidden = true, .includeNoDisplay = true, .includeHiddenOnCurrentDesktop = true
+        }
     );
     if (!entry.has_value()) {
       return false;
@@ -136,6 +138,9 @@ namespace {
       return true;
     }
     if (!entry->noDisplay) {
+      return false;
+    }
+    if (!entry->showOnCurrentDesktop) {
       return false;
     }
     const auto& idLower = entry->idLower;
@@ -181,7 +186,8 @@ namespace {
 
     const std::string baseKey = canonicalAppKey(appKey);
     const auto lookupOptions = baseKey.starts_with("steam_app_")
-        ? app_identity::DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true}
+        ? app_identity::
+              DesktopEntryLookupOptions{.includeHidden = true, .includeNoDisplay = true, .includeHiddenOnCurrentDesktop = true}
         : app_identity::DesktopEntryLookupOptions{};
     if (const auto entry = app_identity::findDesktopEntry(baseKey, desktopEntries(), lookupOptions);
         entry.has_value()) {

--- a/tests/app_identity_test.cpp
+++ b/tests/app_identity_test.cpp
@@ -127,6 +127,10 @@ int main() {
   noDisplay.noDisplay = true;
   assert(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", {noDisplay}).id == "Sample.ChatDesktop");
 
+  DesktopEntry showOnCurrentDesktop = sampleChatEntry();
+  showOnCurrentDesktop.showOnCurrentDesktop = false;
+  assert(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", {showOnCurrentDesktop}).id == "Sample.ChatDesktop");
+
   const std::vector<DesktopEntry> multipleEntries = {sampleChatEntry(), sampleMailEntry()};
   const auto resolvedApps =
       app_identity::resolveRunningApps({"Sample.ChatDesktop", "sample-chat-desktop", "SampleMail"}, multipleEntries);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add support for `OnlyShowIn`/`NotShowIn` desktop entry keys in the launcher:
https://github.com/Electronic-Mango/noctalia/pull/new/onlyshowin-notshowin-support

## Motivation

`OnlyShowIn`/`NotShowIn` desktop entry keys (the `.desktop` files) allow for filtering programs in the launcher based on current desktop environment. For example - show GNOME-specific apps (like GNOME Shell extension manager) only when using GNOME shell, etc.

Both `OnlyShowIn`/`NotShowIn` are now stored in `DesktopEntry` struct as vectors of strings. However, the struct also stores pre-calculated `showOnCurrentDesktop` which contains information if the given entry should be shown in current desktop. The `showOnCurrentDesktop` is pre-calculated for caching - there's no need to re-calculate it every time, it's only needed when `.desktop` file changes, or `XDG_CURRENT_DESKTOP` env var changes. The original vectors are still there for completeness - so that the structure contains all information from parsed `.desktop` file, `showOnCurrentDesktop` doesn't store all information.

`showOnCurrentDesktop` is used outside of `desktop_entry.cpp`, where it's usage matches `noDisplay` field. At least looking at the documentation I interpreted the new keys as a "conditional" `NoDisplay` key, rather than conditional `Hidden` key.

> _Hidden_: **Hidden should have been called Deleted. It means the user deleted (at their level) something that was present** (at an upper level, e.g. in the system dirs). It's strictly equivalent to the .desktop file not existing at all, as far as that user is concerned.

> _NoDisplay_: NoDisplay means "this application exists, but don't display it in the menus".

> _OnlyShowIn, NotShowIn_:  A list of strings identifying the desktop environments that **should display/not display** a given desktop entry.

However, I'm not sure if right now it matters - since `parseDesktopFile` function excludes entries with `Hidden`, or `NoDisplay` (or now with not matching `OnlyShowIn`/`NotShowIn`) from target vector, they won't be taken into account anyways. I added the "extra" handling to match existing fields, as I'm not sure which is the "correct" approach - exclude them immediately, or exclude them from only displaying to user.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

Built manually and checked if the new keys are reflected in the launcher.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before - GNOME extension manager visible in niri, even though it cannot be used there (and has appropriate `OnlyShowIn` set in the `.desktop` file):
<img width="565" height="507" alt="Before" src="https://github.com/user-attachments/assets/432bf102-45ea-48a7-a18f-e7da765968df" />


After - GNOME extension manager is no longer visible in niri:
<img width="565" height="507" alt="After" src="https://github.com/user-attachments/assets/cd4b5bf9-6a17-40ba-bf91-b3fc96aca194" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
N/A
