### PR TITLE
Fix guix package build

### DIFF
--- a/noctalia.scm
+++ b/noctalia.scm
@@ -48,20 +48,20 @@
 ;; expects them in include/stb/stb_x.h
 (define* (wrap-stb-header stb-package name #:key deprecated?)
   (package
-    (inherit stb-package)
-    (arguments
-     (list
-      #:modules '((guix build utils))
-      #:builder
-      #~(begin
-          (use-modules (guix build utils))
-          (let ((headers-dir #$(file-append (this-package-input "stb")
-                                            (if deprecated? "/deprecated" "")))
-                (lib (string-join (string-split #$name #\-) "_"))
-                (out #$output))
-            (install-file (string-append headers-dir "/" lib ".h")
-                          (string-append out "/include/stb/"))
-            #t))))))
+   (inherit stb-package)
+   (arguments
+    (list
+     #:modules '((guix build utils))
+     #:builder
+     #~(begin
+         (use-modules (guix build utils))
+         (let ((headers-dir #$(file-append (this-package-input "stb")
+                                           (if deprecated? "/deprecated" "")))
+               (lib (string-join (string-split #$name #\-) "_"))
+               (out #$output))
+           (install-file (string-append headers-dir "/" lib ".h")
+                         (string-append out "/include/stb/"))
+           #t))))))
 (define stb-image-resize2-wrapped
   (wrap-stb-header stb-image-resize2 "stb-image-resize2"))
 (define stb-image-write-wrapped

--- a/noctalia.scm
+++ b/noctalia.scm
@@ -24,12 +24,11 @@
   #:use-module (guix build-system meson)
   #:use-module (guix build-system gnu)
   ;; Guix packages
-  #:use-module (gnu packages curl)
   #:use-module (gnu packages cpp)
+  #:use-module (gnu packages curl)
   #:use-module (gnu packages fontutils)
   #:use-module (gnu packages freedesktop)
   #:use-module (gnu packages gl)
-  #:use-module (gnu packages stb)
   #:use-module (gnu packages glib)
   #:use-module (gnu packages gnome)
   #:use-module (gnu packages gtk)
@@ -41,6 +40,7 @@
   #:use-module (gnu packages multiprecision)
   #:use-module (gnu packages pkg-config)
   #:use-module (gnu packages polkit)
+  #:use-module (gnu packages stb)
   #:use-module (gnu packages xdisorg)
   #:use-module (gnu packages xml))
 
@@ -117,27 +117,27 @@
            freetype
            glib
            gmp
-           mpfr
            harfbuzz
            jemalloc
+           mpfr
            (librsvg-for-system)
            libqalculate
            libwebp
            libxkbcommon
-           nlohmann-json
-           tomlplusplus
            libxml2
            linux-pam
+           md4c
            mesa
+           nlohmann-json
            pango
-           stb-image-resize2-wrapped
-           stb-image-write-wrapped
            pipewire
            polkit
            sdbus-c++
+           stb-image-resize2-wrapped
+           stb-image-write-wrapped
+           tomlplusplus
            wayland
            wayland-protocols-1.48
-           md4c
            wireplumber))
     (home-page "https://noctalia.dev/")
     (synopsis "Wayland shell and bar")

--- a/noctalia.scm
+++ b/noctalia.scm
@@ -22,23 +22,50 @@
   #:use-module (guix git-download)
   ;; Guix build systems
   #:use-module (guix build-system meson)
+  #:use-module (guix build-system gnu)
   ;; Guix packages
   #:use-module (gnu packages curl)
+  #:use-module (gnu packages cpp)
   #:use-module (gnu packages fontutils)
   #:use-module (gnu packages freedesktop)
   #:use-module (gnu packages gl)
+  #:use-module (gnu packages stb)
   #:use-module (gnu packages glib)
   #:use-module (gnu packages gnome)
   #:use-module (gnu packages gtk)
   #:use-module (gnu packages image)
   #:use-module (gnu packages jemalloc)
   #:use-module (gnu packages linux)
+  #:use-module (gnu packages markup)
   #:use-module (gnu packages maths)
   #:use-module (gnu packages multiprecision)
   #:use-module (gnu packages pkg-config)
   #:use-module (gnu packages polkit)
   #:use-module (gnu packages xdisorg)
   #:use-module (gnu packages xml))
+
+;; guix distributes stb headers under include/stb_x.h, but noctalia
+;; expects them in include/stb/stb_x.h
+(define* (wrap-stb-header stb-package name #:key deprecated?)
+  (package
+    (inherit stb-package)
+    (arguments
+     (list
+      #:modules '((guix build utils))
+      #:builder
+      #~(begin
+          (use-modules (guix build utils))
+          (let ((headers-dir #$(file-append (this-package-input "stb")
+                                            (if deprecated? "/deprecated" "")))
+                (lib (string-join (string-split #$name #\-) "_"))
+                (out #$output))
+            (install-file (string-append headers-dir "/" lib ".h")
+                          (string-append out "/include/stb/"))
+            #t))))))
+(define stb-image-resize2-wrapped
+  (wrap-stb-header stb-image-resize2 "stb-image-resize2"))
+(define stb-image-write-wrapped
+  (wrap-stb-header stb-image-write "stb-image-write"))
 
 (define wayland-protocols-1.48
   (package
@@ -97,15 +124,20 @@
            libqalculate
            libwebp
            libxkbcommon
+           nlohmann-json
+           tomlplusplus
            libxml2
            linux-pam
            mesa
            pango
+           stb-image-resize2-wrapped
+           stb-image-write-wrapped
            pipewire
            polkit
            sdbus-c++
            wayland
            wayland-protocols-1.48
+           md4c
            wireplumber))
     (home-page "https://noctalia.dev/")
     (synopsis "Wayland shell and bar")
@@ -121,3 +153,4 @@ Wayland and OpenGL ES, with no Qt or GTK dependency.")
 ;; guix shell --file=noctalia.scm
 ;; guix package --install-from-file=noctalia.scm
 noctalia-git
+;; wrapped-stb

--- a/noctalia.scm
+++ b/noctalia.scm
@@ -153,4 +153,3 @@ Wayland and OpenGL ES, with no Qt or GTK dependency.")
 ;; guix shell --file=noctalia.scm
 ;; guix package --install-from-file=noctalia.scm
 noctalia-git
-;; wrapped-stb


### PR DESCRIPTION
## Summary

This guix package was broken due to missing dependencies that have been added since the last update to the guix build in #2863 

## Motivation

This should enable guix users to build noctalia easily

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [X] Build / packaging

## Related Issue

## Testing

```sh
guix build -f noctalia.scm
/gnu/store/...-noctalia-git-latest/bin/noctalia
```

Currently running noctalia v5 in a guix environment. Working well

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.