### PR TITLE
Changed punctuation theme in helix.toml

### DIFF
--- a/assets/templates/helix/helix.toml
+++ b/assets/templates/helix/helix.toml
@@ -28,8 +28,7 @@
 
 "label" = "secondary"
 
-"punctuation" = "outlineVariant"
-"punctuation.special" = "outline"
+"punctuation" = "outline"
 
 "keyword" = { fg = "primary", modifiers = ["bold"] }
 "keyword.control.conditional" = { fg = "tertiary", modifiers = ["italic", "bold"] }


### PR DESCRIPTION
## Summary

Punctuation symbols in the helix theme are too dark which make them much harder to see. 

## Motivation

Now it's much easier to see the punctuation symbols.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

No related issue as far as I could see

## Testing

Manual testing by seeing how to change it so that it looks better.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before, all "[", "]", etc symbols are pretty dark and are very hard to see.

<img width="821" height="310" alt="image" src="https://github.com/user-attachments/assets/c3655cc8-8eec-4781-8916-fe198d7bc6f6" />


After, all such symbols are much easier to see now.

<img width="821" height="310" alt="image" src="https://github.com/user-attachments/assets/fc667e81-4383-45ba-8cb2-6fb358684868" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No additional notes.
