### PR TITLE
feat(plugins): expose barWidget.outputName to bar widgets

### DIFF
--- a/src/scripting/plugin_bindings.cpp
+++ b/src/scripting/plugin_bindings.cpp
@@ -207,6 +207,16 @@ namespace {
     return 1;
   }
 
+  int luau_outputName(lua_State* L) {
+    auto* context = getContext(L);
+    if (context == nullptr || context->snapshot.outputName.empty()) {
+      lua_pushnil(L);
+      return 1;
+    }
+    lua_pushlstring(L, context->snapshot.outputName.data(), context->snapshot.outputName.size());
+    return 1;
+  }
+
   int luau_setVisible(lua_State* L) {
     bool visible = lua_toboolean(L, 1) != 0;
     if (auto* context = getContext(L)) {
@@ -229,6 +239,7 @@ namespace {
       {"setColor", luau_setColor},
       {"setGlyphColor", luau_setGlyphColor},
       {"isVertical", luau_isVertical},
+      {"outputName", luau_outputName},
       {"setVisible", luau_setVisible},
       {"render", luau_ui_render},
       {"getConfig", scripting::luau_getConfig},


### PR DESCRIPTION
## Summary

Adds a `barWidget.outputName()` binding for bar-widget plugins, returning the connector name of the output the widget instance is placed on, mirroring the existing `barWidget.isVertical()` binding.

## Motivation

A bar-widget plugin instance currently has no way to know which monitor
it is rendered on. `noctalia.focusedOutputName()` exists but returns the
globally focused output — the same value for every bar on every monitor
— so it can't be used to scope per-monitor content. Native widgets get
their output at construction (e.g. the workspaces widget filters its
workspaces by it); plugins can't replicate that, which forces manual
per-placement settings like "type your connector name here".

Concrete case: a niri workspace/taskbar plugin that should show each
bar's own monitor's workspaces, the way the built-in workspaces widget
does. With this binding it Just Works on multi-monitor setups with zero
configuration.

## Type of Change

- [x] New feature

## Related Issue

—

## Testing

- Built from source on NixOS (patch applied on `main` @ 3137323) and ran the full shell.
- Exercised live by a niri workspace/taskbar bar-widget plugin on a two output setup: each bar's widget instance reports its own connector name and filters its content accordingly; the same plugin placed on both bars returns different values.
- Verified `nil` handling: the binding returns nil (not an empty string) when the snapshot carries no output name, and plugins without the call are unaffected.
- `just format` (clang-format 22) — no diff.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="259" height="53" alt="image" src="https://github.com/user-attachments/assets/27acf9ad-0d05-4f1e-98c5-7ad3ba01428a" />

workspaces on mon 1

<img width="70" height="39" alt="image" src="https://github.com/user-attachments/assets/890e3769-87f2-40d8-81c2-00fdf6ec351a" />

workspaces on mon 2 (only 1)

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test command not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation aft change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Returns the raw connector name rather than a richer output object to keep the surface minimal; plugins needing geometry can cross-reference `noctalia.outputs()` by name. Docs follow-up after merge: add `outputName()` next to `isVertical()` on the bar-widget API page.

Disclaimer: AI-assisted tooling was used.