### PR TITLE
fix(pw): simplify relative volume adjustment to use flat steps

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1816,29 +1816,18 @@ float PipeWireService::relativeAdjustTarget(
 ) {
   const auto now = std::chrono::steady_clock::now();
   const bool held = m_relativeAdjust.gesture == gesture && (now - m_relativeAdjust.lastAt) <= kVolumeHoldWindow;
-  const float dt =
-      held ? std::min(std::chrono::duration<float>(now - m_relativeAdjust.lastAt).count(), kVolumeHoldMaxDt) : 0.0f;
   m_relativeAdjust.gesture = gesture;
   m_relativeAdjust.lastAt = now;
 
   if (!held) {
     // Isolated tap or new gesture: a fixed, granular step from the live volume.
-    m_relativeAdjust.heldSeconds = 0.0f;
     m_relativeAdjust.target = std::clamp(current + direction * baseStep, 0.0f, maxVolume);
     return m_relativeAdjust.target;
   }
 
-  // Held: advance the gesture-local target by velocity * capped event-time credit. Accumulating the
-  // target across the gesture keeps stale daemon echoes in the read-back volume from rubber-banding
-  // the ramp, and capping dt makes an arrival gap (keyboard repeat delay, IPC spawn jitter) worth
-  // about one base step instead of a jump. The velocity ramp advances by the same capped credit, so
-  // acceleration follows the event flow rather than the wall clock. The per-event cap of one base
-  // step keeps burst sources (rotary knobs) proportional to their tick count.
-  const float baseVel = baseStep / kVolumeHoldMaxDt;
-  const float velocity = std::min(kVolumeHoldMaxVel, baseVel + kVolumeHoldAccel * m_relativeAdjust.heldSeconds);
-  m_relativeAdjust.heldSeconds += dt;
-  const float delta = std::min(velocity * dt, baseStep);
-  m_relativeAdjust.target = std::clamp(m_relativeAdjust.target + direction * delta, 0.0f, maxVolume);
+  // Held: advance the gesture-local target by a flat baseStep on every event, relying on
+  // the gesture-local target accumulator to bypass asynchronous read-back echoes.
+  m_relativeAdjust.target = std::clamp(m_relativeAdjust.target + direction * baseStep, 0.0f, maxVolume);
   return m_relativeAdjust.target;
 }
 

--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1771,10 +1771,10 @@ bool PipeWireService::applyNodeVolume(std::uint32_t id, float volume) {
   // committed value back through onMixerVolumeChanged.
   const bool isDeviceNode = nd.mediaClass == "Audio/Sink" || nd.mediaClass == "Audio/Source";
   if (isDeviceNode) {
-    if (m_wpMixer != nullptr) {
-      m_wpMixer->setVolume(id, volume);
-    }
     if (std::abs(nd.volume - volume) >= 0.0001f) {
+      if (m_wpMixer != nullptr) {
+        m_wpMixer->setVolume(id, volume);
+      }
       nd.volume = volume;
       return true;
     }
@@ -1816,6 +1816,13 @@ float PipeWireService::relativeAdjustTarget(
 ) {
   const auto now = std::chrono::steady_clock::now();
   const bool held = m_relativeAdjust.gesture == gesture && (now - m_relativeAdjust.lastAt) <= kVolumeHoldWindow;
+
+  // Rate-limit: return the last target if repeat events arrive faster than once every 80ms
+  constexpr auto kMinIpcInterval = std::chrono::milliseconds(80);
+  if (held && (now - m_relativeAdjust.lastAt) < kMinIpcInterval) {
+    return m_relativeAdjust.target;
+  }
+
   m_relativeAdjust.gesture = gesture;
   m_relativeAdjust.lastAt = now;
 

--- a/src/pipewire/pipewire_service.h
+++ b/src/pipewire/pipewire_service.h
@@ -229,7 +229,6 @@ private:
   relativeAdjustTarget(int gesture, float baseStep, float direction, float current, float maxVolume);
   struct RelativeAdjust {
     std::chrono::steady_clock::time_point lastAt;
-    float heldSeconds = 0.0f;
     float target = 0.0f;
     int gesture = 0;
   };

--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -52,8 +52,11 @@ namespace settings {
     // Horizontal space the leading invert slot occupies: corner glyph + gap + a Small toggle.
     // Invertible sliders give this much (plus the row gap) back from their track so the toggle tucks
     // in on the left without widening the control cluster.
-    constexpr float kInvertSlotContentWidth = Style::fontSizeBody + Style::spaceXs + Style::toggleThumbSizeSm
-        + (2.0f * Style::toggleInsetSm) + Style::toggleTravelSm;
+    constexpr float kInvertSlotContentWidth = Style::fontSizeBody
+        + Style::spaceXs
+        + Style::toggleThumbSizeSm
+        + (2.0f * Style::toggleInsetSm)
+        + Style::toggleTravelSm;
 
     // Leading slot carrying the concave-corner invert toggle: a corner glyph (labelling the toggle
     // in lieu of a text caption) plus a Small toggle. The slot sizes to its content. Reserve builds


### PR DESCRIPTION
## Summary
Simplifies the relative volume adjustment logic by restoring flat step increments (e.g., exactly 5% per event tick) for keybind-driven adjustments. This resolves the issue where volume steps are uneven when media keys are held down (due to attempted time interval based smoothing).

## Motivation

The previous time-based acceleration logic integrated over the wall-clock interval (`dt`) between consecutive IPC calls to calculate the step size. However, since compositors (usually) handle key repeats by spawning asynchronous client processes (`noctalia msg volume-up`), scheduling overhead and process-start latency introduced variable arrival jitter (`dt` fluctuations) at the daemon, making the volume step sizes feel highly uneven and non-granular.

Looking at the history of the method, flat steps were originally dropped due to stale echoes in the read-back volume (`sink->volume`) causing lost updates and rubber-banding when commands were sent in rapid succession. Because of the introduction of the gesture-local accumulator (`m_relativeAdjust.target`) which tracks the target volume independently of the lagging read-back volume, we can safely move back to a flat step without re-introducing the lost update and rubber-banding issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes: #3265 

## Testing

verified behaviour against original faulty flat step impl, current impl, and proposed fix with the following (fish) shell script
```sh
for i in (seq 1 30) # default vol step 5, with overdrive 150/5
    noctalia msg volume-up &
end
```

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/fea4e534-9ce9-43cd-9f48-61c67a11561e

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I do not have a knob to control volume with, and I believe this fix carries the intended behaviour w.r.t knob based ipc invocations but I'm not 100% sure.
