### PR TITLE
fix(shell): guard hot corners reload before init

### DIFF
--- a/src/shell/hot_corners/hot_corners.cpp
+++ b/src/shell/hot_corners/hot_corners.cpp
@@ -27,6 +27,10 @@ void HotCorners::initialize(WaylandConnection& wayland, ConfigService* config, R
 }
 
 void HotCorners::onConfigReload() {
+  if (m_config == nullptr || m_wayland == nullptr) {
+    return;
+  }
+
   const auto& config = m_config->config().hotCorners;
   // Recreate whenever enabled (not just on an enabled toggle): the resolved
   // trigger layer follows the bar's layer, which a reload may have changed.


### PR DESCRIPTION
## Summary

Guard `HotCorners::onConfigReload()` until the hot-corners service has been initialized.

On a fresh state directory, lockscreen widget defaults can be normalized and written to `settings.toml` while startup is still in progress. That write fires config reload callbacks before hot corners have received their `ConfigService` and `WaylandConnection` pointers, so the reload handler needs the same lifecycle guard that `onOutputChange()` already has.

## Motivation

Prevents a first-start crash when Noctalia creates the initial lockscreen widgets state during startup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3250

## Testing

- `just format`
- `just build`
- `just test`
- Manual fresh-state launch on Niri with isolated `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, `XDG_CACHE_HOME`, and `XDG_RUNTIME_DIR`: Noctalia generated a new `state/noctalia/settings.toml` and stayed running until the test timeout instead of segfaulting.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors
- [x] Not a UI/visual layout change

## Screenshots / Videos

N/A. This is a startup crash fix with no visual change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No unit test was added for this path. The affected code is tied to Wayland/application startup ordering, so the regression was checked with a fresh-state runtime launch instead.
