### PR TITLE
Add Parent Panel toggle feature.

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1664,6 +1664,10 @@
           "description": "Pixels an attached panel overlaps the bar edge to hide the seam (adjust if you see a line or gap)",
           "label": "Panel Overlap"
         },
+        "panel-parent": {
+          "description": "All attached panels always dock to this bar, regardless of which bar's widget opened them.",
+          "label": "Anchor Panels Here"
+        },
         "position": {
           "description": "Which screen edge the bar sits on"
         },

--- a/src/config/config_service.cpp
+++ b/src/config/config_service.cpp
@@ -1620,6 +1620,17 @@ void ConfigService::parseConfigTable(
           break;
         }
       }
+      // Only one bar may be the panel parent; if config (hand-edited or stale) has more
+      // than one, keep the first in final order and clear the rest.
+      bool sawPanelParent = false;
+      for (auto& bar : config.bars) {
+        if (bar.isPanelParent) {
+          if (sawPanelParent) {
+            bar.isPanelParent = false;
+          }
+          sawPanelParent = true;
+        }
+      }
     }
 
     for (std::size_t i = 0; i < parsedBars.size(); ++i) {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -178,6 +178,12 @@ struct BarConfig {
   std::optional<ColorSpec> widgetCapsuleBorder;
   // Soft tint of a widget's foreground color over the widget under the pointer (per member in capsule groups).
   bool hoverHighlight = true;
+
+  // When true, every attached panel (Control Center, Audio tab, etc.) docks to THIS bar
+  // regardless of which bar's widget was clicked to open it. Only one bar should have this
+  // set at a time; ConfigService::parseConfigTable enforces that on load.
+  bool isPanelParent = false;
+
   BarDeadZoneConfig deadZone;
   std::vector<BarMonitorOverride> monitorOverrides;
 

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1959,6 +1959,7 @@ namespace noctalia::config::schema {
         field(&BarConfig::widgetCapsuleOpacity, "capsule_opacity", kBarOpacityRange),
         capsuleBorderField(&BarConfig::widgetCapsuleBorder, &BarConfig::widgetCapsuleBorderSpecified, "capsule_border"),
         field(&BarConfig::hoverHighlight, "hover_highlight"),
+        field(&BarConfig::isPanelParent, "panel_parent"),
         subTable(&BarConfig::deadZone, "dead_zone", barDeadZoneSchema()),
     };
     return s;

--- a/src/shell/panel/panel_manager.cpp
+++ b/src/shell/panel/panel_manager.cpp
@@ -484,8 +484,19 @@ void PanelManager::openPanel(const std::string& panelId, PanelOpenRequest reques
 
   auto panelWidth = static_cast<std::uint32_t>(m_activePanel->preferredWidth());
   auto panelHeight = static_cast<std::uint32_t>(m_activePanel->preferredHeight());
-  auto barConfig = resolvePanelBarConfig(m_config, m_platform, request.output, request.sourceBarName);
-  m_sourceBarName = request.sourceBarName.empty() ? barConfig.name : std::string(request.sourceBarName);
+  std::string_view effectiveSourceBarName = request.sourceBarName;
+  if (m_config != nullptr) {
+    for (const auto& bar : m_config->config().bars) {
+      if (bar.isPanelParent) {
+        effectiveSourceBarName = bar.name;
+        break;
+      }
+    }
+  }
+  auto barConfig = resolvePanelBarConfig(m_config, m_platform, request.output, effectiveSourceBarName);
+  m_sourceBarName = effectiveSourceBarName.empty() ? barConfig.name : std::string(effectiveSourceBarName);
+  // parent panel code :3
+
   if (m_attachedPanelLayerProvider != nullptr) {
     if (auto layer = m_attachedPanelLayerProvider(request.output, m_sourceBarName); layer.has_value()) {
       barConfig.layer = *layer;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2630,6 +2630,11 @@ namespace settings {
           "exclusive zone"
       ));
       entries.push_back(makeEntry(
+          section, "general", tr("settings.schema.bar.panel-parent.label"),
+          tr("settings.schema.bar.panel-parent.description"), path("panel_parent"), ToggleSetting{bar.isPanelParent},
+          "anchor pin parent control center attach dock"
+      ));
+      entries.push_back(makeEntry(
           section, "general", tr("settings.schema.bar.layer.label"), tr("settings.schema.bar.layer.description"),
           path("layer"),
           asSegmented(plainSelect(


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
I added a parent paneling feature so that panels can always be clipped to one bar.
## Motivation

<!-- What problem does this solve? -->
 I had an issue that I could fix. And I figured its also for the better.
## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [ ] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
This will need translation for every language and added to documentation if you want. It works though!
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/16c497a1-6eca-4b65-9154-cebe8da52f06" />
