### PR TITLE
fix(launcher): use grid cell height for list result rows

### DIFF
--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -274,7 +274,8 @@ namespace {
 
     void setListStyle(LauncherListStyle style) { m_style = style; }
 
-    void bind(Renderer& renderer, const LauncherResult& result, float width, bool selected, bool hovered) {
+    void
+    bind(Renderer& renderer, const LauncherResult& result, float width, float height, bool selected, bool hovered) {
       m_selected = selected;
       m_hovered = hovered;
       m_iconPath = result.iconPath;
@@ -282,10 +283,10 @@ namespace {
       const float iconSize = launcherIconSize(m_style);
       m_iconTargetSize = static_cast<int>(std::round(iconSize));
       m_badgeVisible = !result.badge.empty();
-      m_rowHeight = launcherRowHeight(renderer, m_style);
+      m_rowHeight = height;
 
-      setSize(width, m_rowHeight);
-      m_row->setFrameSize(width, m_rowHeight);
+      setSize(width, height);
+      m_row->setFrameSize(width, height);
 
       m_badgeLabel->setVisible(false);
       m_badgeLabel->setParticipatesInLayout(false);
@@ -603,7 +604,7 @@ public:
     }
     auto* row = static_cast<LauncherResultRow*>(&tile);
     row->setListStyle(m_style);
-    row->bind(*m_renderer, (*m_results)[index], tile.width(), selected, hovered);
+    row->bind(*m_renderer, (*m_results)[index], tile.width(), tile.height(), selected, hovered);
   }
 
   void onActivate(std::size_t index) override {
@@ -923,7 +924,12 @@ void LauncherPanel::syncLauncherViewLayout(Renderer* renderer) {
     m_grid->setColumns(1);
     m_grid->setColumnGap(0.0f);
     m_grid->setRowGap(Style::spaceXs * scale);
-    m_grid->setCellHeight(launcherRowHeightEstimate(style));
+    const float listCellHeight =
+        renderer != nullptr ? launcherRowHeight(*renderer, style) : launcherRowHeightEstimate(style);
+    m_grid->setCellHeight(listCellHeight);
+    if (renderer != nullptr) {
+      m_launcherRowHeight = listCellHeight;
+    }
     if (modeChanged) {
       m_grid->setAdapter(m_listAdapter.get());
     }


### PR DESCRIPTION
## Summary
Bind each result row to the tile's actual height instead of recomputing the row height independently, keeping row sizing consistent with the grid cell height.

## Motivation

List rows recomputed their own height independently of the grid cell height, and resized late after launch leaving selection/hover highlight boxes mismatched with the actual row bounds. Binding each row to the tile's actual height keeps sizing consistent, avoiding the post-launch resize and fixes the highlight boxes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3285 

## Testing

opened launcher to verify no post-launch resize and no overlap between selection/hover highlights

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/8b8c29ed-2d58-4b64-826b-2a7fe0d6d45f

<img width="2240" height="1400" alt="0068" src="https://github.com/user-attachments/assets/77fd4184-68c9-47f9-a02a-c68151f2ede9" />

<img width="2240" height="1400" alt="0676" src="https://github.com/user-attachments/assets/2c1e0ef2-d61b-4093-9e01-c14bf6fcd596" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x]  I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A