### PR TITLE
fix(notification): keep toast icons within long notifications

### DIFF
--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -2225,7 +2225,7 @@ InputArea* NotificationToast::buildCard(
   );
 
   auto contentRow = ui::row({
-      .align = FlexAlign::Center,
+      .align = FlexAlign::Start,
       .gap = iconTextGap(scale),
       .padding = cardInnerPad(scale),
       .width = cardW,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Align notification toast icons to the top of the content row instead of vertically centring them.   

## Motivation

When a notification contains long text, the text column can become much taller than the icon. Vertically centring the icon may push it outside the visible notification card when the card reaches its maximum height and is clipped.                                         
                                                                                                                                                                                                                                                                                 
   Top-aligning the icon keeps it within the notification box and provides a more predictable layout for long notifications.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
None

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
via 
```bash
notify-send --icon noctalia TEST "$(hyprctl activewindow)"
```

Behaviour before this fix:
<img width="579" height="514" alt="image" src="https://github.com/user-attachments/assets/db7a5c94-8a7e-4193-befe-36d66e1bb110" />
Behaviour after this fix:
<img width="615" height="492" alt="image" src="https://github.com/user-attachments/assets/a7af7efe-03c9-4b38-92ab-746aa6fc00e5" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior. 
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
