### PR TITLE
feat(wallpaper-next-prev): add next and previous to ipc msg

### DIFF
--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -224,7 +224,9 @@ namespace {
     return a.size() < b.size();
   }
 
-  std::string pickAlphabeticalWallpaperPath(std::vector<std::string> candidates, const std::string& currentPath) {
+  std::string pickAlphabeticalWallpaperPath(
+      std::vector<std::string> candidates, const std::string& currentPath, int direction = 1
+  ) {
     if (candidates.empty()) {
       return {};
     }
@@ -237,8 +239,10 @@ namespace {
     if (it == candidates.end()) {
       return candidates.front();
     }
+    const auto n = candidates.size();
     const auto idx = static_cast<std::size_t>(std::distance(candidates.begin(), it));
-    return candidates[(idx + 1) % candidates.size()];
+    const std::size_t step = (direction < 0) ? n - 1 : 1;
+    return candidates[(idx + step) % n];
   }
 
   std::string pickAutomationWallpaperPath(
@@ -748,13 +752,46 @@ void Wallpaper::registerIpc(IpcService& ipc) {
         if (!trimmed.empty()) {
           connector = trimmed;
         }
-        if (!switchToRandomWallpaper(connector)) {
+        if (!switchWallpaperTo(PickWallpaper::Random, connector)) {
           return "error: failed to pick a random wallpaper\n";
         }
         return "ok\n";
       },
       "wallpaper-random [<connector>]", "Switch to a random wallpaper immediately"
   );
+
+  ipc.registerHandler(
+      "wallpaper-next",
+      [this](const std::string& args) -> std::string {
+        const auto trimmed = StringUtils::trim(args);
+        std::optional<std::string_view> connector;
+        if (!trimmed.empty()) {
+          connector = trimmed;
+        }
+        if (!switchWallpaperTo(PickWallpaper::Next, connector)) {
+          return "error: failed to pick next wallpaper\n";
+        }
+        return "ok\n";
+      },
+      "wallpaper-next [<connector>]", "Switch to the next wallpaper immediately"
+  );
+
+  ipc.registerHandler(
+      "wallpaper-previous",
+      [this](const std::string& args) -> std::string {
+        const auto trimmed = StringUtils::trim(args);
+        std::optional<std::string_view> connector;
+        if (!trimmed.empty()) {
+          connector = trimmed;
+        }
+        if (!switchWallpaperTo(PickWallpaper::Previous, connector)) {
+          return "error: failed to pick previous wallpaper\n";
+        }
+        return "ok\n";
+      },
+      "wallpaper-previous [<connector>]", "Switch to the previous wallpaper immediately"
+  );
+
   ipc.registerHandler(
       "wallpaper-get",
       [this, validateOutputConnector](const std::string& args) -> std::string {
@@ -1060,7 +1097,7 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
   m_lastAutomationSwitchSecond = secondStamp;
 }
 
-bool Wallpaper::switchToRandomWallpaper(std::optional<std::string_view> connector) {
+bool Wallpaper::switchWallpaperTo(PickWallpaper action, std::optional<std::string_view> connector) {
   if (m_config == nullptr || !m_config->config().wallpaper.enabled || m_instances.empty()) {
     return false;
   }
@@ -1069,6 +1106,18 @@ bool Wallpaper::switchToRandomWallpaper(std::optional<std::string_view> connecto
   const ThemeMode mode = wallpaper.perMonitorDirectories
       ? (m_config->config().theme.mode == ThemeMode::Light ? ThemeMode::Light : ThemeMode::Dark)
       : ThemeMode::Dark;
+
+  const auto pick = [action](std::vector<std::string> candidates, const std::string& currentPath) -> std::string {
+    switch (action) {
+    case PickWallpaper::Random:
+      return pickRandomWallpaperPath(candidates, currentPath);
+    case PickWallpaper::Next:
+      return pickAlphabeticalWallpaperPath(std::move(candidates), currentPath, 1);
+    case PickWallpaper::Previous:
+      return pickAlphabeticalWallpaperPath(std::move(candidates), currentPath, -1);
+    }
+    return {};
+  };
 
   if (connector.has_value()) {
     if (m_wayland != nullptr) {
@@ -1109,7 +1158,7 @@ bool Wallpaper::switchToRandomWallpaper(std::optional<std::string_view> connecto
       return false;
     }
     const std::string currentPath = m_config->getWallpaperPath(std::string(*connector));
-    const std::string picked = pickRandomWallpaperPath(candidates, currentPath);
+    const std::string picked = pick(std::move(candidates), currentPath);
     if (picked.empty() || picked == currentPath) {
       return false;
     }
@@ -1143,7 +1192,7 @@ bool Wallpaper::switchToRandomWallpaper(std::optional<std::string_view> connecto
         continue;
       }
       const std::string currentPath = m_config->getWallpaperPath(inst->connectorName);
-      const std::string picked = pickRandomWallpaperPath(candidates, currentPath);
+      const std::string picked = pick(std::move(candidates), currentPath);
       if (picked.empty() || picked == currentPath) {
         continue;
       }
@@ -1157,7 +1206,7 @@ bool Wallpaper::switchToRandomWallpaper(std::optional<std::string_view> connecto
     collectWallpaperCandidates(dir, wallpaper.automation.recursive, candidates);
     if (!candidates.empty()) {
       const std::string currentDefault = m_config->getDefaultWallpaperPath();
-      const std::string picked = pickRandomWallpaperPath(candidates, currentDefault);
+      const std::string picked = pick(std::move(candidates), currentDefault);
       if (!picked.empty()) {
         for (const auto& inst : m_instances) {
           if (!inst->connectorName.empty()) {

--- a/src/shell/wallpaper/wallpaper.h
+++ b/src/shell/wallpaper/wallpaper.h
@@ -67,6 +67,12 @@ private:
     Redirected,
   };
 
+  enum class PickWallpaper {
+    Random,
+    Previous,
+    Next,
+  };
+
   [[nodiscard]] bool isConnectorKnown(std::string_view connector) const;
   // Persist a resolved image path to a single connector, or to every connected
   // output plus the default when no connector is given.
@@ -77,7 +83,7 @@ private:
   void resetAutomationState();
   void runAutomation(std::int64_t secondStamp);
   [[nodiscard]] bool automationAllowed() const noexcept;
-  [[nodiscard]] bool switchToRandomWallpaper(std::optional<std::string_view> connector = std::nullopt);
+  [[nodiscard]] bool switchWallpaperTo(PickWallpaper action, std::optional<std::string_view> connector = std::nullopt);
   void createInstance(const WaylandOutput& output);
   [[nodiscard]] TextureHandle acquireTexture(const std::string& path);
   void releaseTexture(TextureHandle& handle, const std::string& path);


### PR DESCRIPTION
## Summary

Added 2 IPC messages:  `wallpaper-next` and `wallpaper-previous` 

`wallpaper-next`: Changes the wallpaper to the next based on alphabetical order
`wallpaper-previous`: Changes the wallpaper to the previous based on alphabetical order

Along with this, while the message signatures have not changed I did edit the random function as to not have to repeat code. Random was already doing most of the work I needed as well as calling `pickAlphabeticalWallpaperPath` which already sorted and did an `index + 1`. To change this I renamed `switchToRandomWallaper` to `switchWallpaperTo` and added an enum of `Random, Next, Previous` as a private part of the class. this lets the logic mainly be wrapped into a simple switch lambda which just calls the function needed based on the provided `PickWallpaper` value.

This also keeps it readable as the function now looks like `switchWallpaperTo(PickWallpaper::Next, ...)` which I think is pretty nice.


## Motivation

#3289 Requested for the addition of both as a way to quickly swap between wallpapers, outside of the wallpaper panel. I thought this would be a pretty handy feature so I took a shot at it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

#3289 

## Testing

Ran inside of hyprland in debug and release mode and called the commands using.
- `noctalia msg wallpaper-next`
- `noctalia msg wallpaper-previous`
- `noctalia msg wallpaper-random`
All of which still worked as expected without issue.

## Manual Coverage


- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/0d4f2844-6dd7-4738-8c14-37fd5e438f8d

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The transition for all three  is a bit slow/memory intensive because its having to do IO, allocate a vector of strings, do some parsing and so on. Its not something load bearing so I don't think its at the top of the list, but it could have possible improvements in the future. 
