### PR TITLE
feat(calendar): allow toggling the events panel

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -212,6 +212,7 @@
       "all-day": "All day",
       "events": "Events",
       "no-events": "No events.",
+      "toggle-events-card": "Toggle events card",
       "today": "Today"
     },
     "display": {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1324,11 +1324,17 @@ struct ThemeConfig {
 struct ControlCenterConfig {
   static constexpr std::int32_t kDefaultWidth = 700;
 
+  struct CalendarTabConfig {
+    bool showEventsCard = true;
+    bool operator==(const CalendarTabConfig&) const = default;
+  };
+
   std::vector<ShortcutConfig> shortcuts;
   std::vector<std::string> hiddenTabs; // tab keys (see kTabs) the user has hidden; empty = all available shown
   ControlCenterSidebarMode sidebarMode = ControlCenterSidebarMode::Compact;
   ControlCenterSidebarMode sidebarSectionMode = ControlCenterSidebarMode::Compact;
   std::int32_t width = kDefaultWidth; // full-sidebar logical width; compact/none modes scale down from this
+  CalendarTabConfig calendarTab;
   bool operator==(const ControlCenterConfig&) const = default;
 };
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -496,6 +496,13 @@ namespace noctalia::config::schema {
       static const Schema<ShortcutConfig> s = {field(&ShortcutConfig::type, "type")};
       return s;
     }
+
+    const Schema<ControlCenterConfig::CalendarTabConfig>& calendarTabSchema() {
+      static const Schema<ControlCenterConfig::CalendarTabConfig> s = {
+          field(&ControlCenterConfig::CalendarTabConfig::showEventsCard, "show_events_card"),
+      };
+      return s;
+    }
   } // namespace
 
   const Schema<ControlCenterConfig>& controlCenterSchema() {
@@ -504,6 +511,7 @@ namespace noctalia::config::schema {
         enumField(&ControlCenterConfig::sidebarSectionMode, "sidebar_section", kControlCenterSidebarModes),
         field(&ControlCenterConfig::width, "width", kControlCenterWidthRange),
         field(&ControlCenterConfig::hiddenTabs, "hidden_tabs"),
+        subTable(&ControlCenterConfig::calendarTab, "calendar", calendarTabSchema()),
         arrayOf<ControlCenterConfig, ShortcutConfig>(
             &ControlCenterConfig::shortcuts, "shortcuts", shortcutSchema(),
             [](const ShortcutConfig& sc) { return !sc.type.empty(); }

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -10,6 +10,7 @@
 #include "render/core/renderer.h"
 #include "render/scene/input_area.h"
 #include "shell/control_center/tab.h"
+#include "shell/panel/panel_button_style.h"
 #include "shell/panel/panel_manager.h"
 #include "time/time_format.h"
 #include "ui/builders.h"
@@ -143,6 +144,10 @@ std::unique_ptr<Flex> CalendarTab::create() {
       m_eventsDirty = true;
       PanelManager::instance().refresh();
     });
+  }
+
+  if (m_config != nullptr) {
+    m_showEventsCard = m_config->config().controlCenter.calendarTab.showEventsCard;
   }
 
   auto tab = ui::row({
@@ -309,10 +314,32 @@ std::unique_ptr<Flex> CalendarTab::create() {
           .flexGrow = 1.0f,
       })
   );
+  eventsCard->setVisible(m_showEventsCard);
 
   tab->addChild(std::move(eventsCard));
 
   return tab;
+}
+
+std::unique_ptr<Flex> CalendarTab::createHeaderActions() {
+  const float scale = contentScale();
+  if (m_config != nullptr) {
+    m_showEventsCard = m_config->config().controlCenter.calendarTab.showEventsCard;
+  }
+  return ui::row(
+      {
+          .align = FlexAlign::Center,
+          .gap = Style::spaceSm * scale,
+      },
+      ui::button({
+          .out = &m_toggleEventsCardButton,
+          .glyph = m_showEventsCard ? "calendar-event" : "calendar-off",
+          .selected = m_showEventsCard,
+          .tooltip = i18n::tr("control-center.calendar.toggle-events-card"),
+          .onClick = [this]() { toggleEventsCard(); },
+          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+      })
+  );
 }
 
 void CalendarTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight) {
@@ -913,5 +940,19 @@ void CalendarTab::rebuildEventList(float scale) {
 
     auto eventRow = ui::row({.align = FlexAlign::Stretch, .gap = rowGap}, std::move(dot), std::move(details));
     content->addChild(std::move(eventRow));
+  }
+}
+
+void CalendarTab::toggleEventsCard() {
+  m_showEventsCard = !m_showEventsCard;
+  if (m_config != nullptr) {
+    m_config->setOverride({"control_center", "calendar", "show_events_card"}, m_showEventsCard);
+  }
+  if (m_toggleEventsCardButton != nullptr) {
+    m_toggleEventsCardButton->setGlyph(m_showEventsCard ? "calendar-event" : "calendar-off");
+    m_toggleEventsCardButton->setSelected(m_showEventsCard);
+  }
+  if (m_eventsCard != nullptr) {
+    m_eventsCard->setVisible(m_showEventsCard);
   }
 }

--- a/src/shell/control_center/tabs/calendar_tab.h
+++ b/src/shell/control_center/tabs/calendar_tab.h
@@ -17,6 +17,7 @@ public:
   explicit CalendarTab(ConfigService* config = nullptr, CalendarService* calendar = nullptr);
 
   std::unique_ptr<Flex> create() override;
+  std::unique_ptr<Flex> createHeaderActions() override;
   void setActive(bool active) override;
   void onClose() override;
 
@@ -31,12 +32,14 @@ private:
   void doUpdate(Renderer& renderer) override;
   void rebuild();
   void rebuildEventList(float scale);
+  void toggleEventsCard();
 
   ConfigService* m_config = nullptr;
   CalendarService* m_calendar = nullptr;
   bool m_changeCallbackRegistered = false;
   bool m_eventsDirty = false;
   Flex* m_rootLayout = nullptr;
+  Button* m_toggleEventsCardButton = nullptr;
   InputArea* m_calendarArea = nullptr;
   Flex* m_card = nullptr;
   Flex* m_header = nullptr;
@@ -68,4 +71,5 @@ private:
   int m_pendingMonthDelta = 0;
   bool m_startMonthSlideIn = false;
   AnimationManager::Id m_monthSlideAnimId = 0;
+  bool m_showEventsCard = true;
 };

--- a/tests/config_path_resolution_test.cpp
+++ b/tests/config_path_resolution_test.cpp
@@ -63,6 +63,7 @@ int main() {
   expectKnown({"battery", "warning_threshold"});
   expectKnown({"calendar", "refresh_minutes"});
   expectKnown({"calendar", "account", "icloud", "provider"});
+  expectKnown({"control_center", "calendar", "show_events_card"});
   expectKnown({"nightlight", "temperature_day"});
   expectKnown({"location", "auto_locate"});
   expectKnown({"keybinds", "validate"});

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -344,6 +344,7 @@ location = "https://example.invalid/bad"
     c.battery.deviceThresholds = {{"BAT0", 10}, {"hidpp:1", 25}};
     c.controlCenter.sidebarMode = ControlCenterSidebarMode::Full;
     c.controlCenter.sidebarSectionMode = ControlCenterSidebarMode::None;
+    c.controlCenter.calendarTab.showEventsCard = false;
     c.controlCenter.shortcuts = {{"wifi"}, {"bluetooth"}};
     c.calendar.enabled = true;
     c.calendar.refreshMinutes = 30;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Allow toggling the "events" panel in "calendar" tab.

## Motivation

Without any calendar accounts configured, the events panel will never really display any meaningful information, just take space. This allows for quick toggling the panel on or off via a button in the calendar tab.

The events panel "state" is stored in the `settings.toml` file, specifically the "off" state, as "on" is default. This should allow for persistent behavior between restarts, etc. It's stored in the `control_center` section, buit in a new subsection - `calendar`, e.g.:

```toml
[control_center]
sidebar_section = "none"

    [control_center.calendar]
    show_events_panel = false
```

This doesn't necessarily have to be a button - I can make it a toggle in the settings (although I'm not sure where such toggle should be), or a "hidden" option in the `settings.toml` file (the same implementation as it is now, just without the button).

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

N/A

## Testing

Built manually and switched the toggle on and off.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/dc40163c-7a23-4f3f-b1cb-2c75c450d319

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

I'm not sure what would be the appropriate changes to the documentation.

The calendar page contains information only about calendar accounts: https://docs.noctalia.dev/v5/services/calendar/
Details about `control_center` are related mostly to the sidebar: https://docs.noctalia.dev/v5/control-center/?section=sidebar#sidebar
I could expand the basic section for calendar in the control center: https://docs.noctalia.dev/v5/control-center/?section=calendar#calendar

Let me know what would be appropriate changes to the documentation, if any are necessary.
