### PR TITLE
fix(nix): add md4c, nlohmann_json, tomlplusplus, stb to buildInputs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,6 +27,11 @@
   librsvg,
   libqalculate,
   libxml2,
+  md4c,
+  nlohmann_json,
+  tomlplusplus,
+  stb,
+  fetchFromGitHub,
   wireplumber,
   jemalloc,
   autoAddDriverRunpath,
@@ -35,6 +40,17 @@
 let
   inherit (builtins) head match readFile;
   version = head (match ".*version: '([^']+)'.*" (readFile ../meson.build));
+  # nixpkgs stb is pinned to 2023-01-29, which predates stb_image_resize2.h
+  # (added upstream 2023-10-10). Override to latest until NixOS/nixpkgs#491159 merges.
+  stb' = stb.overrideAttrs (_: {
+    version = "0-unstable-2025-10-26";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
+    };
+  });
 in
 stdenv.mkDerivation {
   pname = "noctalia";
@@ -79,6 +95,10 @@ stdenv.mkDerivation {
     librsvg
     libqalculate
     libxml2
+    md4c
+    nlohmann_json
+    tomlplusplus
+    stb'
   ];
 
   mesonBuildType = "release";


### PR DESCRIPTION
## Summary

Add `md4c`, `nlohmann_json`, `tomlplusplus`, and `stb` to `nix/package.nix` function arguments and `buildInputs`.

## Motivation

PR #3311 moved these four libraries from vendored `third_party/` copies to required system dependencies. `meson.build` now calls `dependency('md4c')`, `dependency('nlohmann_json')`, `dependency('tomlplusplus')`, and errors hard if the `stb` headers are absent — no `required: false` fallback on any of them.

`nix/package.nix` was not updated in that PR, so NixOS builds fail immediately:

```
> Run-time dependency md4c found: NO (tried pkgconfig)
>
> meson.build:75:22: ERROR: Dependency "md4c" not found, tried pkgconfig
```

The full cascade from that single missing dep breaks `home-manager-path`, `home-manager-generation`, the system `user-environment`, and the final `nixos-system` derivation.

### Note on `stb`

The nixpkgs `stb` package is pinned to `2023-01-29`, which predates `stb_image_resize2.h` (added upstream 2023-10-10). The PR overrides `stb` inline to `0-unstable-2025-10-26` — the same version as NixOS/nixpkgs#491159, which is an open nixpkgs PR to bump the system package. Once that merges, the override here can be dropped.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

Caused by #3311. Related: NixOS/nixpkgs#491159 (pending nixpkgs stb bump).

## Testing

Verified with a local `nix build path:/tmp/noctalia-upstream` — noctalia 5.0.0 compiled and installed successfully to the Nix store. All four deps resolved:

```
Run-time dependency md4c found: YES 0.5.2
Run-time dependency nlohmann_json found: YES 3.12.0
Run-time dependency tomlplusplus found: YES 3.4.0
Has header "stb/stb_image_resize2.h" : YES
```

Also tested on **Niri via Weston composition on NixOS WSL** — noctalia launches and renders correctly.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.