### PR TITLE
feat(theme): add `color_dark` and `color_light` options for custom colors

### DIFF
--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1265,8 +1265,8 @@ struct ThemeConfig {
   struct TemplateColorConfig {
     std::string name;
     std::string color;
-    std::string color_dark;
-    std::string color_light;
+    std::string color_dark = "";
+    std::string color_light = "";
     bool blend = true;
 
     bool operator==(const TemplateColorConfig&) const = default;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1265,6 +1265,8 @@ struct ThemeConfig {
   struct TemplateColorConfig {
     std::string name;
     std::string color;
+    std::string color_dark;
+    std::string color_light;
     bool blend = true;
 
     bool operator==(const TemplateColorConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -945,7 +945,7 @@ namespace noctalia::config::schema {
 
     // [theme.templates.custom_colors]: a name-keyed map whose value is either a
     // bare color string or a { color, color_dark, color_light, blend } table.
-    // Kept only when name+color or name+color_dark+color_light are non-empty;
+    // Kept only when name+color are non-empty (color is set to color_dark if not provided);
     // emitted only when the list is non-empty.
     Field<ThemeConfig::TemplatesConfig> customColorsField() {
       return custom<ThemeConfig::TemplatesConfig>(
@@ -977,10 +977,7 @@ namespace noctalia::config::schema {
                   color.blend = b->get();
                 }
               }
-              if (!StringUtils::trim(color.name).empty()
-                  && (!StringUtils::trim(color.color).empty()
-                      || (!StringUtils::trim(color.color_dark).empty()
-                          && !StringUtils::trim(color.color_light).empty()))) {
+              if (!StringUtils::trim(color.name).empty() && !StringUtils::trim(color.color).empty()) {
                 out.customColors.push_back(std::move(color));
               }
             }
@@ -993,9 +990,13 @@ namespace noctalia::config::schema {
             for (const auto& color : in.customColors) {
               toml::table colorTable;
               colorTable.insert_or_assign("color", color.color);
-              colorTable.insert_or_assign("color_dark", color.color_dark);
-              colorTable.insert_or_assign("color_light", color.color_light);
               colorTable.insert_or_assign("blend", color.blend);
+              if (!color.color_dark.empty()) {
+                colorTable.insert_or_assign("color_dark", color.color_dark);
+              }
+              if (!color.color_light.empty()) {
+                colorTable.insert_or_assign("color_light", color.color_light);
+              }
               map.insert_or_assign(color.name, std::move(colorTable));
             }
             tbl.insert_or_assign("custom_colors", std::move(map));

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -944,8 +944,9 @@ namespace noctalia::config::schema {
     using CompareColor = ThemeConfig::TemplateCompareColorConfig;
 
     // [theme.templates.custom_colors]: a name-keyed map whose value is either a
-    // bare color string or a { color, blend } table. Kept only when name+color
-    // are non-empty; emitted only when the list is non-empty.
+    // bare color string or a { color, color_dark, color_light, blend } table.
+    // Kept only when name+color or name+color_dark+color_light are non-empty;
+    // emitted only when the list is non-empty.
     Field<ThemeConfig::TemplatesConfig> customColorsField() {
       return custom<ThemeConfig::TemplatesConfig>(
           "custom_colors",
@@ -961,14 +962,25 @@ namespace noctalia::config::schema {
               if (const auto* str = value.as_string()) {
                 color.color = str->get();
               } else if (const auto* t = value.as_table()) {
+                if (auto c = t->get_as<std::string>("color_dark")) {
+                  color.color_dark = c->get();
+                }
+                if (auto c = t->get_as<std::string>("color_light")) {
+                  color.color_light = c->get();
+                }
                 if (auto c = t->get_as<std::string>("color")) {
                   color.color = c->get();
+                } else {
+                  color.color = color.color_dark;
                 }
                 if (auto b = t->get_as<bool>("blend")) {
                   color.blend = b->get();
                 }
               }
-              if (!StringUtils::trim(color.name).empty() && !StringUtils::trim(color.color).empty()) {
+              if (!StringUtils::trim(color.name).empty()
+                  && (!StringUtils::trim(color.color).empty()
+                      || (!StringUtils::trim(color.color_dark).empty()
+                          && !StringUtils::trim(color.color_light).empty()))) {
                 out.customColors.push_back(std::move(color));
               }
             }
@@ -981,6 +993,8 @@ namespace noctalia::config::schema {
             for (const auto& color : in.customColors) {
               toml::table colorTable;
               colorTable.insert_or_assign("color", color.color);
+              colorTable.insert_or_assign("color_dark", color.color_dark);
+              colorTable.insert_or_assign("color_light", color.color_light);
               colorTable.insert_or_assign("blend", color.blend);
               map.insert_or_assign(color.name, std::move(colorTable));
             }

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -945,8 +945,8 @@ namespace noctalia::config::schema {
 
     // [theme.templates.custom_colors]: a name-keyed map whose value is either a
     // bare color string or a { color, color_dark, color_light, blend } table.
-    // Kept only when name+color are non-empty (color is set to color_dark if not provided);
-    // emitted only when the list is non-empty.
+    // Kept only when name+color are non-empty (color falls back to color_dark then
+    // color_light when not provided); emitted only when the list is non-empty.
     Field<ThemeConfig::TemplatesConfig> customColorsField() {
       return custom<ThemeConfig::TemplatesConfig>(
           "custom_colors",
@@ -970,8 +970,10 @@ namespace noctalia::config::schema {
                 }
                 if (auto c = t->get_as<std::string>("color")) {
                   color.color = c->get();
-                } else {
+                } else if (!color.color_dark.empty()) {
                   color.color = color.color_dark;
+                } else {
+                  color.color = color.color_light;
                 }
                 if (auto b = t->get_as<bool>("blend")) {
                   color.blend = b->get();

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -63,8 +63,12 @@ namespace noctalia::theme {
         for (const auto& color : templatesConfig.customColors) {
           toml::table colorTable;
           colorTable.insert_or_assign("color", color.color);
-          colorTable.insert_or_assign("color_dark", color.color_dark);
-          colorTable.insert_or_assign("color_light", color.color_light);
+          if (!color.color_dark.empty()) {
+            colorTable.insert_or_assign("color_dark", color.color_dark);
+          }
+          if (!color.color_light.empty()) {
+            colorTable.insert_or_assign("color_light", color.color_light);
+          }
           colorTable.insert_or_assign("blend", color.blend);
           customColors.insert_or_assign(color.name, std::move(colorTable));
         }

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -63,6 +63,8 @@ namespace noctalia::theme {
         for (const auto& color : templatesConfig.customColors) {
           toml::table colorTable;
           colorTable.insert_or_assign("color", color.color);
+          colorTable.insert_or_assign("color_dark", color.color_dark);
+          colorTable.insert_or_assign("color_light", color.color_light);
           colorTable.insert_or_assign("blend", color.blend);
           customColors.insert_or_assign(color.name, std::move(colorTable));
         }

--- a/src/theme/template_engine.cpp
+++ b/src/theme/template_engine.cpp
@@ -1357,40 +1357,52 @@ namespace noctalia::theme {
 
     if (const toml::table* config = root["config"].as_table()) {
       if (const toml::table* customColors = (*config)["custom_colors"].as_table()) {
-        std::string sourceHex;
-        if (auto modeIt = m_themeData.find(m_options.defaultMode); modeIt != m_themeData.end()) {
-          if (auto it = modeIt->second.find("primary"); it != modeIt->second.end())
-            sourceHex = it->second;
-          else if (auto it2 = modeIt->second.find("source_color"); it2 != modeIt->second.end())
-            sourceHex = it2->second;
+        std::unordered_map<std::string_view, std::string> sourceHexes;
+        for (std::string_view mode : kTemplateModes) {
+          if (auto modeIt = m_themeData.find(std::string(mode)); modeIt != m_themeData.end()) {
+            if (auto it = modeIt->second.find("primary"); it != modeIt->second.end())
+              sourceHexes[mode] = it->second;
+            else if (auto it2 = modeIt->second.find("source_color"); it2 != modeIt->second.end())
+              sourceHexes[mode] = it2->second;
+          }
         }
 
         for (const auto& [nameNode, valueNode] : *customColors) {
           const std::string name = std::string(nameNode.str());
-          std::string colorHex;
+          std::unordered_map<std::string_view, std::string> colorHexes;
           bool blend = true;
 
           if (const auto* str = valueNode.as_string()) {
-            colorHex = str->get();
+            colorHexes["dark"] = str->get();
+            colorHexes["light"] = str->get();
           } else if (const auto* tbl = valueNode.as_table()) {
-            if (auto color = tbl->get_as<std::string>("color"))
-              colorHex = color->get();
+            if (auto colorDark = tbl->get_as<std::string>("color_dark"),
+                colorLight = tbl->get_as<std::string>("color_light");
+                colorDark && colorLight) {
+              colorHexes["dark"] = colorDark->get();
+              colorHexes["light"] = colorLight->get();
+            } else if (auto color = tbl->get_as<std::string>("color")) {
+              colorHexes["dark"] = color->get();
+              colorHexes["light"] = color->get();
+            }
             if (auto blendValue = tbl->get_as<bool>("blend"))
               blend = blendValue->get();
           } else {
             continue;
           }
 
-          if (colorHex.empty())
+          if (colorHexes.empty())
             continue;
 
-          const std::string paletteHex = (blend && !sourceHex.empty()) ? harmonizeHex(colorHex, sourceHex) : colorHex;
-          const auto scheme = makeCustomColorScheme(
-              m_options.schemeType, material_color_utilities::Hct(Color::fromHex(paletteHex).toArgb())
-          );
-          const auto& palette = scheme.primary_palette;
-
           for (std::string_view mode : kTemplateModes) {
+            const std::string sourceHex = sourceHexes[mode];
+            const std::string colorHex = colorHexes[mode];
+            const std::string paletteHex = (blend && !sourceHex.empty()) ? harmonizeHex(colorHex, sourceHex) : colorHex;
+            const auto scheme = makeCustomColorScheme(
+                m_options.schemeType, material_color_utilities::Hct(Color::fromHex(paletteHex).toArgb())
+            );
+            const auto& palette = scheme.primary_palette;
+
             auto& modeData = m_themeData[std::string(mode)];
             modeData[name + "_source"] = colorHex;
             modeData[name + "_value"] = colorHex;

--- a/src/theme/template_engine.cpp
+++ b/src/theme/template_engine.cpp
@@ -1357,46 +1357,51 @@ namespace noctalia::theme {
 
     if (const toml::table* config = root["config"].as_table()) {
       if (const toml::table* customColors = (*config)["custom_colors"].as_table()) {
-        std::unordered_map<std::string_view, std::string> sourceHexes;
-        for (std::string_view mode : kTemplateModes) {
-          if (auto modeIt = m_themeData.find(std::string(mode)); modeIt != m_themeData.end()) {
-            if (auto it = modeIt->second.find("primary"); it != modeIt->second.end())
-              sourceHexes[mode] = it->second;
-            else if (auto it2 = modeIt->second.find("source_color"); it2 != modeIt->second.end())
-              sourceHexes[mode] = it2->second;
-          }
+        std::string sourceHex;
+        if (auto modeIt = m_themeData.find(m_options.defaultMode); modeIt != m_themeData.end()) {
+          if (auto it = modeIt->second.find("primary"); it != modeIt->second.end())
+            sourceHex = it->second;
+          else if (auto it2 = modeIt->second.find("source_color"); it2 != modeIt->second.end())
+            sourceHex = it2->second;
         }
 
         for (const auto& [nameNode, valueNode] : *customColors) {
           const std::string name = std::string(nameNode.str());
-          std::unordered_map<std::string_view, std::string> colorHexes;
+          std::string darkHex;
+          std::string lightHex;
           bool blend = true;
 
           if (const auto* str = valueNode.as_string()) {
-            colorHexes["dark"] = str->get();
-            colorHexes["light"] = str->get();
+            darkHex = str->get();
+            lightHex = darkHex;
           } else if (const auto* tbl = valueNode.as_table()) {
-            if (auto colorDark = tbl->get_as<std::string>("color_dark"),
-                colorLight = tbl->get_as<std::string>("color_light");
-                colorDark && colorLight) {
-              colorHexes["dark"] = colorDark->get();
-              colorHexes["light"] = colorLight->get();
-            } else if (auto color = tbl->get_as<std::string>("color")) {
-              colorHexes["dark"] = color->get();
-              colorHexes["light"] = color->get();
-            }
+            const auto* colorPtr = tbl->get_as<std::string>("color");
+            const auto* colorDarkPtr = tbl->get_as<std::string>("color_dark");
+            const auto* colorLightPtr = tbl->get_as<std::string>("color_light");
+            const std::string base = colorPtr ? colorPtr->get() : std::string{};
+            const std::string darkOverride = colorDarkPtr ? colorDarkPtr->get() : std::string{};
+            const std::string lightOverride = colorLightPtr ? colorLightPtr->get() : std::string{};
+            // Per mode: prefer its own override, then the shared color, then the other mode.
+            auto pick = [](std::initializer_list<const std::string*> candidates) {
+              for (const std::string* c : candidates)
+                if (!c->empty())
+                  return *c;
+              return std::string{};
+            };
+            darkHex = pick({&darkOverride, &base, &lightOverride});
+            lightHex = pick({&lightOverride, &base, &darkOverride});
             if (auto blendValue = tbl->get_as<bool>("blend"))
               blend = blendValue->get();
           } else {
             continue;
           }
 
-          if (colorHexes.empty())
+          // pick() ties dark/light emptiness together, so this also guards lightHex.
+          if (darkHex.empty())
             continue;
 
           for (std::string_view mode : kTemplateModes) {
-            const std::string sourceHex = sourceHexes[mode];
-            const std::string colorHex = colorHexes[mode];
+            const std::string& colorHex = (mode == "dark") ? darkHex : lightHex;
             const std::string paletteHex = (blend && !sourceHex.empty()) ? harmonizeHex(colorHex, sourceHex) : colorHex;
             const auto scheme = makeCustomColorScheme(
                 m_options.schemeType, material_color_utilities::Hct(Color::fromHex(paletteHex).toArgb())

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -424,7 +424,8 @@ location = "https://example.invalid/bad"
     c.theme.mode = ThemeMode::Light;
     c.theme.templates.enableBuiltinTemplates = false;
     c.theme.templates.builtinIds = {"a", "b"};
-    c.theme.templates.customColors = {{"accent", "#112233", true}, {"bg", "#000000", false}};
+    c.theme.templates.customColors = {{"accent", "#112233", "#112233", "#332211", true},
+        {"bg", "#000000", "#000000", "#000000", false}};
     c.theme.templates.userTemplates = {
         ThemeConfig::UserTemplateConfig{
             "tmpl1",

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -129,9 +129,8 @@ location = "https://example.invalid/bad"
       }
     }
 
-    const std::string invalid[] = {
-        "", "hello", "me/", "/hello", "me/foo/bar", "me/../hello", "me/foo bar", "../foo", "me/.hidden"
-    };
+    const std::string invalid[] = {"",           "hello",  "me/",       "/hello", "me/foo/bar", "me/../hello",
+                                   "me/foo bar", "../foo", "me/.hidden"};
     for (const auto& id : invalid) {
       if (scripting::isValidPluginId(id)) {
         fail("plugins: accepted invalid plugin id " + id);
@@ -283,9 +282,8 @@ location = "https://example.invalid/bad"
     c.osd.kinds.lockKeys = false;
     c.osd.kinds.keyboardLayout = false;
     c.backdrop = BackdropConfig{true, 0.8f, 0.2f};
-    c.lockscreen = LockscreenConfig{
-        .blurredDesktop = true, .blurIntensity = 0.6f, .tintIntensity = 0.25f, .monitors = {"DP-1"}
-    };
+    c.lockscreen =
+        LockscreenConfig{.blurredDesktop = true, .blurIntensity = 0.6f, .tintIntensity = 0.25f, .monitors = {"DP-1"}};
     c.system.monitor.enabled = false;
     c.system.monitor.cpuTempSensorPath = "/sys/class/hwmon/hwmon3/temp1_input";
     c.system.monitor.cpuPollSeconds = 5.0f;
@@ -424,8 +422,9 @@ location = "https://example.invalid/bad"
     c.theme.mode = ThemeMode::Light;
     c.theme.templates.enableBuiltinTemplates = false;
     c.theme.templates.builtinIds = {"a", "b"};
-    c.theme.templates.customColors = {{"accent", "#112233", "#112233", "#332211", true},
-        {"bg", "#000000", "#000000", "#000000", false}};
+    c.theme.templates.customColors = {
+        {"accent", "#112233", "#112233", "#332211", true}, {"bg", "#000000", "#000000", "#000000", false}
+    };
     c.theme.templates.userTemplates = {
         ThemeConfig::UserTemplateConfig{
             "tmpl1",
@@ -487,6 +486,48 @@ location = "https://example.invalid/bad"
       if (s.clipboardHistoryMaxEntries != 10000) {
         fail("shell.clipboard_history_max_entries clamp: expected 10000");
       }
+    }
+  }
+
+  // color falls back to color_dark then color_light so a single-mode entry survives
+  // the name+color keep-predicate and carries a usable comparison color.
+  void checkCustomColorFallback() {
+    auto root = toml::parse(R"(
+[templates.custom_colors]
+onlydark = { color_dark = "#111111" }
+onlylight = { color_light = "#222222" }
+bare = { color = "#333333" }
+both = { color_dark = "#444444", color_light = "#555555" }
+)");
+    ThemeConfig theme{};
+    Diagnostics d;
+    readInto(root, theme, themeSchema(), "theme", d);
+
+    auto find = [&](std::string_view name) -> const ThemeConfig::TemplateColorConfig* {
+      for (const auto& c : theme.templates.customColors)
+        if (c.name == name)
+          return &c;
+      return nullptr;
+    };
+
+    const auto* onlydark = find("onlydark");
+    if (onlydark == nullptr || onlydark->color != "#111111" || onlydark->color_dark != "#111111") {
+      fail("custom_colors onlydark: color should fall back to color_dark");
+    }
+    const auto* onlylight = find("onlylight");
+    if (onlylight == nullptr || onlylight->color != "#222222" || onlylight->color_light != "#222222") {
+      fail("custom_colors onlylight: color should fall back to color_light");
+    }
+    const auto* bare = find("bare");
+    if (bare == nullptr || bare->color != "#333333" || !bare->color_dark.empty() || !bare->color_light.empty()) {
+      fail("custom_colors bare: color set, no dark/light overrides");
+    }
+    const auto* both = find("both");
+    if (both == nullptr
+        || both->color != "#444444"
+        || both->color_dark != "#444444"
+        || both->color_light != "#555555") {
+      fail("custom_colors both: color prefers color_dark, both overrides retained");
     }
   }
 
@@ -681,6 +722,7 @@ widget_spacing = 8
   checkPluginIdValidation();
   checkPluginSourceNameValidation();
   checkClamps();
+  checkCustomColorFallback();
 
   if (g_failures == 0) {
     std::puts("config_schema_roundtrip: all checks passed");


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Allows custom colors for user templates to specify `color_dark` and `color_light` separately as an alternative to just `color`, with dark and light mode palettes generated separately in that case. In particular, `<name>_source.dark` and `<name>_source.light` return the original `color_dark` and `color_light` values respectively. Moreover, the `color` value takes the value of `color_dark` if the former is not provided (e.g. for comparing colors).

## Motivation

Noctalia's custom colors gives users very granular control over implementing a consistent color scheme across apps, allowing customization to go beyond the Material 3 palette. However, while palette colors allow for specification of both light and dark mode variants, custom colors do not currently have this feature, instead forcing users to rely on an autogenerated value for the non-default mode.

This pull request adds this feature, giving users better control over their custom colors across both dark and light modes and making Noctalia an even better tool for customization.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3262.

## Testing

`just test` run, all tests passed (except for `noctalia:process`, but this appears to just be my terminal appending a BEL character to the end of a result string, as verified by printing out the result string). New functionality verified on my own NixOS setup.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I'm not the most knowledgeable about Material 3, so feel free to point out any issues like pulling the wrong color tones from palettes for color tokens or whatever. I also hope this doesn't "violate" the design philosophy of Material 3 and Noctalia; after all, users already have the ability to specify dark and light variants separately in user palettes.
