### PR TITLE
feat(calendar): Add option to show week numbers

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2445,6 +2445,10 @@
           "description-unavailable": "No Secret Service provider is available. Calendar events remain available for this session only.",
           "label": "Calendar Event Storage"
         },
+        "calendar-week-numbers": {
+          "description": "Show ISO 8601 week numbers alongside the calendar grid",
+          "label": "Week Numbers"
+        },
         "custom-schedule": {
           "description": "Use manual sunrise/sunset times instead of computing from coordinates",
           "label": "Custom Schedule"

--- a/example.toml
+++ b/example.toml
@@ -225,6 +225,12 @@ disk_poll_seconds = 10.0            # disk usage and swap usage; graph widgets u
 [calendar]
 enabled                     = false
 refresh_minutes             = 15
+
+# Calendar tab of the control center.
+
+[control_center.calendar]
+show_events_card            = true
+show_week_numbers           = false         # ISO 8601 week numbers in the month grid
 event_date_format           = "%A %e %B"    # date format used for events
 event_time_format           = "%H:%M"       # time format used for events
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1071,8 +1071,6 @@ struct CalendarConfig {
 
   bool enabled = false;
   std::int32_t refreshMinutes = 15;
-  std::string eventDateFormat = "%A %e %B";
-  std::string eventTimeFormat = "%H:%M";
   std::vector<Account> accounts;
 
   bool operator==(const CalendarConfig&) const = default;
@@ -1430,6 +1428,9 @@ struct ControlCenterConfig {
 
   struct CalendarTabConfig {
     bool showEventsCard = true;
+    bool showWeekNumbers = false;
+    std::string eventDateFormat = "%A %e %B";
+    std::string eventTimeFormat = "%H:%M";
     bool operator==(const CalendarTabConfig&) const = default;
   };
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -477,6 +477,9 @@ namespace noctalia::config::schema {
     const Schema<ControlCenterConfig::CalendarTabConfig>& calendarTabSchema() {
       static const Schema<ControlCenterConfig::CalendarTabConfig> s = {
           field(&ControlCenterConfig::CalendarTabConfig::showEventsCard, "show_events_card"),
+          field(&ControlCenterConfig::CalendarTabConfig::showWeekNumbers, "show_week_numbers"),
+          field(&ControlCenterConfig::CalendarTabConfig::eventDateFormat, "event_date_format"),
+          field(&ControlCenterConfig::CalendarTabConfig::eventTimeFormat, "event_time_format"),
       };
       return s;
     }
@@ -1562,8 +1565,6 @@ namespace noctalia::config::schema {
     static const Schema<CalendarConfig> s = {
         field(&CalendarConfig::enabled, "enabled"),
         field(&CalendarConfig::refreshMinutes, "refresh_minutes", kRefreshMinutesRange),
-        field(&CalendarConfig::eventDateFormat, "event_date_format"),
-        field(&CalendarConfig::eventTimeFormat, "event_time_format"),
         namedMap<CalendarConfig, CalendarConfig::Account>(
             &CalendarConfig::accounts, "account", calendarAccountSchema(),
             [](CalendarConfig::Account& a, std::string_view id) { a.id = std::string(id); },

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstddef>
 #include <ctime>
+#include <format>
 #include <memory>
 #include <string>
 #include <vector>
@@ -41,6 +42,10 @@ namespace {
   constexpr float kCalendarCellSizeMax = Style::controlHeightLg + Style::spaceXs;
   constexpr float kCalendarDayButtonSizeMax = Style::controlHeightLg;
   constexpr float kCalendarLayoutEpsilon = 0.5f;
+  // Week-number column: a fraction of a day column so it stays visually subordinate, floored at the
+  // width of the two digits it holds (as a multiple of the caption font size) so it can never clip.
+  constexpr float kCalendarWeekColumnRatio = 0.55f;
+  constexpr float kCalendarWeekColumnMinFontScale = 1.45f;
 
   std::string monthName(int month) {
     if (month < 0 || month > 11) {
@@ -149,6 +154,7 @@ std::unique_ptr<Flex> CalendarTab::create() {
 
   if (m_config != nullptr) {
     m_showEventsCard = m_config->config().controlCenter.calendarTab.showEventsCard;
+    m_showWeekNumbers = m_config->config().controlCenter.calendarTab.showWeekNumbers;
   }
 
   auto tab = ui::row({
@@ -573,7 +579,28 @@ void CalendarTab::rebuild() {
       (gridHeightAvailable - weekdayHeight - kCalendarGridGap * scale * 6.0f) / 6.0f, kCalendarCellSizeMin * scale,
       kCalendarCellSizeMax * scale
   );
-  const float dayColumnWidth = std::max(0.0f, (innerWidth - kCalendarGridGap * scale * 6.0f) / 7.0f);
+
+  // The week-number column takes its share of the row before the day columns split the rest. It is
+  // inset from the divider by one grid gap, which reads as balanced against the card padding on its
+  // other side without spending a full card padding's worth of width on a two-digit number.
+  const float weekLaneInset = m_showWeekNumbers ? kCalendarGridGap * scale : 0.0f;
+  const float weekDividerWidth = m_showWeekNumbers ? std::round(1.0f * scale) : 0.0f;
+  const float weekLaneOverhead = m_showWeekNumbers ? weekLaneInset + weekDividerWidth + kCalendarGridGap * scale : 0.0f;
+  // Solve for a day column that leaves the week column its fraction, then floor the week column at the
+  // width of its text and give the day grid whatever is actually left.
+  const float provisionalDayColumn = std::max(
+      0.0f,
+      (innerWidth - kCalendarGridGap * scale * 6.0f - weekLaneOverhead)
+          / (m_showWeekNumbers ? 7.0f + kCalendarWeekColumnRatio : 7.0f)
+  );
+  const float weekColumnWidth = m_showWeekNumbers
+      ? std::max(
+            std::round(provisionalDayColumn * kCalendarWeekColumnRatio),
+            std::round(Style::fontSizeCaption * scale * kCalendarWeekColumnMinFontScale)
+        )
+      : 0.0f;
+  const float dayGridWidth = std::max(0.0f, innerWidth - weekColumnWidth - weekLaneOverhead);
+  const float dayColumnWidth = std::max(0.0f, (dayGridWidth - kCalendarGridGap * scale * 6.0f) / 7.0f);
   // Reserve a fixed strip under each day number for event indicator dots so all cells stay aligned.
   const float dotDiameter = std::round(5.0f * scale);
   const float dotGap = std::round(2.0f * scale);
@@ -634,7 +661,7 @@ void CalendarTab::rebuild() {
   weekdayRow->setColumns(weekdays.size());
   weekdayRow->setColumnGap(kCalendarGridGap * scale);
   weekdayRow->setStretchItems(true);
-  weekdayRow->setSize(innerWidth, weekdayHeight);
+  weekdayRow->setSize(dayGridWidth, weekdayHeight);
   weekdayRow->setMinCellHeight(weekdayHeight);
   for (std::size_t i = 0; i < weekdays.size(); ++i) {
     auto dayCell = std::make_unique<GridTile>();
@@ -655,8 +682,6 @@ void CalendarTab::rebuild() {
 
     weekdayRow->addChild(std::move(dayCell));
   }
-  m_grid->addChild(std::move(weekdayRow));
-
   const int firstWeekdayOffset = (state.displayWeekday - firstDayOfWeek + 7) % 7;
   const int previousMonth = month == 0 ? 11 : month - 1;
   const int previousMonthYear = month == 0 ? year - 1 : year;
@@ -693,7 +718,7 @@ void CalendarTab::rebuild() {
   dayGrid->setColumns(7);
   dayGrid->setColumnGap(kCalendarGridGap * scale);
   dayGrid->setStretchItems(true);
-  dayGrid->setSize(innerWidth, 0.0f);
+  dayGrid->setSize(dayGridWidth, 0.0f);
   dayGrid->setMinCellHeight(dayCellHeight);
 
   int day = 1;
@@ -805,10 +830,69 @@ void CalendarTab::rebuild() {
     dayGrid->addChild(std::move(dayTile));
   }
 
-  m_grid->addChild(std::move(dayGrid));
-
   const float gridContentHeight =
       weekdayHeight + kCalendarGridGap * scale + 6.0f * dayCellHeight + 5.0f * kCalendarGridGap * scale;
+
+  auto daysColumn = ui::column({.gap = kCalendarGridGap * scale});
+  daysColumn->addChild(std::move(weekdayRow));
+  daysColumn->addChild(std::move(dayGrid));
+  daysColumn->setSize(dayGridWidth, gridContentHeight);
+
+  if (m_showWeekNumbers) {
+    const auto spacer = [](float w, float h) {
+      auto s = ui::column({});
+      s->setSize(w, h);
+      return s;
+    };
+    // Each row is labelled by the ISO week its Thursday falls in.
+    const int thursdayColumn = (4 - firstDayOfWeek + 7) % 7;
+    const auto firstThursday =
+        std::chrono::sys_days(std::chrono::year{year} / std::chrono::month{static_cast<unsigned>(month + 1)} / 1)
+        - std::chrono::days{firstWeekdayOffset}
+        + std::chrono::days{thursdayColumn};
+
+    auto weekNumberColumn = ui::column({.gap = kCalendarGridGap * scale});
+    weekNumberColumn->addChild(spacer(weekColumnWidth, weekdayHeight));
+    for (int i = 0; i < 6; ++i) {
+      auto label = ui::column({.align = FlexAlign::Center, .justify = FlexJustify::Center});
+      label->setSize(weekColumnWidth, dayButtonSize);
+      label->addChild(
+          ui::label({
+              .text = std::format("{:%V}", firstThursday + std::chrono::days{i * 7}),
+              .fontSize = Style::fontSizeCaption * scale,
+              .fontWeight = FontWeight::Normal,
+              .color = colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.7f),
+              .maxLines = 1,
+          })
+      );
+      auto weekCell = ui::column({.align = FlexAlign::Center, .justify = FlexJustify::Center, .gap = dotGap});
+      weekCell->setSize(weekColumnWidth, dayCellHeight);
+      weekCell->addChild(std::move(label));
+      weekCell->addChild(spacer(weekColumnWidth, dotStripHeight));
+      weekNumberColumn->addChild(std::move(weekCell));
+    }
+    weekNumberColumn->setSize(weekColumnWidth, gridContentHeight);
+
+    // A hairline rule keeps the week column from reading as an eighth day column.
+    auto divider = ui::separator({
+        .thickness = weekDividerWidth,
+        .orientation = SeparatorOrientation::VerticalRule,
+        .width = weekDividerWidth,
+        .height = gridContentHeight,
+    });
+
+    auto gridRow = ui::row({.gap = 0.0f});
+    gridRow->addChild(std::move(weekNumberColumn));
+    gridRow->addChild(spacer(weekLaneInset, gridContentHeight));
+    gridRow->addChild(std::move(divider));
+    gridRow->addChild(spacer(kCalendarGridGap * scale, gridContentHeight));
+    gridRow->addChild(std::move(daysColumn));
+    gridRow->setSize(innerWidth, gridContentHeight);
+    m_grid->addChild(std::move(gridRow));
+  } else {
+    m_grid->addChild(std::move(daysColumn));
+  }
+
   if (m_gridViewport != nullptr) {
     m_gridViewport->setSize(innerWidth, gridContentHeight);
   }
@@ -846,7 +930,8 @@ void CalendarTab::rebuildEventList(float scale) {
   selectedTm.tm_isdst = -1;
   const std::time_t selectedRaw = std::mktime(&selectedTm); // normalize tm_wday
   if (m_eventsTitle != nullptr) {
-    const char* format = m_config != nullptr ? m_config->config().calendar.eventDateFormat.c_str() : "%A %e %B";
+    const char* format =
+        m_config != nullptr ? m_config->config().controlCenter.calendarTab.eventDateFormat.c_str() : "%A %e %B";
     m_eventsTitle->setText(formatLocalUnixTime(static_cast<std::int64_t>(selectedRaw), format));
   }
 
@@ -886,7 +971,8 @@ void CalendarTab::rebuildEventList(float scale) {
       timeText = i18n::tr("control-center.calendar.all-day");
     } else {
       const std::time_t raw = std::chrono::system_clock::to_time_t(event->start);
-      const char* format = m_config != nullptr ? m_config->config().calendar.eventTimeFormat.c_str() : "%H:%M";
+      const char* format =
+          m_config != nullptr ? m_config->config().controlCenter.calendarTab.eventTimeFormat.c_str() : "%H:%M";
       timeText = formatLocalUnixTime(static_cast<std::int64_t>(raw), format);
     }
 

--- a/src/shell/control_center/tabs/calendar_tab.h
+++ b/src/shell/control_center/tabs/calendar_tab.h
@@ -71,4 +71,5 @@ private:
   bool m_startMonthSlideIn = false;
   AnimationManager::Id m_monthSlideAnimId = 0;
   bool m_showEventsCard = true;
+  bool m_showWeekNumbers = false;
 };

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2498,18 +2498,14 @@ namespace settings {
     ));
     {
       auto e = makeEntry(
-          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-refresh-interval.label"),
-          tr("settings.schema.services.calendar-refresh-interval.description"), {"calendar", "refresh_minutes"},
-          sliderFor(cfg.calendar.refreshMinutes, noctalia::config::schema::kRefreshMinutesRange, true), "calendar sync"
-      );
-      e.visibleWhen = calendarOn;
-      entries.push_back(std::move(e));
-    }
-    {
-      auto e = makeEntry(
           SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-date-format.label"),
-          tr("settings.schema.services.calendar-event-date-format.description"), {"calendar", "event_date_format"},
-          TextSetting{.value = cfg.calendar.eventDateFormat, .placeholder = "%A %e %B", .browseFileExtensions = {}},
+          tr("settings.schema.services.calendar-event-date-format.description"),
+          {"control_center", "calendar", "event_date_format"},
+          TextSetting{
+              .value = cfg.controlCenter.calendarTab.eventDateFormat,
+              .placeholder = "%A %e %B",
+              .browseFileExtensions = {}
+          },
           "calendar date format strftime chrono"
       );
       e.visibleWhen = calendarOn;
@@ -2518,9 +2514,29 @@ namespace settings {
     {
       auto e = makeEntry(
           SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-time-format.label"),
-          tr("settings.schema.services.calendar-event-time-format.description"), {"calendar", "event_time_format"},
-          TextSetting{.value = cfg.calendar.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}},
+          tr("settings.schema.services.calendar-event-time-format.description"),
+          {"control_center", "calendar", "event_time_format"},
+          TextSetting{
+              .value = cfg.controlCenter.calendarTab.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}
+          },
           "calendar time format strftime chrono"
+      );
+      e.visibleWhen = calendarOn;
+      entries.push_back(std::move(e));
+    }
+    // Week numbers are a grid decoration, so they stay available when event syncing is off.
+    entries.push_back(makeEntry(
+        SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-week-numbers.label"),
+        tr("settings.schema.services.calendar-week-numbers.description"),
+        {"control_center", "calendar", "show_week_numbers"},
+        ToggleSetting{cfg.controlCenter.calendarTab.showWeekNumbers}, "calendar week numbers iso"
+    ));
+    // Sync cadence belongs with the accounts it drives; the account rows are injected right after it.
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-refresh-interval.label"),
+          tr("settings.schema.services.calendar-refresh-interval.description"), {"calendar", "refresh_minutes"},
+          sliderFor(cfg.calendar.refreshMinutes, noctalia::config::schema::kRefreshMinutesRange, true), "calendar sync"
       );
       e.visibleWhen = calendarOn;
       entries.push_back(std::move(e));

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -1801,7 +1801,7 @@ void SettingsWindow::refreshSettingsRegistry(const Config& cfg) {
     auto it = std::ranges::find_if(m_settingsRegistry, [](const settings::SettingEntry& e) {
       return e.section == settings::SettingsSection::Services
           && e.group == "calendar"
-          && e.path == std::vector<std::string>{"calendar", "event_time_format"};
+          && e.path == std::vector<std::string>{"calendar", "refresh_minutes"};
     });
     if (it != m_settingsRegistry.end()) {
       ++it;

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -378,11 +378,12 @@ location = "https://example.invalid/bad"
     c.controlCenter.sidebarMode = ControlCenterSidebarMode::Full;
     c.controlCenter.sidebarSectionMode = ControlCenterSidebarMode::None;
     c.controlCenter.calendarTab.showEventsCard = false;
+    c.controlCenter.calendarTab.showWeekNumbers = true;
+    c.controlCenter.calendarTab.eventDateFormat = "%Y-%m-%d";
+    c.controlCenter.calendarTab.eventTimeFormat = "%I:%M %p";
     c.controlCenter.shortcuts = {{"wifi"}, {"bluetooth"}};
     c.calendar.enabled = true;
     c.calendar.refreshMinutes = 30;
-    c.calendar.eventDateFormat = "%Y-%m-%d";
-    c.calendar.eventTimeFormat = "%I:%M %p";
     c.calendar.accounts = {
         {"acc1", "google", "Work", "#ff0000", "", "", "", {}},
         {"acc2",


### PR DESCRIPTION
## Summary
This adds a column displaying the ISO-8601 week numbers to the left of the date grid in the calendar tab of the control center. 

It is an opt-in feature which can be enabled in settings under the services tab with the other calendar settings.

## Motivation

Week numbers are heavily used in certain locales, it is very useful to get the current(and future) week numbers at a glance.

Furthermore this seems to have been supported before the rewrite.

## Type of Change

- [x] New feature

## Related Issue

<!-- Example: Closes #123 -->

## Testing
`just test && just test release`
`python3 tools/i18n-check.py`

Tested with `LC_TIME=en_DK.UTF-8` and the numbers match other calendars.

Also tested setting the new config value directly in both `~/.config/` and `~/.local/state` toml file.

## Manual Coverage

- [x] Tested on Hyprland
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
Setting enabled:
<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="588" height="560" alt="image" src="https://github.com/user-attachments/assets/a9c0ae25-e7ea-47e4-bcf9-0f9c0dae7c1c" />

Setting disabled:
<img width="582" height="560" alt="image" src="https://github.com/user-attachments/assets/175f9438-8420-47db-a8ef-2d9540bea6ce" />

Settings:
<img width="1014" height="243" alt="image" src="https://github.com/user-attachments/assets/9f95f229-e3c6-4101-86a4-81e096687a22" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
Let me know if I should add some header for the week number column instead of keeping it blank or if the colors should be changed.