### PR TITLE
fix(calendar): expand CalDAV recurring events client-side when server ignores <C:expand>

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1108,6 +1108,16 @@ string_utils_test = executable('string_utils_test',
 
 test('string_utils', string_utils_test)
 
+ical_recurrence_test = executable('ical_recurrence_test',
+  sources: files(
+    'tests/ical_recurrence_test.cpp',
+    'src/calendar/ical_parser.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('ical_recurrence', ical_recurrence_test)
+
 time_format_test = executable('time_format_test',
   sources: files(
     'tests/time_format_test.cpp',

--- a/src/calendar/caldav_client.cpp
+++ b/src/calendar/caldav_client.cpp
@@ -73,7 +73,7 @@ namespace calendar {
 
     const std::string calendarName = account.calendarName;
     const std::string color = account.color;
-    http.request(std::move(req), [cb = std::move(cb), calendarName, color](HttpResponse resp) {
+    http.request(std::move(req), [cb = std::move(cb), calendarName, color, start, end](HttpResponse resp) {
       if (!resp.transportOk || (resp.status != 207 && resp.status != 200)) {
         kLog.warn("caldav REPORT failed http={}", resp.status);
         cb(false, {});
@@ -98,7 +98,7 @@ namespace calendar {
 
       std::vector<CalendarEvent> events;
       for (const std::string& ics : calendarDataBlocks) {
-        for (CalendarEvent& event : parseICalEvents(ics)) {
+        for (CalendarEvent& event : parseICalEvents(ics, start, end)) {
           event.calendarName = calendarName;
           event.colorHex = color;
           events.push_back(std::move(event));

--- a/src/calendar/ical_parser.cpp
+++ b/src/calendar/ical_parser.cpp
@@ -258,15 +258,21 @@ namespace calendar {
 
       // For all-day (VALUE=DATE) events, base.start is local midnight stored as UTC, so flooring the
       // UTC instant to a day lands on the previous civil day for zones east of UTC. Recover the civil
-      // date from the local zone and rebuild each occurrence's instant through it (also fixes DST drift).
+      // date from the local zone and rebuild each occurrence's instant through it.
+      const auto localDay = [](system_clock::time_point t) -> sys_days {
+        try {
+          return sys_days{year_month_day{floor<days>(current_zone()->to_local(t))}};
+        } catch (...) {
+          return floor<days>(t);
+        }
+      };
       sys_days startDay;
+      days allDaySpan{0};
       system_clock::duration tod{0};
       if (base.allDay) {
-        try {
-          startDay = sys_days{year_month_day{floor<days>(current_zone()->to_local(base.start))}};
-        } catch (...) {
-          startDay = floor<days>(base.start);
-        }
+        startDay = localDay(base.start);
+        const sys_days endDay = localDay(base.end);
+        allDaySpan = std::max(days{0}, endDay - startDay);
       } else {
         startDay = floor<days>(base.start);
         tod = base.start - startDay;
@@ -286,7 +292,8 @@ namespace calendar {
 
       const auto excluded = [&](system_clock::time_point t) { return std::ranges::find(exdates, t) != exdates.end(); };
       int occurrenceNo = 0; // counts every occurrence (in or out of window) toward COUNT
-      const auto step = [&](system_clock::time_point occ) -> bool {
+      const auto step = [&](sys_days occDay) -> bool {
+        const system_clock::time_point occ = occInstant(occDay);
         if (rule.until && occ > *rule.until)
           return false;
         if (occ > windowEnd)
@@ -297,7 +304,7 @@ namespace calendar {
         if (occ >= windowStart && !excluded(occ)) {
           CalendarEvent ev = base;
           ev.start = occ;
-          ev.end = occ + duration;
+          ev.end = base.allDay ? occInstant(occDay + allDaySpan) : occ + duration;
           out.push_back(std::move(ev));
         }
         return true;
@@ -314,7 +321,7 @@ namespace calendar {
           i0 = static_cast<int>(duration_cast<days>(windowStart - base.start).count() / rule.interval);
         }
         for (int i = i0; i < i0 + kMaxIterations; ++i) {
-          if (!step(occInstant(startDay + days{i * rule.interval})))
+          if (!step(startDay + days{i * rule.interval}))
             break;
         }
         break;
@@ -335,7 +342,7 @@ namespace calendar {
             const system_clock::time_point occ = occInstant(occDay);
             if (occ < base.start)
               continue; // days earlier in the first week than DTSTART
-            if (!step(occ)) {
+            if (!step(occDay)) {
               stop = true;
               break;
             }
@@ -351,7 +358,7 @@ namespace calendar {
           const year_month_day occYmd{ym.year(), ym.month(), ymd0.day()};
           if (!occYmd.ok())
             continue; // e.g. day 31 in a short month: RFC skips it
-          if (!step(occInstant(sys_days{occYmd})))
+          if (!step(sys_days{occYmd}))
             break;
         }
         break;
@@ -362,7 +369,7 @@ namespace calendar {
           const year_month_day occYmd{ymd0.year() + years{y}, ymd0.month(), ymd0.day()};
           if (!occYmd.ok())
             continue; // Feb 29 in a non-leap year
-          if (!step(occInstant(sys_days{occYmd})))
+          if (!step(sys_days{occYmd}))
             break;
         }
         break;

--- a/src/calendar/ical_parser.cpp
+++ b/src/calendar/ical_parser.cpp
@@ -4,6 +4,7 @@
 #include <charconv>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace calendar {
@@ -377,8 +378,17 @@ namespace calendar {
       std::string_view ics, std::chrono::system_clock::time_point windowStart,
       std::chrono::system_clock::time_point windowEnd
   ) {
-    std::vector<CalendarEvent> events;
     const std::vector<std::string> lines = unfold(ics);
+
+    // A parsed VEVENT held until every event is seen: RECURRENCE-ID overrides may appear before or
+    // after their master, so masters can't be expanded until the full set of overridden instants is known.
+    struct Parsed {
+      CalendarEvent event;
+      std::string_view rrule;
+      std::vector<std::chrono::system_clock::time_point> exdates;
+      std::optional<std::chrono::system_clock::time_point> recurrenceId;
+    };
+    std::vector<Parsed> parsed;
 
     bool inEvent = false;
     CalendarEvent event;
@@ -388,6 +398,7 @@ namespace calendar {
     bool endAllDay = false;
     std::string_view rrule;
     std::vector<std::chrono::system_clock::time_point> exdates;
+    std::optional<std::chrono::system_clock::time_point> recurrenceId;
 
     for (const std::string& line : lines) {
       if (line == "BEGIN:VEVENT") {
@@ -396,6 +407,7 @@ namespace calendar {
         haveStart = haveEnd = startAllDay = endAllDay = false;
         rrule = {};
         exdates.clear();
+        recurrenceId.reset();
         continue;
       }
       if (line == "END:VEVENT") {
@@ -404,12 +416,7 @@ namespace calendar {
             event.end = event.start;
           }
           event.allDay = startAllDay;
-          if (rrule.empty()) {
-            events.push_back(std::move(event));
-          } else {
-            // Server didn't honor <C:expand>; expand the RRULE ourselves.
-            expandRecurrence(event, parseRRule(rrule), exdates, windowStart, windowEnd, events);
-          }
+          parsed.push_back({std::move(event), rrule, std::move(exdates), recurrenceId});
         }
         inEvent = false;
         continue;
@@ -437,6 +444,9 @@ namespace calendar {
         }
       } else if (prop.name == "RRULE") {
         rrule = prop.value;
+      } else if (prop.name == "RECURRENCE-ID") {
+        bool ignored = false;
+        recurrenceId = parseDateTime(prop, ignored);
       } else if (prop.name == "EXDATE") {
         // May be a comma-separated list; each shares the line's TZID/VALUE params.
         std::string_view v = prop.value;
@@ -452,6 +462,29 @@ namespace calendar {
           p = comma == std::string_view::npos ? v.size() : comma + 1;
         }
       }
+    }
+
+    // A RECURRENCE-ID VEVENT is a modified instance: it replaces the master's occurrence at that
+    // instant. Collect those instants per UID and exclude them from the master's expansion, so the
+    // standalone override VEVENT is the only copy of that occurrence.
+    std::unordered_map<std::string, std::vector<std::chrono::system_clock::time_point>> overrides;
+    for (const Parsed& p : parsed) {
+      if (p.recurrenceId) {
+        overrides[p.event.id].push_back(*p.recurrenceId);
+      }
+    }
+
+    std::vector<CalendarEvent> events;
+    for (Parsed& p : parsed) {
+      if (p.rrule.empty()) {
+        events.push_back(std::move(p.event));
+        continue;
+      }
+      // Server didn't honor <C:expand>; expand the RRULE ourselves.
+      if (auto it = overrides.find(p.event.id); it != overrides.end()) {
+        p.exdates.insert(p.exdates.end(), it->second.begin(), it->second.end());
+      }
+      expandRecurrence(p.event, parseRRule(p.rrule), p.exdates, windowStart, windowEnd, events);
     }
 
     return events;

--- a/src/calendar/ical_parser.cpp
+++ b/src/calendar/ical_parser.cpp
@@ -1,8 +1,10 @@
 #include "calendar/ical_parser.h"
 
+#include <algorithm>
 #include <charconv>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace calendar {
 
@@ -161,9 +163,194 @@ namespace calendar {
       }
     }
 
+    // A numeric prefix ("2MO") is stripped and ignored: nth-of-period BYDAY is not supported.
+    std::optional<std::chrono::weekday> parseWeekdayToken(std::string_view t) {
+      while (!t.empty() && (t.front() == '+' || t.front() == '-' || (t.front() >= '0' && t.front() <= '9'))) {
+        t.remove_prefix(1);
+      }
+      if (t == "SU")
+        return std::chrono::Sunday;
+      if (t == "MO")
+        return std::chrono::Monday;
+      if (t == "TU")
+        return std::chrono::Tuesday;
+      if (t == "WE")
+        return std::chrono::Wednesday;
+      if (t == "TH")
+        return std::chrono::Thursday;
+      if (t == "FR")
+        return std::chrono::Friday;
+      if (t == "SA")
+        return std::chrono::Saturday;
+      return std::nullopt;
+    }
+
+    struct RRule {
+      enum class Freq { None, Daily, Weekly, Monthly, Yearly } freq = Freq::None;
+      int interval = 1;
+      int count = 0; // 0 = unbounded
+      std::optional<std::chrono::system_clock::time_point> until;
+      std::vector<std::chrono::weekday> byDay; // WEEKLY only
+    };
+
+    RRule parseRRule(std::string_view value) {
+      RRule rule;
+      std::size_t pos = 0;
+      while (pos < value.size()) {
+        const std::size_t semi = value.find(';', pos);
+        std::string_view part = semi == std::string_view::npos ? value.substr(pos) : value.substr(pos, semi - pos);
+        pos = semi == std::string_view::npos ? value.size() : semi + 1;
+
+        const std::size_t eq = part.find('=');
+        if (eq == std::string_view::npos) {
+          continue;
+        }
+        const std::string_view key = part.substr(0, eq);
+        const std::string_view val = part.substr(eq + 1);
+        if (key == "FREQ") {
+          if (val == "DAILY")
+            rule.freq = RRule::Freq::Daily;
+          else if (val == "WEEKLY")
+            rule.freq = RRule::Freq::Weekly;
+          else if (val == "MONTHLY")
+            rule.freq = RRule::Freq::Monthly;
+          else if (val == "YEARLY")
+            rule.freq = RRule::Freq::Yearly;
+        } else if (key == "INTERVAL") {
+          rule.interval = std::max(1, toInt(val));
+        } else if (key == "COUNT") {
+          rule.count = toInt(val);
+        } else if (key == "UNTIL") {
+          PropertyLine p;
+          p.value = val;
+          bool ignored = false;
+          rule.until = parseDateTime(p, ignored);
+        } else if (key == "BYDAY") {
+          std::size_t p = 0;
+          while (p < val.size()) {
+            const std::size_t comma = val.find(',', p);
+            const std::string_view tok = comma == std::string_view::npos ? val.substr(p) : val.substr(p, comma - p);
+            if (auto wd = parseWeekdayToken(tok)) {
+              rule.byDay.push_back(*wd);
+            }
+            p = comma == std::string_view::npos ? val.size() : comma + 1;
+          }
+        }
+      }
+      return rule;
+    }
+
+    // Occurrences repeat at the same UTC instant shifted by whole days/weeks/months/years, so they can
+    // drift by an hour across a DST boundary — acceptable for display.
+    void expandRecurrence(
+        const CalendarEvent& base, const RRule& rule, const std::vector<std::chrono::system_clock::time_point>& exdates,
+        std::chrono::system_clock::time_point windowStart, std::chrono::system_clock::time_point windowEnd,
+        std::vector<CalendarEvent>& out
+    ) {
+      using namespace std::chrono;
+      if (rule.freq == RRule::Freq::None) {
+        out.push_back(base);
+        return;
+      }
+
+      const auto duration = base.end - base.start;
+      const sys_days startDay = floor<days>(base.start);
+      const auto tod = base.start - startDay;
+
+      const auto excluded = [&](system_clock::time_point t) { return std::ranges::find(exdates, t) != exdates.end(); };
+      int occurrenceNo = 0; // counts every occurrence (in or out of window) toward COUNT
+      const auto step = [&](system_clock::time_point occ) -> bool {
+        if (rule.until && occ > *rule.until)
+          return false;
+        if (occ > windowEnd)
+          return false;
+        ++occurrenceNo;
+        if (rule.count != 0 && occurrenceNo > rule.count)
+          return false;
+        if (occ >= windowStart && !excluded(occ)) {
+          CalendarEvent ev = base;
+          ev.start = occ;
+          ev.end = occ + duration;
+          out.push_back(std::move(ev));
+        }
+        return true;
+      };
+
+      constexpr int kMaxIterations = 4000; // backstop; the window is ~1 year each way
+
+      switch (rule.freq) {
+      case RRule::Freq::Daily: {
+        // Without COUNT there's nothing to tally, so skip straight to the window rather than stepping day
+        // by day from a possibly years-old DTSTART and exhausting kMaxIterations before reaching it.
+        int i0 = 0;
+        if (rule.count == 0 && base.start < windowStart) {
+          i0 = static_cast<int>(duration_cast<days>(windowStart - base.start).count() / rule.interval);
+        }
+        for (int i = i0; i < i0 + kMaxIterations; ++i) {
+          if (!step(base.start + days{i * rule.interval}))
+            break;
+        }
+        break;
+      }
+      case RRule::Freq::Weekly: {
+        std::vector<weekday> byDay = rule.byDay;
+        if (byDay.empty()) {
+          byDay.push_back(weekday{startDay});
+        }
+        std::ranges::sort(byDay, {}, [](weekday w) { return w.iso_encoding(); });
+        const unsigned fromMonday = weekday{startDay}.iso_encoding() - 1;
+        const sys_days baseMonday = startDay - days{fromMonday};
+        bool stop = false;
+        for (int k = 0; k < kMaxIterations && !stop; ++k) {
+          const sys_days weekMonday = baseMonday + weeks{k * rule.interval};
+          for (const weekday wd : byDay) {
+            const sys_days occDay = weekMonday + days{wd.iso_encoding() - 1};
+            const system_clock::time_point occ = occDay + tod;
+            if (occ < base.start)
+              continue; // days earlier in the first week than DTSTART
+            if (!step(occ)) {
+              stop = true;
+              break;
+            }
+          }
+        }
+        break;
+      }
+      case RRule::Freq::Monthly: {
+        const year_month_day ymd0{startDay};
+        const year_month base0{ymd0.year(), ymd0.month()};
+        for (int m = 0; m < kMaxIterations; m += rule.interval) {
+          const year_month ym = base0 + months{m};
+          const year_month_day occYmd{ym.year(), ym.month(), ymd0.day()};
+          if (!occYmd.ok())
+            continue; // e.g. day 31 in a short month: RFC skips it
+          if (!step(sys_days{occYmd} + tod))
+            break;
+        }
+        break;
+      }
+      case RRule::Freq::Yearly: {
+        const year_month_day ymd0{startDay};
+        for (int y = 0; y < kMaxIterations; y += rule.interval) {
+          const year_month_day occYmd{ymd0.year() + years{y}, ymd0.month(), ymd0.day()};
+          if (!occYmd.ok())
+            continue; // Feb 29 in a non-leap year
+          if (!step(sys_days{occYmd} + tod))
+            break;
+        }
+        break;
+      }
+      case RRule::Freq::None:
+        break;
+      }
+    }
+
   } // namespace
 
-  std::vector<CalendarEvent> parseICalEvents(std::string_view ics) {
+  std::vector<CalendarEvent> parseICalEvents(
+      std::string_view ics, std::chrono::system_clock::time_point windowStart,
+      std::chrono::system_clock::time_point windowEnd
+  ) {
     std::vector<CalendarEvent> events;
     const std::vector<std::string> lines = unfold(ics);
 
@@ -173,12 +360,16 @@ namespace calendar {
     bool haveEnd = false;
     bool startAllDay = false;
     bool endAllDay = false;
+    std::string_view rrule;
+    std::vector<std::chrono::system_clock::time_point> exdates;
 
     for (const std::string& line : lines) {
       if (line == "BEGIN:VEVENT") {
         inEvent = true;
         event = CalendarEvent{};
         haveStart = haveEnd = startAllDay = endAllDay = false;
+        rrule = {};
+        exdates.clear();
         continue;
       }
       if (line == "END:VEVENT") {
@@ -187,7 +378,12 @@ namespace calendar {
             event.end = event.start;
           }
           event.allDay = startAllDay;
-          events.push_back(std::move(event));
+          if (rrule.empty()) {
+            events.push_back(std::move(event));
+          } else {
+            // Server didn't honor <C:expand>; expand the RRULE ourselves.
+            expandRecurrence(event, parseRRule(rrule), exdates, windowStart, windowEnd, events);
+          }
         }
         inEvent = false;
         continue;
@@ -212,6 +408,22 @@ namespace calendar {
         if (auto tp = parseDateTime(prop, endAllDay)) {
           event.end = *tp;
           haveEnd = true;
+        }
+      } else if (prop.name == "RRULE") {
+        rrule = prop.value;
+      } else if (prop.name == "EXDATE") {
+        // May be a comma-separated list; each shares the line's TZID/VALUE params.
+        std::string_view v = prop.value;
+        std::size_t p = 0;
+        while (p < v.size()) {
+          const std::size_t comma = v.find(',', p);
+          PropertyLine ex = prop;
+          ex.value = comma == std::string_view::npos ? v.substr(p) : v.substr(p, comma - p);
+          bool ignored = false;
+          if (auto tp = parseDateTime(ex, ignored)) {
+            exdates.push_back(*tp);
+          }
+          p = comma == std::string_view::npos ? v.size() : comma + 1;
         }
       }
     }

--- a/src/calendar/ical_parser.cpp
+++ b/src/calendar/ical_parser.cpp
@@ -254,8 +254,34 @@ namespace calendar {
       }
 
       const auto duration = base.end - base.start;
-      const sys_days startDay = floor<days>(base.start);
-      const auto tod = base.start - startDay;
+
+      // For all-day (VALUE=DATE) events, base.start is local midnight stored as UTC, so flooring the
+      // UTC instant to a day lands on the previous civil day for zones east of UTC. Recover the civil
+      // date from the local zone and rebuild each occurrence's instant through it (also fixes DST drift).
+      sys_days startDay;
+      system_clock::duration tod{0};
+      if (base.allDay) {
+        try {
+          startDay = sys_days{year_month_day{floor<days>(current_zone()->to_local(base.start))}};
+        } catch (...) {
+          startDay = floor<days>(base.start);
+        }
+      } else {
+        startDay = floor<days>(base.start);
+        tod = base.start - startDay;
+      }
+
+      const auto occInstant = [&](sys_days civilDay) -> system_clock::time_point {
+        if (base.allDay) {
+          const local_days ld{year_month_day{civilDay}};
+          try {
+            return toSystem(time_point_cast<seconds>(current_zone()->to_sys(ld)));
+          } catch (...) {
+            return toSystem(sys_days{year_month_day{civilDay}});
+          }
+        }
+        return civilDay + tod;
+      };
 
       const auto excluded = [&](system_clock::time_point t) { return std::ranges::find(exdates, t) != exdates.end(); };
       int occurrenceNo = 0; // counts every occurrence (in or out of window) toward COUNT
@@ -287,7 +313,7 @@ namespace calendar {
           i0 = static_cast<int>(duration_cast<days>(windowStart - base.start).count() / rule.interval);
         }
         for (int i = i0; i < i0 + kMaxIterations; ++i) {
-          if (!step(base.start + days{i * rule.interval}))
+          if (!step(occInstant(startDay + days{i * rule.interval})))
             break;
         }
         break;
@@ -305,7 +331,7 @@ namespace calendar {
           const sys_days weekMonday = baseMonday + weeks{k * rule.interval};
           for (const weekday wd : byDay) {
             const sys_days occDay = weekMonday + days{wd.iso_encoding() - 1};
-            const system_clock::time_point occ = occDay + tod;
+            const system_clock::time_point occ = occInstant(occDay);
             if (occ < base.start)
               continue; // days earlier in the first week than DTSTART
             if (!step(occ)) {
@@ -324,7 +350,7 @@ namespace calendar {
           const year_month_day occYmd{ym.year(), ym.month(), ymd0.day()};
           if (!occYmd.ok())
             continue; // e.g. day 31 in a short month: RFC skips it
-          if (!step(sys_days{occYmd} + tod))
+          if (!step(occInstant(sys_days{occYmd})))
             break;
         }
         break;
@@ -335,7 +361,7 @@ namespace calendar {
           const year_month_day occYmd{ymd0.year() + years{y}, ymd0.month(), ymd0.day()};
           if (!occYmd.ok())
             continue; // Feb 29 in a non-leap year
-          if (!step(sys_days{occYmd} + tod))
+          if (!step(occInstant(sys_days{occYmd})))
             break;
         }
         break;

--- a/src/calendar/ical_parser.h
+++ b/src/calendar/ical_parser.h
@@ -2,14 +2,20 @@
 
 #include "calendar/calendar_types.h"
 
+#include <chrono>
 #include <string_view>
 #include <vector>
 
 namespace calendar {
 
-  // Parse iCalendar (RFC 5545) text into concrete event instances. Recurrence is not expanded here:
-  // callers request server-side expansion (CalDAV <C:expand>), so each VEVENT is one instance.
-  // UID/SUMMARY/DTSTART/DTEND/LOCATION are read; VTODO/VALARM and other components are ignored.
-  std::vector<CalendarEvent> parseICalEvents(std::string_view ics);
+  // Parse iCalendar (RFC 5545) text into concrete event instances. Callers request server-side
+  // recurrence expansion (CalDAV <C:expand>), so a compliant server already returns one VEVENT per
+  // occurrence. As a fallback for servers that ignore <C:expand> and return the master VEVENT with an
+  // RRULE, that RRULE is expanded client-side, bounded to [windowStart, windowEnd].
+  // UID/SUMMARY/DTSTART/DTEND/LOCATION/RRULE/EXDATE are read; VTODO/VALARM and others are ignored.
+  std::vector<CalendarEvent> parseICalEvents(
+      std::string_view ics, std::chrono::system_clock::time_point windowStart,
+      std::chrono::system_clock::time_point windowEnd
+  );
 
 } // namespace calendar

--- a/tests/ical_recurrence_test.cpp
+++ b/tests/ical_recurrence_test.cpp
@@ -75,5 +75,16 @@ int main() {
     ok = expectCount(ics, start, end, 31, "old unbounded daily reaches window") && ok;
   }
 
+  // All-day (VALUE=DATE) MONTHLY on the 1st, over a one-year window, is exactly 12 - one per month.
+  // The old code derived the day-of-month from floor<days> of the UTC instant, which for a zone east
+  // of UTC rolls back to the previous civil day (the 31st of Dec), so months without a 31st were
+  // dropped. Correct behaviour is zone-independent. Window is padded ±half-month so each local-midnight
+  // occurrence lands inside regardless of the running zone's UTC offset.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:ad\r\nSUMMARY:s\r\nDTSTART;VALUE=DATE:20240101\r\n"
+                            "DTEND;VALUE=DATE:20240102\r\nRRULE:FREQ=MONTHLY\r\nEND:VEVENT\r\n";
+    ok = expectCount(ics, utc(2023, 12, 15), utc(2024, 12, 15), 12, "all-day monthly civil date") && ok;
+  }
+
   return ok ? 0 : 1;
 }

--- a/tests/ical_recurrence_test.cpp
+++ b/tests/ical_recurrence_test.cpp
@@ -1,8 +1,10 @@
 #include "calendar/ical_parser.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -10,6 +12,28 @@ namespace {
 
   system_clock::time_point utc(int y, int mo, int d, int h = 0) {
     return sys_days{year{y} / month{static_cast<unsigned>(mo)} / day{static_cast<unsigned>(d)}} + hours{h};
+  }
+
+  // Assert the parsed occurrences' start instants exactly match `expected` (order-independent).
+  bool expectStarts(
+      const std::string& ics, system_clock::time_point start, system_clock::time_point end,
+      std::vector<system_clock::time_point> expected, const char* message
+  ) {
+    std::vector<system_clock::time_point> actual;
+    for (const auto& ev : calendar::parseICalEvents(ics, start, end)) {
+      actual.push_back(ev.start);
+    }
+    std::ranges::sort(actual);
+    std::ranges::sort(expected);
+    if (actual != expected) {
+      std::fprintf(stderr, "ical_recurrence_test: %s: expected %zu starts, got %zu\n", message, expected.size(),
+          actual.size());
+      for (const auto& t : actual) {
+        std::fprintf(stderr, "  got %lld\n", static_cast<long long>(t.time_since_epoch().count()));
+      }
+      return false;
+    }
+    return true;
   }
 
   // A VEVENT starting Mon 2024-01-01 09:00 UTC (1h long), with the given extra property lines appended.
@@ -84,6 +108,20 @@ int main() {
     const std::string ics = "BEGIN:VEVENT\r\nUID:ad\r\nSUMMARY:s\r\nDTSTART;VALUE=DATE:20240101\r\n"
                             "DTEND;VALUE=DATE:20240102\r\nRRULE:FREQ=MONTHLY\r\nEND:VEVENT\r\n";
     ok = expectCount(ics, utc(2023, 12, 15), utc(2024, 12, 15), 12, "all-day monthly civil date") && ok;
+  }
+
+  // RECURRENCE-ID override: a modified instance replaces the master's occurrence at that instant,
+  // it does not add a duplicate. Master DAILY COUNT=3 (Jan 1/2/3 @09:00); the override moves Jan 3
+  // to 14:00. Expect Jan 1 @09, Jan 2 @09, Jan 3 @14 - not four events, and no leftover Jan 3 @09.
+  {
+    const std::string ics =
+        "BEGIN:VEVENT\r\nUID:x\r\nDTSTART:20240101T090000Z\r\nDTEND:20240101T100000Z\r\n"
+        "RRULE:FREQ=DAILY;COUNT=3\r\nEND:VEVENT\r\n"
+        "BEGIN:VEVENT\r\nUID:x\r\nRECURRENCE-ID:20240103T090000Z\r\n"
+        "DTSTART:20240103T140000Z\r\nDTEND:20240103T150000Z\r\nEND:VEVENT\r\n";
+    ok = expectStarts(ics, start, end, {utc(2024, 1, 1, 9), utc(2024, 1, 2, 9), utc(2024, 1, 3, 14)},
+             "recurrence-id override replaces occurrence")
+        && ok;
   }
 
   return ok ? 0 : 1;

--- a/tests/ical_recurrence_test.cpp
+++ b/tests/ical_recurrence_test.cpp
@@ -1,0 +1,79 @@
+#include "calendar/ical_parser.h"
+
+#include <chrono>
+#include <cstdio>
+#include <string>
+
+namespace {
+
+  using namespace std::chrono;
+
+  system_clock::time_point utc(int y, int mo, int d, int h = 0) {
+    return sys_days{year{y} / month{static_cast<unsigned>(mo)} / day{static_cast<unsigned>(d)}} + hours{h};
+  }
+
+  // A VEVENT starting Mon 2024-01-01 09:00 UTC (1h long), with the given extra property lines appended.
+  std::string wrap(const std::string& props) {
+    return "BEGIN:VEVENT\r\nUID:x\r\nSUMMARY:s\r\nDTSTART:20240101T090000Z\r\nDTEND:20240101T100000Z\r\n"
+        + props
+        + "END:VEVENT\r\n";
+  }
+
+  bool expectCount(
+      const std::string& ics, system_clock::time_point start, system_clock::time_point end, std::size_t expected,
+      const char* message
+  ) {
+    const std::size_t actual = calendar::parseICalEvents(ics, start, end).size();
+    if (actual != expected) {
+      std::fprintf(stderr, "ical_recurrence_test: %s: expected %zu, got %zu\n", message, expected, actual);
+      return false;
+    }
+    return true;
+  }
+
+} // namespace
+
+int main() {
+  const auto start = utc(2024, 1, 1);
+  const auto end = utc(2024, 2, 1);
+  bool ok = true;
+
+  // No RRULE: exactly one instance passes through.
+  ok = expectCount(wrap(""), start, end, 1, "non-recurring event") && ok;
+
+  // DAILY COUNT=3 -> 3 instances.
+  ok = expectCount(wrap("RRULE:FREQ=DAILY;COUNT=3\r\n"), start, end, 3, "daily count") && ok;
+
+  // WEEKLY BYDAY=MO,WE, window 2024-01-01..2024-01-15 (excl): Mon 1, Wed 3, Mon 8, Wed 10 = 4.
+  ok = expectCount(wrap("RRULE:FREQ=WEEKLY;BYDAY=MO,WE\r\n"), start, utc(2024, 1, 15), 4, "weekly byday") && ok;
+
+  // WEEKLY INTERVAL=2 (no BYDAY): every other Monday from Jan 1 to Feb 1: Jan 1, 15, 29 = 3.
+  ok = expectCount(wrap("RRULE:FREQ=WEEKLY;INTERVAL=2\r\n"), start, end, 3, "weekly interval") && ok;
+
+  // MONTHLY unbounded over one year: Jan..Dec 2024 = 12.
+  ok = expectCount(wrap("RRULE:FREQ=MONTHLY\r\n"), start, utc(2025, 1, 1), 12, "monthly") && ok;
+
+  // UNTIL clips: DAILY until Jan 3 -> Jan 1, 2, 3 = 3.
+  ok = expectCount(wrap("RRULE:FREQ=DAILY;UNTIL=20240103T090000Z\r\n"), start, end, 3, "daily until") && ok;
+
+  // EXDATE drops one occurrence: DAILY COUNT=5 minus Jan 3 = 4.
+  ok = expectCount(wrap("RRULE:FREQ=DAILY;COUNT=5\r\nEXDATE:20240103T090000Z\r\n"), start, end, 4, "exdate") && ok;
+
+  // Window clips leading occurrences but COUNT still counts them: DAILY COUNT=10 from Dec 30 2023,
+  // window opens Jan 1 -> Dec 30/31 not shown, Jan 1..8 shown = 8.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:y\r\nDTSTART:20231230T090000Z\r\nDTEND:20231230T100000Z\r\n"
+                            "RRULE:FREQ=DAILY;COUNT=10\r\nEND:VEVENT\r\n";
+    ok = expectCount(ics, start, end, 8, "count spans window start") && ok;
+  }
+
+  // Unbounded daily series starting far before the window (2005) must still fill the whole Jan 2024
+  // month window: 31 days. Guards against the iteration cap truncating an old series to nothing.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:z\r\nDTSTART:20050101T090000Z\r\nDTEND:20050101T100000Z\r\n"
+                            "RRULE:FREQ=DAILY\r\nEND:VEVENT\r\n";
+    ok = expectCount(ics, start, end, 31, "old unbounded daily reaches window") && ok;
+  }
+
+  return ok ? 0 : 1;
+}

--- a/tests/ical_recurrence_test.cpp
+++ b/tests/ical_recurrence_test.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -26,8 +27,9 @@ namespace {
     std::ranges::sort(actual);
     std::ranges::sort(expected);
     if (actual != expected) {
-      std::fprintf(stderr, "ical_recurrence_test: %s: expected %zu starts, got %zu\n", message, expected.size(),
-          actual.size());
+      std::fprintf(
+          stderr, "ical_recurrence_test: %s: expected %zu starts, got %zu\n", message, expected.size(), actual.size()
+      );
       for (const auto& t : actual) {
         std::fprintf(stderr, "  got %lld\n", static_cast<long long>(t.time_since_epoch().count()));
       }
@@ -55,9 +57,36 @@ namespace {
     return true;
   }
 
+  bool expectRanges(
+      const std::string& ics, system_clock::time_point start, system_clock::time_point end,
+      std::vector<std::pair<system_clock::time_point, system_clock::time_point>> expected, const char* message
+  ) {
+    std::vector<std::pair<system_clock::time_point, system_clock::time_point>> actual;
+    for (const auto& ev : calendar::parseICalEvents(ics, start, end)) {
+      actual.emplace_back(ev.start, ev.end);
+    }
+    std::ranges::sort(actual);
+    std::ranges::sort(expected);
+    if (actual != expected) {
+      std::fprintf(
+          stderr, "ical_recurrence_test: %s: expected %zu ranges, got %zu\n", message, expected.size(), actual.size()
+      );
+      for (const auto& [s, e] : actual) {
+        std::fprintf(
+            stderr, "  got %lld..%lld\n", static_cast<long long>(s.time_since_epoch().count()),
+            static_cast<long long>(e.time_since_epoch().count())
+        );
+      }
+      return false;
+    }
+    return true;
+  }
+
 } // namespace
 
 int main() {
+  setenv("TZ", "Europe/Kyiv", 1);
+
   const auto start = utc(2024, 1, 1);
   const auto end = utc(2024, 2, 1);
   bool ok = true;
@@ -110,17 +139,31 @@ int main() {
     ok = expectCount(ics, utc(2023, 12, 15), utc(2024, 12, 15), 12, "all-day monthly civil date") && ok;
   }
 
+  // Multi-day all-day recurrences must preserve their civil-day span, not a fixed UTC duration.
+  // 2024-03-30..2024-04-01 in Europe/Kyiv is 47 UTC hours because DST starts on Mar 31; applying
+  // that duration to the May occurrence would end it at 23:00 local on May 31 instead of midnight Jun 1.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:dst\r\nSUMMARY:s\r\nDTSTART;VALUE=DATE:20240330\r\n"
+                            "DTEND;VALUE=DATE:20240401\r\nRRULE:FREQ=MONTHLY;COUNT=3\r\nEND:VEVENT\r\n";
+    ok = expectRanges(
+             ics, utc(2024, 5, 1), utc(2024, 6, 15), {{utc(2024, 5, 29, 21), utc(2024, 5, 31, 21)}},
+             "all-day monthly preserves civil end across dst"
+         )
+        && ok;
+  }
+
   // RECURRENCE-ID override: a modified instance replaces the master's occurrence at that instant,
   // it does not add a duplicate. Master DAILY COUNT=3 (Jan 1/2/3 @09:00); the override moves Jan 3
   // to 14:00. Expect Jan 1 @09, Jan 2 @09, Jan 3 @14 - not four events, and no leftover Jan 3 @09.
   {
-    const std::string ics =
-        "BEGIN:VEVENT\r\nUID:x\r\nDTSTART:20240101T090000Z\r\nDTEND:20240101T100000Z\r\n"
-        "RRULE:FREQ=DAILY;COUNT=3\r\nEND:VEVENT\r\n"
-        "BEGIN:VEVENT\r\nUID:x\r\nRECURRENCE-ID:20240103T090000Z\r\n"
-        "DTSTART:20240103T140000Z\r\nDTEND:20240103T150000Z\r\nEND:VEVENT\r\n";
-    ok = expectStarts(ics, start, end, {utc(2024, 1, 1, 9), utc(2024, 1, 2, 9), utc(2024, 1, 3, 14)},
-             "recurrence-id override replaces occurrence")
+    const std::string ics = "BEGIN:VEVENT\r\nUID:x\r\nDTSTART:20240101T090000Z\r\nDTEND:20240101T100000Z\r\n"
+                            "RRULE:FREQ=DAILY;COUNT=3\r\nEND:VEVENT\r\n"
+                            "BEGIN:VEVENT\r\nUID:x\r\nRECURRENCE-ID:20240103T090000Z\r\n"
+                            "DTSTART:20240103T140000Z\r\nDTEND:20240103T150000Z\r\nEND:VEVENT\r\n";
+    ok = expectStarts(
+             ics, start, end, {utc(2024, 1, 1, 9), utc(2024, 1, 2, 9), utc(2024, 1, 3, 14)},
+             "recurrence-id override replaces occurrence"
+         )
         && ok;
   }
 


### PR DESCRIPTION
## Summary

Recurring events only showed up on their start date instead of repeating.

Noctalia's calendar service never expanded recurrence -  it relies on the server (Google's `singleEvents=true`, CalDAV's `<C:expand>`). If a CalDAV server ignores `<C:expand>`, it hands back the master `VEVENT` with its `RRULE` and `ical_parser` turned that into a single instance on `DTSTART`.

The fix: if a `VEVENT` still has a `RRULE` after fetch - expand it, bounded to the fetch window. Server that already expand are unaffected (no `RRULE` left to act on), and Google doesn't touch this path. The fix handles `FREQ`, `INTERVAL`, `COUNT`, `UNTIL`, weekly `BYDAY` and `EXDATE`.

## Motivation

On self-hosted CalDAV servers without `<C:expand>` support, a daily/weekly event shows up exactly once, which makes recurring events basically useless.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

No related issue was created before.

## Testing

Added `tests/ical_recurrence_test.cpp` (wired into `meson.build`) with cases for daily/weekly/monthly recurrence, `INTERVAL`, `COUNT`, `UNTIL`, `EXDATE`, a series that starts before the window, and an old unbounded daily one that still needs to reach today. All pass.

Manually switched noctalia flake from github source to local, built and tested the results - recurring events are shown correctly(added before/after screenshots below).

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:
<img width="311" height="456" alt="image" src="https://github.com/user-attachments/assets/63401ce7-b81b-4f5d-9373-369f19ebf321" />

After:
<img width="311" height="456" alt="image" src="https://github.com/user-attachments/assets/1d060e63-2ae8-4c85-81bd-04acd3026736" />

Using the same calendar config, "after" events are all valid, so there are no "ghost" events.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Occurrences repeat at the same UTC instant, so times can be off by an hour across a DST change. Doesn't handle nth-of-month `BYDAY` (`2MO`), `BYMONTHDAY`/`BYMONTH`/`BYSETPOS`, or `WKST` - none of my calendars use them, easy to add later if needed(decided to skip things I can't easily verify to be sure I deliver a completely working commit).