### PR TITLE
chore(nix): add libclang to devshell for run-clang-tidy

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -12,6 +12,7 @@ pkgs.mkShell {
 
     # Formatting (required by justfile)
     llvmPackages_22.clang-tools
+    llvmPackages_22.libclang
     gnugrep
     gnused
     findutils


### PR DESCRIPTION
## Summary

Adds `llvmPackages_22.libclang` to `nativeBuildInputs` in `nix/devshell.nix`.

## Motivation

The `just lint` and `just fix` recipes use `run-clang-tidy` under the hood to lint and fix static analysis issues. While `clang-tools` provides `clang-tidy` itself, it does not package the `run-clang-tidy` wrapper script. Adding `libclang` ensures `run-clang-tidy` is present in the `nix develop` shell, unblocking local linting and project formatting tasks.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

N/A

## Testing

entered devshell, verified `run-clang-tidy` is available and ran `lint` and `fix` recipes

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A