### PR TITLE
feat(idle): add per-behavior locked screen timeout

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1099,6 +1099,7 @@
           "suspend": "Suspend"
         },
         "kind-section-label": "Action",
+        "locked-timeout-label": "Timeout while locked (seconds, 0 = off)",
         "name-label": "Name",
         "name-placeholder": "idle-behavior",
         "resume-command-label": "Resume command",

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -324,11 +324,13 @@ void Application::initLockScreenAndSession() {
       [this]() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
+        m_idleManager.setSessionLocked(true);
         m_hookManager.fire(HookKind::SessionLocked);
       },
       [this]() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
+        m_idleManager.setSessionLocked(false);
         m_hookManager.fire(HookKind::SessionUnlocked);
         requestAllSurfacesRedraw();
         if (m_logindService != nullptr) {

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -528,6 +528,9 @@ namespace {
               toml::table row;
               row.insert_or_assign("enabled", item.enabled);
               row.insert_or_assign("timeout", item.timeoutSeconds);
+              if (item.lockedTimeoutSeconds > 0.0) {
+                row.insert_or_assign("locked_timeout", item.lockedTimeoutSeconds);
+              }
               if (!item.action.empty()) {
                 row.insert_or_assign("action", item.action);
               }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -259,6 +259,8 @@ struct IdleBehaviorConfig {
   std::string resumeCommand;
   /// When `action` is `suspend`, lock the session before running suspend so lock surfaces are ready (recommended).
   bool lockBeforeSuspend = true;
+  /// Shorter timeout (seconds) applied only while the session is locked; 0 = always use timeoutSeconds.
+  double lockedTimeoutSeconds = 0.0;
 
   bool operator==(const IdleBehaviorConfig&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -836,6 +836,7 @@ namespace noctalia::config::schema {
       static const Schema<IdleBehaviorConfig> s = {
           field(&IdleBehaviorConfig::enabled, "enabled"),
           field(&IdleBehaviorConfig::timeoutSeconds, "timeout"),
+          field(&IdleBehaviorConfig::lockedTimeoutSeconds, "locked_timeout"),
           // action is trimmed on read.
           custom<IdleBehaviorConfig>(
               "action",

--- a/src/idle/idle_manager.cpp
+++ b/src/idle/idle_manager.cpp
@@ -83,6 +83,21 @@ void IdleManager::setScreenSaverInhibitLocks(std::int64_t locks) {
   }
 }
 
+void IdleManager::setSessionLocked(bool locked) {
+  if (m_sessionLocked == locked) {
+    return;
+  }
+  m_sessionLocked = locked;
+  recreateBehaviorNotifications();
+}
+
+double IdleManager::effectiveTimeoutSeconds(const IdleBehaviorConfig& config) const {
+  if (m_sessionLocked && std::isfinite(config.lockedTimeoutSeconds) && config.lockedTimeoutSeconds > 0.0) {
+    return config.lockedTimeoutSeconds;
+  }
+  return config.timeoutSeconds;
+}
+
 void IdleManager::reload(const IdleConfig& config) {
   clearBehaviors();
   m_idleConfig = config;
@@ -157,19 +172,24 @@ void IdleManager::recreateBehaviorNotification(BehaviorState& behavior) {
     return;
   }
 
+  // Re-arming an idled behavior (e.g. on unlock) has no natural resume event, so run it here —
+  // otherwise screen_off's display-off is never undone and the screen stays black.
+  if (behavior.phase == BehaviorPhase::Idled) {
+    runResumeBehavior(behavior);
+  }
+
   if (behavior.notification != nullptr) {
     ext_idle_notification_v1_destroy(behavior.notification);
     behavior.notification = nullptr;
   }
   behavior.phase = BehaviorPhase::Waiting;
 
-  if (!behavior.config.enabled
-      || !std::isfinite(behavior.config.timeoutSeconds)
-      || behavior.config.timeoutSeconds <= 0.0) {
+  const double timeout = effectiveTimeoutSeconds(behavior.config);
+  if (!behavior.config.enabled || !std::isfinite(timeout) || timeout <= 0.0) {
     return;
   }
 
-  const auto timeoutMs = timeoutSecondsToMilliseconds(behavior.config.timeoutSeconds);
+  const auto timeoutMs = timeoutSecondsToMilliseconds(timeout);
   behavior.notification = m_wayland->createIdleNotification(timeoutMs);
   if (behavior.notification == nullptr) {
     kLog.warn("failed to re-register idle behavior '{}'", behavior.config.name);
@@ -187,7 +207,7 @@ void IdleManager::recreateBehaviorNotifications() {
   for (auto& behavior : m_behaviors) {
     recreateBehaviorNotification(*behavior);
   }
-  kLog.info("idle behavior notifications reset after screensaver inhibit released");
+  kLog.debug("idle behavior notifications re-armed");
 }
 
 void IdleManager::createBehavior(const IdleBehaviorConfig& config) {
@@ -198,7 +218,11 @@ void IdleManager::createBehavior(const IdleBehaviorConfig& config) {
     kLog.warn("idle behavior '{}' ignored: timeout must be >= 0 seconds", config.name);
     return;
   }
-  if (config.timeoutSeconds == 0.0) {
+  if (!std::isfinite(config.lockedTimeoutSeconds) || config.lockedTimeoutSeconds < 0.0) {
+    kLog.warn("idle behavior '{}' ignored: locked timeout must be >= 0 seconds", config.name);
+    return;
+  }
+  if (config.timeoutSeconds == 0.0 && config.lockedTimeoutSeconds == 0.0) {
     kLog.debug("idle behavior '{}' disabled by zero timeout", config.name);
     return;
   }
@@ -211,15 +235,11 @@ void IdleManager::createBehavior(const IdleBehaviorConfig& config) {
   auto behavior = std::make_unique<BehaviorState>();
   behavior->owner = this;
   behavior->config = config;
-  const auto timeoutMs = timeoutSecondsToMilliseconds(config.timeoutSeconds);
-  behavior->notification = m_wayland->createIdleNotification(timeoutMs);
-  if (behavior->notification == nullptr) {
-    kLog.warn("failed to register idle behavior '{}'", config.name);
-    return;
-  }
-
-  ext_idle_notification_v1_add_listener(behavior->notification, &kIdleNotificationListener, behavior.get());
-  kLog.info("registered idle behavior '{}' timeout={}s", config.name, config.timeoutSeconds);
+  recreateBehaviorNotification(*behavior);
+  kLog.info(
+      "registered idle behavior '{}' timeout={}s locked_timeout={}s", config.name, config.timeoutSeconds,
+      config.lockedTimeoutSeconds
+  );
   m_behaviors.push_back(std::move(behavior));
 }
 

--- a/src/idle/idle_manager.h
+++ b/src/idle/idle_manager.h
@@ -42,6 +42,8 @@ public:
   void reload(const IdleConfig& config);
   /// D-Bus screensaver inhibits (e.g. Chrome video playback). Suppresses idle actions while > 0.
   void setScreenSaverInhibitLocks(std::int64_t locks);
+  /// While locked, behaviors with a positive lockedTimeoutSeconds re-arm at that shorter timeout.
+  void setSessionLocked(bool locked);
   /// Seconds the compositor has reported session-idle (1s heartbeat notification); 0 when active.
   [[nodiscard]] std::int64_t liveIdleSeconds() const noexcept { return m_liveIdleSeconds; }
   void onSecondTick();
@@ -64,6 +66,7 @@ private:
     BehaviorPhase phase = BehaviorPhase::Waiting;
   };
 
+  [[nodiscard]] double effectiveTimeoutSeconds(const IdleBehaviorConfig& config) const;
   void clearBehaviors();
   void syncHeartbeat();
   void destroyHeartbeat();
@@ -95,4 +98,5 @@ private:
   std::int64_t m_liveIdleSeconds = 0;
   std::int64_t m_screenSaverInhibitLocks = 0;
   bool m_idledWhileScreenSaverInhibited = false;
+  bool m_sessionLocked = false;
 };

--- a/src/shell/settings/settings_content_idle_behavior.cpp
+++ b/src/shell/settings/settings_content_idle_behavior.cpp
@@ -37,6 +37,7 @@ namespace settings {
     IdleBehaviorConfig norm = row;
     normalizeIdleBehaviorAction(norm);
     const bool showCustomCommands = (norm.action == "command");
+    const bool showLockedTimeout = (norm.action == "screen_off");
 
     auto body = ui::column({
         .align = FlexAlign::Stretch,
@@ -204,6 +205,45 @@ namespace settings {
     timeoutIn->setOnFocusLoss(commitTimeout);
     timeoutBlock->addChild(std::move(timeoutIn));
     body->addChild(std::move(timeoutBlock));
+
+    if (showLockedTimeout) {
+      auto lockedTimeoutBlock = ui::column(
+          {.align = FlexAlign::Stretch, .gap = Style::spaceXs * scale},
+          makeLabel(
+              i18n::tr("settings.idle.behavior.locked-timeout-label"), Style::fontSizeCaption * scale,
+              colorSpecFromRole(ColorRole::OnSurfaceVariant), FontWeight::Normal
+          )
+      );
+      Input* lockedTimeoutPtr = nullptr;
+      auto lockedTimeoutIn = ui::input({
+          .out = &lockedTimeoutPtr,
+          .value = StringUtils::formatDotDecimal(row.lockedTimeoutSeconds),
+          .placeholder = "0",
+          .fontSize = Style::fontSizeBody * scale,
+          .controlHeight = Style::controlHeight * scale,
+          .horizontalPadding = Style::spaceSm * scale,
+      });
+      const auto commitLockedTimeout = [&row, persist, lockedTimeoutPtr]() {
+        const auto parsed = parseDoubleInput(lockedTimeoutPtr->value());
+        constexpr double kMaxIdleTimeoutSeconds =
+            static_cast<double>(std::numeric_limits<std::uint32_t>::max()) / 1000.0;
+        if (!parsed.has_value() || *parsed < 0.0 || *parsed > kMaxIdleTimeoutSeconds) {
+          lockedTimeoutPtr->setInvalid(true);
+          return;
+        }
+        row.lockedTimeoutSeconds = *parsed;
+        lockedTimeoutPtr->setInvalid(false);
+        lockedTimeoutPtr->setValue(StringUtils::formatDotDecimal(row.lockedTimeoutSeconds));
+        persist();
+      };
+      lockedTimeoutIn->setOnChange([lockedTimeoutPtr](const std::string& /*t*/) {
+        lockedTimeoutPtr->setInvalid(false);
+      });
+      lockedTimeoutIn->setOnSubmit([commitLockedTimeout](const std::string& /*text*/) { commitLockedTimeout(); });
+      lockedTimeoutIn->setOnFocusLoss(commitLockedTimeout);
+      lockedTimeoutBlock->addChild(std::move(lockedTimeoutIn));
+      body->addChild(std::move(lockedTimeoutBlock));
+    }
 
     body->addChild(std::move(customCommandsGrp));
     body->addChild(std::move(resumeCommandGrp));

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -417,7 +417,7 @@ location = "https://example.invalid/bad"
     // Explicit normalized actions so normalizeIdleBehaviorAction is a no-op on read.
     c.idle.behaviors = {
         {"dim", true, 60, "lock", "", "", true},
-        {"off", false, 300, "screen_off", "", "", true},
+        {"off", false, 300, "screen_off", "", "", true, 30},
     };
     c.wallpaper.enabled = false;
     c.wallpaper.fillColor = colorSpecFromConfigString("#ff8800");


### PR DESCRIPTION
## Summary

Idle behaviors get an optional `locked_timeout` (seconds). While the session is locked, a behavior with `locked_timeout > 0` arms at that value instead of its normal `timeout`, and goes back to the normal value on unlock. Setting `timeout = 0` with `locked_timeout > 0` makes a behavior run only while locked.

The main use is `screen_off`: turn the display off quickly on the lock screen (and again after each wake, since the behavior re-arms) without making the display sleep aggressively while you're actually using the machine.

<img width="1815" height="1132" alt="image" src="https://github.com/user-attachments/assets/1e5e521b-8180-482a-a271-3b550c2e3cee" />

## Motivation

A single `timeout` can't express "turn the screen off 10s after locking, but leave it alone for 10 minutes while I'm working." You had to pick one value for both states. This gives the locked state its own, shorter timeout.

## Type of Change

- [x] New feature

## Related Issue

None.

## Testing

- `just build debug`
- `just test debug`, 38/38 pass (config_schema_roundtrip covers the new field)
- `clang-format --dry-run -Werror` clean on the changed files
- `clang-tidy -p build-debug` clean on the changed files
- `noctalia config validate` on a config using `locked_timeout` reports valid

Ran the dev build on my setup and went through the whole cycle: idle while unlocked uses the normal timeout; after locking, `screen_off` fires at the locked timeout; waking brings the display back; leaving it idle turns it off again; unlocking leaves the display on.

While testing I hit a bug this change introduced: on unlock the notifications re-arm, which tore down the `screen_off` behavior while it was already off without running its resume, leaving the display black. Fixed by running the resume action when re-arming a behavior that is still in the idled state.

## Manual Coverage

- [x] Tested on Hyprland
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Off by default (`locked_timeout = 0` for every behavior), so existing configs behave exactly as before.
