### PR TITLE
feat(calendar): add CalDAV calendar visibility toggles

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -835,6 +835,7 @@
     },
     "calendar-accounts": {
       "add-title": "Add Calendar Account",
+      "calendars-label": "Calendars",
       "color-label": "Color",
       "delete-error": "Could not delete calendar account.",
       "edit-title": "Edit Calendar Account",

--- a/meson.build
+++ b/meson.build
@@ -409,6 +409,7 @@ _noctalia_sources = files(
   'src/auth/pam_authenticator.cpp',
   'src/calendar/caldav_client.cpp',
   'src/calendar/caldav_discovery.cpp',
+  'src/calendar/calendar_discovery_state.cpp',
   'src/calendar/calendar_service.cpp',
   'src/calendar/google_client.cpp',
   'src/calendar/google_oauth.cpp',
@@ -1187,6 +1188,20 @@ google_client_calendar_list_test = executable('google_client_calendar_list_test'
 )
 
 test('google_client_calendar_list', google_client_calendar_list_test)
+
+calendar_discovery_state_test = executable('calendar_discovery_state_test',
+  sources: files(
+    'tests/calendar_discovery_state_test.cpp',
+    'src/calendar/calendar_discovery_state.cpp',
+    'src/core/log.cpp',
+  ),
+  dependencies: [
+    nlohmann_dep,
+  ],
+  include_directories: _noctalia_inc,
+)
+
+test('calendar_discovery_state', calendar_discovery_state_test)
 
 time_format_test = executable('time_format_test',
   sources: files(

--- a/src/calendar/calendar_discovery_state.cpp
+++ b/src/calendar/calendar_discovery_state.cpp
@@ -1,0 +1,113 @@
+#include "calendar/calendar_discovery_state.h"
+
+#include "core/log.h"
+
+#include <algorithm>
+#include <nlohmann/json.hpp>
+#include <unordered_set>
+
+namespace calendar {
+
+  namespace {
+    constexpr Logger kLog("calendar-discovery");
+  }
+
+  std::string serializeCalendarSources(const std::vector<CalendarSource>& sources) {
+    nlohmann::json items = nlohmann::json::array();
+    for (const CalendarSource& source : sources) {
+      if (source.id.empty()) {
+        continue;
+      }
+      items.push_back({
+          {"id", source.id},
+          {"name", source.name},
+      });
+    }
+    return nlohmann::json{{"calendars", std::move(items)}}.dump();
+  }
+
+  std::vector<CalendarSource> parseCalendarSources(std::string_view value) {
+    std::vector<CalendarSource> sources;
+    if (value.empty()) {
+      return sources;
+    }
+
+    try {
+      const auto root = nlohmann::json::parse(value);
+      const auto calendars = root.find("calendars");
+      if (calendars == root.end() || !calendars->is_array()) {
+        return sources;
+      }
+
+      for (const auto& item : *calendars) {
+        CalendarSource source;
+        source.id = item.value("id", std::string{});
+        source.name = item.value("name", std::string{});
+        if (!source.id.empty()) {
+          sources.push_back(std::move(source));
+        }
+      }
+    } catch (const std::exception& e) {
+      kLog.warn("calendar discovery state parse error: {}", e.what());
+    }
+    return sources;
+  }
+
+  std::vector<std::string>
+  selectedCalendarSourceIds(const std::vector<CalendarSource>& sources, const std::vector<std::string>& selectedIds) {
+    if (selectedIds.empty()) {
+      std::vector<std::string> ids;
+      ids.reserve(sources.size());
+      for (const CalendarSource& source : sources) {
+        if (!source.id.empty()) {
+          ids.push_back(source.id);
+        }
+      }
+      return ids;
+    }
+
+    const std::unordered_set<std::string> selected(selectedIds.begin(), selectedIds.end());
+    std::vector<std::string> ids;
+    ids.reserve(sources.size());
+    for (const CalendarSource& source : sources) {
+      if (selected.contains(source.id)) {
+        ids.push_back(source.id);
+      }
+    }
+    return ids;
+  }
+
+  std::vector<std::string> setCalendarSourceChecked(
+      const std::vector<CalendarSource>& sources, const std::vector<std::string>& selectedIds,
+      const std::string& sourceId, bool checked
+  ) {
+    if (sources.empty()) {
+      return selectedIds;
+    }
+
+    std::vector<std::string> next = selectedIds;
+    if (next.empty()) {
+      next = selectedCalendarSourceIds(sources, {});
+    }
+
+    if (checked) {
+      if (!std::ranges::contains(next, sourceId)) {
+        next.push_back(sourceId);
+      }
+    } else {
+      std::erase(next, sourceId);
+      if (next.empty()) {
+        next.push_back(sourceId);
+      }
+    }
+
+    const bool allDiscoveredSelected = std::ranges::all_of(sources, [&](const CalendarSource& source) {
+      return std::ranges::contains(next, source.id);
+    });
+    if (allDiscoveredSelected) {
+      next.clear();
+    }
+    return next;
+  }
+
+} // namespace calendar

--- a/src/calendar/calendar_discovery_state.h
+++ b/src/calendar/calendar_discovery_state.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "calendar/calendar_types.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace calendar {
+
+  [[nodiscard]] std::string serializeCalendarSources(const std::vector<CalendarSource>& sources);
+  [[nodiscard]] std::vector<CalendarSource> parseCalendarSources(std::string_view value);
+  [[nodiscard]] std::vector<std::string>
+  selectedCalendarSourceIds(const std::vector<CalendarSource>& sources, const std::vector<std::string>& selectedIds);
+  [[nodiscard]] std::vector<std::string> setCalendarSourceChecked(
+      const std::vector<CalendarSource>& sources, const std::vector<std::string>& selectedIds,
+      const std::string& sourceId, bool checked
+  );
+
+} // namespace calendar

--- a/src/calendar/calendar_service.cpp
+++ b/src/calendar/calendar_service.cpp
@@ -2,6 +2,7 @@
 
 #include "calendar/caldav_client.h"
 #include "calendar/caldav_discovery.h"
+#include "calendar/calendar_discovery_state.h"
 #include "config/config_service.h"
 #include "core/log.h"
 #include "i18n/i18n.h"
@@ -15,11 +16,11 @@
 #include <iterator>
 #include <memory>
 #include <nlohmann/json.hpp>
-#include <unordered_set>
 
 namespace {
   constexpr Logger kLog("calendar");
   constexpr const char* kCredentialOwner = "calendar_credentials";
+  constexpr const char* kCalendarDiscoveryOwner = "calendar_discovery";
   constexpr const char* kICloudCalDavServerUrl = "https://caldav.icloud.com/";
   constexpr auto kConnectPollInterval = std::chrono::seconds{2};
   // Wide enough for month navigation in the control-center calendar (~1 year each way).
@@ -42,6 +43,21 @@ namespace {
       return account.serverUrl;
     }
     return {};
+  }
+
+  std::vector<CalendarSource> sourcesFromCollections(const std::vector<calendar::CalDavCollection>& collections) {
+    std::vector<CalendarSource> sources;
+    sources.reserve(collections.size());
+    for (const calendar::CalDavCollection& collection : collections) {
+      if (collection.id.empty()) {
+        continue;
+      }
+      sources.push_back({
+          .id = collection.id,
+          .name = collection.name,
+      });
+    }
+    return sources;
   }
 } // namespace
 
@@ -231,12 +247,16 @@ void CalendarService::fetchCalDav(const CalendarConfig::Account& account) {
           return;
         }
 
-        if (!selectedCalendars.empty()) {
-          const std::unordered_set<std::string> selected(selectedCalendars.begin(), selectedCalendars.end());
-          std::erase_if(collections, [&](const calendar::CalDavCollection& collection) {
-            return !selected.contains(collection.id);
-          });
-        }
+        const std::vector<CalendarSource> discoveredSources = sourcesFromCollections(collections);
+        (void)m_configService.setStateString(
+            kCalendarDiscoveryOwner, accountId + "_calendars", calendar::serializeCalendarSources(discoveredSources)
+        );
+
+        const std::vector<std::string> selectedIds =
+            calendar::selectedCalendarSourceIds(discoveredSources, selectedCalendars);
+        std::erase_if(collections, [&](const calendar::CalDavCollection& collection) {
+          return !std::ranges::contains(selectedIds, collection.id);
+        });
 
         if (collections.empty()) {
           kLog.warn("caldav account {} has no selected calendars after discovery", accountId);

--- a/src/calendar/calendar_types.h
+++ b/src/calendar/calendar_types.h
@@ -21,3 +21,10 @@ struct CalendarSnapshot {
   bool valid = false; // true once at least one successful sync has populated events
   std::vector<CalendarEvent> events;
 };
+
+struct CalendarSource {
+  std::string id;
+  std::string name;
+
+  bool operator==(const CalendarSource&) const = default;
+};

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -1,3 +1,4 @@
+#include "calendar/calendar_discovery_state.h"
 #include "config/atomic_file.h"
 #include "config/config_service.h"
 #include "config/config_types.h"
@@ -48,6 +49,7 @@ namespace {
   constexpr std::int32_t kActionSupportReport = 1;
   constexpr std::int32_t kActionExportConfig = 2;
   constexpr std::string_view kCalendarCredentialOwner = "calendar_credentials";
+  constexpr std::string_view kCalendarDiscoveryOwner = "calendar_discovery";
 
   XdgPopupParent popupParentFor(ToplevelSurface& surface, wl_output* output, std::uint32_t serial) {
     return XdgPopupParent{
@@ -86,6 +88,8 @@ namespace {
     std::string password;
     std::string serverUrl;
     std::string color;
+    std::vector<std::string> calendars;
+    std::vector<CalendarSource> discoveredCalendars;
     bool idInvalid = false;
     bool usernameInvalid = false;
     bool passwordInvalid = false;
@@ -138,6 +142,10 @@ namespace {
       return i18n::tr("settings.calendar-accounts.provider.google");
     }
     return i18n::tr("settings.calendar-accounts.provider.icloud");
+  }
+
+  bool calendarSourceChecked(const CalendarAccountDraft& draft, const CalendarSource& source) {
+    return draft.calendars.empty() || std::ranges::contains(draft.calendars, source.id);
   }
 
   std::string trimInput(Input* input) { return input != nullptr ? StringUtils::trim(input->value()) : std::string{}; }
@@ -1024,11 +1032,15 @@ void SettingsWindow::openCalendarAccountEditor(std::optional<std::string> accoun
     draft->username = account->username;
     draft->serverUrl = account->serverUrl;
     draft->color = account->color;
+    draft->calendars = account->calendars;
     if (account->type == "google") {
       draft->provider = CalendarAccountProvider::Google;
     } else {
       draft->provider =
           account->provider == "custom" ? CalendarAccountProvider::CustomCalDav : CalendarAccountProvider::ICloud;
+      const std::string rawDiscovery =
+          m_config->stateString(kCalendarDiscoveryOwner, account->id + "_calendars").value_or(std::string{});
+      draft->discoveredCalendars = calendar::parseCalendarSources(rawDiscovery);
     }
   }
 
@@ -1060,6 +1072,7 @@ void SettingsWindow::openCalendarAccountEditor(std::optional<std::string> accoun
       (void)m_config->setStateString(kCalendarCredentialOwner, accountId + "_refresh_token", "");
       (void)m_config->setStateString(kCalendarCredentialOwner, accountId + "_access_token", "");
       (void)m_config->setStateString(kCalendarCredentialOwner, accountId + "_access_expiry", "");
+      (void)m_config->setStateString(kCalendarDiscoveryOwner, accountId + "_calendars", "");
       markSettingsWriteSuccess(true);
       if (m_editorSheetPopup != nullptr) {
         m_editorSheetPopup->close();
@@ -1228,6 +1241,80 @@ void SettingsWindow::openCalendarAccountEditor(std::optional<std::string> accoun
         )
     );
 
+    if (!draft->creating && draft->provider != CalendarAccountProvider::Google && !draft->discoveredCalendars.empty()) {
+      auto calendars = ui::column({
+          .align = FlexAlign::Stretch,
+          .gap = Style::spaceXs * scale,
+      });
+      calendars->addChild(
+          ui::label({
+              .text = i18n::tr("settings.calendar-accounts.calendars-label"),
+              .fontSize = Style::fontSizeCaption * scale,
+              .fontWeight = FontWeight::Medium,
+              .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+          })
+      );
+
+      auto list = ui::column({
+          .align = FlexAlign::Stretch,
+          .gap = Style::spaceXs * scale,
+          .padding = Style::spaceSm * scale,
+          .fill = colorSpecFromRole(ColorRole::SurfaceVariant, 0.35f),
+          .radius = Style::scaledRadiusMd(scale),
+      });
+      for (const CalendarSource& source : draft->discoveredCalendars) {
+        const bool checked = calendarSourceChecked(*draft, source);
+        auto row = ui::row({
+            .align = FlexAlign::Center,
+            .gap = Style::spaceSm * scale,
+            .fillWidth = true,
+        });
+        auto info = ui::column({
+            .align = FlexAlign::Start,
+            .gap = 2.0f * scale,
+            .flexGrow = 1.0f,
+        });
+        info->addChild(
+            ui::label({
+                .text = source.name.empty() ? source.id : source.name,
+                .fontSize = Style::fontSizeBody * scale,
+                .fontWeight = FontWeight::Medium,
+                .color = colorSpecFromRole(ColorRole::OnSurface),
+                .maxLines = 1,
+                .ellipsize = TextEllipsize::End,
+            })
+        );
+        if (!source.name.empty()) {
+          info->addChild(
+              ui::label({
+                  .text = source.id,
+                  .fontSize = Style::fontSizeCaption * scale,
+                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                  .maxLines = 1,
+                  .ellipsize = TextEllipsize::End,
+              })
+          );
+        }
+        row->addChild(std::move(info));
+        row->addChild(
+            ui::toggle({
+                .checked = checked,
+                .scale = scale,
+                .onChange = [this, draft, sourceId = source.id](bool on) {
+                  draft->calendars =
+                      calendar::setCalendarSourceChecked(draft->discoveredCalendars, draft->calendars, sourceId, on);
+                  if (m_editorSheetPopup != nullptr) {
+                    m_editorSheetPopup->rebuildBody();
+                  }
+                },
+            })
+        );
+        list->addChild(std::move(row));
+      }
+      calendars->addChild(std::move(list));
+      body.addChild(std::move(calendars));
+    }
+
     const auto persistAccount = [this, draft, idInput, nameInput, usernameInput, passwordInput,
                                  serverInput](bool closeAfter, bool connectAfter) {
       if (m_config == nullptr) {
@@ -1282,6 +1369,8 @@ void SettingsWindow::openCalendarAccountEditor(std::optional<std::string> accoun
       );
       overrides.push_back({{base[0], base[1], base[2], "name"}, draft->name});
       overrides.push_back({{base[0], base[1], base[2], "color"}, draft->color});
+      // Manual calendar selection is currently populated by CalDAV discovery; Google uses CalendarList selected.
+      overrides.push_back({{base[0], base[1], base[2], "calendars"}, draft->calendars});
       if (caldav) {
         overrides.push_back({{base[0], base[1], base[2], "provider"}, calendarProviderKey(draft->provider)});
         overrides.push_back({{base[0], base[1], base[2], "username"}, draft->username});

--- a/tests/calendar_discovery_state_test.cpp
+++ b/tests/calendar_discovery_state_test.cpp
@@ -1,0 +1,58 @@
+#include "calendar/calendar_discovery_state.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::fprintf(stderr, "calendar_discovery_state_test: %s\n", message);
+      return false;
+    }
+    return true;
+  }
+
+  bool expectIds(const std::vector<std::string>& ids, const std::vector<std::string>& expected) {
+    if (ids.size() != expected.size()) {
+      std::fprintf(stderr, "calendar_discovery_state_test: expected %zu ids, got %zu\n", expected.size(), ids.size());
+      return false;
+    }
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+      if (ids[i] != expected[i]) {
+        std::fprintf(
+            stderr, "calendar_discovery_state_test: id %zu expected %s, got %s\n", i, expected[i].c_str(),
+            ids[i].c_str()
+        );
+        return false;
+      }
+    }
+    return true;
+  }
+
+} // namespace
+
+int main() {
+  const std::vector<CalendarSource> discovered{
+      {.id = "personal", .name = "Personal"},
+      {.id = "work", .name = "Work"},
+  };
+
+  bool ok = true;
+  const std::vector<CalendarSource> parsed =
+      calendar::parseCalendarSources(calendar::serializeCalendarSources(discovered));
+  ok = expect(parsed == discovered, "serialized discovery metadata round-trips") && ok;
+
+  ok = expectIds(calendar::selectedCalendarSourceIds(discovered, {}), {"personal", "work"}) && ok;
+  ok = expectIds(calendar::selectedCalendarSourceIds(discovered, {"work"}), {"work"}) && ok;
+  ok = expectIds(calendar::selectedCalendarSourceIds(discovered, {"missing"}), {}) && ok;
+  ok = expectIds(calendar::setCalendarSourceChecked(discovered, {}, "work", false), {"personal"}) && ok;
+  ok = expectIds(calendar::setCalendarSourceChecked(discovered, {"personal"}, "work", true), {}) && ok;
+  ok = expectIds(calendar::setCalendarSourceChecked(discovered, {"work"}, "work", false), {"work"}) && ok;
+  ok = expectIds(calendar::setCalendarSourceChecked(discovered, {"work"}, "personal", true), {}) && ok;
+  ok = expect(calendar::parseCalendarSources("{}").empty(), "missing calendar array parses as empty") && ok;
+  ok = expect(calendar::parseCalendarSources("not json").empty(), "invalid discovery JSON parses as empty") && ok;
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds CalDAV calendar visibility toggles to the calendar account editor.

- Stores discovered CalDAV calendar metadata in app state under `calendar_discovery`
- Shows discovered calendars when editing an existing CalDAV account
- Persists selected calendar IDs to `calendar.account.<id>.calendars`
- Keeps `calendars = []` as the existing “all calendars” behavior
- Leaves Google calendar selection unchanged (why - in additional notes)

Worth mentioning, the list of calendars is available only after first sync.

## Motivation

CalDAV accounts can discover multiple calendars, but settings did not expose a way to choose which discovered calendars should sync. This adds UI for that existing config field without changing the public config contract.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

This PR probably handles #3158 (if I understood it correctly)

## Testing

- `nix develop --command meson compile -C build-debug noctalia`
- `nix develop --command meson test -C build-debug calendar_discovery_state config_schema_roundtrip --print-errorlogs`
- `nix develop --command meson test -C build-debug calendar_discovery_state --print-errorlogs`
- Manual testing via Nix flake local path + rebuild

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots  / Videos 

When creating a new calendar (unchanged):

<img width="803" height="633" alt="image" src="https://github.com/user-attachments/assets/f1c1d618-00fc-485e-a50d-d10b86bb85ab" />

When editing already synced calendar(blurred = calendar names):

<img width="823" height="1029" alt="image" src="https://github.com/user-attachments/assets/358a264a-7f5b-4bd0-8372-8da54d620290" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Google calendar selection is intentionally unchanged, cause it is handled by Google API's `selected` field. This PR only exposes calendar selection for CalDAV accounts.