### PR TITLE
feat(osd/audio): show audio sink/source name in osd when default sink/source is set

### DIFF
--- a/src/shell/osd/audio_osd.cpp
+++ b/src/shell/osd/audio_osd.cpp
@@ -27,6 +27,15 @@ namespace {
     };
   }
 
+  OsdContent makeOutputNameContent(std::string name, bool muted) {
+    return OsdContent{
+        .kind = OsdKind::Volume,
+        .icon = audioVolumeGlyph(1.0f, muted, false),
+        .value = name,
+        .showProgress = false,
+    };
+  }
+
   OsdContent makeInputContent(float volume, bool muted) {
     const int percent = static_cast<int>(std::round(std::max(0.0f, volume) * 100.0f));
     return OsdContent{
@@ -36,6 +45,15 @@ namespace {
         .progress = std::clamp(volume, 0.0f, 1.0f),
         .overLimit = percent > 100,
         .inactive = muted,
+    };
+  }
+
+  OsdContent makeInputNameContent(std::string name, bool muted) {
+    return OsdContent{
+        .kind = OsdKind::Microphone,
+        .icon = audioVolumeGlyph(1.0f, muted, true),
+        .value = name,
+        .showProgress = false,
     };
   }
 
@@ -84,6 +102,18 @@ void AudioOsd::showOutput(std::uint32_t sinkId, float volume, bool muted, bool p
   m_lastSinkMuted = muted;
 }
 
+void AudioOsd::showOutputName(std::string name, bool muted) {
+  const auto now = std::chrono::steady_clock::now();
+  if (now < m_suppressUntil) {
+    return;
+  }
+  m_suppressAutoInputOsdUntil = now + kSuppressInputOsdAfterOutput;
+  if (m_overlay != nullptr) {
+    m_overlay->show(makeOutputNameContent(name, muted));
+    m_currentKind = OsdKind::Volume;
+  }
+}
+
 void AudioOsd::showInput(std::uint32_t sourceId, float volume, bool muted, bool playFeedback) {
   const auto now = std::chrono::steady_clock::now();
   if (now < m_suppressUntil) {
@@ -103,16 +133,29 @@ void AudioOsd::showInput(std::uint32_t sourceId, float volume, bool muted, bool 
   m_lastSourceMuted = muted;
 }
 
+void AudioOsd::showInputName(std::string name, bool muted) {
+  const auto now = std::chrono::steady_clock::now();
+  if (now < m_suppressUntil) {
+    return;
+  }
+  if (m_overlay != nullptr) {
+    m_overlay->show(makeInputNameContent(name, muted));
+    m_currentKind = OsdKind::Microphone;
+  }
+}
+
 void AudioOsd::onAudioStateChanged(const PipeWireService& service) {
   const auto* sink = service.defaultSink();
   const auto* source = service.defaultSource();
 
   const std::uint32_t sinkId = sink != nullptr ? sink->id : 0;
+  const std::string sinkName = sink != nullptr ? sink->description : "";
   const float sinkVolume = sink != nullptr ? sink->volume : 0.0f;
   const int sinkPercent = sink != nullptr ? static_cast<int>(std::round(std::max(0.0f, sinkVolume) * 100.0f)) : 0;
   const bool sinkMuted = sink != nullptr ? sink->muted : false;
 
   const std::uint32_t sourceId = source != nullptr ? source->id : 0;
+  const std::string sourceName = source != nullptr ? source->description : "";
   const float sourceVolume = source != nullptr ? source->volume : 0.0f;
   const int sourcePercent = source != nullptr ? static_cast<int>(std::round(std::max(0.0f, sourceVolume) * 100.0f)) : 0;
   const bool sourceMuted = source != nullptr ? source->muted : false;
@@ -146,23 +189,25 @@ void AudioOsd::onAudioStateChanged(const PipeWireService& service) {
 
   const bool sinkVolumeChanged = sink != nullptr && volumeChanged(sinkVolume, m_lastSinkVolume);
   const bool sinkMuteChanged = sink != nullptr && sinkMuted != m_lastSinkMuted;
-  const bool sinkChanged = sink != nullptr && (sinkId != m_lastSinkId || sinkVolumeChanged || sinkMuteChanged);
   const bool sinkRouteChanged = sink != nullptr && sinkId != m_lastSinkId;
   const bool sinkDisappeared = sink == nullptr && m_lastSinkId != 0;
   const bool sourceVolumeChanged = source != nullptr && volumeChanged(sourceVolume, m_lastSourceVolume);
   const bool sourceMuteChanged = source != nullptr && sourceMuted != m_lastSourceMuted;
-  const bool sourceChanged =
-      source != nullptr && (sourceId != m_lastSourceId || sourceVolumeChanged || sourceMuteChanged);
+  const bool sourceRouteChanged = source != nullptr && sourceId != m_lastSourceId;
 
   if (sinkRouteChanged || sinkDisappeared) {
     m_suppressAutoInputOsdUntil = now + std::chrono::milliseconds(400);
   }
 
   if (m_overlay != nullptr) {
-    if (sinkChanged) {
+    if (sinkRouteChanged) {
+      showOutputName(sinkName, sinkMuted);
+    } else if (sinkVolumeChanged || sinkMuteChanged) {
       // Passive PipeWire updates: click only on real volume changes while unmuted.
       showOutput(sink->id, sink->volume, sinkMuted, sinkVolumeChanged && !sinkMuted);
-    } else if (sourceChanged && now >= m_suppressAutoInputOsdUntil) {
+    } else if (sourceRouteChanged) {
+      showInputName(sourceName, sourceMuted);
+    } else if ((sourceVolumeChanged || sourceMuteChanged) && now >= m_suppressAutoInputOsdUntil) {
       showInput(source->id, source->volume, sourceMuted, sourceVolumeChanged && !sourceMuted);
     }
   }

--- a/src/shell/osd/audio_osd.cpp
+++ b/src/shell/osd/audio_osd.cpp
@@ -31,8 +31,9 @@ namespace {
     return OsdContent{
         .kind = OsdKind::Volume,
         .icon = audioVolumeGlyph(1.0f, muted, false),
-        .value = name,
+        .value = std::move(name),
         .showProgress = false,
+        .inactive = muted,
     };
   }
 
@@ -52,8 +53,9 @@ namespace {
     return OsdContent{
         .kind = OsdKind::Microphone,
         .icon = audioVolumeGlyph(1.0f, muted, true),
-        .value = name,
+        .value = std::move(name),
         .showProgress = false,
+        .inactive = muted,
     };
   }
 
@@ -109,7 +111,7 @@ void AudioOsd::showOutputName(std::string name, bool muted) {
   }
   m_suppressAutoInputOsdUntil = now + kSuppressInputOsdAfterOutput;
   if (m_overlay != nullptr) {
-    m_overlay->show(makeOutputNameContent(name, muted));
+    m_overlay->show(makeOutputNameContent(std::move(name), muted));
     m_currentKind = OsdKind::Volume;
   }
 }
@@ -139,7 +141,7 @@ void AudioOsd::showInputName(std::string name, bool muted) {
     return;
   }
   if (m_overlay != nullptr) {
-    m_overlay->show(makeInputNameContent(name, muted));
+    m_overlay->show(makeInputNameContent(std::move(name), muted));
     m_currentKind = OsdKind::Microphone;
   }
 }
@@ -149,13 +151,13 @@ void AudioOsd::onAudioStateChanged(const PipeWireService& service) {
   const auto* source = service.defaultSource();
 
   const std::uint32_t sinkId = sink != nullptr ? sink->id : 0;
-  const std::string sinkName = sink != nullptr ? sink->description : "";
+  const std::string sinkName = sink != nullptr ? audioDeviceLabel(*sink) : "";
   const float sinkVolume = sink != nullptr ? sink->volume : 0.0f;
   const int sinkPercent = sink != nullptr ? static_cast<int>(std::round(std::max(0.0f, sinkVolume) * 100.0f)) : 0;
   const bool sinkMuted = sink != nullptr ? sink->muted : false;
 
   const std::uint32_t sourceId = source != nullptr ? source->id : 0;
-  const std::string sourceName = source != nullptr ? source->description : "";
+  const std::string sourceName = source != nullptr ? audioDeviceLabel(*source) : "";
   const float sourceVolume = source != nullptr ? source->volume : 0.0f;
   const int sourcePercent = source != nullptr ? static_cast<int>(std::round(std::max(0.0f, sourceVolume) * 100.0f)) : 0;
   const bool sourceMuted = source != nullptr ? source->muted : false;
@@ -205,7 +207,7 @@ void AudioOsd::onAudioStateChanged(const PipeWireService& service) {
     } else if (sinkVolumeChanged || sinkMuteChanged) {
       // Passive PipeWire updates: click only on real volume changes while unmuted.
       showOutput(sink->id, sink->volume, sinkMuted, sinkVolumeChanged && !sinkMuted);
-    } else if (sourceRouteChanged) {
+    } else if (sourceRouteChanged && now >= m_suppressAutoInputOsdUntil) {
       showInputName(sourceName, sourceMuted);
     } else if ((sourceVolumeChanged || sourceMuteChanged) && now >= m_suppressAutoInputOsdUntil) {
       showInput(source->id, source->volume, sourceMuted, sourceVolumeChanged && !sourceMuted);

--- a/src/shell/osd/audio_osd.h
+++ b/src/shell/osd/audio_osd.h
@@ -14,7 +14,9 @@ public:
   void primeFromService(const PipeWireService& service);
   void suppressFor(std::chrono::milliseconds duration);
   void showOutput(std::uint32_t sinkId, float volume, bool muted, bool playFeedback = true);
+  void showOutputName(std::string name, bool muted);
   void showInput(std::uint32_t sourceId, float volume, bool muted, bool playFeedback = true);
+  void showInputName(std::string name, bool muted);
   void onAudioStateChanged(const PipeWireService& service);
 
 private:

--- a/src/shell/osd/osd_overlay.cpp
+++ b/src/shell/osd/osd_overlay.cpp
@@ -676,12 +676,14 @@ void OsdOverlay::updateInstanceContent(Instance& inst) {
                                                   : ColorRole::OnSurface;
   inst.value->setColor(colorSpecFromRole(valueRole));
   inst.value->setTextAlign((vertical || !m_content.showProgress) ? TextAlign::Center : TextAlign::End);
-  // Media titles are arbitrary length; cap them to the card so they ellipsize instead of overflowing.
+  // Text OSDs (media title, device name, ...) carry arbitrary-length values; cap them to the card
+  // interior so they ellipsize within the padding instead of overflowing. Progress OSDs keep the
+  // uncapped "100%" value so it can reserve minWidth beside the bar.
   const float horizontalValueMax = cw - cardPadding(s) * 2.0f - glyphSize(s) - innerGap(s);
   inst.value->setMaxWidth(
-      vertical                               ? cw - cardPadding(s) * 2.0f
-          : m_content.kind == OsdKind::Media ? std::max(0.0f, horizontalValueMax)
-                                             : 0.0f
+      vertical                      ? cw - cardPadding(s) * 2.0f
+          : !m_content.showProgress ? std::max(0.0f, horizontalValueMax)
+                                    : 0.0f
   );
   inst.value->setMinWidth((!vertical && m_content.showProgress) ? inst.progressValueMinWidth : 0.0f);
   inst.value->setText(m_content.value);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

When the default audio sink/source is changed, show the name of the sink/source instead of the volume in OSD

<!-- What changed and why? -->

## Motivation

see linked issue; differentiate between "volume changed" and "device changed"

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
closes #3362

## Testing

- `just build` / `just run` runs successfully
- `just test` has the same two tests failing as on main (`process` and `plugin_git_export`)

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [n/a] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="668" height="109" alt="image" src="https://github.com/user-attachments/assets/6d0584e8-faa2-4d7c-b3fc-f5750a58b702" />

(this has the name clipping, similar things happen with the media osd too though, so this is a thing of the user setting the osd width and not of the implementation itself)
<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [ x I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
