### PR TITLE
feat(bar): concave edge corners

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1541,7 +1541,7 @@
           "description": "Bottom right corner radius for the bar"
         },
         "concave-edge-corners": {
-          "description": "Carve inward corners on the bar edge that touches the screen; requires Edge Margin to be 0",
+          "description": "Carve concave (inward-curving) corners into the bar; requires Edge Margin to be 0. With Ends Margin at 0 the inner corners are carved, otherwise the corners meeting the screen edge",
           "label": "Concave Edge Corners"
         },
         "corner-radius": {
@@ -1722,7 +1722,7 @@
           "description": "Background opacity of the dock"
         },
         "concave-edge-corners": {
-          "description": "Carve inward corners on the side that touches the screen edge; requires the margin to the screen edge to be 0",
+          "description": "Carve concave (inward-curving) corners into the bar; requires Edge Margin to be 0. With Ends Margin at 0 the inner corners are carved, otherwise the corners meeting the screen edge",
           "label": "Concave Edge Corners"
         },
         "corner-bottom-left": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1541,7 +1541,7 @@
           "description": "Bottom right corner radius for the bar"
         },
         "concave-edge-corners": {
-          "description": "Carve concave (inward-curving) corners into the bar; requires Edge Margin to be 0. With Ends Margin at 0 the inner corners are carved, otherwise the corners meeting the screen edge",
+          "description": "Carve concave notches into two of the bar's corners. Requires Edge Margin to be 0. With Ends Margin at 0, the corners on the bar's inner edge are carved; otherwise the corners touching the screen edge are carved.",
           "label": "Concave Edge Corners"
         },
         "corner-radius": {
@@ -1722,7 +1722,7 @@
           "description": "Background opacity of the dock"
         },
         "concave-edge-corners": {
-          "description": "Carve concave (inward-curving) corners into the bar; requires Edge Margin to be 0. With Ends Margin at 0 the inner corners are carved, otherwise the corners meeting the screen edge",
+          "description": "Carve concave (inward-curving) notches into two of the bar's corners. Requires Edge Margin to be 0. With Ends Margin at 0, the corners on the bar's inner edge are carved; otherwise the corners touching the screen edge are carved.",
           "label": "Concave Edge Corners"
         },
         "corner-bottom-left": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1535,19 +1535,23 @@
           "label": "Content Scale"
         },
         "corner-bottom-left": {
-          "description": "Bottom left corner radius for the bar. Enable invert to carve a concave corner, available only when this corner faces away from the screen edge"
+          "description": "Bottom left corner radius for the bar"
         },
         "corner-bottom-right": {
-          "description": "Bottom right corner radius for the bar. Enable invert to carve a concave corner, available only when this corner faces away from the screen edge"
+          "description": "Bottom right corner radius for the bar"
+        },
+        "concave-edge-corners": {
+          "description": "Carve inward corners on the bar edge that touches the screen; requires Edge Margin to be 0",
+          "label": "Concave Edge Corners"
         },
         "corner-radius": {
           "description": "Corner radius of the bar"
         },
         "corner-top-left": {
-          "description": "Top left corner radius for the bar. Enable invert to carve a concave corner, available only when this corner faces away from the screen edge"
+          "description": "Top left corner radius for the bar"
         },
         "corner-top-right": {
-          "description": "Top right corner radius for the bar. Enable invert to carve a concave corner, available only when this corner faces away from the screen edge"
+          "description": "Top right corner radius for the bar"
         },
         "dead-zone-command": {
           "description": "Shell command to run on left-click in the bar margin outside widget sections",

--- a/src/compositors/mango/mango_workspace_backend.cpp
+++ b/src/compositors/mango/mango_workspace_backend.cpp
@@ -159,7 +159,7 @@ std::vector<Workspace> MangoWorkspaceBackend::forOutput(wl_output* output) const
 
   std::vector<Workspace> result;
   result.reserve(state->tags.size());
-  for (const TagInfo& tag : state->tags) {
+  for (const std::uint32_t tag : state->tags) {
     result.push_back(makeWorkspace(tag));
   }
   return result;

--- a/src/compositors/mango/mango_workspace_backend.cpp
+++ b/src/compositors/mango/mango_workspace_backend.cpp
@@ -159,7 +159,7 @@ std::vector<Workspace> MangoWorkspaceBackend::forOutput(wl_output* output) const
 
   std::vector<Workspace> result;
   result.reserve(state->tags.size());
-  for (const std::uint32_t tag : state->tags) {
+  for (const TagInfo& tag : state->tags) {
     result.push_back(makeWorkspace(tag));
   }
   return result;

--- a/src/compositors/mango/mango_workspace_backend.cpp
+++ b/src/compositors/mango/mango_workspace_backend.cpp
@@ -159,8 +159,8 @@ std::vector<Workspace> MangoWorkspaceBackend::forOutput(wl_output* output) const
 
   std::vector<Workspace> result;
   result.reserve(state->tags.size());
-  for (std::size_t i = 0; i < state->tags.size(); ++i) {
-    result.push_back(makeWorkspace(state->tags[i]));
+  for (const auto& tag : state->tags) {
+    result.push_back(makeWorkspace(tag));
   }
   return result;
 }

--- a/src/config/config_export.cpp
+++ b/src/config/config_export.cpp
@@ -119,6 +119,8 @@ namespace config_export {
         resolved.radiusBottomLeft = *ovr.radiusBottomLeft;
       if (ovr.radiusBottomRight)
         resolved.radiusBottomRight = *ovr.radiusBottomRight;
+      if (ovr.concaveEdgeCorners)
+        resolved.concaveEdgeCorners = *ovr.concaveEdgeCorners;
       if (ovr.marginEnds)
         resolved.marginEnds = *ovr.marginEnds;
       if (ovr.marginEdge)

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -201,6 +201,9 @@ namespace {
     if (ovr.radiusBottomRight) {
       resolved.radiusBottomRight = *ovr.radiusBottomRight;
     }
+    if (ovr.concaveEdgeCorners) {
+      resolved.concaveEdgeCorners = *ovr.concaveEdgeCorners;
+    }
     if (ovr.marginEnds) {
       resolved.marginEnds = *ovr.marginEnds;
     }

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -865,6 +865,8 @@ BarConfig ConfigService::resolveForOutput(const BarConfig& base, const WaylandOu
       resolved.radiusBottomLeft = *ovr.radiusBottomLeft;
     if (ovr.radiusBottomRight)
       resolved.radiusBottomRight = *ovr.radiusBottomRight;
+    if (ovr.concaveEdgeCorners)
+      resolved.concaveEdgeCorners = *ovr.concaveEdgeCorners;
     if (ovr.marginEnds)
       resolved.marginEnds = *ovr.marginEnds;
     if (ovr.marginEdge)

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -71,6 +71,7 @@ struct BarMonitorOverride {
   std::optional<std::int32_t> radiusTopRight;
   std::optional<std::int32_t> radiusBottomLeft;
   std::optional<std::int32_t> radiusBottomRight;
+  std::optional<bool> concaveEdgeCorners;
   std::optional<std::int32_t> marginEnds;         // inset from each end of the bar along its main axis
   std::optional<std::int32_t> marginEdge;         // distance from the nearest screen edge (floats the bar when > 0)
   std::optional<std::int32_t> marginOppositeEdge; // extra reserved space on the inward side of the bar
@@ -130,6 +131,7 @@ struct BarConfig {
   std::int32_t radiusTopRight = static_cast<std::int32_t>(Style::radiusXl);
   std::int32_t radiusBottomLeft = static_cast<std::int32_t>(Style::radiusXl);
   std::int32_t radiusBottomRight = static_cast<std::int32_t>(Style::radiusXl);
+  bool concaveEdgeCorners = false;
   std::int32_t marginEnds = 180;       // inset from each end of the bar along its main axis
   std::int32_t marginEdge = 10;        // distance from the nearest screen edge (floats the bar when > 0)
   std::int32_t marginOppositeEdge = 0; // extra reserved space on the inward side of the bar

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1673,10 +1673,7 @@ namespace noctalia::config::schema {
     // optional BarMonitorOverride fields — declared once so the two schemas can't
     // drift apart.
     constexpr Range<std::int64_t> kBarThicknessRange{10, 300};
-    // Negative corner radius marks a concave corner of magnitude |value|; positive
-    // is the usual convex rounding. Only the two corners on the bar's inner edge
-    // (away from the screen) render a concave spike.
-    constexpr Range<std::int64_t> kBarRadiusRange{-500, 500};
+    constexpr Range<std::int64_t> kBarRadiusRange{0, 500};
     constexpr Range<std::int64_t> kBarPanelOverlapRange{-2, 3};
     constexpr Range<float> kBarCapsuleThicknessRange{0.1f, 1.0f};
     constexpr Range<float> kBarOpacityRange{0.0f, 1.0f};
@@ -2008,6 +2005,7 @@ namespace noctalia::config::schema {
         field(&BarConfig::radiusTopRight, "radius_top_right", kBarRadiusRange),
         field(&BarConfig::radiusBottomLeft, "radius_bottom_left", kBarRadiusRange),
         field(&BarConfig::radiusBottomRight, "radius_bottom_right", kBarRadiusRange),
+        field(&BarConfig::concaveEdgeCorners, "concave_edge_corners"),
         field(&BarConfig::marginEnds, "margin_ends"),
         field(&BarConfig::marginEdge, "margin_edge"),
         field(&BarConfig::marginOppositeEdge, "margin_opposite_edge"),
@@ -2077,6 +2075,7 @@ namespace noctalia::config::schema {
         optionalIntField(&BarMonitorOverride::radiusTopRight, "radius_top_right", kBarRadiusRange),
         optionalIntField(&BarMonitorOverride::radiusBottomLeft, "radius_bottom_left", kBarRadiusRange),
         optionalIntField(&BarMonitorOverride::radiusBottomRight, "radius_bottom_right", kBarRadiusRange),
+        optionalBoolField(&BarMonitorOverride::concaveEdgeCorners, "concave_edge_corners"),
         optionalIntField(&BarMonitorOverride::marginEnds, "margin_ends"),
         optionalIntField(&BarMonitorOverride::marginEdge, "margin_edge"),
         optionalIntField(&BarMonitorOverride::marginOppositeEdge, "margin_opposite_edge"),

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -91,7 +91,7 @@ namespace {
     float innerBulge = 0.0f; // px the surface/box grow on the inner edge
   };
 
-  [[nodiscard]] BarConcaveShape barConcaveShape(const BarConfig& cfg, std::int32_t desktopCornerSize) {
+  [[nodiscard]] BarConcaveShape barConcaveShape(const BarConfig& cfg) {
     const auto radius = [](std::int32_t v) { return static_cast<float>(std::max<std::int32_t>(0, v)); };
     const auto cappedRadius = [&](std::int32_t v) {
       return std::min(static_cast<float>(cfg.thickness) * 0.5f, radius(v));
@@ -148,43 +148,34 @@ namespace {
       return g;
     }
 
-    // Screen-edge concavity: inset bar carves the corners touching the screen edge.
-    const std::int32_t desktopCorner = std::max<std::int32_t>(0, desktopCornerSize);
-    std::int32_t edgeThreshold = 0;
+    // Screen-edge concavity: the bar flares outward into its end margins to meet
+    // the screen edge. Each concave corner consumes its radius of that margin, so
+    // scale the carve to the room available — radius, half-thickness, and
+    // margin_ends — and keep radii and inset identical so the drawn arc matches
+    // the reserved flare instead of overflowing it.
+    const float endRoom = radius(cfg.marginEnds);
+    const auto carve = [&](std::int32_t v) { return std::min(cappedRadius(v), endRoom); };
     const std::string_view pos = cfg.position;
     if (pos == "bottom") {
-      edgeThreshold = std::max(cfg.radiusBottomLeft, cfg.radiusBottomRight) + desktopCorner;
-    } else if (pos == "left") {
-      edgeThreshold = std::max(cfg.radiusTopLeft, cfg.radiusBottomLeft) + desktopCorner;
-    } else if (pos == "right") {
-      edgeThreshold = std::max(cfg.radiusTopRight, cfg.radiusBottomRight) + desktopCorner;
-    } else { // top
-      edgeThreshold = std::max(cfg.radiusTopLeft, cfg.radiusTopRight) + desktopCorner;
-    }
-    if (cfg.marginEnds <= edgeThreshold) {
-      return g;
-    }
-
-    if (pos == "bottom") {
       g.corners.bl = CornerShape::Concave;
       g.corners.br = CornerShape::Concave;
-      g.logicalInset.left = cappedRadius(cfg.radiusBottomLeft);
-      g.logicalInset.right = cappedRadius(cfg.radiusBottomRight);
+      g.radii.bl = g.logicalInset.left = carve(cfg.radiusBottomLeft);
+      g.radii.br = g.logicalInset.right = carve(cfg.radiusBottomRight);
     } else if (pos == "left") {
       g.corners.tl = CornerShape::Concave;
       g.corners.bl = CornerShape::Concave;
-      g.logicalInset.top = cappedRadius(cfg.radiusTopLeft);
-      g.logicalInset.bottom = cappedRadius(cfg.radiusBottomLeft);
+      g.radii.tl = g.logicalInset.top = carve(cfg.radiusTopLeft);
+      g.radii.bl = g.logicalInset.bottom = carve(cfg.radiusBottomLeft);
     } else if (pos == "right") {
       g.corners.tr = CornerShape::Concave;
       g.corners.br = CornerShape::Concave;
-      g.logicalInset.top = cappedRadius(cfg.radiusTopRight);
-      g.logicalInset.bottom = cappedRadius(cfg.radiusBottomRight);
+      g.radii.tr = g.logicalInset.top = carve(cfg.radiusTopRight);
+      g.radii.br = g.logicalInset.bottom = carve(cfg.radiusBottomRight);
     } else { // top
       g.corners.tl = CornerShape::Concave;
       g.corners.tr = CornerShape::Concave;
-      g.logicalInset.left = cappedRadius(cfg.radiusTopLeft);
-      g.logicalInset.right = cappedRadius(cfg.radiusTopRight);
+      g.radii.tl = g.logicalInset.left = carve(cfg.radiusTopLeft);
+      g.radii.tr = g.logicalInset.right = carve(cfg.radiusTopRight);
     }
 
     return g;
@@ -617,9 +608,8 @@ namespace {
     std::int32_t exclusiveZone = 0;
   };
 
-  [[nodiscard]] BarSurfaceSpec computeBarSurfaceSpec(
-      const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig, std::int32_t desktopCornerSize
-  ) {
+  [[nodiscard]] BarSurfaceSpec
+  computeBarSurfaceSpec(const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig) {
     const bool vertical = (barConfig.position == "left" || barConfig.position == "right");
     const bool isBottom = barConfig.position == "bottom";
     const bool isRight = barConfig.position == "right";
@@ -627,7 +617,7 @@ namespace {
     const std::int32_t mEdge = barConfig.marginEdge;
     const auto sb = shell::surface_shadow::bleed(barConfig.shadow, shadowConfig);
     const int edgeGutter = barAutoHideEdgeGutter(barConfig);
-    const auto concave = barConcaveShape(barConfig, desktopCornerSize);
+    const auto concave = barConcaveShape(barConfig);
     const int insetL = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.left)));
     const int insetT = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.top)));
     const int insetR = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.right)));
@@ -689,10 +679,9 @@ namespace {
   }
 
   [[nodiscard]] float barInnerSurfaceExtension(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, float surfaceWidth,
-      float surfaceHeight
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceWidth, float surfaceHeight
   ) {
-    const auto base = computeBarSurfaceSpec(cfg, shadow, desktopCornerSize);
+    const auto base = computeBarSurfaceSpec(cfg, shadow);
     const bool isVertical = (cfg.position == "left" || cfg.position == "right");
     const float current = isVertical ? surfaceWidth : surfaceHeight;
     const auto normal = static_cast<float>(isVertical ? base.surfaceWidth : base.surfaceHeight);
@@ -752,8 +741,8 @@ namespace {
   }
 
   BarVisualGeometry computeBarVisualGeometry(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, float surfaceWidth,
-      float surfaceHeight, float innerSurfaceExtension = 0.0f
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceWidth, float surfaceHeight,
+      float innerSurfaceExtension = 0.0f
   ) {
     const auto barThickness = static_cast<float>(cfg.thickness);
     const auto marginEnds = static_cast<float>(cfg.marginEnds);
@@ -762,7 +751,7 @@ namespace {
     const bool isRight = cfg.position == "right";
     const bool isVertical = (cfg.position == "left" || cfg.position == "right");
     const auto sbi = shell::surface_shadow::bleed(cfg.shadow, shadow);
-    const auto concave = barConcaveShape(cfg, desktopCornerSize);
+    const auto concave = barConcaveShape(cfg);
     const float insetL = std::ceil(std::max(0.0f, concave.logicalInset.left));
     const float insetT = std::ceil(std::max(0.0f, concave.logicalInset.top));
     const float insetR = std::ceil(std::max(0.0f, concave.logicalInset.right));
@@ -821,14 +810,12 @@ namespace {
     };
   }
 
-  [[nodiscard]] InputRect barContentInputRegion(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, int surfW,
-      int surfH
-  ) {
+  [[nodiscard]] InputRect
+  barContentInputRegion(const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, int surfW, int surfH) {
     const float innerSurfaceExtension =
-        barInnerSurfaceExtension(cfg, shadow, desktopCornerSize, static_cast<float>(surfW), static_cast<float>(surfH));
+        barInnerSurfaceExtension(cfg, shadow, static_cast<float>(surfW), static_cast<float>(surfH));
     const auto barVisual = computeBarVisualGeometry(
-        cfg, shadow, desktopCornerSize, static_cast<float>(surfW), static_cast<float>(surfH), innerSurfaceExtension
+        cfg, shadow, static_cast<float>(surfW), static_cast<float>(surfH), innerSurfaceExtension
     );
     return InputRect{
         static_cast<int>(barVisual.x), static_cast<int>(barVisual.y), static_cast<int>(barVisual.width),
@@ -854,19 +841,17 @@ namespace {
   }
 
   void applyBarShadowStyle(
-      BarInstance& instance, const ShellConfig::ShadowConfig& shadowConfig, std::int32_t desktopCornerSize,
-      float surfaceWidth, float surfaceHeight
+      BarInstance& instance, const ShellConfig::ShadowConfig& shadowConfig, float surfaceWidth, float surfaceHeight
   ) {
     if (instance.shadow == nullptr) {
       return;
     }
 
-    const auto concave = barConcaveShape(instance.barConfig, desktopCornerSize);
+    const auto concave = barConcaveShape(instance.barConfig);
     const float innerSurfaceExtension =
-        barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight);
-    const auto barVisual = computeBarVisualGeometry(
-        instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight, innerSurfaceExtension
-    );
+        barInnerSurfaceExtension(instance.barConfig, shadowConfig, surfaceWidth, surfaceHeight);
+    const auto barVisual =
+        computeBarVisualGeometry(instance.barConfig, shadowConfig, surfaceWidth, surfaceHeight, innerSurfaceExtension);
     // Shadow follows the same shape as the background: the body expanded outward by
     // the concave inset into the visual rect, so concave spikes cast a matching shadow.
     const float barAreaW = barVisual.width + concave.logicalInset.left + concave.logicalInset.right;
@@ -1876,9 +1861,8 @@ void Bar::setAttachedPanelGeometry(
 
   instance->attachedPanelGeometry = geometry;
   if (instance->surface != nullptr && instance->surface->width() > 0 && instance->surface->height() > 0) {
-    const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
     applyBarShadowStyle(
-        *instance, m_config->config().shell.shadow, desktopCornerSize, static_cast<float>(instance->surface->width()),
+        *instance, m_config->config().shell.shadow, static_cast<float>(instance->surface->width()),
         static_cast<float>(instance->surface->height())
     );
     instance->surface->requestRedraw();
@@ -2034,8 +2018,7 @@ void Bar::createInstance(const WaylandOutput& output, std::size_t barIndex, cons
   instance->barIndex = barIndex;
 
   const auto anchor = positionToAnchor(barConfig.position);
-  const auto surfaceSpec =
-      computeBarSurfaceSpec(barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size);
+  const auto surfaceSpec = computeBarSurfaceSpec(barConfig, m_config->config().shell.shadow);
 
   kLog.info(
       "creating #{} \"{}\" on {} ({}), thickness={} position={} reserve_space={} exclusive_zone={}", barIndex,
@@ -2612,9 +2595,9 @@ void Bar::syncBarAutoHideInputRegion(BarInstance& instance) const {
     instance.surface->setInputRegion(barAutoHideSurfaceInputRegion(instance.barConfig, surfW, surfH, fullSurface));
     return;
   }
-  instance.surface->setInputRegion({barContentInputRegion(
-      instance.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size, surfW, surfH
-  )});
+  instance.surface->setInputRegion(
+      {barContentInputRegion(instance.barConfig, m_config->config().shell.shadow, surfW, surfH)}
+  );
 }
 
 void Bar::revealAutoHideBar(BarInstance& instance) {
@@ -2692,7 +2675,7 @@ void Bar::applyBarCompositorBlur(BarInstance& instance) const {
   const int py = static_cast<int>(std::lround(absY));
   const int pw = static_cast<int>(std::lround(std::max(0.0f, instance.bg->width())));
   const int ph = static_cast<int>(std::lround(std::max(0.0f, instance.bg->height())));
-  const auto concave = barConcaveShape(instance.barConfig, m_config->config().shell.screenCorners.size);
+  const auto concave = barConcaveShape(instance.barConfig);
   // The bg node is the visual rect; tessellateShape expects the body rect and
   // expands it outward by logicalInset itself. With all-convex corners and no
   // inset it takes its own fast path down to a plain rounded rect.
@@ -2747,7 +2730,6 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const auto widgetSpacing = static_cast<float>(instance.barConfig.widgetSpacing);
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
   const auto shadowOffset = shadowDirectionOffset(shadowConfig.direction);
   const float shadowSize = shell::surface_shadow::enabled(instance.barConfig.shadow, shadowConfig)
       ? static_cast<float>(shell::surface_shadow::kBlurRadius)
@@ -2757,12 +2739,10 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
   const bool isBottom = instance.barConfig.position == "bottom";
   const bool isRight = instance.barConfig.position == "right";
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
-  const auto concave = barConcaveShape(instance.barConfig, desktopCornerSize);
+  const auto concave = barConcaveShape(instance.barConfig);
 
-  const float innerSurfaceExtension =
-      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
-  const auto barVisual =
-      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
+  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
+  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
   const float barAreaX = barVisual.x;
   const float barAreaY = barVisual.y;
   const float barAreaW = barVisual.width;
@@ -2902,7 +2882,7 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
     instance.contentClip->setSize(barAreaW, barAreaH);
   }
 
-  applyBarShadowStyle(instance, shadowConfig, desktopCornerSize, w, h);
+  applyBarShadowStyle(instance, shadowConfig, w, h);
 
   layoutBarSections(instance, *renderer, barAreaW, barAreaH, padding, isVertical);
 
@@ -2946,11 +2926,8 @@ void Bar::updateWidgets(BarInstance& instance) {
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
-  const float innerSurfaceExtension =
-      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
-  const auto barVisual =
-      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
+  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
+  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 
@@ -2992,11 +2969,8 @@ void Bar::prepareFrame(BarInstance& instance, bool needsUpdate, bool needsLayout
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
-  const float innerSurfaceExtension =
-      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
-  const auto barVisual =
-      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
+  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
+  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 
@@ -3491,9 +3465,7 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
       if (inst.surface == nullptr) {
         return;
       }
-      const auto spec = computeBarSurfaceSpec(
-          inst.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size
-      );
+      const auto spec = computeBarSurfaceSpec(inst.barConfig, m_config->config().shell.shadow);
       inst.surface->setMargins(spec.marginTop, spec.marginRight, spec.marginBottom, spec.marginLeft);
       inst.surface->requestSize(spec.surfaceWidth, spec.surfaceHeight);
     };

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -616,8 +616,7 @@ namespace {
     std::int32_t exclusiveZone = 0;
   };
 
-  [[nodiscard]] BarSurfaceSpec
-  computeBarSurfaceSpec(
+  [[nodiscard]] BarSurfaceSpec computeBarSurfaceSpec(
       const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig, std::int32_t desktopCornerSize
   ) {
     const bool vertical = (barConfig.position == "left" || barConfig.position == "right");
@@ -752,8 +751,8 @@ namespace {
   }
 
   BarVisualGeometry computeBarVisualGeometry(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize,
-      float surfaceWidth, float surfaceHeight, float innerSurfaceExtension = 0.0f
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, float surfaceWidth,
+      float surfaceHeight, float innerSurfaceExtension = 0.0f
   ) {
     const auto barThickness = static_cast<float>(cfg.thickness);
     const auto marginEnds = static_cast<float>(cfg.marginEnds);
@@ -821,8 +820,7 @@ namespace {
     };
   }
 
-  [[nodiscard]] InputRect
-  barContentInputRegion(
+  [[nodiscard]] InputRect barContentInputRegion(
       const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, int surfW,
       int surfH
   ) {
@@ -865,10 +863,9 @@ namespace {
     const auto concave = barConcaveShape(instance.barConfig, desktopCornerSize);
     const float innerSurfaceExtension =
         barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight);
-    const auto barVisual =
-        computeBarVisualGeometry(
-            instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight, innerSurfaceExtension
-        );
+    const auto barVisual = computeBarVisualGeometry(
+        instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight, innerSurfaceExtension
+    );
     // Shadow follows the same shape as the background: the body expanded outward by
     // the concave inset into the visual rect, so concave spikes cast a matching shadow.
     const float barAreaW = barVisual.width + concave.logicalInset.left + concave.logicalInset.right;
@@ -2614,12 +2611,9 @@ void Bar::syncBarAutoHideInputRegion(BarInstance& instance) const {
     instance.surface->setInputRegion(barAutoHideSurfaceInputRegion(instance.barConfig, surfW, surfH, fullSurface));
     return;
   }
-  instance.surface->setInputRegion(
-      {barContentInputRegion(
-          instance.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size, surfW,
-          surfH
-      )}
-  );
+  instance.surface->setInputRegion({barContentInputRegion(
+      instance.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size, surfW, surfH
+  )});
 }
 
 void Bar::revealAutoHideBar(BarInstance& instance) {
@@ -2698,15 +2692,21 @@ void Bar::applyBarCompositorBlur(BarInstance& instance) const {
   const int pw = static_cast<int>(std::lround(std::max(0.0f, instance.bg->width())));
   const int ph = static_cast<int>(std::lround(std::max(0.0f, instance.bg->height())));
   const auto concave = barConcaveShape(instance.barConfig, m_config->config().shell.screenCorners.size);
-  const bool anyConcave = concave.corners.tl == CornerShape::Concave || concave.corners.tr == CornerShape::Concave
-      || concave.corners.br == CornerShape::Concave || concave.corners.bl == CornerShape::Concave;
-  const bool anyInset = concave.logicalInset.left > 0.0f || concave.logicalInset.top > 0.0f
-      || concave.logicalInset.right > 0.0f || concave.logicalInset.bottom > 0.0f;
+  const bool anyConcave = concave.corners.tl == CornerShape::Concave
+      || concave.corners.tr == CornerShape::Concave
+      || concave.corners.br == CornerShape::Concave
+      || concave.corners.bl == CornerShape::Concave;
+  const bool anyInset = concave.logicalInset.left > 0.0f
+      || concave.logicalInset.top > 0.0f
+      || concave.logicalInset.right > 0.0f
+      || concave.logicalInset.bottom > 0.0f;
 
   // Fast-path: the common all-convex/no-inset case is a plain rounded rect.
   if (!anyConcave && !anyInset) {
     instance.surface->setBlurRegion(
-        Surface::tessellateRoundedRect(px, py, pw, ph, concave.radii.tl, concave.radii.tr, concave.radii.br, concave.radii.bl)
+        Surface::tessellateRoundedRect(
+            px, py, pw, ph, concave.radii.tl, concave.radii.tr, concave.radii.br, concave.radii.bl
+        )
     );
     return;
   }
@@ -2966,9 +2966,8 @@ void Bar::updateWidgets(BarInstance& instance) {
   const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
   const float innerSurfaceExtension =
       barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
-  const auto barVisual = computeBarVisualGeometry(
-      instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension
-  );
+  const auto barVisual =
+      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 
@@ -3013,9 +3012,8 @@ void Bar::prepareFrame(BarInstance& instance, bool needsUpdate, bool needsLayout
   const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
   const float innerSurfaceExtension =
       barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
-  const auto barVisual = computeBarVisualGeometry(
-      instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension
-  );
+  const auto barVisual =
+      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2698,9 +2698,21 @@ void Bar::applyBarCompositorBlur(BarInstance& instance) const {
   const int pw = static_cast<int>(std::lround(std::max(0.0f, instance.bg->width())));
   const int ph = static_cast<int>(std::lround(std::max(0.0f, instance.bg->height())));
   const auto concave = barConcaveShape(instance.barConfig, m_config->config().shell.screenCorners.size);
+  const bool anyConcave = concave.corners.tl == CornerShape::Concave || concave.corners.tr == CornerShape::Concave
+      || concave.corners.br == CornerShape::Concave || concave.corners.bl == CornerShape::Concave;
+  const bool anyInset = concave.logicalInset.left > 0.0f || concave.logicalInset.top > 0.0f
+      || concave.logicalInset.right > 0.0f || concave.logicalInset.bottom > 0.0f;
+
+  // Fast-path: the common all-convex/no-inset case is a plain rounded rect.
+  if (!anyConcave && !anyInset) {
+    instance.surface->setBlurRegion(
+        Surface::tessellateRoundedRect(px, py, pw, ph, concave.radii.tl, concave.radii.tr, concave.radii.br, concave.radii.bl)
+    );
+    return;
+  }
+
   // The bg node is the visual rect; tessellateShape expects the body rect and
-  // expands it outward by logicalInset itself. With all-convex corners this is the
-  // plain rounded rect.
+  // expands it outward by logicalInset itself.
   const int insetL = static_cast<int>(std::lround(concave.logicalInset.left));
   const int insetT = static_cast<int>(std::lround(concave.logicalInset.top));
   const int insetR = static_cast<int>(std::lround(concave.logicalInset.right));

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -627,16 +627,21 @@ namespace {
     const std::int32_t mEdge = barConfig.marginEdge;
     const auto sb = shell::surface_shadow::bleed(barConfig.shadow, shadowConfig);
     const int edgeGutter = barAutoHideEdgeGutter(barConfig);
+    const auto concave = barConcaveShape(barConfig, desktopCornerSize);
+    const int insetL = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.left)));
+    const int insetT = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.top)));
+    const int insetR = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.right)));
+    const int insetB = static_cast<int>(std::ceil(std::max(0.0f, concave.logicalInset.bottom)));
     // Reserve room for a concave-corner spike on the inner edge (opaque bar material),
     // in addition to the shadow bleed that renders beyond the spike tips.
-    const int concaveBulge = static_cast<int>(std::lround(barConcaveShape(barConfig, desktopCornerSize).innerBulge));
+    const int concaveBulge = static_cast<int>(std::lround(concave.innerBulge));
 
     const std::int32_t edgeMargin = barEdgeLayerMargin(barConfig, shadowConfig);
 
     BarSurfaceSpec spec;
     if (!vertical) {
-      spec.marginLeft = std::max(0, mEnds - sb.left);
-      spec.marginRight = std::max(0, mEnds - sb.right);
+      spec.marginLeft = std::max(0, mEnds - sb.left - insetL);
+      spec.marginRight = std::max(0, mEnds - sb.right - insetR);
       if (isBottom) {
         if (edgeGutter > 0) {
           // Surface reaches the screen edge (no layer margin); the margin is folded
@@ -658,8 +663,8 @@ namespace {
         }
       }
     } else {
-      spec.marginTop = std::max(0, mEnds - sb.up);
-      spec.marginBottom = std::max(0, mEnds - sb.down);
+      spec.marginTop = std::max(0, mEnds - sb.up - insetT);
+      spec.marginBottom = std::max(0, mEnds - sb.down - insetB);
       if (isRight) {
         if (edgeGutter > 0) {
           spec.surfaceWidth = static_cast<std::uint32_t>(sb.left + concaveBulge + barConfig.thickness + edgeGutter);
@@ -757,6 +762,11 @@ namespace {
     const bool isRight = cfg.position == "right";
     const bool isVertical = (cfg.position == "left" || cfg.position == "right");
     const auto sbi = shell::surface_shadow::bleed(cfg.shadow, shadow);
+    const auto concave = barConcaveShape(cfg, desktopCornerSize);
+    const float insetL = std::ceil(std::max(0.0f, concave.logicalInset.left));
+    const float insetT = std::ceil(std::max(0.0f, concave.logicalInset.top));
+    const float insetR = std::ceil(std::max(0.0f, concave.logicalInset.right));
+    const float insetB = std::ceil(std::max(0.0f, concave.logicalInset.bottom));
     const auto bleedLeft = static_cast<float>(sbi.left);
     const auto bleedRight = static_cast<float>(sbi.right);
     const auto bleedUp = static_cast<float>(sbi.up);
@@ -765,11 +775,11 @@ namespace {
     // pushes the body inward by its bulge. Top/left bars grow away from the origin
     // and need no body shift. Gutter (auto-hide) placements derive from the surface
     // size, which already includes the bulge, so they shift automatically.
-    const float concaveBulge = barConcaveShape(cfg, desktopCornerSize).innerBulge;
+    const float concaveBulge = concave.innerBulge;
 
     if (isVertical) {
       // Vertical bar: edge gap is left/right, ends inset is top/bottom.
-      const float y = std::min(marginEnds, bleedUp);
+      const float y = std::min(marginEnds, bleedUp) + insetT;
       float x = isRight ? (bleedLeft + concaveBulge) : std::min(marginEdge, bleedLeft);
       if (const int gutter = barAutoHideEdgeGutter(cfg); gutter > 0) {
         // The gutter equals marginEdge and sits between the screen edge and the bar.
@@ -787,12 +797,12 @@ namespace {
           .x = x,
           .y = y,
           .width = barThickness,
-          .height = surfaceHeight - y - std::min(marginEnds, bleedDown),
+          .height = surfaceHeight - y - std::min(marginEnds, bleedDown) - insetB,
       };
     }
 
     // Horizontal bar: edge gap is top/bottom, ends inset is left/right.
-    const float x = std::min(marginEnds, bleedLeft);
+    const float x = std::min(marginEnds, bleedLeft) + insetL;
     float y = isBottom ? (bleedUp + concaveBulge) : std::min(marginEdge, bleedUp);
     if (const int gutter = barAutoHideEdgeGutter(cfg); gutter > 0) {
       if (isBottom) {
@@ -806,7 +816,7 @@ namespace {
     return {
         .x = x,
         .y = y,
-        .width = surfaceWidth - x - std::min(marginEnds, bleedRight),
+        .width = surfaceWidth - x - std::min(marginEnds, bleedRight) - insetR,
         .height = barThickness,
     };
   }

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -77,12 +77,13 @@ namespace {
     return cfg.marginEdge;
   }
 
-  // Concave bar shape modes:
-  // - Inner-edge mode (legacy bar behavior): enabled when concave_edge_corners is on
-  //   and both margin_edge and margin_ends are zero.
-  // - Screen-edge mode (dock-like): enabled when concave_edge_corners is on,
-  //   margin_edge is zero, and margin_ends exceeds the edge-facing corner radius
-  //   plus desktop screen-corner size.
+  // concave_edge_corners carves concave corners on one of the bar's two long
+  // edges, chosen by the margin configuration (both require margin_edge == 0):
+  // - Inner-edge: full-length bar (margin_ends == 0). Carves the corners on the
+  //   edge facing away from the screen.
+  // - Screen-edge: bar inset from its ends (margin_ends exceeds the edge-facing
+  //   corner radius plus the screen-corner size). Carves the corners on the edge
+  //   touching the screen.
   struct BarConcaveShape {
     CornerShapes corners{};
     Radii radii;
@@ -110,7 +111,7 @@ namespace {
 
     const BarConcaveCorners inner = barInnerEdgeCorners(cfg.position);
 
-    // Mode A: margin_edge == 0 && margin_ends == 0 -> legacy inner-edge concavity.
+    // Inner-edge concavity: full-length bar carves the corners on the inner edge.
     if (cfg.marginEnds == 0) {
       g.corners = CornerShapes{
           .tl = inner.topLeft ? CornerShape::Concave : CornerShape::Convex,
@@ -147,7 +148,7 @@ namespace {
       return g;
     }
 
-    // Mode B: dock-like concavity on screen-edge corners.
+    // Screen-edge concavity: inset bar carves the corners touching the screen edge.
     const std::int32_t desktopCorner = std::max<std::int32_t>(0, desktopCornerSize);
     std::int32_t edgeThreshold = 0;
     const std::string_view pos = cfg.position;

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -77,12 +77,12 @@ namespace {
     return cfg.marginEdge;
   }
 
-  // "Concave corners": a per-corner radius < 0 marks that corner Concave, bulging
-  // outward by |value|. Only the two corners on the bar's inner edge (away from
-  // the screen) can grow into reserved surface space, so the inner bulge (and the
-  // logical inset that hosts it) is taken from those two corners and capped at
-  // thickness/2 to match the rect shader's per-corner radius clamp. With all radii
-  // >= 0 the result is byte-for-byte the previous plain rounded rect.
+  // Concave bar shape modes:
+  // - Inner-edge mode (legacy bar behavior): enabled when concave_edge_corners is on
+  //   and both margin_edge and margin_ends are zero.
+  // - Screen-edge mode (dock-like): enabled when concave_edge_corners is on,
+  //   margin_edge is zero, and margin_ends exceeds the edge-facing corner radius
+  //   plus desktop screen-corner size.
   struct BarConcaveShape {
     CornerShapes corners{};
     Radii radii;
@@ -90,40 +90,102 @@ namespace {
     float innerBulge = 0.0f; // px the surface/box grow on the inner edge
   };
 
-  [[nodiscard]] BarConcaveShape barConcaveShape(const BarConfig& cfg) {
-    const auto shapeFor = [](std::int32_t v) { return v < 0 ? CornerShape::Concave : CornerShape::Convex; };
-    const auto mag = [](std::int32_t v) { return static_cast<float>(v < 0 ? -v : v); };
+  [[nodiscard]] BarConcaveShape barConcaveShape(const BarConfig& cfg, std::int32_t desktopCornerSize) {
+    const auto radius = [](std::int32_t v) { return static_cast<float>(std::max<std::int32_t>(0, v)); };
+    const auto cappedRadius = [&](std::int32_t v) {
+      return std::min(static_cast<float>(cfg.thickness) * 0.5f, radius(v));
+    };
 
     BarConcaveShape g;
-    g.corners = CornerShapes{
-        .tl = shapeFor(cfg.radiusTopLeft),
-        .tr = shapeFor(cfg.radiusTopRight),
-        .br = shapeFor(cfg.radiusBottomRight),
-        .bl = shapeFor(cfg.radiusBottomLeft),
+    g.radii = Radii{
+        radius(cfg.radiusTopLeft),
+        radius(cfg.radiusTopRight),
+        radius(cfg.radiusBottomRight),
+        radius(cfg.radiusBottomLeft),
     };
-    g.radii =
-        Radii{mag(cfg.radiusTopLeft), mag(cfg.radiusTopRight), mag(cfg.radiusBottomRight), mag(cfg.radiusBottomLeft)};
 
-    const float cap = static_cast<float>(cfg.thickness) * 0.5f;
+    if (!cfg.concaveEdgeCorners || cfg.marginEdge > 0) {
+      return g;
+    }
+
     const BarConcaveCorners inner = barInnerEdgeCorners(cfg.position);
-    const auto innerContribution = [&](bool flagged, std::int32_t v) { return (flagged && v < 0) ? mag(v) : 0.0f; };
-    float bulge = 0.0f;
-    bulge = std::max(bulge, innerContribution(inner.topLeft, cfg.radiusTopLeft));
-    bulge = std::max(bulge, innerContribution(inner.topRight, cfg.radiusTopRight));
-    bulge = std::max(bulge, innerContribution(inner.bottomLeft, cfg.radiusBottomLeft));
-    bulge = std::max(bulge, innerContribution(inner.bottomRight, cfg.radiusBottomRight));
-    g.innerBulge = std::min(bulge, cap);
 
+    // Mode A: margin_edge == 0 && margin_ends == 0 -> legacy inner-edge concavity.
+    if (cfg.marginEnds == 0) {
+      g.corners = CornerShapes{
+          .tl = inner.topLeft ? CornerShape::Concave : CornerShape::Convex,
+          .tr = inner.topRight ? CornerShape::Concave : CornerShape::Convex,
+          .br = inner.bottomRight ? CornerShape::Concave : CornerShape::Convex,
+          .bl = inner.bottomLeft ? CornerShape::Concave : CornerShape::Convex,
+      };
+
+      float bulge = 0.0f;
+      if (inner.topLeft) {
+        bulge = std::max(bulge, cappedRadius(cfg.radiusTopLeft));
+      }
+      if (inner.topRight) {
+        bulge = std::max(bulge, cappedRadius(cfg.radiusTopRight));
+      }
+      if (inner.bottomLeft) {
+        bulge = std::max(bulge, cappedRadius(cfg.radiusBottomLeft));
+      }
+      if (inner.bottomRight) {
+        bulge = std::max(bulge, cappedRadius(cfg.radiusBottomRight));
+      }
+      g.innerBulge = bulge;
+
+      const std::string_view pos = cfg.position;
+      if (pos == "bottom") {
+        g.logicalInset.top = g.innerBulge;
+      } else if (pos == "left") {
+        g.logicalInset.right = g.innerBulge;
+      } else if (pos == "right") {
+        g.logicalInset.left = g.innerBulge;
+      } else { // top
+        g.logicalInset.bottom = g.innerBulge;
+      }
+      return g;
+    }
+
+    // Mode B: dock-like concavity on screen-edge corners.
+    const std::int32_t desktopCorner = std::max<std::int32_t>(0, desktopCornerSize);
+    std::int32_t edgeThreshold = 0;
     const std::string_view pos = cfg.position;
     if (pos == "bottom") {
-      g.logicalInset.top = g.innerBulge;
+      edgeThreshold = std::max(cfg.radiusBottomLeft, cfg.radiusBottomRight) + desktopCorner;
     } else if (pos == "left") {
-      g.logicalInset.right = g.innerBulge;
+      edgeThreshold = std::max(cfg.radiusTopLeft, cfg.radiusBottomLeft) + desktopCorner;
     } else if (pos == "right") {
-      g.logicalInset.left = g.innerBulge;
+      edgeThreshold = std::max(cfg.radiusTopRight, cfg.radiusBottomRight) + desktopCorner;
     } else { // top
-      g.logicalInset.bottom = g.innerBulge;
+      edgeThreshold = std::max(cfg.radiusTopLeft, cfg.radiusTopRight) + desktopCorner;
     }
+    if (cfg.marginEnds <= edgeThreshold) {
+      return g;
+    }
+
+    if (pos == "bottom") {
+      g.corners.bl = CornerShape::Concave;
+      g.corners.br = CornerShape::Concave;
+      g.logicalInset.left = cappedRadius(cfg.radiusBottomLeft);
+      g.logicalInset.right = cappedRadius(cfg.radiusBottomRight);
+    } else if (pos == "left") {
+      g.corners.tl = CornerShape::Concave;
+      g.corners.bl = CornerShape::Concave;
+      g.logicalInset.top = cappedRadius(cfg.radiusTopLeft);
+      g.logicalInset.bottom = cappedRadius(cfg.radiusBottomLeft);
+    } else if (pos == "right") {
+      g.corners.tr = CornerShape::Concave;
+      g.corners.br = CornerShape::Concave;
+      g.logicalInset.top = cappedRadius(cfg.radiusTopRight);
+      g.logicalInset.bottom = cappedRadius(cfg.radiusBottomRight);
+    } else { // top
+      g.corners.tl = CornerShape::Concave;
+      g.corners.tr = CornerShape::Concave;
+      g.logicalInset.left = cappedRadius(cfg.radiusTopLeft);
+      g.logicalInset.right = cappedRadius(cfg.radiusTopRight);
+    }
+
     return g;
   }
 
@@ -555,7 +617,9 @@ namespace {
   };
 
   [[nodiscard]] BarSurfaceSpec
-  computeBarSurfaceSpec(const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig) {
+  computeBarSurfaceSpec(
+      const BarConfig& barConfig, const ShellConfig::ShadowConfig& shadowConfig, std::int32_t desktopCornerSize
+  ) {
     const bool vertical = (barConfig.position == "left" || barConfig.position == "right");
     const bool isBottom = barConfig.position == "bottom";
     const bool isRight = barConfig.position == "right";
@@ -565,7 +629,7 @@ namespace {
     const int edgeGutter = barAutoHideEdgeGutter(barConfig);
     // Reserve room for a concave-corner spike on the inner edge (opaque bar material),
     // in addition to the shadow bleed that renders beyond the spike tips.
-    const int concaveBulge = static_cast<int>(std::lround(barConcaveShape(barConfig).innerBulge));
+    const int concaveBulge = static_cast<int>(std::lround(barConcaveShape(barConfig, desktopCornerSize).innerBulge));
 
     const std::int32_t edgeMargin = barEdgeLayerMargin(barConfig, shadowConfig);
 
@@ -620,9 +684,10 @@ namespace {
   }
 
   [[nodiscard]] float barInnerSurfaceExtension(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceWidth, float surfaceHeight
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, float surfaceWidth,
+      float surfaceHeight
   ) {
-    const auto base = computeBarSurfaceSpec(cfg, shadow);
+    const auto base = computeBarSurfaceSpec(cfg, shadow, desktopCornerSize);
     const bool isVertical = (cfg.position == "left" || cfg.position == "right");
     const float current = isVertical ? surfaceWidth : surfaceHeight;
     const auto normal = static_cast<float>(isVertical ? base.surfaceWidth : base.surfaceHeight);
@@ -652,6 +717,7 @@ namespace {
         && a.radiusTopRight == b.radiusTopRight
         && a.radiusBottomLeft == b.radiusBottomLeft
         && a.radiusBottomRight == b.radiusBottomRight
+        && a.concaveEdgeCorners == b.concaveEdgeCorners
         && a.marginEnds == b.marginEnds
         && a.marginEdge == b.marginEdge
         && a.shadow == b.shadow
@@ -681,8 +747,8 @@ namespace {
   }
 
   BarVisualGeometry computeBarVisualGeometry(
-      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, float surfaceWidth, float surfaceHeight,
-      float innerSurfaceExtension = 0.0f
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize,
+      float surfaceWidth, float surfaceHeight, float innerSurfaceExtension = 0.0f
   ) {
     const auto barThickness = static_cast<float>(cfg.thickness);
     const auto marginEnds = static_cast<float>(cfg.marginEnds);
@@ -699,7 +765,7 @@ namespace {
     // pushes the body inward by its bulge. Top/left bars grow away from the origin
     // and need no body shift. Gutter (auto-hide) placements derive from the surface
     // size, which already includes the bulge, so they shift automatically.
-    const float concaveBulge = barConcaveShape(cfg).innerBulge;
+    const float concaveBulge = barConcaveShape(cfg, desktopCornerSize).innerBulge;
 
     if (isVertical) {
       // Vertical bar: edge gap is left/right, ends inset is top/bottom.
@@ -746,11 +812,14 @@ namespace {
   }
 
   [[nodiscard]] InputRect
-  barContentInputRegion(const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, int surfW, int surfH) {
+  barContentInputRegion(
+      const BarConfig& cfg, const ShellConfig::ShadowConfig& shadow, std::int32_t desktopCornerSize, int surfW,
+      int surfH
+  ) {
     const float innerSurfaceExtension =
-        barInnerSurfaceExtension(cfg, shadow, static_cast<float>(surfW), static_cast<float>(surfH));
+        barInnerSurfaceExtension(cfg, shadow, desktopCornerSize, static_cast<float>(surfW), static_cast<float>(surfH));
     const auto barVisual = computeBarVisualGeometry(
-        cfg, shadow, static_cast<float>(surfW), static_cast<float>(surfH), innerSurfaceExtension
+        cfg, shadow, desktopCornerSize, static_cast<float>(surfW), static_cast<float>(surfH), innerSurfaceExtension
     );
     return InputRect{
         static_cast<int>(barVisual.x), static_cast<int>(barVisual.y), static_cast<int>(barVisual.width),
@@ -776,17 +845,20 @@ namespace {
   }
 
   void applyBarShadowStyle(
-      BarInstance& instance, const ShellConfig::ShadowConfig& shadowConfig, float surfaceWidth, float surfaceHeight
+      BarInstance& instance, const ShellConfig::ShadowConfig& shadowConfig, std::int32_t desktopCornerSize,
+      float surfaceWidth, float surfaceHeight
   ) {
     if (instance.shadow == nullptr) {
       return;
     }
 
-    const auto concave = barConcaveShape(instance.barConfig);
+    const auto concave = barConcaveShape(instance.barConfig, desktopCornerSize);
     const float innerSurfaceExtension =
-        barInnerSurfaceExtension(instance.barConfig, shadowConfig, surfaceWidth, surfaceHeight);
+        barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight);
     const auto barVisual =
-        computeBarVisualGeometry(instance.barConfig, shadowConfig, surfaceWidth, surfaceHeight, innerSurfaceExtension);
+        computeBarVisualGeometry(
+            instance.barConfig, shadowConfig, desktopCornerSize, surfaceWidth, surfaceHeight, innerSurfaceExtension
+        );
     // Shadow follows the same shape as the background: the body expanded outward by
     // the concave inset into the visual rect, so concave spikes cast a matching shadow.
     const float barAreaW = barVisual.width + concave.logicalInset.left + concave.logicalInset.right;
@@ -1796,8 +1868,9 @@ void Bar::setAttachedPanelGeometry(
 
   instance->attachedPanelGeometry = geometry;
   if (instance->surface != nullptr && instance->surface->width() > 0 && instance->surface->height() > 0) {
+    const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
     applyBarShadowStyle(
-        *instance, m_config->config().shell.shadow, static_cast<float>(instance->surface->width()),
+        *instance, m_config->config().shell.shadow, desktopCornerSize, static_cast<float>(instance->surface->width()),
         static_cast<float>(instance->surface->height())
     );
     instance->surface->requestRedraw();
@@ -1953,7 +2026,8 @@ void Bar::createInstance(const WaylandOutput& output, std::size_t barIndex, cons
   instance->barIndex = barIndex;
 
   const auto anchor = positionToAnchor(barConfig.position);
-  const auto surfaceSpec = computeBarSurfaceSpec(barConfig, m_config->config().shell.shadow);
+  const auto surfaceSpec =
+      computeBarSurfaceSpec(barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size);
 
   kLog.info(
       "creating #{} \"{}\" on {} ({}), thickness={} position={} reserve_space={} exclusive_zone={}", barIndex,
@@ -2531,7 +2605,10 @@ void Bar::syncBarAutoHideInputRegion(BarInstance& instance) const {
     return;
   }
   instance.surface->setInputRegion(
-      {barContentInputRegion(instance.barConfig, m_config->config().shell.shadow, surfW, surfH)}
+      {barContentInputRegion(
+          instance.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size, surfW,
+          surfH
+      )}
   );
 }
 
@@ -2610,7 +2687,7 @@ void Bar::applyBarCompositorBlur(BarInstance& instance) const {
   const int py = static_cast<int>(std::lround(absY));
   const int pw = static_cast<int>(std::lround(std::max(0.0f, instance.bg->width())));
   const int ph = static_cast<int>(std::lround(std::max(0.0f, instance.bg->height())));
-  const auto concave = barConcaveShape(instance.barConfig);
+  const auto concave = barConcaveShape(instance.barConfig, m_config->config().shell.screenCorners.size);
   // The bg node is the visual rect; tessellateShape expects the body rect and
   // expands it outward by logicalInset itself. With all-convex corners this is the
   // plain rounded rect.
@@ -2665,6 +2742,7 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const auto widgetSpacing = static_cast<float>(instance.barConfig.widgetSpacing);
   const auto& shadowConfig = m_config->config().shell.shadow;
+  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
   const auto shadowOffset = shadowDirectionOffset(shadowConfig.direction);
   const float shadowSize = shell::surface_shadow::enabled(instance.barConfig.shadow, shadowConfig)
       ? static_cast<float>(shell::surface_shadow::kBlurRadius)
@@ -2674,10 +2752,12 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
   const bool isBottom = instance.barConfig.position == "bottom";
   const bool isRight = instance.barConfig.position == "right";
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
-  const auto concave = barConcaveShape(instance.barConfig);
+  const auto concave = barConcaveShape(instance.barConfig, desktopCornerSize);
 
-  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
-  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
+  const float innerSurfaceExtension =
+      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
+  const auto barVisual =
+      computeBarVisualGeometry(instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension);
   const float barAreaX = barVisual.x;
   const float barAreaY = barVisual.y;
   const float barAreaW = barVisual.width;
@@ -2817,7 +2897,7 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
     instance.contentClip->setSize(barAreaW, barAreaH);
   }
 
-  applyBarShadowStyle(instance, shadowConfig, w, h);
+  applyBarShadowStyle(instance, shadowConfig, desktopCornerSize, w, h);
 
   layoutBarSections(instance, *renderer, barAreaW, barAreaH, padding, isVertical);
 
@@ -2861,8 +2941,12 @@ void Bar::updateWidgets(BarInstance& instance) {
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
-  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
+  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
+  const float innerSurfaceExtension =
+      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
+  const auto barVisual = computeBarVisualGeometry(
+      instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension
+  );
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 
@@ -2904,8 +2988,12 @@ void Bar::prepareFrame(BarInstance& instance, bool needsUpdate, bool needsLayout
   const auto padding = static_cast<float>(instance.barConfig.padding);
   const bool isVertical = (instance.barConfig.position == "left" || instance.barConfig.position == "right");
   const auto& shadowConfig = m_config->config().shell.shadow;
-  const float innerSurfaceExtension = barInnerSurfaceExtension(instance.barConfig, shadowConfig, w, h);
-  const auto barVisual = computeBarVisualGeometry(instance.barConfig, shadowConfig, w, h, innerSurfaceExtension);
+  const auto desktopCornerSize = m_config->config().shell.screenCorners.size;
+  const float innerSurfaceExtension =
+      barInnerSurfaceExtension(instance.barConfig, shadowConfig, desktopCornerSize, w, h);
+  const auto barVisual = computeBarVisualGeometry(
+      instance.barConfig, shadowConfig, desktopCornerSize, w, h, innerSurfaceExtension
+  );
   const float barAreaW = barVisual.width;
   const float barAreaH = barVisual.height;
 
@@ -3400,7 +3488,9 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
       if (inst.surface == nullptr) {
         return;
       }
-      const auto spec = computeBarSurfaceSpec(inst.barConfig, m_config->config().shell.shadow);
+      const auto spec = computeBarSurfaceSpec(
+          inst.barConfig, m_config->config().shell.shadow, m_config->config().shell.screenCorners.size
+      );
       inst.surface->setMargins(spec.marginTop, spec.marginRight, spec.marginBottom, spec.marginLeft);
       inst.surface->requestSize(spec.surfaceWidth, spec.surfaceHeight);
     };

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2693,27 +2693,9 @@ void Bar::applyBarCompositorBlur(BarInstance& instance) const {
   const int pw = static_cast<int>(std::lround(std::max(0.0f, instance.bg->width())));
   const int ph = static_cast<int>(std::lround(std::max(0.0f, instance.bg->height())));
   const auto concave = barConcaveShape(instance.barConfig, m_config->config().shell.screenCorners.size);
-  const bool anyConcave = concave.corners.tl == CornerShape::Concave
-      || concave.corners.tr == CornerShape::Concave
-      || concave.corners.br == CornerShape::Concave
-      || concave.corners.bl == CornerShape::Concave;
-  const bool anyInset = concave.logicalInset.left > 0.0f
-      || concave.logicalInset.top > 0.0f
-      || concave.logicalInset.right > 0.0f
-      || concave.logicalInset.bottom > 0.0f;
-
-  // Fast-path: the common all-convex/no-inset case is a plain rounded rect.
-  if (!anyConcave && !anyInset) {
-    instance.surface->setBlurRegion(
-        Surface::tessellateRoundedRect(
-            px, py, pw, ph, concave.radii.tl, concave.radii.tr, concave.radii.br, concave.radii.bl
-        )
-    );
-    return;
-  }
-
   // The bg node is the visual rect; tessellateShape expects the body rect and
-  // expands it outward by logicalInset itself.
+  // expands it outward by logicalInset itself. With all-convex corners and no
+  // inset it takes its own fast path down to a plain rounded rect.
   const int insetL = static_cast<int>(std::lround(concave.logicalInset.left));
   const int insetT = static_cast<int>(std::lround(concave.logicalInset.top));
   const int insetR = static_cast<int>(std::lround(concave.logicalInset.right));

--- a/src/shell/bar/bar_corner_shape.h
+++ b/src/shell/bar/bar_corner_shape.h
@@ -5,8 +5,7 @@
 /// The bar's four corners flagged for whether they sit on the bar's inner edge —
 /// the edge facing away from the docked screen edge. Only inner-edge corners can
 /// grow a concave notch into reserved surface space, so this is the single source
-/// of truth for both the renderer (barConcaveShape) and the settings UI (which
-/// corners may be inverted).
+/// of truth for concave-shape mode decisions in barConcaveShape.
 struct BarConcaveCorners {
   bool topLeft = false;
   bool topRight = false;

--- a/src/shell/settings/settings_content_common.cpp
+++ b/src/shell/settings/settings_content_common.cpp
@@ -80,6 +80,9 @@ namespace settings {
     if (key == "radius_bottom_right") {
       return override->radiusBottomRight.has_value();
     }
+    if (key == "concave_edge_corners") {
+      return override->concaveEdgeCorners.has_value();
+    }
     if (key == "background_opacity") {
       return override->backgroundOpacity.has_value();
     }

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -7,7 +7,6 @@
 #include "core/log.h"
 #include "core/process/process.h"
 #include "i18n/i18n.h"
-#include "shell/bar/bar_corner_shape.h"
 #include "shell/control_center/control_center_panel.h"
 #include "shell/control_center/shortcut_registry.h"
 #include "shell/settings/color_spec_picker.h"
@@ -35,22 +34,13 @@ namespace settings {
     constexpr int kBarMarginMax = 4096;
     constexpr float kBarCornerRadiusMax = 80.0f;
 
-    // Per-corner bar radius slider: shows magnitude (0..max) with an inline invert toggle carrying
-    // the sign (negative = concave). `enabled` reflects whether this corner faces away from the
-    // docked screen edge and can render a meaningful concave notch.
-    [[nodiscard]] SliderSetting barCornerSlider(std::int32_t value, bool enabled) {
+    [[nodiscard]] SliderSetting barCornerSlider(std::int32_t value) {
       SliderSetting s{value, 0.0f, kBarCornerRadiusMax, 1.0f, true};
-      s.invertSlot = SliderSetting::InvertSlot::Toggle;
-      s.invertEnabled = enabled;
       return s;
     }
 
-    // Slider that reserves an empty invert slot so its value box stays column-aligned with sibling
-    // corner sliders in the same group.
     [[nodiscard]] SliderSetting barReservedSlider(double value, double maxValue, double step, bool integer) {
-      SliderSetting s{value, 0.0f, maxValue, step, integer};
-      s.invertSlot = SliderSetting::InvertSlot::Reserve;
-      return s;
+      return SliderSetting{value, 0.0f, maxValue, step, integer};
     }
 
     [[nodiscard]] std::vector<KeyChord>
@@ -2594,7 +2584,6 @@ namespace settings {
           tr("settings.schema.bar.content-padding.description"), path("padding"),
           SliderSetting{bar.padding, 0.0f, 80.0f, 1.0f, true}, "inset"
       ));
-      const BarConcaveCorners barInner = barInnerEdgeCorners(bar.position);
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.shared.corner-radius.label"),
           tr("settings.schema.bar.corner-radius.description"), path("radius"),
@@ -2603,23 +2592,35 @@ namespace settings {
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.shared.corner-top-left.label"),
           tr("settings.schema.bar.corner-top-left.description"), path("radius_top_left"),
-          barCornerSlider(bar.radiusTopLeft, barInner.topLeft), "rounded corner", true
+          barCornerSlider(bar.radiusTopLeft), "rounded corner", true
       ));
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.shared.corner-top-right.label"),
           tr("settings.schema.bar.corner-top-right.description"), path("radius_top_right"),
-          barCornerSlider(bar.radiusTopRight, barInner.topRight), "rounded corner", true
+          barCornerSlider(bar.radiusTopRight), "rounded corner", true
       ));
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.shared.corner-bottom-left.label"),
           tr("settings.schema.bar.corner-bottom-left.description"), path("radius_bottom_left"),
-          barCornerSlider(bar.radiusBottomLeft, barInner.bottomLeft), "rounded corner", true
+          barCornerSlider(bar.radiusBottomLeft), "rounded corner", true
       ));
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.shared.corner-bottom-right.label"),
           tr("settings.schema.bar.corner-bottom-right.description"), path("radius_bottom_right"),
-          barCornerSlider(bar.radiusBottomRight, barInner.bottomRight), "rounded corner", true
+          barCornerSlider(bar.radiusBottomRight), "rounded corner", true
       ));
+      {
+        auto e = makeEntry(
+            section, "shape", tr("settings.schema.bar.concave-edge-corners.label"),
+            tr("settings.schema.bar.concave-edge-corners.description"), path("concave_edge_corners"),
+            ToggleSetting{bar.concaveEdgeCorners}, "rounded corner carve"
+        );
+        e.visibleWhen = [barName = bar.name](const Config& c) {
+          const BarConfig* b = findBar(c, barName);
+          return b != nullptr && b->marginEdge == 0;
+        };
+        entries.push_back(std::move(e));
+      }
       entries.push_back(makeEntry(
           section, "shape", tr("settings.schema.bar.border.label"), tr("settings.schema.bar.border.description"),
           path("border"), colorSpecPicker(bar.border), "outline color", true
@@ -2918,7 +2919,6 @@ namespace settings {
             tr("settings.schema.bar.content-padding.description"), monitorPath("padding"),
             SliderSetting{ovr.padding.value_or(bar.padding), 0.0f, 80.0f, 1.0f, true}, "inset"
         ));
-        const BarConcaveCorners ovrInner = barInnerEdgeCorners(ovr.position.value_or(bar.position));
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.shared.corner-radius.label"),
             tr("settings.schema.bar.corner-radius.description"), monitorPath("radius"),
@@ -2927,25 +2927,40 @@ namespace settings {
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.shared.corner-top-left.label"),
             tr("settings.schema.bar.corner-top-left.description"), monitorPath("radius_top_left"),
-            barCornerSlider(ovr.radiusTopLeft.value_or(bar.radiusTopLeft), ovrInner.topLeft), "rounded corner", true
+            barCornerSlider(ovr.radiusTopLeft.value_or(bar.radiusTopLeft)), "rounded corner", true
         ));
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.shared.corner-top-right.label"),
             tr("settings.schema.bar.corner-top-right.description"), monitorPath("radius_top_right"),
-            barCornerSlider(ovr.radiusTopRight.value_or(bar.radiusTopRight), ovrInner.topRight), "rounded corner", true
+            barCornerSlider(ovr.radiusTopRight.value_or(bar.radiusTopRight)), "rounded corner", true
         ));
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.shared.corner-bottom-left.label"),
             tr("settings.schema.bar.corner-bottom-left.description"), monitorPath("radius_bottom_left"),
-            barCornerSlider(ovr.radiusBottomLeft.value_or(bar.radiusBottomLeft), ovrInner.bottomLeft), "rounded corner",
-            true
+            barCornerSlider(ovr.radiusBottomLeft.value_or(bar.radiusBottomLeft)), "rounded corner", true
         ));
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.shared.corner-bottom-right.label"),
             tr("settings.schema.bar.corner-bottom-right.description"), monitorPath("radius_bottom_right"),
-            barCornerSlider(ovr.radiusBottomRight.value_or(bar.radiusBottomRight), ovrInner.bottomRight),
-            "rounded corner", true
+            barCornerSlider(ovr.radiusBottomRight.value_or(bar.radiusBottomRight)), "rounded corner", true
         ));
+        {
+          auto e = makeEntry(
+              section, "shape", tr("settings.schema.bar.concave-edge-corners.label"),
+              tr("settings.schema.bar.concave-edge-corners.description"), monitorPath("concave_edge_corners"),
+              ToggleSetting{ovr.concaveEdgeCorners.value_or(bar.concaveEdgeCorners)}, "rounded corner carve"
+          );
+          e.visibleWhen = [barName = bar.name, match = ovr.match](const Config& c) {
+            const BarConfig* b = findBar(c, barName);
+            if (b == nullptr) {
+              return false;
+            }
+            const BarMonitorOverride* mo = findMonitorOverride(*b, match);
+            const std::int32_t marginEdge = mo && mo->marginEdge.has_value() ? *mo->marginEdge : b->marginEdge;
+            return marginEdge == 0;
+          };
+          entries.push_back(std::move(e));
+        }
         entries.push_back(makeEntry(
             section, "shape", tr("settings.schema.bar.border.label"), tr("settings.schema.bar.border.description"),
             monitorPath("border"), colorSpecPicker(ovr.border, true, tr("common.states.inherit")), "outline color", true

--- a/tests/config_path_resolution_test.cpp
+++ b/tests/config_path_resolution_test.cpp
@@ -71,9 +71,11 @@ int main() {
   expectKnown({"hooks", "wallpaper_changed"});
   // Bar: base field, container levels, and a resolved monitor-override field.
   expectKnown({"bar", "default", "thickness"});
+  expectKnown({"bar", "default", "concave_edge_corners"});
   expectKnown({"bar", "default", "position"});
   expectKnown({"bar", "default"});
   expectKnown({"bar", "default", "monitor", "DP-1", "thickness"});
+  expectKnown({"bar", "default", "monitor", "DP-1", "concave_edge_corners"});
 
   // Typos and bogus paths must NOT resolve.
   expectUnknown({"shell", "ui_scl"});                            // leaf typo

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -129,9 +129,8 @@ location = "https://example.invalid/bad"
       }
     }
 
-    const std::string invalid[] = {
-        "", "hello", "me/", "/hello", "me/foo/bar", "me/../hello", "me/foo bar", "../foo", "me/.hidden"
-    };
+    const std::string invalid[] = {"",           "hello",  "me/",       "/hello", "me/foo/bar", "me/../hello",
+                                   "me/foo bar", "../foo", "me/.hidden"};
     for (const auto& id : invalid) {
       if (scripting::isValidPluginId(id)) {
         fail("plugins: accepted invalid plugin id " + id);
@@ -163,6 +162,7 @@ location = "https://example.invalid/bad"
     bar.radiusTopRight = 6;
     bar.radiusBottomLeft = 8;
     bar.radiusBottomRight = 10;
+    bar.concaveEdgeCorners = true;
     bar.marginEnds = 100;
     bar.marginEdge = 5;
     bar.marginOppositeEdge = 12;
@@ -223,6 +223,7 @@ location = "https://example.invalid/bad"
     ovr.radiusTopRight = 2;
     ovr.radiusBottomLeft = 3;
     ovr.radiusBottomRight = 4;
+    ovr.concaveEdgeCorners = false;
     ovr.marginEnds = 70;
     ovr.marginEdge = 9;
     ovr.marginOppositeEdge = 4;
@@ -285,9 +286,8 @@ location = "https://example.invalid/bad"
     c.osd.kinds.lockKeys = false;
     c.osd.kinds.keyboardLayout = false;
     c.backdrop = BackdropConfig{true, 0.8f, 0.2f};
-    c.lockscreen = LockscreenConfig{
-        .blurredDesktop = true, .blurIntensity = 0.6f, .tintIntensity = 0.25f, .monitors = {"DP-1"}
-    };
+    c.lockscreen =
+        LockscreenConfig{.blurredDesktop = true, .blurIntensity = 0.6f, .tintIntensity = 0.25f, .monitors = {"DP-1"}};
     c.system.monitor.enabled = false;
     c.system.monitor.cpuTempSensorPath = "/sys/class/hwmon/hwmon3/temp1_input";
     c.system.monitor.cpuPollSeconds = 5.0f;
@@ -516,6 +516,7 @@ capsule_radius = 12.0
 capsule_thickness = 0.5
 center = [ "clock", "weather" ]
 color = "#0A0B0C"
+concave_edge_corners = true
 contact_shadow = true
 enabled = false
 end = [ "battery" ]
@@ -565,6 +566,7 @@ widget_spacing = 8
     capsule_thickness = 0.25
     center = [ "media" ]
     color = "#E1E2E3"
+    concave_edge_corners = false
     contact_shadow = false
     enabled = true
     end = [ "volume" ]


### PR DESCRIPTION
## Summary

Added support for concave bar edge corners with a single concave_edge_corners toggle and plain radius sliders, wired through config types/schema/export/overrides/settings UI, and updated bar geometry/rendering behavior accordingly.  
Also added a rounded-rect fast-path for blur/tessellation in the all-convex/no-inset case and included a clang-tidy follow-up cleanup.

## Motivation

This PR makes concave bar corners simpler and more consistent to configure by replacing older inversion-style behavior with a single concave_edge_corners toggle and straightforward radius controls. It also keeps the bar’s visual geometry coherent when concave corners are enabled, so background, shadow, and interaction regions remain aligned and predictable.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing
-  just format
- just build debug
- just lint debug
- just test debug
- just build release

### Results:
- Lint passes (after clang-tidy fix)
- Debug tests pass (35/35)
- Debug and release builds pass

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/73dd321b-2d72-4915-a00d-dabee792ee3b

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- The feature now uses a single concave_edge_corners toggle and radius controls (no per-corner invert setting UI).
- Includes fast-path optimization for all-convex/no-inset blur/tessellation.
- Includes a small follow-up commit for clang-tidy compliance.