### PR TITLE
feat: add M3-Oled generation scheme

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3413,6 +3413,7 @@
       "m3-content": "M3 Content",
       "m3-fruit-salad": "M3 Fruit Salad",
       "m3-monochrome": "M3 Monochrome",
+      "m3-oled": "M3 OLED",
       "m3-rainbow": "M3 Rainbow",
       "m3-tonal-spot": "M3 Tonal Spot",
       "muted": "Muted",

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -193,6 +193,7 @@ namespace settings {
     SelectSetting wallpaperSchemeSelect(std::string_view selected) {
       return plainSelect(
           {{"m3-content", "theme.scheme.m3-content"},
+           {"m3-oled", "theme.scheme.m3-oled"},
            {"m3-tonal-spot", "theme.scheme.m3-tonal-spot"},
            {"m3-fruit-salad", "theme.scheme.m3-fruit-salad"},
            {"m3-rainbow", "theme.scheme.m3-rainbow"},

--- a/src/shell/setup_wizard/setup_wizard_panel.cpp
+++ b/src/shell/setup_wizard/setup_wizard_panel.cpp
@@ -37,6 +37,7 @@ namespace {
 
   constexpr SelectOption kWallpaperSchemes[] = {
       {"theme.scheme.m3-content", "m3-content"},
+      {"theme.scheme.m3-oled", "m3-oled"},
       {"theme.scheme.m3-tonal-spot", "m3-tonal-spot"},
       {"theme.scheme.m3-fruit-salad", "m3-fruit-salad"},
       {"theme.scheme.m3-rainbow", "m3-rainbow"},

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -78,18 +78,19 @@ namespace {
 
   [[nodiscard]] std::vector<std::string> wallpaperSchemeOptions() {
     return {
-        i18n::tr("theme.scheme.m3-content"),     i18n::tr("theme.scheme.m3-tonal-spot"),
-        i18n::tr("theme.scheme.m3-fruit-salad"), i18n::tr("theme.scheme.m3-rainbow"),
-        i18n::tr("theme.scheme.m3-monochrome"),  i18n::tr("theme.scheme.vibrant"),
-        i18n::tr("theme.scheme.faithful"),       i18n::tr("theme.scheme.soft"),
-        i18n::tr("theme.scheme.dysfunctional"),  i18n::tr("theme.scheme.muted"),
+        i18n::tr("theme.scheme.m3-content"),    i18n::tr("theme.scheme.m3-oled"),
+        i18n::tr("theme.scheme.m3-tonal-spot"), i18n::tr("theme.scheme.m3-fruit-salad"),
+        i18n::tr("theme.scheme.m3-rainbow"),    i18n::tr("theme.scheme.m3-monochrome"),
+        i18n::tr("theme.scheme.vibrant"),       i18n::tr("theme.scheme.faithful"),
+        i18n::tr("theme.scheme.soft"),          i18n::tr("theme.scheme.dysfunctional"),
+        i18n::tr("theme.scheme.muted"),
     };
   }
 
   [[nodiscard]] std::vector<std::string> wallpaperSchemeValues() {
     return {
-        "m3-content", "m3-tonal-spot", "m3-fruit-salad", "m3-rainbow",    "m3-monochrome",
-        "vibrant",    "faithful",      "soft",           "dysfunctional", "muted",
+        "m3-content", "m3-oled",  "m3-tonal-spot", "m3-fruit-salad", "m3-rainbow", "m3-monochrome",
+        "vibrant",    "faithful", "soft",          "dysfunctional",  "muted",
     };
   }
 

--- a/src/theme/cli.cpp
+++ b/src/theme/cli.cpp
@@ -42,6 +42,7 @@ namespace noctalia::theme {
         "  --scheme <name>   Material You (Material Design 3):\n"
         "                      m3-tonal-spot  (default)\n"
         "                      m3-content\n"
+        "                      m3-oled\n"
         "                      m3-fruit-salad\n"
         "                      m3-rainbow\n"
         "                      m3-monochrome\n"

--- a/src/theme/custom_palettes.cpp
+++ b/src/theme/custom_palettes.cpp
@@ -196,9 +196,9 @@ namespace noctalia::theme {
 
     std::string shortSchemeTag(std::string_view scheme) {
       static constexpr std::pair<std::string_view, std::string_view> kTags[] = {
-          {"m3-tonal-spot", "ts"},  {"m3-content", "mc"}, {"m3-fruit-salad", "fs"}, {"m3-rainbow", "rb"},
-          {"m3-monochrome", "mo"},  {"vibrant", "vib"},   {"faithful", "fth"},      {"soft", "sft"},
-          {"dysfunctional", "dys"}, {"muted", "mut"},
+          {"m3-tonal-spot", "ts"}, {"m3-content", "mc"},     {"m3-oled", "ol"},  {"m3-fruit-salad", "fs"},
+          {"m3-rainbow", "rb"},    {"m3-monochrome", "mo"},  {"vibrant", "vib"}, {"faithful", "fth"},
+          {"soft", "sft"},         {"dysfunctional", "dys"}, {"muted", "mut"},
       };
       for (const auto& [full, tag] : kTags) {
         if (scheme == full) {

--- a/src/theme/m3_schemes.cpp
+++ b/src/theme/m3_schemes.cpp
@@ -342,6 +342,7 @@ namespace noctalia::theme {
       case Scheme::TonalSpot:
         return std::make_unique<mcu::SchemeTonalSpot>(source, isDark, 0.0);
       case Scheme::Content:
+      case Scheme::Oled:
         return std::make_unique<mcu::SchemeContent>(source, isDark, 0.0);
       case Scheme::FruitSalad:
         return std::make_unique<mcu::SchemeFruitSalad>(source, isDark, 0.0);
@@ -445,6 +446,14 @@ namespace noctalia::theme {
     out.light = buildTokenMap(*lightScheme);
     out.dark["source_color"] = seed;
     out.light["source_color"] = seed;
+
+    if (scheme == Scheme::Oled) {
+      out.dark["background"] = 0xff000000u;
+      out.dark["surface"] = 0xff000000u;
+      out.dark["surface_dim"] = 0xff000000u;
+      out.dark["surface_container_lowest"] = 0xff000000u;
+    }
+
     synthesizeTerminalPaletteTokens(out);
     return out;
   }

--- a/src/theme/scheme.cpp
+++ b/src/theme/scheme.cpp
@@ -7,6 +7,8 @@ namespace noctalia::theme {
       return Scheme::TonalSpot;
     if (s == "m3-content")
       return Scheme::Content;
+    if (s == "m3-oled")
+      return Scheme::Oled;
     if (s == "m3-fruit-salad")
       return Scheme::FruitSalad;
     if (s == "m3-rainbow")
@@ -32,6 +34,8 @@ namespace noctalia::theme {
       return "m3-tonal-spot";
     case Scheme::Content:
       return "m3-content";
+    case Scheme::Oled:
+      return "m3-oled";
     case Scheme::FruitSalad:
       return "m3-fruit-salad";
     case Scheme::Rainbow:

--- a/src/theme/scheme.h
+++ b/src/theme/scheme.h
@@ -13,6 +13,7 @@ namespace noctalia::theme {
   enum class Scheme {
     TonalSpot,
     Content,
+    Oled,
     FruitSalad,
     Rainbow,
     Monochrome,
@@ -27,6 +28,7 @@ namespace noctalia::theme {
   constexpr bool isMaterialScheme(Scheme s) {
     return s == Scheme::TonalSpot
         || s == Scheme::Content
+        || s == Scheme::Oled
         || s == Scheme::FruitSalad
         || s == Scheme::Rainbow
         || s == Scheme::Monochrome;


### PR DESCRIPTION
## Summary
Added a OLED version of the M3 Content color palette generation scheme. This is useful in certain models of OLED monitor to avoid the banding issued that is present with a dark gray background (probably it is also useful to implement OLED panel background, but that will be another pull request in case).
While there are community palette sources that implement a OLED color scheme they do not adapt the colors to the current wallpaper. This pull request tries to fix that.
For the name of the color scheme I've chose M3 OLED, but since that version doesn't actually exists maybe it should be named differently.

Here it is an example of the banding issue for reference (photo taken from a reddit post):
<img width="4000" height="3000" alt="banding" src="https://github.com/user-attachments/assets/6d964488-cf06-4b86-8d70-288edcb9f5e0" />

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
<img width="861" height="67" alt="image" src="https://github.com/user-attachments/assets/3c15dc72-344a-4946-b9ff-eeb3fc49b139" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.