### PR TITLE
chore(readme): Mention more runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ Polkit agent support requires development files that provide the `polkit-agent-1
 modules. Some distros ship these in the runtime `polkit` package, while split-package distros use names such as
 `polkit-devel`, `polkit-dev`, or `libpolkit-agent-1-dev` / `libpolkit-gobject-1-dev`.
 
+Pipewire libraries/headers are sufficient to build Noctalia, but there is also a runtime requirement for the pipewire
+daemon.  Noctalia will abort startup if it can't connect to the daemon.  If your distro splits the pipewire libraries
+and daemon into separate packages, make sure you have both installed.
+
+`upower` is an optional dependency used for battery and power device integration.
+
+`ddcutil` is an optional dependency used for controlling monitor brightness.
+
+`wtype` is an optional dependency used for clipboard auto-paste.
+
 `jemalloc` is recommended but optional. It reduces memory fragmentation in long-running sessions, and on glibc systems
 it is used automatically when detected. Use Meson's `-Djemalloc=enabled` or `-Djemalloc=disabled` option to require or
 disable it explicitly.


### PR DESCRIPTION
## Summary

Mention more runtime requirements in the readme.

## Motivation

Noctalia will abort at startup if it can't connect to the pipewire daemon, so it is a mandatory runtime requirement.

There are also a few optional runtime requirements for various functionality.

* upower
* ddctuil
* wtype

Clarifying these in the readme will help packagers make informed decisions for their package dependencies.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.