### PR TITLE
feat(plugins): expose radius and padding on button nodes

### DIFF
--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -279,10 +279,11 @@ namespace ui {
                                                                  "color",   "spacing", "orientation"};
       static const std::unordered_set<std::string> kProgress = {"width",    "height", "flexGrow", "opacity", "visible",
                                                                 "progress", "fill",   "track",    "radius"};
-      static const std::unordered_set<std::string> kButton = {"width",     "height",  "flexGrow",     "opacity",
-                                                              "visible",   "text",    "glyph",        "fontSize",
-                                                              "glyphSize", "variant", "contentAlign", "enabled",
-                                                              "selected",  "onClick", "onRightClick"};
+      static const std::unordered_set<std::string> kButton = {"width",     "height",   "flexGrow",     "opacity",
+                                                              "visible",   "text",     "glyph",        "fontSize",
+                                                              "glyphSize", "variant",  "contentAlign", "enabled",
+                                                              "selected",  "onClick",  "onRightClick", "radius",
+                                                              "padding",   "paddingH", "paddingV"};
       static const std::unordered_set<std::string> kGraph = {"width",   "height",    "flexGrow",   "opacity",
                                                              "visible", "values",    "values2",    "color",
                                                              "color2",  "lineWidth", "fillOpacity"};
@@ -893,6 +894,21 @@ namespace ui {
       if (m_compactControls) {
         button->setMinHeight(0.0f);
         button->setPadding(Style::spaceXs * m_scale);
+      }
+      // Button is a Flex, so shape/inset setters are inherited; expose them
+      // the same way the row/column branch does. Applied after the compact
+      // block so explicit props always win over host chrome defaults.
+      if (const double* radius = numProp(desired, "radius")) {
+        button->setRadius(scaled(*radius));
+      }
+      const double* padding = numProp(desired, "padding");
+      const double* paddingV = numProp(desired, "paddingV");
+      const double* paddingH = numProp(desired, "paddingH");
+      if (padding != nullptr || paddingV != nullptr || paddingH != nullptr) {
+        const float fallback = padding != nullptr ? scaled(*padding) : 0.0f;
+        button->setPadding(
+            paddingV != nullptr ? scaled(*paddingV) : fallback, paddingH != nullptr ? scaled(*paddingH) : fallback
+        );
       }
       if (width != nullptr) {
         button->setMinWidth(scaled(*width));


### PR DESCRIPTION
## Summary

Exposes `radius`, `padding`, `paddingH`, and `paddingV` on declarative
`button` nodes in the plugin UI tree. `Button` already inherits these
setters from `Flex`; this change adds the four keys to the button prop
allowlist and applies them mirroring the existing `row`/`column`
handling. Application happens after the compact-host chrome block, so
explicit props win over the bar-widget padding/min-height reset. No
behavior change for trees that do not pass the new props.

## Motivation

Plugin bar widgets can't shape their buttons: `button` is the only
clickable text-bearing node, but its corner radius and padding are fixed
by the control's chrome. A widget that wants capsule chips visually
consistent with the built-in workspaces widget's pills (fully rounded,
active pill wider via a larger horizontal inset) has no way to express
that — the workaround is padding the label with literal spaces. With
this change a plugin passes `radius`/`paddingH` per node with the same
semantics and scaling as the flex containers.

## Type of Change

- [x] New feature

## Testing

- Built from source on NixOS (patch on `main` @ 3137323), full shell run.
- Exercised live by a niri workspace/taskbar bar-widget plugin: capsule
  chips (`height` + `radius`), wider active chip via `paddingH`, props
  re-applied correctly across re-renders, and confirmed the compact-host
  ordering: explicit padding survives the bar-widget chrome reset.
- Trees omitting the new props render identically to before.
- `just format` (clang-format 22) — no diff.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested with different bar positions and density settings
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="259" height="53" alt="niri-2026-07-10-01-59-06" src="https://github.com/user-attachments/assets/2e4818f2-5ed6-4024-8bc8-ab2956ba385b" />

before

<img width="212" height="50" alt="image" src="https://github.com/user-attachments/assets/6161e489-da15-4063-a3ae-9141e14ab247" />

after

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.


## Additional Notes

Prop names and application semantics are copied verbatim from the
`row`/`column` branch (`padding` fallback for `paddingV`/`paddingH`,
values through `scaled()`) — one consistent vocabulary across node
types. Docs follow-up after merge: add the props to the declarative-UI
button section.

Disclaimer: AI-assisted tooling was used.