### PR TITLE
refactor(lock-surface): replace manual panel calculation with declarative layout

### DIFF
--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -72,51 +72,35 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
   }
 
   m_root.addChild(
-      ui::box({
-          .out = &m_loginPanel,
-          .configure = [](Box& box) { box.setZIndex(2); },
-      })
+      ui::flex(
+          FlexDirection::Vertical,
+          {
+              .out = &m_loginPanel,
+              .align = FlexAlign::Stretch,
+              .justify = FlexJustify::Center,
+              .gap = Style::spaceXs,
+              .paddingV = 0.0f,
+              .paddingH = Style::spaceLg,
+              .configure = [](Flex& flex) { flex.setZIndex(2); },
+          }
+      )
   );
 
-  m_root.addChild(
-      ui::input({
-          .out = &m_passwordField,
-          .placeholder = i18n::tr("lockscreen.password-placeholder"),
-          .passwordMode = true,
-          .onChange =
-              [this](const std::string& value) {
-                if (m_onPasswordChanged) {
-                  m_onPasswordChanged(value);
-                }
-              },
-          .onSubmit =
-              [this](const std::string& /*value*/) {
-                if (m_onLogin) {
-                  m_onLogin();
-                }
-              },
-          .configure = [](Input& input) { input.setZIndex(2); },
-      })
+  m_loginPanel->addChild(
+      ui::flex(
+          FlexDirection::Horizontal,
+          {
+              .out = &m_loginContentRow,
+              .align = FlexAlign::Center,
+              .justify = FlexJustify::Start,
+              .gap = Style::spaceSm,
+              .widthPolicy = FlexSizePolicy::Fill,
+              .heightPolicy = FlexSizePolicy::Content,
+          }
+      )
   );
 
-  m_root.addChild(
-      ui::button({
-          .out = &m_loginButton,
-          .text = "",
-          .glyph = "check",
-          .glyphSize = 16.0f,
-          .variant = ButtonVariant::Primary,
-          .onClick =
-              [this]() {
-                if (m_onLogin) {
-                  m_onLogin();
-                }
-              },
-          .configure = [](Button& button) { button.setZIndex(2); },
-      })
-  );
-
-  m_root.addChild(
+  m_loginContentRow->addChild(
       ui::button({
           .out = &m_layoutChip,
           .text = "",
@@ -133,7 +117,49 @@ LockSurface::LockSurface(WaylandConnection& connection, ConfigService* config) :
       })
   );
 
-  m_root.addChild(
+  m_loginContentRow->addChild(
+      ui::input({
+          .out = &m_passwordField,
+          .placeholder = i18n::tr("lockscreen.password-placeholder"),
+          .passwordMode = true,
+          .onChange =
+              [this](const std::string& value) {
+                if (m_onPasswordChanged) {
+                  m_onPasswordChanged(value);
+                }
+              },
+          .onSubmit =
+              [this](const std::string& /*value*/) {
+                if (m_onLogin) {
+                  m_onLogin();
+                }
+              },
+          .configure =
+              [](Input& input) {
+                input.setZIndex(2);
+                input.setFlexGrow(1.0f);
+              },
+      })
+  );
+
+  m_loginContentRow->addChild(
+      ui::button({
+          .out = &m_loginButton,
+          .text = "",
+          .glyph = "check",
+          .glyphSize = 16.0f,
+          .variant = ButtonVariant::Primary,
+          .onClick =
+              [this]() {
+                if (m_onLogin) {
+                  m_onLogin();
+                }
+              },
+          .configure = [](Button& button) { button.setZIndex(2); },
+      })
+  );
+
+  m_loginPanel->addChild(
       ui::label({
           .out = &m_statusLabel,
           .fontSize = Style::fontSizeCaption,
@@ -513,6 +539,7 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
   m_widgetLayer->setVisible(true);
   const bool loginVisible = isLoginBoxEnabled();
   m_loginPanel->setVisible(loginVisible);
+  m_loginContentRow->setVisible(loginVisible);
   m_passwordField->setVisible(loginVisible);
   m_loginButton->setVisible(loginVisible && resolveLoginStyle().showLoginButton);
   float panelHeight = lockscreen_login_box::defaultPanelHeight();
@@ -572,77 +599,37 @@ void LockSurface::layoutScene(std::uint32_t width, std::uint32_t height) {
 
   const lockscreen_login_box::LoginBoxStyle loginStyle = resolveLoginStyle();
 
-  m_loginPanel->setPosition(panelX, panelY);
-  m_loginPanel->setSize(panelWidth, panelHeight);
-  m_loginPanel->setStyle(
-      RoundedRectStyle{
-          .fill = resolveColorSpec(loginStyle.panelFill),
-          .border = colorForRole(ColorRole::Outline),
-          .fillMode = FillMode::Solid,
-          .radius = Style::scaledRadius(loginStyle.panelRadius),
-          .softness = 1.0f,
-          .borderWidth = Style::borderWidth,
-      }
-  );
+  m_loginPanel->setFill(loginStyle.panelFill);
+  m_loginPanel->setBorder(colorForRole(ColorRole::Outline), Style::borderWidth);
+  m_loginPanel->setRadius(Style::scaledRadius(loginStyle.panelRadius));
+  m_loginPanel->setSoftness(1.0f);
 
-  // Measure the status/hint line first so the panel can reserve a band for it below the input.
-  const bool hintVisible = m_statusLabel != nullptr && m_statusLabel->visible();
-  float hintHeight = 0.0f;
-  if (hintVisible) {
-    m_statusLabel->setMaxWidth(std::max(0.0f, panelWidth - 2.0f * Style::spaceLg));
-    m_statusLabel->layout(*renderer);
-    hintHeight = m_statusLabel->height();
-  }
+  const float controlHeight = std::clamp(panelHeight - Style::spaceSm * 2.0f, 0.0f, Style::controlHeight);
 
-  const lockscreen_login_box::PanelContentLayout contentLayout =
-      lockscreen_login_box::panelContentLayout(panelWidth, panelHeight, loginStyle.showLoginButton);
-  const float gap = Style::spaceSm;
-  const float controlHeight = contentLayout.controlHeight;
-  const float hintBand = hintVisible ? (Style::spaceXs + hintHeight) : 0.0f;
-  const float groupHeight = controlHeight + hintBand;
-  const float contentTop = panelY + std::max(0.0f, (panelHeight - groupHeight) * 0.5f);
-  const float contentLeft = panelX + contentLayout.contentLeft;
-  const float inputRightEdge = contentLeft + contentLayout.inputWidth;
+  m_loginContentRow->setMinHeight(controlHeight);
 
-  // Keyboard-layout chip sits to the left of the input. It grows to fit its label; a max width keeps it
-  // from crowding out the input, and the label ellipsizes within that cap (Button clamps only when maxWidth is set).
-  // Place it via measure()+arrange() rather than setSize(): setSize() latches Flex::m_explicitWidth, which pins the
-  // measured width to the previous frame's size and stops the chip from resizing when the layout label changes.
-  float inputLeft = contentLeft;
-  if (m_layoutChip != nullptr && m_layoutChip->visible()) {
+  const bool showChip = loginVisible && m_layoutChip != nullptr && m_layoutChip->visible();
+  if (showChip) {
+    const float rowContentWidth = std::max(0.0f, panelWidth - 2.0f * Style::spaceLg);
     m_layoutChip->setRadius(Style::scaledRadius(loginStyle.inputRadius));
-    const float maxChipWidth = std::max(0.0f, (inputRightEdge - contentLeft) * 0.5f);
-    m_layoutChip->setMaxWidth(maxChipWidth);
-    const LayoutSize chipSize = m_layoutChip->measure(*renderer, LayoutConstraints::unconstrained());
-    const float chipWidth = std::clamp(chipSize.width, 0.0f, maxChipWidth);
-    m_layoutChip->arrange(
-        *renderer, LayoutRect{std::round(contentLeft), std::round(contentTop), chipWidth, controlHeight}
-    );
-    inputLeft = contentLeft + chipWidth + gap;
+    m_layoutChip->setMaxWidth(rowContentWidth * 0.5f);
   }
 
-  const float inputWidth = std::max(0.0f, inputRightEdge - inputLeft);
   m_passwordField->setSurfaceOpacity(loginStyle.inputOpacity);
   m_passwordField->setFrameRadius(loginStyle.inputRadius);
-  m_passwordField->setSize(inputWidth, 0.0f);
-  m_passwordField->setPosition(inputLeft, contentTop);
-  m_passwordField->layout(*renderer);
 
-  m_loginButton->setVisible(loginVisible && loginStyle.showLoginButton);
-  if (loginVisible && loginStyle.showLoginButton) {
+  const bool showLoginButton = loginVisible && loginStyle.showLoginButton;
+  m_loginButton->setVisible(showLoginButton);
+  if (showLoginButton) {
     m_loginButton->setRadius(Style::scaledRadius(loginStyle.inputRadius));
     m_loginButton->setSize(controlHeight, controlHeight);
-    m_loginButton->setPosition(panelX + contentLayout.buttonX, contentTop);
-    m_loginButton->layout(*renderer);
   }
 
-  // Status/hint line: centered horizontally, placed in the reserved band directly below the input.
-  if (hintVisible) {
-    const float inputBottom = contentTop + controlHeight;
-    const float labelX = panelX + (panelWidth - m_statusLabel->width()) * 0.5f;
-    const float labelY = inputBottom + Style::spaceXs;
-    m_statusLabel->setPosition(labelX, labelY);
+  if (m_statusLabel != nullptr && m_statusLabel->visible()) {
+    m_statusLabel->setMaxWidth(std::max(0.0f, panelWidth - 2.0f * Style::spaceLg));
   }
+
+  m_loginPanel->arrange(*renderer, LayoutRect{panelX, panelY, panelWidth, panelHeight});
 }
 
 lockscreen_login_box::LoginBoxStyle LockSurface::resolveLoginStyle() const {

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -22,6 +22,7 @@ struct wl_output;
 
 class Button;
 class Box;
+class Flex;
 class Input;
 class Label;
 class SharedTextureCache;
@@ -99,7 +100,8 @@ private:
   WallpaperNode* m_wallpaper = nullptr;
   Box* m_tintOverlay = nullptr;
   Box* m_backdrop = nullptr;
-  Box* m_loginPanel = nullptr;
+  Flex* m_loginPanel = nullptr;
+  Flex* m_loginContentRow = nullptr;
   Input* m_passwordField = nullptr;
   Button* m_loginButton = nullptr;
   Button* m_layoutChip = nullptr;

--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -52,8 +52,11 @@ namespace settings {
     // Horizontal space the leading invert slot occupies: corner glyph + gap + a Small toggle.
     // Invertible sliders give this much (plus the row gap) back from their track so the toggle tucks
     // in on the left without widening the control cluster.
-    constexpr float kInvertSlotContentWidth = Style::fontSizeBody + Style::spaceXs + Style::toggleThumbSizeSm
-        + (2.0f * Style::toggleInsetSm) + Style::toggleTravelSm;
+    constexpr float kInvertSlotContentWidth = Style::fontSizeBody
+        + Style::spaceXs
+        + Style::toggleThumbSizeSm
+        + (2.0f * Style::toggleInsetSm)
+        + Style::toggleTravelSm;
 
     // Leading slot carrying the concave-corner invert toggle: a corner glyph (labelling the toggle
     // in lieu of a text caption) plus a Small toggle. The slot sizes to its content. Reserve builds


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

Refactors the lockscreen login panel to replace the flat structure and manual dimension calculation with a declarative `Flex` hierarchy.

## Motivation

<!-- What problem does this solve? -->

The panel's internal layout was built from manual float arithmetics.
That made the code hard to follow and fragile to change.
This PR replaces manual placement with declarative, semantic layout that matches the rest of the shell's UI.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

- I ran `just test` and confirmed all tests passed.
- I ran `just build` and manually verified the lock screen renders with no visual regression.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

No visual change is expected.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

For complete separation of layout and visual concerns, a dedicated inner `Flex` for arrangement might be better than making `m_loginPanel` itself a `Flex`