### PR TITLE
widget settings: add per-widget interactive toggle

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3094,6 +3094,10 @@
           "description": "Network interface to monitor; leave empty to use the total across all interfaces",
           "label": "Interface"
         },
+        "interactive": {
+          "description": "Allow pointer hover, clicks, scrolls, and tooltips for this widget",
+          "label": "Interactive"
+        },
         "label": {
           "description": "Optional static text shown on this button",
           "label": "Label"

--- a/example.toml
+++ b/example.toml
@@ -468,3 +468,4 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # tooltip_format = "{:%A, %B %d, %Y}"
 # scale = 1.0                         # multiplies the bar scale for this widget only
 # font_weight = 700
+# interactive = false                 # pass clicks/scrolls through to the bar and disable hover/tooltips

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2040,6 +2040,7 @@ void Bar::populateWidgets(BarInstance& instance) {
     widget->setConfigName(name);
     if (wcPtr != nullptr) {
       widget->setAnchor(wcPtr->getBool("anchor", false));
+      widget->setNonInteractive(!wcPtr->getBool("interactive", true));
       if (!wcPtr->getBool("enabled", true)) {
         return;
       }

--- a/src/shell/bar/widget.cpp
+++ b/src/shell/bar/widget.cpp
@@ -71,6 +71,13 @@ void Widget::setBarCapsuleScene(Node* shell, Box* box) noexcept {
   m_capsuleBox = box;
 }
 
+void Widget::setNonInteractive(bool nonInteractive) noexcept {
+  m_nonInteractive = nonInteractive;
+  if (Node* r = root(); r != nullptr) {
+    r->setHitTestVisible(!m_nonInteractive);
+  }
+}
+
 float Widget::width() const noexcept { return root() ? root()->width() : 0.0f; }
 
 float Widget::height() const noexcept { return root() ? root()->height() : 0.0f; }
@@ -78,6 +85,13 @@ float Widget::height() const noexcept { return root() ? root()->height() : 0.0f;
 std::unique_ptr<Node> Widget::releaseRoot() {
   m_rootPtr = m_root.get();
   return std::move(m_root);
+}
+
+void Widget::setRoot(std::unique_ptr<Node> root) {
+  m_root = std::move(root);
+  if (m_root != nullptr) {
+    m_root->setHitTestVisible(!m_nonInteractive);
+  }
 }
 
 void Widget::setAnimationManager(AnimationManager* mgr) noexcept { m_animations = mgr; }

--- a/src/shell/bar/widget.h
+++ b/src/shell/bar/widget.h
@@ -47,11 +47,11 @@ public:
   [[nodiscard]] virtual bool reservesMiddleClick() const noexcept { return false; }
 
   [[nodiscard]] virtual bool noGapAroundMe() const noexcept { return false; }
-  // Layout-only bar widgets (spacers): clicks pass through to bar dead-zone handlers.
-  [[nodiscard]] virtual bool isBarClickThrough() const noexcept { return false; }
+  // Layout-only or non-interactive bar widgets: clicks pass through to bar dead-zone handlers.
+  [[nodiscard]] virtual bool isBarClickThrough() const noexcept { return m_nonInteractive; }
   // Widgets with interactive sub-items (workspaces, taskbar, tray) manage hover per item and
   // opt out of the bar's generic whole-widget hover highlight.
-  [[nodiscard]] virtual bool wantsBarHoverHighlight() const noexcept { return true; }
+  [[nodiscard]] virtual bool wantsBarHoverHighlight() const noexcept { return !m_nonInteractive; }
 
   [[nodiscard]] Node* root() const noexcept { return m_root ? m_root.get() : m_rootPtr; }
   [[nodiscard]] float width() const noexcept;
@@ -78,6 +78,8 @@ public:
   void setBarCapsuleSpec(WidgetBarCapsuleSpec spec) noexcept { m_barCapsuleSpec = std::move(spec); }
   void setWidgetForeground(std::optional<ColorSpec> color) noexcept { m_widgetForeground = color; }
   void setWidgetIconColor(std::optional<ColorSpec> color) noexcept { m_widgetIconColor = color; }
+  void setNonInteractive(bool nonInteractive) noexcept;
+  [[nodiscard]] bool nonInteractive() const noexcept { return m_nonInteractive; }
   [[nodiscard]] const WidgetBarCapsuleSpec& barCapsuleSpec() const noexcept { return m_barCapsuleSpec; }
   void setBarCapsuleScene(Node* shell, Box* box) noexcept;
   [[nodiscard]] Node* barCapsuleShell() const noexcept { return m_capsuleShell; }
@@ -108,7 +110,7 @@ protected:
       std::string_view panelId, std::string_view context = {}, std::optional<float> anchorSurfaceX = std::nullopt,
       std::optional<float> anchorSurfaceY = std::nullopt
   );
-  void setRoot(std::unique_ptr<Node> root) { m_root = std::move(root); }
+  void setRoot(std::unique_ptr<Node> root);
   void clearReleasedRoot() noexcept { m_rootPtr = nullptr; }
   virtual void doLayout(Renderer& renderer, float containerWidth, float containerHeight) = 0;
   virtual void doUpdate(Renderer& renderer) { (void)renderer; }
@@ -126,6 +128,7 @@ protected:
   WidgetBarCapsuleSpec m_barCapsuleSpec{};
   std::optional<ColorSpec> m_widgetForeground;
   std::optional<ColorSpec> m_widgetIconColor;
+  bool m_nonInteractive = false;
   Node* m_capsuleShell = nullptr;
   Box* m_capsuleBox = nullptr;
   Box* m_hoverBox = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -551,6 +551,7 @@ namespace settings {
     const WidgetSettingVisibility capsuleOn{"capsule", {"true"}};
 
     auto anchor = withGroup(boolSpec("anchor", false, true), WidgetSettingGroup::Presentation);
+    auto interactive = withGroup(boolSpec("interactive", true), WidgetSettingGroup::Presentation);
     auto scale = withGroup(doubleSpec("scale", 1.0, 0.2, 2.5, 0.05), WidgetSettingGroup::Presentation);
     auto widgetColor = withGroup(colorSpec("color", {}, true), WidgetSettingGroup::Presentation);
     auto widgetIconColor = withGroup(colorSpec("icon_color", {}, true), WidgetSettingGroup::Presentation);
@@ -590,10 +591,10 @@ namespace settings {
     capsuleOpacity.visibleWhen = capsuleOn;
 
     return {
-        std::move(anchor),         std::move(scale),         std::move(widgetColor),       std::move(widgetIconColor),
-        std::move(fontFamily),     std::move(fontWeight),    std::move(capsuleToggle),     std::move(capsuleRadius),
-        std::move(capsuleFill),    std::move(capsuleBorder), std::move(capsuleForeground), std::move(capsulePadding),
-        std::move(capsuleOpacity),
+        std::move(anchor),          std::move(interactive),    std::move(scale),         std::move(widgetColor),
+        std::move(widgetIconColor), std::move(fontFamily),     std::move(fontWeight),    std::move(capsuleToggle),
+        std::move(capsuleRadius),   std::move(capsuleFill),    std::move(capsuleBorder), std::move(capsuleForeground),
+        std::move(capsulePadding),  std::move(capsuleOpacity),
     };
   }
 


### PR DESCRIPTION
Setting interactive to `false`:
- disables hover effects and tooltips
- passes through pointer events to bar

## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.