### PR TITLE
fix(nix): add system build deps dropped by third-party cleanup

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -43,13 +43,15 @@ let
 
   # nixpkgs pins stb to 2023-01-29, which predates stb_image_resize2.h
   # (the v2 resize API that meson.build requires via cc.has_header).
+  # Pin to the snapshot targeted by NixOS/nixpkgs#491159 so this matches
+  # upstream nixpkgs once that bump lands and the override can be dropped.
   stb' = stb.overrideAttrs (_: {
-    version = "0-unstable-2026-04-15";
+    version = "0-unstable-2025-10-26";
     src = fetchFromGitHub {
       owner = "nothings";
       repo = "stb";
-      rev = "31c1ad37456438565541f4919958214b6e762fb4";
-      hash = "sha256-m2yNUlA37hDkKQVrQ+R8nufHfW/cXLnMo+n1X1Cyun0=";
+      rev = "f1c79c02822848a9bed4315b12c8c8f3761e1296";
+      hash = "sha256-BlyXJtAI7WqXCTT3ylww8zoG0hBxaojJnQDvdQOXJPE=";
     };
   });
 in

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -43,7 +43,7 @@ let
 
   # nixpkgs pins stb to 2023-01-29, which predates stb_image_resize2.h
   # (the v2 resize API that meson.build requires via cc.has_header).
-  stb' = stb.overrideAttrs {
+  stb' = stb.overrideAttrs (_: {
     version = "0-unstable-2026-04-15";
     src = fetchFromGitHub {
       owner = "nothings";
@@ -51,7 +51,7 @@ let
       rev = "31c1ad37456438565541f4919958214b6e762fb4";
       hash = "sha256-m2yNUlA37hDkKQVrQ+R8nufHfW/cXLnMo+n1X1Cyun0=";
     };
-  };
+  });
 in
 stdenv.mkDerivation {
   pname = "noctalia";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -29,12 +29,29 @@
   libxml2,
   wireplumber,
   jemalloc,
+  md4c,
+  nlohmann_json,
+  tomlplusplus,
+  stb,
+  fetchFromGitHub,
   autoAddDriverRunpath,
   cudaSupport ? config.cudaSupport,
 }:
 let
   inherit (builtins) head match readFile;
   version = head (match ".*version: '([^']+)'.*" (readFile ../meson.build));
+
+  # nixpkgs pins stb to 2023-01-29, which predates stb_image_resize2.h
+  # (the v2 resize API that meson.build requires via cc.has_header).
+  stb' = stb.overrideAttrs {
+    version = "0-unstable-2026-04-15";
+    src = fetchFromGitHub {
+      owner = "nothings";
+      repo = "stb";
+      rev = "31c1ad37456438565541f4919958214b6e762fb4";
+      hash = "sha256-m2yNUlA37hDkKQVrQ+R8nufHfW/cXLnMo+n1X1Cyun0=";
+    };
+  };
 in
 stdenv.mkDerivation {
   pname = "noctalia";
@@ -79,6 +96,10 @@ stdenv.mkDerivation {
     librsvg
     libqalculate
     libxml2
+    md4c
+    nlohmann_json
+    tomlplusplus
+    stb'
   ];
 
   mesonBuildType = "release";


### PR DESCRIPTION
## Summary

PR #3311 removed the vendored `third_party` copies of md4c, nlohmann_json, tomlplusplus, and stb, making `meson.build` require system versions. `nix/package.nix` was not updated to match, so `nix build .#default` has failed since. This adds the four to `buildInputs`. stb additionally needs a source override because nixpkgs pins stb to 2023-01-29, which predates `stb_image_resize2.h` that `meson.build` checks for via `cc.has_header`.

## Motivation

Since #3311, building noctalia on NixOS fails at meson configure:

```
Run-time dependency md4c found: NO (tried pkgconfig)
meson.build:75:22: ERROR: Dependency "md4c" not found, tried pkgconfig
```

The nix flake is currently unbuildable on `main`.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

Caused by #3311.

## Testing

- `nix build .#default --no-link` succeeds (produces noctalia 5.0.0).
- `nix run .#default -- --help` confirms the binary loads — libmd4c resolves at runtime.
- Built and deployed via my NixOS + Niri config (flake input pointed at this branch); running this build as my daily shell — bar, rendering, etc. behave normally.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- `just format` is N/A here — only `nix/package.nix` changed, no C++ files.
- stb is overridden to a 2026-04-15 commit because nixpkgs' stb (2023-01-29) is too old. A cleaner long-term fix would be bumping stb in nixpkgs itself; out of scope for this PR.
- Side note: PR CI (`ci.yml`) only builds via Arch packages and doesn't run `nix build` on PRs (that only runs via `cachix.yml` on push to `main`), which is how this breakage slipped past #3311.