### PR TITLE
fix(wallpaper): prevent crash loop on directory or invalid paths

### DIFF
--- a/src/render/core/image_file_loader.cpp
+++ b/src/render/core/image_file_loader.cpp
@@ -498,6 +498,11 @@ loadImageFile(const std::string& path, int targetSize, bool centerSquareCrop) {
     });
   }
 
+  std::error_code ec;
+  if(!std::filesystem::is_regular_file(path, ec)) {
+     return std::unexpected("path is not a regular file");
+  }
+
   auto fileData = FileUtils::readBinaryFile(path);
   if (fileData.empty()) {
     return std::unexpected("failed to read image file");

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -112,7 +112,7 @@ namespace {
     }
     const std::filesystem::path resolved = FileUtils::resolvePath(path, callerCwd);
     std::error_code ec;
-    if (std::filesystem::exists(resolved, ec)) {
+    if (std::filesystem::is_regular_file(resolved, ec)) {
       return resolved.string();
     }
     return std::nullopt;
@@ -806,7 +806,7 @@ void Wallpaper::registerIpc(IpcService& ipc) {
         if (const auto path = resolveWallpaperPath(parsed.path, callerCwd); path.has_value()) {
           resolved = *path;
         } else {
-          return "error: path does not exist\n";
+          return "error: path does not exist or is not a regular file\n";
         }
 
         if (outputConnector.has_value()) {


### PR DESCRIPTION
## Summary

Validate wallpaper path arguments and introduce checks in the image file loader to prevent crashes.

## Motivation

Running `noctalia msg wallpaper-set .` or `noctalia msg wallpaper-set ~` succeeds the initial validation check because `std::filesystem::exists` returns `true` even for directories. It subsequently writes invalid configuration to settings.

During loading, the image loader attempts to parse the directory as an image file, causing a crash. Since this bad configuration state is loaded on startup, it makes starting impossible, unless you change the settings file manually.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

Checked that `noctalia msg wallpaper-set .` (and similar combinations) now fails on the client side with an error message and is not persisted to `settings.toml`.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A