### PR TITLE
fix(bar/widget): expand user path in custom_image for bar widgets

### DIFF
--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -16,6 +16,21 @@
 
 namespace noctalia::config::schema {
 
+  namespace {
+    // String holding a filesystem path: ~ expands on read, emitted raw.
+    template <typename Struct> Field<Struct> pathStringField(std::string Struct::* member, std::string_view key) {
+      return custom<Struct>(
+          key,
+          [member, key](const toml::table& tbl, Struct& out, std::string_view, Diagnostics&) {
+            if (auto v = tbl[key].value<std::string>()) {
+              out.*member = v->empty() ? *v : FileUtils::expandUserPath(*v).string();
+            }
+          },
+          [member, key](toml::table& tbl, const Struct& in) { tbl.insert_or_assign(key, in.*member); }
+      );
+    }
+  } // namespace
+
   const Schema<AudioConfig>& audioSchema() {
     static const Schema<AudioConfig> s = {
         field(&AudioConfig::enableOverdrive, "enable_overdrive"),
@@ -89,7 +104,7 @@ namespace noctalia::config::schema {
         field(&LockscreenConfig::blurredDesktop, "blurred_desktop"),
         field(&LockscreenConfig::blurIntensity, "blur_intensity", kUnitRange),
         field(&LockscreenConfig::tintIntensity, "tint_intensity", kUnitRange),
-        field(&LockscreenConfig::wallpaper, "wallpaper"),
+        pathStringField(&LockscreenConfig::wallpaper, "wallpaper"),
         field(&LockscreenConfig::monitors, "monitors"),
     };
     return s;
@@ -396,7 +411,7 @@ namespace noctalia::config::schema {
         field(&DockConfig::showInstanceCount, "show_instance_count"),
         enumField(&DockConfig::launcherPosition, "launcher_position", kDockLauncherPositions),
         field(&DockConfig::launcherIcon, "launcher_icon"),
-        field(&DockConfig::launcherCustomImage, "launcher_custom_image"),
+        pathStringField(&DockConfig::launcherCustomImage, "launcher_custom_image"),
         field(&DockConfig::launcherCustomImageColorize, "launcher_custom_image_colorize"),
         field(&DockConfig::pinned, "pinned"),
         field(&DockConfig::monitors, "monitors"),
@@ -635,19 +650,6 @@ namespace noctalia::config::schema {
               tbl.insert_or_assign(key, std::string{});
             }
           }
-      );
-    }
-
-    // String holding a filesystem path: ~ and $VARS expand on read, emitted raw.
-    template <typename Struct> Field<Struct> pathStringField(std::string Struct::* member, std::string_view key) {
-      return custom<Struct>(
-          key,
-          [member, key](const toml::table& tbl, Struct& out, std::string_view, Diagnostics&) {
-            if (auto v = tbl[key].value<std::string>()) {
-              out.*member = v->empty() ? *v : FileUtils::expandUserPath(*v).string();
-            }
-          },
-          [member, key](toml::table& tbl, const Struct& in) { tbl.insert_or_assign(key, in.*member); }
       );
     }
 

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -91,10 +91,12 @@ namespace {
   }
 
   WidgetCustomImage customImageFor(const WidgetConfig* wc) {
-    const std::string path = wc != nullptr ? wc->getString("custom_image", "") : std::string{};
+    if (wc == nullptr) {
+      return {};
+    }
     return WidgetCustomImage{
-        .path = FileUtils::expandUserPath(path).string(),
-        .colorize = wc != nullptr ? wc->getBool("custom_image_colorize", false) : false,
+        .path = FileUtils::expandUserPath(wc->getString("custom_image", "")).string(),
+        .colorize = wc->getBool("custom_image_colorize", false),
     };
   }
 
@@ -470,7 +472,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "sysmon") {
     const bool verticalBar = barPosition == "left" || barPosition == "right";
     std::string statStr = wc != nullptr ? wc->getString("stat", "cpu_usage") : std::string("cpu_usage");
-    std::string path = wc != nullptr ? wc->getString("path", "/") : std::string("/");
+    std::string path =
+        FileUtils::expandUserPath(wc != nullptr ? wc->getString("path", "/") : std::string("/")).string();
     SysmonStat stat = SysmonStat::CpuUsage;
     if (statStr == "cpu_temp") {
       stat = SysmonStat::CpuTemp;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -46,6 +46,7 @@
 #include "shell/bar/widgets/workspaces_widget.h"
 #include "system/format_units.h"
 #include "ui/style.h"
+#include "util/file_utils.h"
 #include "util/string_utils.h"
 #include "wayland/wayland_connection.h"
 
@@ -90,8 +91,9 @@ namespace {
   }
 
   WidgetCustomImage customImageFor(const WidgetConfig* wc) {
+    const std::string path = wc != nullptr ? wc->getString("custom_image", "") : std::string{};
     return WidgetCustomImage{
-        .path = wc != nullptr ? wc->getString("custom_image", "") : std::string{},
+        .path = FileUtils::expandUserPath(path).string(),
         .colorize = wc != nullptr ? wc->getBool("custom_image_colorize", false) : false,
     };
   }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

This PR changes to expand the `~` in custom image path resolving since it currently does not resolve yet.

## Motivation

<!-- What problem does this solve? -->

This would allow users to write `~/path/to/image`, the same as we can currently for wallpaper directory.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
