### PR TITLE
fix(clipboard): fix insufficient height for list items

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -32,7 +32,7 @@
 
 namespace {
 
-  constexpr float kRowHeight = 46.0f;
+  constexpr float kRowHeight = 56.0f;
   constexpr float kPreviewImageHeight = 280.0f;
   constexpr float kListGlyphSize = 24.0f;
   constexpr float kListThumbSize = 40.0f;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Increase the height of clipboard history items to provide balanced vertical padding around the contents.

## Motivation

The clipboard history items have noticeably less bottom padding than top padding, making them look unbalanced (see the screenshots below).
The cause is that the current height is too small.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None.

## Testing

Ran `just test` and `just build`.
Confirmed there were no errors.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:
<img width="941" height="747" alt="Screenshot from 2026-07-04 16-26-19" src="https://github.com/user-attachments/assets/07944399-7858-421b-8b06-023accebfcfb" />

After:
<img width="941" height="747" alt="image" src="https://github.com/user-attachments/assets/42340c61-5c27-4078-a0a6-b4fde5e33912" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I think the ideal solution might be to fit the item height to its contents rather than using a fixed value, as that would keep the layout consistent if the contents change in the future. 
However, since the height is currently hardcoded, this PR simply increases it.

The new height (56px) was chosen because it is the smallest multiple of 8 that fully accommodates the current contents. While that value is somewhat arbitrary, it follows the existing spacing convention.
