### PR TITLE
fix(greeter-sync): use wallpaper for greeter pinned output

### DIFF
--- a/src/shell/greeter/greeter_appearance_sync.cpp
+++ b/src/shell/greeter/greeter_appearance_sync.cpp
@@ -96,14 +96,19 @@ namespace {
   }
 
   [[nodiscard]] std::string resolveSyncWallpaperPath(const ConfigService& configService) {
-    const Config& config = configService.config();
-    if (config.theme.source != PaletteSource::Wallpaper) {
-      if (const auto output = readGreeterConfiguredOutput(); output.has_value() && !output->empty()) {
-        const std::string path = configService.getWallpaperPath(*output);
-        if (!path.empty()) {
-          return path;
-        }
+    // Prefer the wallpaper for the greeter's pinned connector ([output].name in
+    // greeter.toml). Multi-monitor setups often have different images per screen
+    // (e.g. portrait vs ultrawide); using the last palette wallpaper or a sorted
+    // map entry can copy the wrong screen's image onto the login UI.
+    if (const auto output = readGreeterConfiguredOutput(); output.has_value() && !output->empty()) {
+      const std::string path = configService.getWallpaperPath(*output);
+      if (!path.empty()) {
+        kLog.info("greeter sync: using wallpaper for greeter output '{}'", *output);
+        return path;
       }
+      kLog.info(
+          "greeter sync: no wallpaper path for greeter output '{}'; falling back", *output
+      );
     }
     return configService.getGreeterSyncWallpaperPath();
   }


### PR DESCRIPTION
## Summary

Greeter appearance sync can copy the **wrong monitor’s wallpaper** on multi-monitor setups.

### Root cause

`resolveSyncWallpaperPath()` only preferred `greeter.toml` `[output].name` when theme source was **not** wallpaper. With wallpaper-based theming (common), it fell through to `getGreeterSyncWallpaperPath()`, which uses the **last applied** wallpaper path — often a secondary / portrait panel.

Example (lea):

| Connector | Wallpaper |
|-----------|-----------|
| DP-2 (greeter pin) | Widescreen |
| HDMI-A-1 | Portrait |

Sync staged the portrait image while the greeter is pinned to DP-2.

### Fix

Always try wallpaper for `[output].name` first; only then fall back to the previous selection logic.

## Test plan

- [ ] Multi-monitor with different wallpapers; greeter.toml `name` set to one connector
- [ ] Sync Now → `/var/lib/noctalia-greeter/wallpaper.webp` matches that connector’s image
- [ ] No `[output].name` → previous fallback behavior still works
- [ ] Palette / theme colors still sync as before