### PR TITLE
fix(calendar): preserve recurring event wall time across DST

### DIFF
--- a/src/calendar/ical_parser.cpp
+++ b/src/calendar/ical_parser.cpp
@@ -113,8 +113,15 @@ namespace calendar {
       return std::chrono::time_point_cast<std::chrono::system_clock::duration>(t);
     }
 
-    // Parse an iCal DATE or DATE-TIME value into a UTC time_point. Sets allDay for DATE values.
-    std::optional<std::chrono::system_clock::time_point> parseDateTime(const PropertyLine& prop, bool& allDay) {
+    struct ParsedDateTime {
+      std::chrono::system_clock::time_point instant;
+      std::chrono::sys_days civilDay;
+      std::chrono::seconds timeOfDay{0};
+      const std::chrono::time_zone* zone = nullptr;
+      bool allDay = false;
+    };
+
+    std::optional<ParsedDateTime> parseDateTime(const PropertyLine& prop) {
       using namespace std::chrono;
       std::string_view v = prop.value;
       if (v.size() < 8) {
@@ -127,40 +134,46 @@ namespace calendar {
       if (!ymd.ok()) {
         return std::nullopt;
       }
+      const sys_days civilDay{ymd};
 
       if (prop.valueIsDate || v.size() < 15 || (v[8] != 'T')) {
-        allDay = true;
         // Local midnight of the date.
         const local_days ld{ymd};
         try {
-          return toSystem(time_point_cast<seconds>(current_zone()->to_sys(ld)));
+          return ParsedDateTime{
+              toSystem(time_point_cast<seconds>(current_zone()->to_sys(ld))), civilDay, {}, nullptr, true
+          };
         } catch (...) {
-          return toSystem(sys_days{ymd});
+          return ParsedDateTime{toSystem(civilDay), civilDay, {}, nullptr, true};
         }
       }
 
-      allDay = false;
       const int hour = toInt(v.substr(9, 2));
       const int minute = toInt(v.substr(11, 2));
       const int second = toInt(v.substr(13, 2));
       const auto timeOfDay = hours{hour} + minutes{minute} + seconds{second};
 
       if (v.back() == 'Z') {
-        return toSystem(sys_days{ymd} + timeOfDay);
+        return ParsedDateTime{toSystem(civilDay + timeOfDay), civilDay, timeOfDay, nullptr, false};
       }
 
       const local_seconds local = local_days{ymd} + timeOfDay;
       if (!prop.tzid.empty()) {
         try {
-          return toSystem(time_point_cast<seconds>(locate_zone(std::string(prop.tzid))->to_sys(local)));
+          const time_zone* zone = locate_zone(std::string(prop.tzid));
+          return ParsedDateTime{
+              toSystem(time_point_cast<seconds>(zone->to_sys(local))), civilDay, timeOfDay, zone, false
+          };
         } catch (...) {
           // Fall through to the local zone when the TZID is unknown.
         }
       }
       try {
-        return toSystem(time_point_cast<seconds>(current_zone()->to_sys(local)));
+        return ParsedDateTime{
+            toSystem(time_point_cast<seconds>(current_zone()->to_sys(local))), civilDay, timeOfDay, nullptr, false
+        };
       } catch (...) {
-        return toSystem(sys_days{ymd} + timeOfDay);
+        return ParsedDateTime{toSystem(civilDay + timeOfDay), civilDay, timeOfDay, nullptr, false};
       }
     }
 
@@ -194,6 +207,12 @@ namespace calendar {
       std::vector<std::chrono::weekday> byDay; // WEEKLY only
     };
 
+    struct RecurrenceZone {
+      const std::chrono::time_zone* zone = nullptr;
+      std::chrono::sys_days startDay;
+      std::chrono::seconds timeOfDay{0};
+    };
+
     RRule parseRRule(std::string_view value) {
       RRule rule;
       std::size_t pos = 0;
@@ -224,8 +243,9 @@ namespace calendar {
         } else if (key == "UNTIL") {
           PropertyLine p;
           p.value = val;
-          bool ignored = false;
-          rule.until = parseDateTime(p, ignored);
+          if (auto parsed = parseDateTime(p)) {
+            rule.until = parsed->instant;
+          }
         } else if (key == "BYDAY") {
           std::size_t p = 0;
           while (p < val.size()) {
@@ -241,12 +261,12 @@ namespace calendar {
       return rule;
     }
 
-    // Occurrences repeat at the same UTC instant shifted by whole days/weeks/months/years, so they can
-    // drift by an hour across a DST boundary — acceptable for display.
+    // Timed DTSTART values with TZID repeat at the same local wall time in that zone; UTC/floating
+    // values keep the previous UTC-based expansion.
     void expandRecurrence(
         const CalendarEvent& base, const RRule& rule, const std::vector<std::chrono::system_clock::time_point>& exdates,
-        std::chrono::system_clock::time_point windowStart, std::chrono::system_clock::time_point windowEnd,
-        std::vector<CalendarEvent>& out
+        const std::optional<RecurrenceZone>& recurrenceZone, std::chrono::system_clock::time_point windowStart,
+        std::chrono::system_clock::time_point windowEnd, std::vector<CalendarEvent>& out
     ) {
       using namespace std::chrono;
       if (rule.freq == RRule::Freq::None) {
@@ -273,6 +293,9 @@ namespace calendar {
         startDay = localDay(base.start);
         const sys_days endDay = localDay(base.end);
         allDaySpan = std::max(days{0}, endDay - startDay);
+      } else if (recurrenceZone) {
+        startDay = recurrenceZone->startDay;
+        tod = recurrenceZone->timeOfDay;
       } else {
         startDay = floor<days>(base.start);
         tod = base.start - startDay;
@@ -287,12 +310,20 @@ namespace calendar {
             return toSystem(sys_days{year_month_day{civilDay}});
           }
         }
+        if (recurrenceZone) {
+          const local_seconds local = time_point_cast<seconds>(local_days{year_month_day{civilDay}} + tod);
+          try {
+            return toSystem(time_point_cast<seconds>(recurrenceZone->zone->to_sys(local)));
+          } catch (...) {
+            return civilDay + tod;
+          }
+        }
         return civilDay + tod;
       };
 
-      // Our occurrences hold a constant UTC instant, but the server's EXDATE/RECURRENCE-ID carries the
-      // true local wall time, so the two drift by up to the DST offset. Occurrences are always >= 1 day
-      // apart, so a 12h tolerance matches the intended one across that drift without catching a neighbour.
+      // Legacy UTC-based occurrences can drift from the server's local-wall EXDATE/RECURRENCE-ID by a
+      // DST offset. Occurrences are always >= 1 day apart, so a 12h tolerance matches the intended one
+      // across that drift without catching a neighbour.
       const auto excluded = [&](system_clock::time_point t) {
         return std::ranges::any_of(exdates, [&](system_clock::time_point ex) {
           return std::chrono::abs(t - ex) < hours{12};
@@ -404,6 +435,7 @@ namespace calendar {
       std::string_view rrule;
       std::vector<std::chrono::system_clock::time_point> exdates;
       std::optional<std::chrono::system_clock::time_point> recurrenceId;
+      std::optional<RecurrenceZone> recurrenceZone;
     };
     std::vector<Parsed> parsed;
 
@@ -412,19 +444,20 @@ namespace calendar {
     bool haveStart = false;
     bool haveEnd = false;
     bool startAllDay = false;
-    bool endAllDay = false;
     std::string_view rrule;
     std::vector<std::chrono::system_clock::time_point> exdates;
     std::optional<std::chrono::system_clock::time_point> recurrenceId;
+    std::optional<RecurrenceZone> recurrenceZone;
 
     for (const std::string& line : lines) {
       if (line == "BEGIN:VEVENT") {
         inEvent = true;
         event = CalendarEvent{};
-        haveStart = haveEnd = startAllDay = endAllDay = false;
+        haveStart = haveEnd = startAllDay = false;
         rrule = {};
         exdates.clear();
         recurrenceId.reset();
+        recurrenceZone.reset();
         continue;
       }
       if (line == "END:VEVENT") {
@@ -433,7 +466,7 @@ namespace calendar {
             event.end = event.start;
           }
           event.allDay = startAllDay;
-          parsed.push_back({std::move(event), rrule, std::move(exdates), recurrenceId});
+          parsed.push_back({std::move(event), rrule, std::move(exdates), recurrenceId, recurrenceZone});
         }
         inEvent = false;
         continue;
@@ -450,20 +483,25 @@ namespace calendar {
       } else if (prop.name == "LOCATION") {
         event.location = unescapeText(prop.value);
       } else if (prop.name == "DTSTART") {
-        if (auto tp = parseDateTime(prop, startAllDay)) {
-          event.start = *tp;
+        if (auto parsed = parseDateTime(prop)) {
+          event.start = parsed->instant;
+          startAllDay = parsed->allDay;
           haveStart = true;
+          if (!parsed->allDay && parsed->zone != nullptr) {
+            recurrenceZone = RecurrenceZone{parsed->zone, parsed->civilDay, parsed->timeOfDay};
+          }
         }
       } else if (prop.name == "DTEND") {
-        if (auto tp = parseDateTime(prop, endAllDay)) {
-          event.end = *tp;
+        if (auto parsed = parseDateTime(prop)) {
+          event.end = parsed->instant;
           haveEnd = true;
         }
       } else if (prop.name == "RRULE") {
         rrule = prop.value;
       } else if (prop.name == "RECURRENCE-ID") {
-        bool ignored = false;
-        recurrenceId = parseDateTime(prop, ignored);
+        if (auto parsed = parseDateTime(prop)) {
+          recurrenceId = parsed->instant;
+        }
       } else if (prop.name == "EXDATE") {
         // May be a comma-separated list; each shares the line's TZID/VALUE params.
         std::string_view v = prop.value;
@@ -472,9 +510,8 @@ namespace calendar {
           const std::size_t comma = v.find(',', p);
           PropertyLine ex = prop;
           ex.value = comma == std::string_view::npos ? v.substr(p) : v.substr(p, comma - p);
-          bool ignored = false;
-          if (auto tp = parseDateTime(ex, ignored)) {
-            exdates.push_back(*tp);
+          if (auto parsed = parseDateTime(ex)) {
+            exdates.push_back(parsed->instant);
           }
           p = comma == std::string_view::npos ? v.size() : comma + 1;
         }
@@ -501,7 +538,7 @@ namespace calendar {
       if (auto it = overrides.find(p.event.id); it != overrides.end()) {
         p.exdates.insert(p.exdates.end(), it->second.begin(), it->second.end());
       }
-      expandRecurrence(p.event, parseRRule(p.rrule), p.exdates, windowStart, windowEnd, events);
+      expandRecurrence(p.event, parseRRule(p.rrule), p.exdates, p.recurrenceZone, windowStart, windowEnd, events);
     }
 
     return events;

--- a/tests/ical_recurrence_test.cpp
+++ b/tests/ical_recurrence_test.cpp
@@ -115,6 +115,20 @@ int main() {
   // MONTHLY unbounded over one year: Jan..Dec 2024 = 12.
   ok = expectCount(wrap("RRULE:FREQ=MONTHLY\r\n"), start, utc(2025, 1, 1), 12, "monthly") && ok;
 
+  // Timed monthly recurrences with TZID must preserve the local wall time across DST. Kyiv is UTC+2
+  // in February and UTC+3 in July, so an 11:00 February event should recur at 08:00Z in July.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:kyiv-monthly\r\nSUMMARY:s\r\n"
+                            "DTSTART;TZID=Europe/Kyiv:20240205T110000\r\n"
+                            "DTEND;TZID=Europe/Kyiv:20240205T120000\r\nRRULE:FREQ=MONTHLY;COUNT=6\r\n"
+                            "END:VEVENT\r\n";
+    ok = expectRanges(
+             ics, utc(2024, 7, 1), utc(2024, 8, 1), {{utc(2024, 7, 5, 8), utc(2024, 7, 5, 9)}},
+             "monthly timed recurrence preserves Kyiv wall time across dst"
+         )
+        && ok;
+  }
+
   // UNTIL clips: DAILY until Jan 3 -> Jan 1, 2, 3 = 3.
   ok = expectCount(wrap("RRULE:FREQ=DAILY;UNTIL=20240103T090000Z\r\n"), start, end, 3, "daily until") && ok;
 
@@ -181,6 +195,15 @@ int main() {
                             "DTEND;TZID=America/New_York:20240301T130000\r\nRRULE:FREQ=DAILY;COUNT=20\r\n"
                             "EXDATE;TZID=America/New_York:20240315T120000\r\nEND:VEVENT\r\n";
     ok = expectCount(ics, utc(2024, 3, 1), utc(2024, 4, 1), 19, "exdate excludes across dst") && ok;
+  }
+
+  // Daily timed recurrences must not crash when an occurrence lands in a spring-forward gap. New York
+  // jumps from 01:59 to 03:00 on Mar 10 2024, so 02:30 does not exist that day.
+  {
+    const std::string ics = "BEGIN:VEVENT\r\nUID:ny-gap\r\nDTSTART;TZID=America/New_York:20240308T023000\r\n"
+                            "DTEND;TZID=America/New_York:20240308T033000\r\nRRULE:FREQ=DAILY;COUNT=5\r\n"
+                            "END:VEVENT\r\n";
+    ok = expectCount(ics, utc(2024, 3, 8), utc(2024, 3, 14), 5, "daily recurrence survives dst gap") && ok;
   }
 
   // RECURRENCE-ID override: a modified instance replaces the master's occurrence at that instant,


### PR DESCRIPTION
## Summary

Fixed client-side recurrence expansion for timed calendar events with `TZID`, so recurring events keep their original local wall time across DST changes.

Refactored datetime parsing so the parser records the resolved instant, civil date, time-of-day, and timezone in one pass instead of reparsing `DTSTART` for recurrence metadata.

Also added a regression test for a monthly `Europe/Kyiv` event from February to July.

## Motivation

Recurring events in DST timezones could appear one hour off after a DST transition. For example, an 11:00 Kyiv meeting created in February should still appear at 11:00 Kyiv in July.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `nix develop --command meson test -C build-debug ical_recurrence`.
- Tested on NixOS using local flake path.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:
<img width="213" height="238" alt="before" src="https://github.com/user-attachments/assets/df2bd2c5-c2ee-4a91-be71-267bb12a0080" />

After:
<img width="213" height="238" alt="after" src="https://github.com/user-attachments/assets/818e2305-281e-4da2-820f-b9827e532180" />

Real calendar:
<img width="539" height="791" alt="real" src="https://github.com/user-attachments/assets/7263f06e-bc8b-4e16-89f4-982992c72406" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.