### PR TITLE
Fix Triad dock restore for duplicate windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1525,4 +1525,17 @@ wayland_toplevels_identity_test = executable('wayland_toplevels_identity_test',
 
 test('wayland_toplevels_identity', wayland_toplevels_identity_test)
 
+triad_workspace_backend_toplevels_test = executable('triad_workspace_backend_toplevels_test',
+  sources: files(
+    'tests/triad_workspace_backend_toplevels_test.cpp',
+    'src/compositors/triad/triad_runtime.cpp',
+    'src/compositors/triad/triad_workspace_backend.cpp',
+    'src/core/log.cpp',
+    'src/system/app_identity.cpp',
+  ),
+  include_directories: _noctalia_inc,
+)
+
+test('triad_workspace_backend_toplevels', triad_workspace_backend_toplevels_test)
+
 endif # build_tests

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -839,6 +839,14 @@ void CompositorPlatform::activateToplevel(zwlr_foreign_toplevel_handle_v1* handl
 }
 
 void CompositorPlatform::activateToplevelInfo(const ToplevelInfo& window) {
+  // Triad's toplevel protocol is observational. Its backend resolves the
+  // selected toplevel identity to a Triad window id and performs the action.
+  if (compositors::isTriad()
+      && !window.identifier.empty()
+      && m_workspaceMetadataBackend != nullptr
+      && m_workspaceMetadataBackend->focusWindowById(window.identifier)) {
+    return;
+  }
   if (window.handle != nullptr) {
     activateToplevel(window.handle);
     return;

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -782,7 +782,13 @@ std::optional<ActiveToplevel> CompositorPlatform::activeToplevel() const {
       }
     }
   }
-  return m_wayland.activeToplevel();
+  auto active = m_wayland.activeToplevel();
+  if (compositors::isTriad() && active.has_value() && m_workspaces != nullptr) {
+    if (const auto focusedWindowId = m_workspaces->focusedWindowId(); focusedWindowId.has_value()) {
+      active->identifier = *focusedWindowId;
+    }
+  }
+  return active;
 }
 
 wl_output* CompositorPlatform::activeToplevelOutput() const { return m_wayland.activeToplevelOutput(); }
@@ -806,6 +812,17 @@ std::vector<ToplevelInfo> CompositorPlatform::windowsForApp(
     if (!kdeWindows.empty()) {
       (void)outputFilter;
       return kdeWindows;
+    }
+  }
+
+  if (compositors::isTriad() && m_workspaceMetadataBackend != nullptr) {
+    if (const auto* triadBackend = dynamic_cast<const TriadWorkspaceBackend*>(m_workspaceMetadataBackend.get());
+        triadBackend != nullptr) {
+      const auto triadWindows =
+          triadBackend->toplevelsForApp(idLower, wmClassLower, connectorNameForOutput(outputFilter));
+      if (!triadWindows.empty()) {
+        return triadWindows;
+      }
     }
   }
 
@@ -863,6 +880,12 @@ void CompositorPlatform::activateToplevelInfo(const ToplevelInfo& window) {
 void CompositorPlatform::closeToplevel(zwlr_foreign_toplevel_handle_v1* handle) { m_wayland.closeToplevel(handle); }
 
 void CompositorPlatform::closeToplevelInfo(const ToplevelInfo& window) {
+  if (compositors::isTriad() && !window.identifier.empty() && m_workspaceMetadataBackend != nullptr) {
+    if (auto* triadBackend = dynamic_cast<TriadWorkspaceBackend*>(m_workspaceMetadataBackend.get());
+        triadBackend != nullptr && triadBackend->closeWindowById(window.identifier)) {
+      return;
+    }
+  }
   if (window.handle != nullptr) {
     closeToplevel(window.handle);
     return;

--- a/src/compositors/triad/triad_workspace_backend.cpp
+++ b/src/compositors/triad/triad_workspace_backend.cpp
@@ -283,12 +283,35 @@ std::vector<WorkspaceWindow> TriadWorkspaceBackend::workspaceWindows(const std::
   return result;
 }
 
-void TriadWorkspaceBackend::focusWindow(const std::string& windowId) {
-  const auto parsed = parseUnsignedId(windowId);
+void TriadWorkspaceBackend::focusWindow(const std::string& windowId) { (void)focusWindowById(windowId); }
+
+bool TriadWorkspaceBackend::focusWindowById(const std::string& windowId) {
+  const auto parsed = resolveFocusWindowId(windowId);
   if (!parsed.has_value()) {
-    return;
+    return false;
   }
-  (void)m_runtime.requestAction("focus-window", nlohmann::json{{"id", *parsed}});
+  return m_runtime.requestAction("focus-window", nlohmann::json{{"id", *parsed}});
+}
+
+std::optional<std::uint64_t> TriadWorkspaceBackend::resolveFocusWindowId(const std::string& windowId) const {
+  if (const auto numericId = parseUnsignedId(windowId); numericId.has_value()) {
+    return numericId;
+  }
+
+  // ext-foreign-toplevel-list identifies windows as app-id:title. Triad's
+  // focus action needs the numeric id carried by the Triad state stream.
+  std::optional<std::uint64_t> matchedId;
+  for (const auto& [id, window] : m_windows) {
+    (void)id;
+    if (windowId != window.appId + ":" + window.title) {
+      continue;
+    }
+    if (matchedId.has_value()) {
+      return std::nullopt;
+    }
+    matchedId = window.id;
+  }
+  return matchedId;
 }
 
 void TriadWorkspaceBackend::cleanup() {

--- a/src/compositors/triad/triad_workspace_backend.cpp
+++ b/src/compositors/triad/triad_workspace_backend.cpp
@@ -2,6 +2,7 @@
 
 #include "compositors/triad/triad_runtime.h"
 #include "core/log.h"
+#include "system/app_identity.h"
 #include "util/string_utils.h"
 
 #include <algorithm>
@@ -283,6 +284,44 @@ std::vector<WorkspaceWindow> TriadWorkspaceBackend::workspaceWindows(const std::
   return result;
 }
 
+std::vector<ToplevelInfo> TriadWorkspaceBackend::toplevelsForApp(
+    const std::string& idLower, const std::string& wmClassLower, const std::string& outputName
+) const {
+  std::unordered_set<std::uint32_t> workspaceIndices;
+  for (const auto* workspace : sortedWorkspaces(outputName)) {
+    workspaceIndices.insert(workspace->index);
+  }
+
+  std::vector<const WindowState*> matched;
+  matched.reserve(m_windows.size());
+  for (const auto& [windowId, window] : m_windows) {
+    (void)windowId;
+    if (!workspaceIndices.contains(window.workspaceIndex)
+        || !app_identity::matchesLower(StringUtils::toLower(window.appId), idLower, wmClassLower, {})) {
+      continue;
+    }
+    matched.push_back(&window);
+  }
+
+  std::ranges::sort(matched, [](const WindowState* lhs, const WindowState* rhs) { return lhs->id < rhs->id; });
+
+  std::vector<ToplevelInfo> result;
+  result.reserve(matched.size());
+  for (const auto* window : matched) {
+    result.push_back(
+        ToplevelInfo{
+            .title = window->title,
+            .appId = window->appId,
+            .identifier = std::to_string(window->id),
+            .order = static_cast<std::uint64_t>(result.size()),
+            .handle = nullptr,
+            .extHandle = nullptr,
+        }
+    );
+  }
+  return result;
+}
+
 void TriadWorkspaceBackend::focusWindow(const std::string& windowId) { (void)focusWindowById(windowId); }
 
 bool TriadWorkspaceBackend::focusWindowById(const std::string& windowId) {
@@ -291,6 +330,14 @@ bool TriadWorkspaceBackend::focusWindowById(const std::string& windowId) {
     return false;
   }
   return m_runtime.requestAction("focus-window", nlohmann::json{{"id", *parsed}});
+}
+
+bool TriadWorkspaceBackend::closeWindowById(const std::string& windowId) {
+  const auto parsed = resolveFocusWindowId(windowId);
+  if (!parsed.has_value()) {
+    return false;
+  }
+  return m_runtime.requestAction("close-window", nlohmann::json{{"id", *parsed}});
 }
 
 std::optional<std::uint64_t> TriadWorkspaceBackend::resolveFocusWindowId(const std::string& windowId) const {
@@ -634,7 +681,8 @@ bool TriadWorkspaceBackend::applyWindows(const nlohmann::json& windows) {
           || oldIt->second.appId != window.appId
           || oldIt->second.title != window.title
           || oldIt->second.x != window.x
-          || oldIt->second.y != window.y) {
+          || oldIt->second.y != window.y
+          || oldIt->second.minimized != window.minimized) {
         same = false;
         break;
       }
@@ -660,7 +708,8 @@ bool TriadWorkspaceBackend::applyWindow(const nlohmann::json& window) {
       && oldIt->second.appId == parsed->appId
       && oldIt->second.title == parsed->title
       && oldIt->second.x == parsed->x
-      && oldIt->second.y == parsed->y) {
+      && oldIt->second.y == parsed->y
+      && oldIt->second.minimized == parsed->minimized) {
     return false;
   }
   m_windows[parsed->id] = *parsed;
@@ -718,6 +767,7 @@ std::optional<TriadWorkspaceBackend::WindowState> TriadWorkspaceBackend::parseWi
   window.output = jsonString(json, "output");
   window.appId = jsonString(json, "app_id");
   window.title = StringUtils::windowTitleSingleLine(jsonString(json, "title"));
+  window.minimized = jsonBool(json, "is_minimized");
   if (const auto* position = objectField(json, "position"); position != nullptr) {
     if (const auto column = position->find("column_idx"); column != position->end()) {
       window.x = jsonInt32(*column).value_or(0);

--- a/src/compositors/triad/triad_workspace_backend.h
+++ b/src/compositors/triad/triad_workspace_backend.h
@@ -47,6 +47,7 @@ public:
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(wl_output* output) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(const std::string& outputName = {}) const override;
   void focusWindow(const std::string& windowId) override;
+  bool focusWindowById(const std::string& windowId) override;
   void cleanup() override;
 
   [[nodiscard]] int pollFd() const noexcept override { return m_socketFd; }
@@ -105,6 +106,7 @@ private:
   [[nodiscard]] std::vector<const WorkspaceState*> sortedWorkspaces(const std::string& outputName = {}) const;
   [[nodiscard]] std::optional<std::uint32_t> parseWorkspaceIndex(const std::string& id) const;
   [[nodiscard]] static std::optional<std::uint64_t> parseUnsignedId(const std::string& id);
+  [[nodiscard]] std::optional<std::uint64_t> resolveFocusWindowId(const std::string& windowId) const;
   void refreshSnapshot();
   void notifyChanged() const;
   void notifyOverviewChanged() const;

--- a/src/compositors/triad/triad_workspace_backend.h
+++ b/src/compositors/triad/triad_workspace_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "compositors/workspace_backend.h"
+#include "wayland/wayland_toplevels.h"
 
 #include <chrono>
 #include <cstdint>
@@ -46,8 +47,12 @@ public:
   appIdsByWorkspace(const std::string& outputName = {}) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(wl_output* output) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(const std::string& outputName = {}) const override;
+  [[nodiscard]] std::vector<ToplevelInfo> toplevelsForApp(
+      const std::string& idLower, const std::string& wmClassLower, const std::string& outputName = {}
+  ) const;
   void focusWindow(const std::string& windowId) override;
   bool focusWindowById(const std::string& windowId) override;
+  bool closeWindowById(const std::string& windowId);
   void cleanup() override;
 
   [[nodiscard]] int pollFd() const noexcept override { return m_socketFd; }
@@ -82,6 +87,7 @@ private:
     std::string title;
     std::int32_t x = 0;
     std::int32_t y = 0;
+    bool minimized = false;
   };
 
   void closeSocket(bool scheduleReconnect);

--- a/tests/triad_workspace_backend_toplevels_test.cpp
+++ b/tests/triad_workspace_backend_toplevels_test.cpp
@@ -1,0 +1,98 @@
+#include "system/internal_app_metadata.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <poll.h>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#define private public
+#include "compositors/triad/triad_workspace_backend.h"
+#undef private
+
+#include "compositors/triad/triad_runtime.h"
+
+namespace internal_apps {
+
+  const InternalAppDefinition* appDefinitionForWindowTitle(std::string_view /*windowTitle*/) { return nullptr; }
+
+  std::optional<AppMetadata> metadataForAppId(std::string_view /*appId*/) { return std::nullopt; }
+
+  void applyMetadataToDesktopEntry(DesktopEntry& /*entry*/) {}
+
+} // namespace internal_apps
+
+int main() {
+  setenv("TRIAD_SOCKET", "/tmp/noctalia-triad-workspace-backend-test.sock", 1);
+
+  compositors::triad::TriadRuntime runtime;
+  TriadWorkspaceBackend backend(runtime);
+
+  backend.m_workspaces.emplace(
+      1,
+      TriadWorkspaceBackend::WorkspaceState{
+          .index = 1,
+          .tagId = 1,
+          .output = "eDP-1",
+          .active = true,
+          .globalActive = true,
+          .occupied = true,
+      }
+  );
+  backend.m_windows.emplace(
+      100,
+      TriadWorkspaceBackend::WindowState{
+          .id = 100,
+          .workspaceIndex = 1,
+          .output = "eDP-1",
+          .appId = "kitty",
+          .title = "~",
+          .minimized = true,
+      }
+  );
+  backend.m_windows.emplace(
+      200,
+      TriadWorkspaceBackend::WindowState{
+          .id = 200,
+          .workspaceIndex = 1,
+          .output = "eDP-1",
+          .appId = "kitty",
+          .title = "~",
+      }
+  );
+  backend.m_windows.emplace(
+      300,
+      TriadWorkspaceBackend::WindowState{
+          .id = 300,
+          .workspaceIndex = 1,
+          .output = "eDP-1",
+          .appId = "brave-origin-beta",
+          .title = "Triad",
+      }
+  );
+
+  const auto windows = backend.toplevelsForApp("kitty", "kitty", "eDP-1");
+  assert(windows.size() == 2);
+  assert(windows[0].identifier == "100");
+  assert(windows[1].identifier == "200");
+  assert(windows[0].title == "~");
+  assert(windows[1].title == "~");
+  assert(backend.resolveFocusWindowId("kitty:~") == std::nullopt);
+  assert(backend.resolveFocusWindowId("100").value() == 100);
+
+  const auto parsed = TriadWorkspaceBackend::parseWindow(
+      nlohmann::json{{"id", 400}, {"workspace_idx", 1}, {"app_id", "kitty"}, {"title", "~"}, {"is_minimized", true}}
+  );
+  assert(parsed.has_value());
+  assert(parsed->minimized);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- use Triad numeric window IDs for dock entries and active-window tracking
- restore exact minimized duplicate-title windows from dock actions
- preserve native close behavior for state-backed Triad entries

## Testing
- The triad_workspace_backend_toplevels Meson test passed.
- The changed compositor platform and Triad workspace backend production objects compiled in the release build.