### PR TITLE
fix(toplevels): prevent null toplevel output when spanning monitors

### DIFF
--- a/src/wayland/wayland_toplevels.cpp
+++ b/src/wayland/wayland_toplevels.cpp
@@ -361,6 +361,9 @@ void WaylandToplevels::closeHandle(zwlr_foreign_toplevel_handle_v1* handle) {
 void WaylandToplevels::onHandleOutputEnter(zwlr_foreign_toplevel_handle_v1* handle, wl_output* output) {
   auto it = m_handles.find(handle);
   if (it != m_handles.end()) {
+    if (!std::ranges::contains(it->second.activeOutputs, output)) {
+      it->second.activeOutputs.push_back(output);
+    }
     if (it->second.output != output) {
       it->second.output = output;
       it->second.dirty = true;
@@ -371,10 +374,16 @@ void WaylandToplevels::onHandleOutputEnter(zwlr_foreign_toplevel_handle_v1* hand
 
 void WaylandToplevels::onHandleOutputLeave(zwlr_foreign_toplevel_handle_v1* handle, wl_output* output) {
   auto it = m_handles.find(handle);
-  if (it != m_handles.end() && it->second.output == output) {
-    it->second.output = nullptr;
-    it->second.dirty = true;
-    it->second.generation = ++m_generation;
+  if (it != m_handles.end()) {
+    const auto pos = std::ranges::find(it->second.activeOutputs, output);
+    if (pos != it->second.activeOutputs.end()) {
+      it->second.activeOutputs.erase(pos);
+    }
+    if (it->second.output == output) {
+      it->second.output = it->second.activeOutputs.empty() ? nullptr : it->second.activeOutputs.back();
+      it->second.dirty = true;
+      it->second.generation = ++m_generation;
+    }
   }
 }
 

--- a/src/wayland/wayland_toplevels.h
+++ b/src/wayland/wayland_toplevels.h
@@ -101,6 +101,7 @@ private:
     std::string title;
     std::string appId;
     wl_output* output = nullptr;
+    std::vector<wl_output*> activeOutputs;
     bool activated = false;
     bool minimized = false;
     bool dirty = false;


### PR DESCRIPTION
## Summary

Track all outputs a toplevel is visible on instead of only the most recently entered one. When a leave event fires, fall back to the latest visible output rather than unconditionally setting `output` to `nullptr`. This prevents `output` becoming null whilst the toplevel is still visible on previously entered outputs.

## Motivation
When using a bar on each monitor, both with a taskbar, and with "Show All Monitors" disabled. When I drag a window to span two monitors, and then drag it back to to its original monitor without having fully left the original monitor. The app icon disappears from both taskbars. 

1. Window opens in Monitor A
    - `output_enter` event and `output = A`
2. Window is dragged so that it partially enters monitor B 
    - `output_enter` event and `output = B` (but no `output_leave` has fired for A)
3. Window is moved back to Monitor A without having fully left it
    - `output_leave` event for monitor B `output = nullptr` 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue


## Testing

- `just format`
- `just test`
- `just build`
- Dragged a window to span two monitors, dragged it back, an icon remained visible in a taskbar throughout. Before this fix the icon disappeared on drag back. 

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: labwc
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The fix was intentionally narrow in scope. No attempt was made to expose multi-output toplevel state more broadly to the rest of the codebase. e.g. through modifying `WlrToplevelSnapshot`, `allAppIds` or other places output is used.

The behaviour of updating `output` on `output_enter` rather than on `output_leave` was also preserved. An alternative specifically related to the taskbar would be to only update `output` when the toplevel leaves its oldest visible output rather than update `output` to its newest visible output.
