### PR TITLE
fix(pw): show all input devices in audio panel, not just the default source

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1604,12 +1604,15 @@ void PipeWireService::rebuildState() {
     // explicitly unavailable and no available alternative is hidden. Cards that report "unknown"
     // (many HDA/HiFi setups) stay visible.
     const std::uint32_t wantDir = routeDirectionForMediaClass(nd->mediaClass);
-    const DeviceRouteData* activeRoute = wantDir != 0 ? activeRouteForDirection(nd->routes, wantDir) : nullptr;
+    // SPA_DIRECTION_INPUT == 0, so `wantDir != 0` would wrongly exclude every Audio/Source; guard on the
+    // media class being a device node instead (matches the isDeviceNode check used during route parsing).
+    const bool isDeviceNode = nd->mediaClass == "Audio/Sink" || nd->mediaClass == "Audio/Source";
+    const DeviceRouteData* activeRoute = isDeviceNode ? activeRouteForDirection(nd->routes, wantDir) : nullptr;
     const DeviceData* device = nullptr;
     if (nd->deviceId != 0) {
       if (const auto devIt = m_devices.find(nd->deviceId); devIt != m_devices.end()) {
         device = &devIt->second;
-        if (activeRoute == nullptr && wantDir != 0) {
+        if (activeRoute == nullptr && isDeviceNode) {
           activeRoute = activeRouteForDirection(device->routes, wantDir);
         }
       }
@@ -1674,9 +1677,11 @@ void PipeWireService::rebuildState() {
 
 void PipeWireService::recomputeEffectiveMute(NodeData& nd) {
   const std::uint32_t wantDir = routeDirectionForMediaClass(nd.mediaClass);
-  const DeviceRouteData* nodeRoute = wantDir != 0 ? activeRouteForDirection(nd.routes, wantDir) : nullptr;
+  // SPA_DIRECTION_INPUT == 0, so guard on the media class rather than `wantDir != 0` (which would skip sources).
+  const bool isDeviceNode = nd.mediaClass == "Audio/Sink" || nd.mediaClass == "Audio/Source";
+  const DeviceRouteData* nodeRoute = isDeviceNode ? activeRouteForDirection(nd.routes, wantDir) : nullptr;
   const DeviceRouteData* deviceRoute = nullptr;
-  if (nd.deviceId != 0 && wantDir != 0) {
+  if (nd.deviceId != 0 && isDeviceNode) {
     const auto it = m_devices.find(nd.deviceId);
     if (it != m_devices.end()) {
       deviceRoute = activeRouteForDirection(it->second.routes, wantDir);


### PR DESCRIPTION
## Summary

The audio panel's input list only ever showed a single microphone — the current default source — hiding every other input device (built-in mic, USB, Bluetooth headset mic, etc.). Outputs were unaffected.

Root cause: `routeDirectionForMediaClass()` returns `SPA_DIRECTION_INPUT` for `Audio/Source`, and `SPA_DIRECTION_INPUT == 0`, which collides with the `0` value used as the "no direction" sentinel. The availability logic in `rebuildState()` guarded on `wantDir != 0`, so for every input device `activeRoute` was forced to `nullptr` while `hasDirRoutes` stayed `true`, giving `node.available = false`. `availableDevices()` then keeps only `device.available || device.id == defaultId`, so all non-default inputs were dropped. The same `wantDir != 0` guard also disabled route resolution in `recomputeEffectiveMute()` for inputs.

The fix guards on the media class being a device node (`Audio/Sink || Audio/Source`) instead of `wantDir != 0`, matching the existing `isDeviceNode` check used during `SPA_PARAM_Route` parsing. Outputs were never affected because `SPA_DIRECTION_OUTPUT == 1`.

## Motivation

Users with more than one microphone could not see or switch between them from the audio panel — only the default input was listed. Reported in #3386.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3386

## Testing

- `just build` (debug) — succeeds, no new warnings.
- `just test debug --print-errorlogs` — 38 passed, 0 failed.
- `just format` with clang-format 22.1.8 — no changes beyond this diff.
- `clang-tidy -p build-debug -warnings-as-errors='*' src/pipewire/pipewire_service.cpp` — no reported diagnostics.
- Manual: on the affected machine (PipeWire 1.6.7 / WirePlumber 0.5.15) with a built-in analog mic, a USB dock input, and a Bluetooth headset, the audio panel previously listed only the default source. After the fix all available inputs appear simultaneously and can be selected. Verified via `pw-dump` that the built-in mic's active input route reports `available = unknown` (should stay visible), confirming availability was never the discriminator — only the direction guard.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A — device-list logic fix, no visual/layout change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The change is intentionally minimal and mirrors the `isDeviceNode` idiom already present in `pipewire_service.cpp`. An alternative would be to make `routeDirectionForMediaClass()` return `std::optional<std::uint32_t>` (`std::nullopt` for non-device classes) to remove the sentinel collision entirely — happy to take that route instead if preferred.
