### PR TITLE
feat(greeter-sync): stage per-output wallpapers for multi-monitor

### DIFF
--- a/src/config/config_service.h
+++ b/src/config/config_service.h
@@ -80,6 +80,9 @@ public:
 
   // Persisted wallpaper paths (written to settings.toml, app-managed).
   [[nodiscard]] std::string getWallpaperPath(const std::string& connectorName) const;
+  [[nodiscard]] const std::unordered_map<std::string, std::string>& monitorWallpaperPaths() const {
+    return m_monitorWallpaperPaths;
+  }
   [[nodiscard]] std::string getDefaultWallpaperPath() const;
   // Last applied wallpaper, else default. Drives palette generation and template previews.
   [[nodiscard]] std::string getPaletteWallpaperPath() const;

--- a/src/shell/greeter/greeter_appearance_sync.cpp
+++ b/src/shell/greeter/greeter_appearance_sync.cpp
@@ -131,11 +131,18 @@ namespace {
   };
 
   // Stage every per-monitor wallpaper so the greeter can pick by connector name.
+  // File wallpapers are copied as wallpaper-<connector>.*; solid color: specs are
+  // kept as sourcePath only (no file) so the wallpapers map can still reference them.
   [[nodiscard]] std::vector<StagedOutputWallpaper>
   stageAllOutputWallpapers(const std::filesystem::path& staging, const ConfigService& configService) {
     std::vector<StagedOutputWallpaper> staged;
     for (const auto& [connector, sourcePath] : configService.monitorWallpaperPaths()) {
-      if (connector.empty() || sourcePath.empty() || sourcePath.starts_with("color:")) {
+      if (connector.empty() || sourcePath.empty()) {
+        continue;
+      }
+      if (sourcePath.starts_with("color:")) {
+        staged.push_back(StagedOutputWallpaper{connector, /*installedName=*/{}, sourcePath});
+        kLog.info("greeter sync: color wallpaper for '{}' -> {}", connector, sourcePath);
         continue;
       }
       std::error_code ec;
@@ -156,6 +163,10 @@ namespace {
       kLog.info("greeter sync: staged wallpaper for '{}' -> {}", connector, installedName);
       staged.push_back(StagedOutputWallpaper{connector, installedName, sourcePath});
     }
+    // unordered_map iteration order is unspecified; keep map/fallback deterministic.
+    std::ranges::sort(staged, [](const StagedOutputWallpaper& a, const StagedOutputWallpaper& b) {
+      return a.connector < b.connector;
+    });
     return staged;
   }
 
@@ -263,19 +274,28 @@ namespace {
     }
     root["wallpaper"] = wallpaper;
 
-    // Per-output wallpapers (connector name -> installed path). Greeter views select by output.
+    // Per-output wallpapers (connector name -> installed path or color:). Greeter views select by output.
     if (!outputWallpapers.empty()) {
       nlohmann::json byOutput = nlohmann::json::object();
       for (const auto& entry : outputWallpapers) {
         nlohmann::json item;
-        item["path"] = (std::filesystem::path("/var/lib/noctalia-greeter") / entry.installedName).string();
+        if (!entry.installedName.empty()) {
+          item["path"] = (std::filesystem::path("/var/lib/noctalia-greeter") / entry.installedName).string();
+        } else if (!entry.sourcePath.empty()) {
+          // color:#RRGGBB (or other non-staged specs) — preserve as-is.
+          item["path"] = entry.sourcePath;
+        } else {
+          continue;
+        }
         item["fill_mode"] = wallpaper["fill_mode"];
         if (wallpaper.contains("fill_color")) {
           item["fill_color"] = wallpaper["fill_color"];
         }
         byOutput[entry.connector] = std::move(item);
       }
-      root["wallpapers"] = std::move(byOutput);
+      if (!byOutput.empty()) {
+        root["wallpapers"] = std::move(byOutput);
+      }
     }
     root["corner_radius_scale"] = config.shell.cornerRadiusScale;
     appendSessionManifest(root, config.shell.session);
@@ -498,20 +518,33 @@ namespace greeter {
     const auto outputWallpapers = stageAllOutputWallpapers(staging, configService);
     std::string wallpaperPath = resolveSyncWallpaperPath(configService);
     std::string installedWallpaperName = stageWallpaper(staging, wallpaperPath);
-    // Prefer a staged per-output file as the legacy single wallpaper fallback when pin matched one.
+    // Prefer a staged per-output entry for the legacy single wallpaper when needed.
     if (installedWallpaperName.empty() && !outputWallpapers.empty()) {
-      if (const auto pin = readGreeterConfiguredOutput(); pin.has_value()) {
+      auto preferEntry = [&](const StagedOutputWallpaper& entry) {
+        wallpaperPath = entry.sourcePath;
+        installedWallpaperName = entry.installedName;
+      };
+      bool pinResolved = false;
+      if (const auto pin = readGreeterConfiguredOutput(); pin.has_value() && !pin->empty()) {
         for (const auto& entry : outputWallpapers) {
           if (entry.connector == *pin) {
-            wallpaperPath = entry.sourcePath;
-            installedWallpaperName = entry.installedName;
+            preferEntry(entry);
+            pinResolved = true;
             break;
           }
         }
       }
-      if (installedWallpaperName.empty()) {
-        wallpaperPath = outputWallpapers.front().sourcePath;
-        installedWallpaperName = outputWallpapers.front().installedName;
+      // Pin hit (file or color:): keep it. Otherwise pick first staged file, else first entry.
+      if (!pinResolved) {
+        for (const auto& entry : outputWallpapers) {
+          if (!entry.installedName.empty()) {
+            preferEntry(entry);
+            break;
+          }
+        }
+        if (installedWallpaperName.empty() && wallpaperPath.empty()) {
+          preferEntry(outputWallpapers.front());
+        }
       }
     }
     if (!writeManifest(

--- a/src/shell/greeter/greeter_appearance_sync.cpp
+++ b/src/shell/greeter/greeter_appearance_sync.cpp
@@ -263,7 +263,7 @@ namespace {
 
     nlohmann::json wallpaper;
     if (!installedWallpaperName.empty()) {
-      wallpaper["path"] = (std::filesystem::path("/var/lib/noctalia-greeter") / installedWallpaperName).string();
+      wallpaper["path"] = (std::filesystem::path(kDefaultGreeterStateDir) / installedWallpaperName).string();
     } else if (!wallpaperPath.empty()) {
       wallpaper["path"] = wallpaperPath;
     }
@@ -280,7 +280,7 @@ namespace {
       for (const auto& entry : outputWallpapers) {
         nlohmann::json item;
         if (!entry.installedName.empty()) {
-          item["path"] = (std::filesystem::path("/var/lib/noctalia-greeter") / entry.installedName).string();
+          item["path"] = (std::filesystem::path(kDefaultGreeterStateDir) / entry.installedName).string();
         } else if (!entry.sourcePath.empty()) {
           // color:#RRGGBB (or other non-staged specs) — preserve as-is.
           item["path"] = entry.sourcePath;

--- a/src/shell/greeter/greeter_appearance_sync.cpp
+++ b/src/shell/greeter/greeter_appearance_sync.cpp
@@ -13,6 +13,7 @@
 #include "util/string_utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -95,17 +96,67 @@ namespace {
     }
   }
 
-  [[nodiscard]] std::string resolveSyncWallpaperPath(const ConfigService& configService) {
-    const Config& config = configService.config();
-    if (config.theme.source != PaletteSource::Wallpaper) {
-      if (const auto output = readGreeterConfiguredOutput(); output.has_value() && !output->empty()) {
-        const std::string path = configService.getWallpaperPath(*output);
-        if (!path.empty()) {
-          return path;
-        }
+  [[nodiscard]] std::string sanitizeConnectorFileToken(std::string_view name) {
+    std::string out;
+    out.reserve(name.size());
+    for (const unsigned char c : name) {
+      if (std::isalnum(c) || c == '-' || c == '_' || c == '.') {
+        out.push_back(static_cast<char>(c));
+      } else {
+        out.push_back('_');
       }
     }
+    return out.empty() ? std::string("unknown") : out;
+  }
+
+  // Fallback single wallpaper when no per-output map is usable.
+  [[nodiscard]] std::string resolveSyncWallpaperPath(const ConfigService& configService) {
+    if (const auto output = readGreeterConfiguredOutput(); output.has_value() && !output->empty()) {
+      const std::string path = configService.getWallpaperPath(*output);
+      if (!path.empty()) {
+        return path;
+      }
+    }
+    const std::string defaultPath = configService.getDefaultWallpaperPath();
+    if (!defaultPath.empty()) {
+      return defaultPath;
+    }
     return configService.getGreeterSyncWallpaperPath();
+  }
+
+  struct StagedOutputWallpaper {
+    std::string connector;
+    std::string installedName;
+    std::string sourcePath;
+  };
+
+  // Stage every per-monitor wallpaper so the greeter can pick by connector name.
+  [[nodiscard]] std::vector<StagedOutputWallpaper>
+  stageAllOutputWallpapers(const std::filesystem::path& staging, const ConfigService& configService) {
+    std::vector<StagedOutputWallpaper> staged;
+    for (const auto& [connector, sourcePath] : configService.monitorWallpaperPaths()) {
+      if (connector.empty() || sourcePath.empty() || sourcePath.starts_with("color:")) {
+        continue;
+      }
+      std::error_code ec;
+      const std::filesystem::path source(sourcePath);
+      if (!std::filesystem::is_regular_file(source, ec) || ec) {
+        kLog.warn("greeter sync: skip missing wallpaper for '{}': {}", connector, sourcePath);
+        continue;
+      }
+      const std::string extension = source.extension().string();
+      const std::string installedName =
+          "wallpaper-" + sanitizeConnectorFileToken(connector) + (extension.empty() ? "" : extension);
+      const auto destination = staging / installedName;
+      std::filesystem::copy_file(source, destination, std::filesystem::copy_options::overwrite_existing, ec);
+      if (ec) {
+        kLog.warn("greeter sync: failed to stage wallpaper for '{}': {}", connector, ec.message());
+        continue;
+      }
+      kLog.info("greeter sync: staged wallpaper for '{}' -> {}", connector, installedName);
+      staged.push_back(StagedOutputWallpaper{connector, installedName, sourcePath});
+    }
+    return staged;
   }
 
   [[nodiscard]] std::string findApplyHelper() {
@@ -173,7 +224,8 @@ namespace {
 
   [[nodiscard]] bool writeManifest(
       const std::filesystem::path& staging, const Config& config, std::string_view resolvedMode,
-      const std::string& wallpaperPath, const std::string& installedWallpaperName
+      const std::string& wallpaperPath, const std::string& installedWallpaperName,
+      const std::vector<StagedOutputWallpaper>& outputWallpapers
   ) {
     nlohmann::json root;
     root["version"] = 1;
@@ -209,7 +261,22 @@ namespace {
     if (fillColor.a > 0.0f) {
       wallpaper["fill_color"] = formatRgbHex(fillColor);
     }
-    root["wallpaper"] = std::move(wallpaper);
+    root["wallpaper"] = wallpaper;
+
+    // Per-output wallpapers (connector name -> installed path). Greeter views select by output.
+    if (!outputWallpapers.empty()) {
+      nlohmann::json byOutput = nlohmann::json::object();
+      for (const auto& entry : outputWallpapers) {
+        nlohmann::json item;
+        item["path"] = (std::filesystem::path("/var/lib/noctalia-greeter") / entry.installedName).string();
+        item["fill_mode"] = wallpaper["fill_mode"];
+        if (wallpaper.contains("fill_color")) {
+          item["fill_color"] = wallpaper["fill_color"];
+        }
+        byOutput[entry.connector] = std::move(item);
+      }
+      root["wallpapers"] = std::move(byOutput);
+    }
     root["corner_radius_scale"] = config.shell.cornerRadiusScale;
     appendSessionManifest(root, config.shell.session);
 
@@ -428,9 +495,28 @@ namespace greeter {
       kLog.info("greeter sync: no compositor platform provided; skipping output layout sync");
     }
 
-    const std::string wallpaperPath = resolveSyncWallpaperPath(configService);
-    const std::string installedWallpaperName = stageWallpaper(staging, wallpaperPath);
-    if (!writeManifest(staging, config, resolvedThemeMode, wallpaperPath, installedWallpaperName)) {
+    const auto outputWallpapers = stageAllOutputWallpapers(staging, configService);
+    std::string wallpaperPath = resolveSyncWallpaperPath(configService);
+    std::string installedWallpaperName = stageWallpaper(staging, wallpaperPath);
+    // Prefer a staged per-output file as the legacy single wallpaper fallback when pin matched one.
+    if (installedWallpaperName.empty() && !outputWallpapers.empty()) {
+      if (const auto pin = readGreeterConfiguredOutput(); pin.has_value()) {
+        for (const auto& entry : outputWallpapers) {
+          if (entry.connector == *pin) {
+            wallpaperPath = entry.sourcePath;
+            installedWallpaperName = entry.installedName;
+            break;
+          }
+        }
+      }
+      if (installedWallpaperName.empty()) {
+        wallpaperPath = outputWallpapers.front().sourcePath;
+        installedWallpaperName = outputWallpapers.front().installedName;
+      }
+    }
+    if (!writeManifest(
+            staging, config, resolvedThemeMode, wallpaperPath, installedWallpaperName, outputWallpapers
+        )) {
       finish(false);
       return GreeterSyncLaunch::Failed;
     }


### PR DESCRIPTION
## Summary

Greeter Sync Now only staged a **single** wallpaper image. On multi-monitor setups with different images per connector (ultrawide vs portrait), the greeter could only show one of them—and often the wrong one when theming used the last-applied wallpaper.

This stages **every** monitor wallpaper and writes a per-connector map for greeters that support it, while keeping the legacy single `wallpaper` field for older greeters.

### Changes

- Stage `wallpaper-<connector>.*` for each monitor wallpaper from Noctalia settings
- Write `appearance.json` `wallpapers` map: `{ "DP-2": { path, fill_mode, fill_color }, ... }`
- Keep legacy `wallpaper` field as fallback
- Resolve the single fallback image by preferring `greeter.toml` `[output].name`, then default path, then previous palette/last-applied logic (supersedes the pin-only approach in #3413)

### Compatibility

| Greeter | Behavior |
|---------|----------|
| New (reads `wallpapers` map) | Each greeter view uses the image for its bound connector |
| Old (single `wallpaper` only) | Still gets one staged image; pin-aware fallback when `[output].name` is set |

No user-facing settings: uses existing per-monitor wallpaper paths + Sync Now / greeter apply helper.

## Test plan

- [ ] Multi-monitor with different wallpapers → Sync Now → `/var/lib/noctalia-greeter/wallpaper-DP-2.*` and `wallpaper-HDMI-A-1.*` (or your connectors) exist
- [ ] `appearance.json` has both `wallpaper` and `wallpapers`
- [ ] With greeter that supports the map + pin `name = "DP-2"` → ultrawide image
- [ ] Pin `name = "HDMI-A-1"` → portrait image
- [ ] Old greeter binary (no map) still loads legacy `wallpaper.path`
- [ ] Theme colors / scheme still sync

Supersedes #3413.