### PR TITLE
feat(control-center/bluetooth_tab): show MAC address in collapsible body

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -182,6 +182,7 @@
     },
     "bluetooth": {
       "accept": "Accept",
+      "address": "Address",
       "auto-reconnect": "Auto-reconnect",
       "bluetooth": "Bluetooth",
       "enter-code": "Enter code",

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -252,8 +252,38 @@ public:
 
     setHeader(std::move(header));
 
+    auto bodyColumn = ui::column(
+        {
+            .align = FlexAlign::Stretch,
+            .gap = Style::spaceSm * scale,
+        },
+        ui::row(
+            {
+                .align = FlexAlign::Center,
+                .gap = Style::spaceSm * scale,
+                .configure =
+                    [scale](Flex& body) {
+                      body.setPadding(
+                          Style::spaceXs * scale, Style::spaceMd * scale, Style::spaceSm * scale, Style::spaceMd * scale
+                      );
+                    },
+            },
+            ui::label({
+                .text = i18n::tr("control-center.bluetooth.address"),
+                .fontSize = Style::fontSizeCaption * scale,
+                .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                .flexGrow = 1.0f,
+            }),
+            ui::label(
+                {.text = m_device.address,
+                 .fontSize = Style::fontSizeCaption * scale,
+                 .color = colorSpecFromRole(ColorRole::OnSurface)}
+            )
+        )
+    );
+
     if (m_device.paired) {
-      setBody(
+      bodyColumn->addChild(
           ui::row(
               {.align = FlexAlign::Center,
                .gap = Style::spaceSm * scale,
@@ -282,6 +312,8 @@ public:
           )
       );
     }
+
+    setBody(std::move(bodyColumn));
   }
 
   void startConnectingSpinner() {

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -252,22 +252,43 @@ public:
 
     setHeader(std::move(header));
 
-    auto bodyColumn = ui::column(
-        {
-            .align = FlexAlign::Stretch,
-            .gap = Style::spaceSm * scale,
+    auto bodyColumn = ui::column({
+        .align = FlexAlign::Stretch,
+        .gap = Style::spaceSm * scale,
+        .configure = [scale](Flex& col) {
+          col.setPadding(
+              Style::spaceXs * scale, Style::spaceMd * scale, Style::spaceSm * scale, Style::spaceMd * scale
+          );
         },
+    });
+
+    if (m_device.paired) {
+      bodyColumn->addChild(
+          ui::row(
+              {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
+              ui::label({
+                  .text = i18n::tr("control-center.bluetooth.auto-reconnect"),
+                  .fontSize = Style::fontSizeCaption * scale,
+                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+                  .flexGrow = 1.0f,
+              }),
+              ui::toggle({
+                  .checkedImmediate = m_device.trusted,
+                  .toggleSize = ToggleSize::Small,
+                  .scale = scale,
+                  .onChange = [this](bool checked) {
+                    if (m_service != nullptr) {
+                      m_service->setTrusted(m_device.path, checked);
+                    }
+                  },
+              })
+          )
+      );
+    }
+
+    bodyColumn->addChild(
         ui::row(
-            {
-                .align = FlexAlign::Center,
-                .gap = Style::spaceSm * scale,
-                .configure =
-                    [scale](Flex& body) {
-                      body.setPadding(
-                          Style::spaceXs * scale, Style::spaceMd * scale, Style::spaceSm * scale, Style::spaceMd * scale
-                      );
-                    },
-            },
+            {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
             ui::label({
                 .text = i18n::tr("control-center.bluetooth.address"),
                 .fontSize = Style::fontSizeCaption * scale,
@@ -281,37 +302,6 @@ public:
             )
         )
     );
-
-    if (m_device.paired) {
-      bodyColumn->addChild(
-          ui::row(
-              {.align = FlexAlign::Center,
-               .gap = Style::spaceSm * scale,
-               .configure =
-                   [scale](Flex& body) {
-                     body.setPadding(
-                         Style::spaceXs * scale, Style::spaceMd * scale, Style::spaceSm * scale, Style::spaceMd * scale
-                     );
-                   }},
-              ui::label({
-                  .text = i18n::tr("control-center.bluetooth.auto-reconnect"),
-                  .fontSize = Style::fontSizeCaption * scale,
-                  .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
-                  .flexGrow = 1.0f,
-              }),
-              ui::toggle({
-                  .checkedImmediate = m_device.trusted,
-                  .toggleSize = ToggleSize::Medium,
-                  .scale = scale,
-                  .onChange = [this](bool checked) {
-                    if (m_service != nullptr) {
-                      m_service->setTrusted(m_device.path, checked);
-                    }
-                  },
-              })
-          )
-      );
-    }
 
     setBody(std::move(bodyColumn));
   }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

The bluetooth tab in the control center now shows the MAC address of the connected device in the device dropdown, where there was only the Auto-Reconnect toggle before.


## Motivation

Two bluetooth devices can have the same name / alias and be indistinguishable in the device list except for remembering that one comes first and the other comes after.

This change shouldn't clutter the UI, because most often ppl only have one collapsible open; so the additional line is mostly visible only once on screen.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing
both on `m=debug` and `m=release`:
- `just build` / `just run` runs successfully
- `just test` has the same two tests failing as on main (`process` and `plugin_git_export`)

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
    collapsible only opens sometimes at UI scales > 1.0; same behaviour on main; see #3421
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="497" height="295" alt="image" src="https://github.com/user-attachments/assets/f04bfc5d-f690-4466-8ed2-5248e72cfc91" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I'm very open to making this opt-in with a config option, but imo I don't really see much reason not to show it.
