### PR TITLE
render/gles: check glTexImage2D errors on texture upload

### DIFF
--- a/src/render/backend/gles_texture_manager.cpp
+++ b/src/render/backend/gles_texture_manager.cpp
@@ -40,6 +40,13 @@ namespace {
     return filter == TextureFilter::Nearest ? GL_NEAREST_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR;
   }
 
+  // Drains any pending GL errors so a subsequent glGetError() check reflects
+  // only the call we care about, not stale errors from earlier GL calls.
+  void clearGlErrors() {
+    while (glGetError() != GL_NO_ERROR) {
+    }
+  }
+
 } // namespace
 
 TextureHandle GlesTextureManager::decodeEncodedRaster(
@@ -268,7 +275,15 @@ TextureHandle GlesTextureManager::uploadBgra(const std::uint8_t* data, int width
   }
   glBindTexture(GL_TEXTURE_2D, tex);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+  clearGlErrors();
   glTexImage2D(GL_TEXTURE_2D, 0, GL_BGRA_EXT, width, height, 0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, data);
+  if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
+    kLog.warn("glTexImage2D failed for {}x{} BGRA texture: 0x{:x}", width, height, err);
+    glDeleteTextures(1, &tex);
+    return {};
+  }
+
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   if (mipmap) {
@@ -301,7 +316,15 @@ TextureHandle GlesTextureManager::uploadPixels(
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
   const GLenum glFormat = toGlesFormat(format);
+
+  clearGlErrors();
   glTexImage2D(GL_TEXTURE_2D, 0, static_cast<GLint>(glFormat), width, height, 0, glFormat, GL_UNSIGNED_BYTE, data);
+  if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
+    kLog.warn("glTexImage2D failed for {}x{} texture (format=0x{:x}): 0x{:x}", width, height, glFormat, err);
+    glDeleteTextures(1, &tex);
+    return {};
+  }
+
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   if (mipmap) {

--- a/src/render/backend/gles_texture_manager.cpp
+++ b/src/render/backend/gles_texture_manager.cpp
@@ -40,11 +40,25 @@ namespace {
     return filter == TextureFilter::Nearest ? GL_NEAREST_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR;
   }
 
-  // Drains any pending GL errors so a subsequent glGetError() check reflects
-  // only the call we care about, not stale errors from earlier GL calls.
+  // Drops errors raised before the call we are about to check. Bounded because a robust context that
+  // has been lost keeps reporting GL_CONTEXT_LOST, which would hang an unbounded drain.
   void clearGlErrors() {
-    while (glGetError() != GL_NO_ERROR) {
+    constexpr int kMaxDrain = 32;
+    for (int i = 0; i < kMaxDrain && glGetError() != GL_NO_ERROR; ++i) {
     }
+  }
+
+  // Uploads level 0 and reports whether the driver accepted it. GLES2 requires internal format and
+  // format to be equal, so both come from `format`.
+  [[nodiscard]] bool
+  texImage2dChecked(GLenum format, int width, int height, const std::uint8_t* data, const char* what) {
+    clearGlErrors();
+    glTexImage2D(GL_TEXTURE_2D, 0, static_cast<GLint>(format), width, height, 0, format, GL_UNSIGNED_BYTE, data);
+    if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
+      kLog.warn("glTexImage2D failed for {}x{} {} texture (format=0x{:x}): 0x{:x}", width, height, what, format, err);
+      return false;
+    }
+    return true;
   }
 
 } // namespace
@@ -275,15 +289,10 @@ TextureHandle GlesTextureManager::uploadBgra(const std::uint8_t* data, int width
   }
   glBindTexture(GL_TEXTURE_2D, tex);
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-  clearGlErrors();
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_BGRA_EXT, width, height, 0, GL_BGRA_EXT, GL_UNSIGNED_BYTE, data);
-  if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
-    kLog.warn("glTexImage2D failed for {}x{} BGRA texture: 0x{:x}", width, height, err);
+  if (!texImage2dChecked(GL_BGRA_EXT, width, height, data, "BGRA")) {
     glDeleteTextures(1, &tex);
     return {};
   }
-
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   if (mipmap) {
@@ -316,15 +325,10 @@ TextureHandle GlesTextureManager::uploadPixels(
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
   const GLenum glFormat = toGlesFormat(format);
-
-  clearGlErrors();
-  glTexImage2D(GL_TEXTURE_2D, 0, static_cast<GLint>(glFormat), width, height, 0, glFormat, GL_UNSIGNED_BYTE, data);
-  if (const GLenum err = glGetError(); err != GL_NO_ERROR) {
-    kLog.warn("glTexImage2D failed for {}x{} texture (format=0x{:x}): 0x{:x}", width, height, glFormat, err);
+  if (!texImage2dChecked(glFormat, width, height, data, "pixel")) {
     glDeleteTextures(1, &tex);
     return {};
   }
-
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   if (mipmap) {


### PR DESCRIPTION


<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
uploadBgra() and uploadPixels() only checked glGenTextures for failure. If glTexImage2D itself failed (oversized dimensions, unsupported internal-format/format combination, out of texture memory etccc) the function still returned a valid TextureHandle wrapping a texture object with undefined storage. Callers had no way to detect this!! the failure surfaced later as a black or garbage texture with no diagnostic pointing at the cause. So I took a good look at render and found this.

Drain the error queue before the call, check glGetError() after and on failure delete th texture object and return a empty handle consistent with the existing glGenTextures failure path.

## Motivation

<!-- What problem does this solve? -->
I have seen a FEW times my screen had some visual bugs in random places on my monitor.
decided to look into rendering found this.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
I did not build compile or test this.
I am too tired to do so will either check in the morning or have it tested on my repo.
## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
Hopefully this fixes the bug I am getting it could be caused by something else.