### PR TITLE
feat(password): add password input glyph animation eye candy like V4

### DIFF
--- a/src/render/render_context.cpp
+++ b/src/render/render_context.cpp
@@ -96,8 +96,8 @@ namespace {
   }
 
   Mat3 nodeLocalTransform(const Node* node) {
-    const float cx = node->width() * 0.5f;
-    const float cy = node->height() * 0.5f;
+    const float cx = node->transformOriginX();
+    const float cy = node->transformOriginY();
     return Mat3::translation(node->x(), node->y())
         * Mat3::translation(cx, cy)
         * Mat3::rotation(node->rotation())

--- a/src/render/scene/node.cpp
+++ b/src/render/scene/node.cpp
@@ -234,6 +234,16 @@ void Node::setScale(float scaleX, float scaleY) {
   markPaintDirty();
 }
 
+void Node::setTransformOrigin(float x, float y) {
+  if (m_hasTransformOrigin && m_transformOriginX == x && m_transformOriginY == y) {
+    return;
+  }
+  m_hasTransformOrigin = true;
+  m_transformOriginX = x;
+  m_transformOriginY = y;
+  markPaintDirty();
+}
+
 void Node::setOpacity(float opacity) {
   if (m_opacity == opacity) {
     return;

--- a/src/render/scene/node.h
+++ b/src/render/scene/node.h
@@ -103,6 +103,12 @@ public:
   [[nodiscard]] HitTestOutset hitTestOutset() const noexcept { return m_hitTestOutset; }
   [[nodiscard]] bool sizeAssignedByLayout() const noexcept { return m_sizeAssignedByLayout; }
   [[nodiscard]] bool arrangingByLayout() const noexcept { return m_arranging; }
+  [[nodiscard]] float transformOriginX() const noexcept {
+    return m_hasTransformOrigin ? m_transformOriginX : m_width * 0.5f;
+  }
+  [[nodiscard]] float transformOriginY() const noexcept {
+    return m_hasTransformOrigin ? m_transformOriginY : m_height * 0.5f;
+  }
   [[nodiscard]] std::int32_t zIndex() const noexcept { return m_zIndex; }
   [[nodiscard]] Node* parent() const noexcept { return m_parent; }
   [[nodiscard]] const std::vector<std::unique_ptr<Node>>& children() const noexcept { return m_children; }
@@ -113,6 +119,7 @@ public:
   void setRotation(float radians);
   void setScale(float scale);
   void setScale(float scaleX, float scaleY);
+  void setTransformOrigin(float x, float y);
   void setOpacity(float opacity);
   void setFlexGrow(float grow);
   void setVisible(bool visible);
@@ -175,6 +182,9 @@ private:
   float m_rotation = 0.0f;
   float m_scaleX = 1.0f;
   float m_scaleY = 1.0f;
+  float m_transformOriginX = 0.0f;
+  float m_transformOriginY = 0.0f;
+  bool m_hasTransformOrigin = false;
   float m_opacity = 1.0f;
   float m_flexGrow = 0.0f;
   bool m_visible = true;

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -150,6 +150,8 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
   });
 
   setSceneRoot(&m_root);
+  setAnimationManager(&m_animations);
+  m_root.setAnimationManager(&m_animations);
   setConfigureCallback([this](std::uint32_t /*width*/, std::uint32_t /*height*/) { requestLayout(); });
   setPrepareFrameCallback([this](bool needsUpdate, bool needsLayout) { prepareFrame(needsUpdate, needsLayout); });
   requestUpdate();

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -2,6 +2,7 @@
 
 #include "capture/screencopy_capture.h"
 #include "config/config_service.h"
+#include "render/animation/animation_manager.h"
 #include "render/core/blur_cache.h"
 #include "render/core/color.h"
 #include "render/core/texture_manager.h"
@@ -93,6 +94,7 @@ private:
   ext_session_lock_surface_v1* m_lockSurface = nullptr;
   wl_output* m_output = nullptr;
   ConfigService* m_config = nullptr;
+  AnimationManager m_animations;
   Node m_root;
   Node* m_backgroundLayer = nullptr;
   Node* m_widgetLayer = nullptr;

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -94,6 +94,7 @@ private:
   ext_session_lock_surface_v1* m_lockSurface = nullptr;
   wl_output* m_output = nullptr;
   ConfigService* m_config = nullptr;
+  // Declared before m_root so it outlives the scene: ~Node cancels its animations through this manager.
   AnimationManager m_animations;
   Node m_root;
   Node* m_backgroundLayer = nullptr;

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -112,8 +112,8 @@ namespace {
     const float inkCenterY = (metrics.top + metrics.bottom) * 0.5f;
     const float rowCenterY = inputHeight * 0.5f;
     glyph.setPosition(cellCenterX - emCenterX, rowCenterY - inkCenterY);
-    // Size the node so animated scale/rotation pivot on the glyph's visual center
-    glyph.setSize(glyphSize, 2.0f * inkCenterY);
+    // The node origin is the glyph baseline, so the ink center is the pivot animated scale/rotation must use.
+    glyph.setTransformOrigin((metrics.left + metrics.right) * 0.5f, inkCenterY);
   }
 
   Color resolved(ColorRole role, float alpha = 1.0f) { return colorForRole(role, alpha); }
@@ -1886,40 +1886,30 @@ void Input::animatePasswordGlyphIn(GlyphNode& glyph) {
   }
 
   constexpr float kStartScale = 0.15f;
-  // The owner is the glyph node, so a backspace that destroys the node auto-cancels this animation.
+  // Fraction of the animation over which the glyph fades in.
+  constexpr float kFadeInFraction = 0.35f;
+  // Three alternating swings (right, left, right), starting and ending at zero rotation.
+  constexpr float kWobbleSwings = 3.0f;
+  constexpr float kWobbleAmplitude = 0.45f; // radians, ~26 degrees
+
   glyph.setOpacity(0.0f);
   glyph.setScale(kStartScale);
   glyph.setRotation(0.0f);
 
   auto* glyphPtr = &glyph;
-  // Linear curve to control curves of each animation knob separately
+  // Driven linearly so each animated property carries its own curve. The owner is the glyph node, so a
+  // backspace that destroys it cancels this animation.
   animations->animate(
       0.0f, 1.0f, static_cast<float>(Style::animNormal), Easing::Linear,
       [glyphPtr](float t) {
-        constexpr float kPi = std::numbers::pi_v<float>;
-
         const float scaleEase = applyEasing(Easing::EaseOutCubic, t);
-        // Ramp initial size to full size
-        const float scale = kStartScale + (1.0f - kStartScale) * scaleEase;
+        glyphPtr->setScale(kStartScale + (1.0f - kStartScale) * scaleEase);
+        glyphPtr->setOpacity(applyEasing(Easing::EaseOutCubic, std::min(1.0f, t / kFadeInFraction)));
 
-        // Clamp opacity ramp from t=0 -> t=0.35
-        const float opacity = applyEasing(Easing::EaseOutCubic, std::min(1.0f, t / 0.35f));
-
-        glyphPtr->setOpacity(opacity);
-        glyphPtr->setScale(scale);
-
-        // The non-random password glyphs have rotational symmetry, so rotation isn't strictly neccesary with
-        // PasswordMaskStyle::CircleFilled. However, leave rotation enabled here in all cases so the pixel snap logic in
-        // cairo_glyph_renderer sees a rotation and disables snapping.
-
-        // TODO: A potential area for improvement is smarter pixel snapping in the renderer. It could maybe recognize
-        // non-unary scale matrix or use animation-aware rendering to disable pixel snapping while animation plays.
-
-        // Wobble sine wave makes three alternating swings (right, left, right), starting and ending at 0 rotation.
-        // Multiplied by an eased decay envelope to attenuate rotation amplitude over time.
+        // Rotation stays on even for the rotationally symmetric circle mask: a non-zero rotation is what makes
+        // the glyph renderer skip pixel snapping, which would otherwise jump the glyph a whole pixel per frame.
         const float wobbleDecay = applyEasing(Easing::EaseOutCubic, 1.0f - t);
-        // Rotation amplitude is 0.45 radians (26 degrees)
-        const float wobble = 0.45f * std::sin(t * 3.0f * kPi) * wobbleDecay;
+        const float wobble = kWobbleAmplitude * std::sin(t * kWobbleSwings * std::numbers::pi_v<float>) * wobbleDecay;
         glyphPtr->setRotation(wobble);
       },
       [glyphPtr]() {

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -5,6 +5,8 @@
 #include "core/input/key_symbols.h"
 #include "core/text_clipboard.h"
 #include "cursor-shape-v1-client-protocol.h"
+#include "render/animation/animation.h"
+#include "render/animation/animation_manager.h"
 #include "render/core/color.h"
 #include "render/core/render_styles.h"
 #include "render/core/renderer.h"
@@ -24,6 +26,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <string>
 #include <wayland-client-protocol.h>
@@ -109,6 +112,8 @@ namespace {
     const float inkCenterY = (metrics.top + metrics.bottom) * 0.5f;
     const float rowCenterY = inputHeight * 0.5f;
     glyph.setPosition(cellCenterX - emCenterX, rowCenterY - inkCenterY);
+    // Size the node so animated scale/rotation pivot on the glyph's visual center
+    glyph.setSize(glyphSize, 2.0f * inkCenterY);
   }
 
   Color resolved(ColorRole role, float alpha = 1.0f) { return colorForRole(role, alpha); }
@@ -1869,7 +1874,61 @@ void Input::syncPasswordGlyphNodes(std::size_t count) {
     auto glyph = std::make_unique<GlyphNode>();
     auto* glyphPtr = static_cast<GlyphNode*>(m_textViewport->insertChildAt(2, std::move(glyph)));
     m_passwordGlyphs.push_back(glyphPtr);
+    // Animate the glyph entrance
+    animatePasswordGlyphIn(*glyphPtr);
   }
+}
+
+void Input::animatePasswordGlyphIn(GlyphNode& glyph) {
+  auto* animations = animationManager();
+  if (animations == nullptr) {
+    return;
+  }
+
+  constexpr float kStartScale = 0.15f;
+  // The owner is the glyph node, so a backspace that destroys the node auto-cancels this animation.
+  glyph.setOpacity(0.0f);
+  glyph.setScale(kStartScale);
+  glyph.setRotation(0.0f);
+
+  auto* glyphPtr = &glyph;
+  // Linear curve to control curves of each animation knob separately
+  animations->animate(
+      0.0f, 1.0f, static_cast<float>(Style::animNormal), Easing::Linear,
+      [glyphPtr](float t) {
+        constexpr float kPi = std::numbers::pi_v<float>;
+
+        const float scaleEase = applyEasing(Easing::EaseOutCubic, t);
+        // Ramp initial size to full size
+        const float scale = kStartScale + (1.0f - kStartScale) * scaleEase;
+
+        // Clamp opacity ramp from t=0 -> t=0.35
+        const float opacity = applyEasing(Easing::EaseOutCubic, std::min(1.0f, t / 0.35f));
+
+        glyphPtr->setOpacity(opacity);
+        glyphPtr->setScale(scale);
+
+        // The non-random password glyphs have rotational symmetry, so rotation isn't strictly neccesary with
+        // PasswordMaskStyle::CircleFilled. However, leave rotation enabled here in all cases so the pixel snap logic in
+        // cairo_glyph_renderer sees a rotation and disables snapping.
+
+        // TODO: A potential area for improvement is smarter pixel snapping in the renderer. It could maybe recognize
+        // non-unary scale matrix or use animation-aware rendering to disable pixel snapping while animation plays.
+
+        // Wobble sine wave makes three alternating swings (right, left, right), starting and ending at 0 rotation.
+        // Multiplied by an eased decay envelope to attenuate rotation amplitude over time.
+        const float wobbleDecay = applyEasing(Easing::EaseOutCubic, 1.0f - t);
+        // Rotation amplitude is 0.45 radians (26 degrees)
+        const float wobble = 0.45f * std::sin(t * 3.0f * kPi) * wobbleDecay;
+        glyphPtr->setRotation(wobble);
+      },
+      [glyphPtr]() {
+        glyphPtr->setOpacity(1.0f);
+        glyphPtr->setScale(1.0f);
+        glyphPtr->setRotation(0.0f);
+      },
+      glyphPtr
+  );
 }
 
 float Input::textViewportWidth() const noexcept {

--- a/src/ui/controls/input.h
+++ b/src/ui/controls/input.h
@@ -142,6 +142,7 @@ private:
   [[nodiscard]] std::size_t xToByteOffset(float localX) const;
   [[nodiscard]] float stopXForByte(std::size_t bytePos) const;
   void syncPasswordGlyphNodes(std::size_t count);
+  void animatePasswordGlyphIn(GlyphNode& glyph);
 
   // Multiline mode: geometry comes from the wrapped cursor-stop rects
   // (m_stopRect, parallel to m_stopByte) instead of the 1-D x array.


### PR DESCRIPTION
## Summary

This PR adds an animation when typing passwords similar to what V4 had. This applies to lock screen, polkit panel, and WiFi password. It animates both "random" glyphs and circular ones. See video below for example.

I designed the animation based on my vague memory of what V4 looked like. :smile: 

## Motivation

Make Noctalia even more dank than DMS.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

See video below. I tested with `shell.password_style` `random` and `default` on lock screen and polkit. I also checked `shell.animation.enabled` = false doesn't break anything.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/b9b280bd-9ea4-459b-ae1e-6cc4807b7597

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I left a note in the PR about render pixel snapping related to the scale animation. The current solution works to avoid snapping mid-animation. Using animation-aware render snapping might make more sense than the stateless matrix transform heuristics in the future. I'd have to think about it more...