### PR TITLE
fix(calendar): skip unselected google calendars

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1129,6 +1129,18 @@ ical_recurrence_test = executable('ical_recurrence_test',
 
 test('ical_recurrence', ical_recurrence_test)
 
+google_client_calendar_list_test = executable('google_client_calendar_list_test',
+  sources: files(
+    'tests/google_client_calendar_list_test.cpp',
+  ),
+  dependencies: [
+    nlohmann_dep,
+  ],
+  include_directories: _noctalia_inc,
+)
+
+test('google_client_calendar_list', google_client_calendar_list_test)
+
 time_format_test = executable('time_format_test',
   sources: files(
     'tests/time_format_test.cpp',

--- a/src/calendar/google_calendar_list.h
+++ b/src/calendar/google_calendar_list.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace calendar::detail {
+
+  [[nodiscard]] inline bool googleCalendarListItemSelected(const nlohmann::json& item) {
+    return item.value("selected", false);
+  }
+
+} // namespace calendar::detail

--- a/src/calendar/google_client.cpp
+++ b/src/calendar/google_client.cpp
@@ -1,5 +1,6 @@
 #include "calendar/google_client.h"
 
+#include "calendar/google_calendar_list.h"
 #include "core/log.h"
 #include "net/http_client.h"
 #include "net/uri.h"
@@ -174,7 +175,7 @@ namespace calendar {
         const auto j = nlohmann::json::parse(resp.body);
         if (auto items = j.find("items"); items != j.end() && items->is_array()) {
           for (const auto& item : *items) {
-            if (item.value("selected", true) == false) {
+            if (!detail::googleCalendarListItemSelected(item)) {
               continue;
             }
             CalendarMeta meta;

--- a/tests/google_client_calendar_list_test.cpp
+++ b/tests/google_client_calendar_list_test.cpp
@@ -1,0 +1,39 @@
+#include "calendar/google_calendar_list.h"
+
+#include <cstdio>
+#include <nlohmann/json.hpp>
+
+namespace {
+
+  bool expectSelected(const nlohmann::json& item, bool expected, const char* message) {
+    const bool actual = calendar::detail::googleCalendarListItemSelected(item);
+    if (actual != expected) {
+      std::fprintf(
+          stderr, "google_client_calendar_list_test: %s: expected %s, got %s\n", message,
+          expected ? "selected" : "unselected", actual ? "selected" : "unselected"
+      );
+      return false;
+    }
+    return true;
+  }
+
+} // namespace
+
+int main() {
+  bool ok = true;
+  ok = expectSelected(
+           nlohmann::json{{"id", "checked@example.com"}, {"selected", true}}, true,
+           "explicitly selected calendar is synced"
+       )
+      && ok;
+  ok = expectSelected(
+           nlohmann::json{{"id", "unchecked@example.com"}, {"selected", false}}, false,
+           "explicitly unselected calendar is skipped"
+       )
+      && ok;
+  ok = expectSelected(
+           nlohmann::json{{"id", "omitted@example.com"}}, false, "omitted selected field uses Google's false default"
+       )
+      && ok;
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixed an issue by matching Google CalendarList's documented `selected` default. Calendar list items with an omitted `selected` field are now treated as unselected and skipped.

Added a regression test for explicit selected, explicit unselected, and omitted `selected` values.

## Motivation

Unchecked Google calendars can be returned without a `selected` field. The previous fallback treated missing `selected` as `true`, so unchecked calendars were still synced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Fixes #3351

## Testing

- `clang-format -i src/calendar/google_client.cpp src/calendar/google_calendar_list.h tests/google_client_calendar_list_test.cpp`
- `nix develop --command g++ -std=c++23 -Isrc tests/google_client_calendar_list_test.cpp -o ./build/google_client_calendar_list_test`
- `nix develop --command g++ -std=c++23 -Isrc -c src/calendar/google_client.cpp -o ./build/google_client.o`

Could not run `meson test -C build-debug google_client_calendar_list --print-errorlogs` because Meson regeneration currently fails resolving the unrelated `md4c` dependency.

Also, tested manually by switching the checkbox in Google Calendar UI and restarting noctalia shell - works as expected.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

None.
