### PR TITLE
feat(bluetooth): also read battery percent from UPower

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -258,11 +258,12 @@ private:
   std::unique_ptr<NetworkSecretAgent> m_networkSecretAgent;
   ExternalIpService m_externalIpService{&m_httpClient, &m_configService};
   std::unique_ptr<IwdSecretAgent> m_iwdSecretAgent;
+  // Declared before m_bluetoothService so it outlives the raw pointer in that service.
+  std::unique_ptr<UPowerService> m_upowerService;
   std::unique_ptr<BluetoothService> m_bluetoothService;
   std::unique_ptr<BluetoothAgent> m_bluetoothAgent;
   Timer m_bluetoothResumeTimer;
   std::unique_ptr<PolkitAgent> m_polkitAgent;
-  std::unique_ptr<UPowerService> m_upowerService;
   std::optional<bool> m_notificationDaemonEnabled;
   bool m_notificationDaemonInitFailed = false;
   bool m_notificationShellRefreshScheduled = false;

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -945,6 +945,9 @@ void Application::initSystemBusServices() {
       m_upowerService->setChangeCallback([this, shouldRefreshControlCenter]() {
         onUpowerStateChangedForHooks();
         m_batteryWarningMonitor.evaluate(m_configService.config().battery, *m_upowerService, m_notificationManager);
+        if (m_bluetoothService != nullptr) {
+          m_bluetoothService->refreshBatteryFromUPower();
+        }
         m_bar.refresh();
         m_settingsWindow.onExternalOptionsChanged();
         if (shouldRefreshControlCenter()) {
@@ -1069,7 +1072,7 @@ void Application::initSystemBusServices() {
     }
 
     try {
-      m_bluetoothService = std::make_unique<BluetoothService>(*m_systemBus);
+      m_bluetoothService = std::make_unique<BluetoothService>(*m_systemBus, m_upowerService.get());
       auto refreshBluetoothUi = [this, shouldRefreshControlCenter]() {
         m_bar.refresh();
         if (shouldRefreshControlCenter()) {

--- a/src/dbus/bluetooth/bluetooth_service.cpp
+++ b/src/dbus/bluetooth/bluetooth_service.cpp
@@ -904,6 +904,9 @@ bool BluetoothService::applyUPowerBattery() {
     }
 
     if (!bluetoothDevice.hasBattery) {
+      if (bluetoothDevice.address.empty()) {
+        continue;
+      }
       auto serial = bluetoothDevice.address;
       auto* deviceInfo = m_upowerService->deviceForSerial(serial);
       if (!deviceInfo) {

--- a/src/dbus/bluetooth/bluetooth_service.cpp
+++ b/src/dbus/bluetooth/bluetooth_service.cpp
@@ -2,6 +2,7 @@
 
 #include "core/log.h"
 #include "dbus/system_bus.h"
+#include "dbus/upower/upower_service.h"
 #include "i18n/i18n.h"
 #include "ipc/ipc_service.h"
 #include "system/rfkill_helper.h"
@@ -10,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <map>
 #include <optional>
 #include <sdbus-c++/IConnection.h>
@@ -210,6 +212,7 @@ namespace {
         } else {
           out.hasBattery = false;
           out.batteryPercent = 0;
+          out.batteryUPowerSerial.clear();
         }
       }
     }
@@ -244,12 +247,15 @@ namespace {
     if (!out.connected) {
       out.hasBattery = false;
       out.batteryPercent = 0;
+      out.batteryUPowerSerial.clear();
       return;
     }
     if (auto it = props.find("Percentage"); it != props.end()) {
       if (auto v = variantGet<std::uint8_t>(it->second)) {
         out.hasBattery = true;
+        // Prefer the battery percentage from the Bluez service over UPower.
         out.batteryPercent = *v;
+        out.batteryUPowerSerial.clear();
       }
     }
   }
@@ -339,6 +345,7 @@ struct BluetoothService::Impl {
         if (auto* dev = self.findDevice(path)) {
           dev->hasBattery = false;
           dev->batteryPercent = 0;
+          dev->batteryUPowerSerial.clear();
           devicesDirty = true;
         }
       }
@@ -451,7 +458,8 @@ struct BluetoothService::Impl {
   }
 };
 
-BluetoothService::BluetoothService(SystemBus& bus) : m_impl(std::make_unique<Impl>(*this, bus)) {
+BluetoothService::BluetoothService(SystemBus& bus, UPowerService* upowerService)
+    : m_impl(std::make_unique<Impl>(*this, bus)), m_upowerService(upowerService) {
   m_impl->root = sdbus::createProxy(bus.connection(), kBluezBusName, kRootPath);
 
   m_impl->root->uponSignal("InterfacesAdded")
@@ -868,7 +876,78 @@ void BluetoothService::emitState(BluetoothStateChangeOrigin origin) {
 }
 
 void BluetoothService::emitDevices() {
+  applyUPowerBattery();
   if (m_devicesCallback) {
     m_devicesCallback(m_devices);
   }
+}
+
+void BluetoothService::refreshBatteryFromUPower() {
+  if (applyUPowerBattery() && m_devicesCallback) {
+    m_devicesCallback(m_devices);
+  }
+}
+
+bool BluetoothService::applyUPowerBattery() {
+  if (!m_upowerService) {
+    return false;
+  }
+
+  const auto getBatteryPercent = [](const auto& deviceInfo) {
+    return static_cast<std::uint8_t>(std::clamp(std::lround(deviceInfo->state.percentage), 0L, 100L));
+  };
+
+  bool hasChange = false;
+  for (auto& bluetoothDevice : m_devices) {
+    if (!bluetoothDevice.connected || (bluetoothDevice.hasBattery && bluetoothDevice.batteryUPowerSerial.empty())) {
+      continue;
+    }
+
+    if (!bluetoothDevice.hasBattery) {
+      auto serial = bluetoothDevice.address;
+      auto* deviceInfo = m_upowerService->deviceForSerial(serial);
+      if (!deviceInfo) {
+        serial = StringUtils::toLower(serial);
+        deviceInfo = m_upowerService->deviceForSerial(serial);
+      }
+      if (deviceInfo && deviceInfo->isPresent) {
+        switch (deviceInfo->type) {
+        case UPowerDeviceType::Unknown:
+        case UPowerDeviceType::LinePower:
+        case UPowerDeviceType::Battery:
+        case UPowerDeviceType::Ups:
+          break;
+        default:
+          bluetoothDevice.hasBattery = true;
+          bluetoothDevice.batteryPercent = getBatteryPercent(deviceInfo);
+          bluetoothDevice.batteryUPowerSerial = serial;
+          hasChange = true;
+          kLog.debug(
+              "battery added from UPower : {} {}", bluetoothDevice.batteryUPowerSerial, bluetoothDevice.batteryPercent
+          );
+          break;
+        }
+      }
+    } else {
+      const auto* deviceInfo = m_upowerService->deviceForSerial(bluetoothDevice.batteryUPowerSerial);
+      if (deviceInfo && deviceInfo->isPresent) {
+        const auto batteryPercent = getBatteryPercent(deviceInfo);
+        if (bluetoothDevice.batteryPercent != batteryPercent) {
+          bluetoothDevice.batteryPercent = batteryPercent;
+          hasChange = true;
+          kLog.debug(
+              "battery updated from UPower : {} {}", bluetoothDevice.batteryUPowerSerial, bluetoothDevice.batteryPercent
+          );
+        }
+      } else {
+        kLog.debug("battery removed from UPower : {}", bluetoothDevice.batteryUPowerSerial);
+        bluetoothDevice.hasBattery = false;
+        bluetoothDevice.batteryPercent = 0;
+        bluetoothDevice.batteryUPowerSerial.clear();
+        hasChange = true;
+      }
+    }
+  }
+
+  return hasChange;
 }

--- a/src/dbus/bluetooth/bluetooth_service.cpp
+++ b/src/dbus/bluetooth/bluetooth_service.cpp
@@ -212,7 +212,7 @@ namespace {
         } else {
           out.hasBattery = false;
           out.batteryPercent = 0;
-          out.batteryUPowerSerial.clear();
+          out.batteryFromUPower = false;
         }
       }
     }
@@ -247,15 +247,15 @@ namespace {
     if (!out.connected) {
       out.hasBattery = false;
       out.batteryPercent = 0;
-      out.batteryUPowerSerial.clear();
+      out.batteryFromUPower = false;
       return;
     }
     if (auto it = props.find("Percentage"); it != props.end()) {
       if (auto v = variantGet<std::uint8_t>(it->second)) {
         out.hasBattery = true;
-        // Prefer the battery percentage from the Bluez service over UPower.
+        // BlueZ's own reading wins over UPower.
         out.batteryPercent = *v;
-        out.batteryUPowerSerial.clear();
+        out.batteryFromUPower = false;
       }
     }
   }
@@ -345,7 +345,7 @@ struct BluetoothService::Impl {
         if (auto* dev = self.findDevice(path)) {
           dev->hasBattery = false;
           dev->batteryPercent = 0;
-          dev->batteryUPowerSerial.clear();
+          dev->batteryFromUPower = false;
           devicesDirty = true;
         }
       }
@@ -876,6 +876,7 @@ void BluetoothService::emitState(BluetoothStateChangeOrigin origin) {
 }
 
 void BluetoothService::emitDevices() {
+  // Merged on emit so devices adopted between UPower ticks pick up their battery.
   applyUPowerBattery();
   if (m_devicesCallback) {
     m_devicesCallback(m_devices);
@@ -889,66 +890,33 @@ void BluetoothService::refreshBatteryFromUPower() {
 }
 
 bool BluetoothService::applyUPowerBattery() {
-  if (!m_upowerService) {
+  if (m_upowerService == nullptr) {
     return false;
   }
 
-  const auto getBatteryPercent = [](const auto& deviceInfo) {
-    return static_cast<std::uint8_t>(std::clamp(std::lround(deviceInfo->state.percentage), 0L, 100L));
-  };
-
   bool hasChange = false;
-  for (auto& bluetoothDevice : m_devices) {
-    if (!bluetoothDevice.connected || (bluetoothDevice.hasBattery && bluetoothDevice.batteryUPowerSerial.empty())) {
+  for (auto& device : m_devices) {
+    const bool fromBluez = device.hasBattery && !device.batteryFromUPower;
+    if (!device.connected || fromBluez || device.address.empty()) {
       continue;
     }
 
-    if (!bluetoothDevice.hasBattery) {
-      if (bluetoothDevice.address.empty()) {
-        continue;
-      }
-      auto serial = bluetoothDevice.address;
-      auto* deviceInfo = m_upowerService->deviceForSerial(serial);
-      if (!deviceInfo) {
-        serial = StringUtils::toLower(serial);
-        deviceInfo = m_upowerService->deviceForSerial(serial);
-      }
-      if (deviceInfo && deviceInfo->isPresent) {
-        switch (deviceInfo->type) {
-        case UPowerDeviceType::Unknown:
-        case UPowerDeviceType::LinePower:
-        case UPowerDeviceType::Battery:
-        case UPowerDeviceType::Ups:
-          break;
-        default:
-          bluetoothDevice.hasBattery = true;
-          bluetoothDevice.batteryPercent = getBatteryPercent(deviceInfo);
-          bluetoothDevice.batteryUPowerSerial = serial;
-          hasChange = true;
-          kLog.debug(
-              "battery added from UPower : {} {}", bluetoothDevice.batteryUPowerSerial, bluetoothDevice.batteryPercent
-          );
-          break;
-        }
-      }
-    } else {
-      const auto* deviceInfo = m_upowerService->deviceForSerial(bluetoothDevice.batteryUPowerSerial);
-      if (deviceInfo && deviceInfo->isPresent) {
-        const auto batteryPercent = getBatteryPercent(deviceInfo);
-        if (bluetoothDevice.batteryPercent != batteryPercent) {
-          bluetoothDevice.batteryPercent = batteryPercent;
-          hasChange = true;
-          kLog.debug(
-              "battery updated from UPower : {} {}", bluetoothDevice.batteryUPowerSerial, bluetoothDevice.batteryPercent
-          );
-        }
-      } else {
-        kLog.debug("battery removed from UPower : {}", bluetoothDevice.batteryUPowerSerial);
-        bluetoothDevice.hasBattery = false;
-        bluetoothDevice.batteryPercent = 0;
-        bluetoothDevice.batteryUPowerSerial.clear();
+    const auto* info = m_upowerService->peripheralBatteryForSerial(device.address);
+    if (info != nullptr) {
+      const auto percent = static_cast<std::uint8_t>(std::clamp(std::lround(info->state.percentage), 0L, 100L));
+      if (!device.hasBattery || device.batteryPercent != percent) {
+        device.hasBattery = true;
+        device.batteryPercent = percent;
+        device.batteryFromUPower = true;
         hasChange = true;
+        kLog.debug("upower battery {} -> {}%", device.address, percent);
       }
+    } else if (device.batteryFromUPower) {
+      device.hasBattery = false;
+      device.batteryPercent = 0;
+      device.batteryFromUPower = false;
+      hasChange = true;
+      kLog.debug("upower battery {} gone", device.address);
     }
   }
 

--- a/src/dbus/bluetooth/bluetooth_service.h
+++ b/src/dbus/bluetooth/bluetooth_service.h
@@ -47,7 +47,8 @@ struct BluetoothDeviceInfo {
   std::int16_t rssi = 0;
   bool hasBattery = false;
   std::uint8_t batteryPercent = 0;
-  std::string batteryUPowerSerial;
+  // Set when batteryPercent came from UPower instead of BlueZ's Battery1.
+  bool batteryFromUPower = false;
 
   bool operator==(const BluetoothDeviceInfo&) const = default;
 };
@@ -77,7 +78,8 @@ public:
   using DevicesCallback = std::function<void(const std::vector<BluetoothDeviceInfo>&)>;
   using StateFeedbackCallback = std::function<void(bool enabled)>;
 
-  explicit BluetoothService(SystemBus& bus, UPowerService* upowerService = nullptr);
+  // upowerService may be null when UPower is unavailable; it must outlive this service.
+  explicit BluetoothService(SystemBus& bus, UPowerService* upowerService);
   ~BluetoothService();
 
   BluetoothService(const BluetoothService&) = delete;

--- a/src/dbus/bluetooth/bluetooth_service.h
+++ b/src/dbus/bluetooth/bluetooth_service.h
@@ -12,6 +12,7 @@
 
 class SystemBus;
 class IpcService;
+class UPowerService;
 
 namespace sdbus {
   class IProxy;
@@ -46,6 +47,7 @@ struct BluetoothDeviceInfo {
   std::int16_t rssi = 0;
   bool hasBattery = false;
   std::uint8_t batteryPercent = 0;
+  std::string batteryUPowerSerial;
 
   bool operator==(const BluetoothDeviceInfo&) const = default;
 };
@@ -75,7 +77,7 @@ public:
   using DevicesCallback = std::function<void(const std::vector<BluetoothDeviceInfo>&)>;
   using StateFeedbackCallback = std::function<void(bool enabled)>;
 
-  explicit BluetoothService(SystemBus& bus);
+  explicit BluetoothService(SystemBus& bus, UPowerService* upowerService = nullptr);
   ~BluetoothService();
 
   BluetoothService(const BluetoothService&) = delete;
@@ -103,6 +105,8 @@ public:
   void setTrusted(const std::string& devicePath, bool trusted);
   void forget(const std::string& devicePath);
 
+  void refreshBatteryFromUPower();
+
 private:
   struct Impl;
   friend struct Impl;
@@ -120,6 +124,8 @@ private:
   void armAutoReconnect();
   void runAutoReconnectPass();
 
+  bool applyUPowerBattery();
+
   std::unique_ptr<Impl> m_impl;
 
   BluetoothState m_state;
@@ -130,4 +136,6 @@ private:
   bool m_hasStateSnapshot = false;
   StateCallback m_stateCallback;
   DevicesCallback m_devicesCallback;
+
+  UPowerService* m_upowerService = nullptr;
 };

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -397,6 +397,9 @@ const UPowerDeviceInfo* UPowerService::deviceForSelector(std::string_view select
 }
 
 const UPowerDeviceInfo* UPowerService::deviceForSerial(std::string_view serial) const {
+  if (serial.empty()) {
+    return nullptr;
+  }
   for (const auto& device : m_devices) {
     if (device.info.serial == serial) {
       return &device.info;

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -396,6 +396,15 @@ const UPowerDeviceInfo* UPowerService::deviceForSelector(std::string_view select
   return nullptr;
 }
 
+const UPowerDeviceInfo* UPowerService::deviceForSerial(std::string_view serial) const {
+  for (const auto& device : m_devices) {
+    if (device.info.serial == serial) {
+      return &device.info;
+    }
+  }
+  return nullptr;
+}
+
 void UPowerService::refreshDisplayDeviceProxy() {
   sdbus::ObjectPath path;
   try {

--- a/src/dbus/upower/upower_service.cpp
+++ b/src/dbus/upower/upower_service.cpp
@@ -100,6 +100,15 @@ namespace {
     return type != UPowerDeviceType::Unknown && type != UPowerDeviceType::LinePower;
   }
 
+  // A battery belonging to a peripheral rather than to the system. UPower reports peripheral packs
+  // with PowerSupply=false, so only PowerSupply batteries and UPS units power the machine itself.
+  bool isPeripheralBattery(const UPowerDeviceInfo& info) {
+    return info.isPresent
+        && isBatteryCapableDeviceType(info.type)
+        && !info.isLaptopBattery()
+        && info.type != UPowerDeviceType::Ups;
+  }
+
   bool isAutoSelector(std::string_view selector) {
     const std::string normalized = StringUtils::toLower(StringUtils::trim(selector));
     return normalized.empty() || normalized == "auto";
@@ -396,12 +405,12 @@ const UPowerDeviceInfo* UPowerService::deviceForSelector(std::string_view select
   return nullptr;
 }
 
-const UPowerDeviceInfo* UPowerService::deviceForSerial(std::string_view serial) const {
+const UPowerDeviceInfo* UPowerService::peripheralBatteryForSerial(std::string_view serial) const {
   if (serial.empty()) {
     return nullptr;
   }
   for (const auto& device : m_devices) {
-    if (device.info.serial == serial) {
+    if (isPeripheralBattery(device.info) && StringUtils::equalsInsensitive(device.info.serial, serial)) {
       return &device.info;
     }
   }

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -14,6 +14,7 @@ namespace sdbus {
   class IProxy;
 } // namespace sdbus
 
+// Mirrors the org.freedesktop.UPower.Device "Type" wire enum.
 enum class UPowerDeviceType : std::uint32_t {
   Unknown = 0,
   LinePower = 1,
@@ -24,6 +25,26 @@ enum class UPowerDeviceType : std::uint32_t {
   Keyboard = 6,
   Pda = 7,
   Phone = 8,
+  MediaPlayer = 9,
+  Tablet = 10,
+  Computer = 11,
+  GamingInput = 12,
+  Pen = 13,
+  Touchpad = 14,
+  Modem = 15,
+  Network = 16,
+  Headset = 17,
+  Speakers = 18,
+  Headphones = 19,
+  Video = 20,
+  OtherAudio = 21,
+  RemoteControl = 22,
+  Printer = 23,
+  Scanner = 24,
+  Camera = 25,
+  Wearable = 26,
+  Toy = 27,
+  BluetoothGeneric = 28,
 };
 
 enum class BatteryState : std::uint8_t {
@@ -91,7 +112,9 @@ public:
   [[nodiscard]] std::vector<UPowerDeviceInfo> batteryDevices() const;
   [[nodiscard]] const UPowerDeviceInfo* defaultSystemBattery() const noexcept;
   [[nodiscard]] const UPowerDeviceInfo* deviceForSelector(std::string_view selector) const;
-  [[nodiscard]] const UPowerDeviceInfo* deviceForSerial(std::string_view serial) const;
+  // Peripheral (non-system) battery whose serial matches, compared case-insensitively because
+  // MAC-style serials differ in case between BlueZ-backed and kernel-backed UPower devices.
+  [[nodiscard]] const UPowerDeviceInfo* peripheralBatteryForSerial(std::string_view serial) const;
 
 private:
   struct TrackedDevice {

--- a/src/dbus/upower/upower_service.h
+++ b/src/dbus/upower/upower_service.h
@@ -91,6 +91,7 @@ public:
   [[nodiscard]] std::vector<UPowerDeviceInfo> batteryDevices() const;
   [[nodiscard]] const UPowerDeviceInfo* defaultSystemBattery() const noexcept;
   [[nodiscard]] const UPowerDeviceInfo* deviceForSelector(std::string_view selector) const;
+  [[nodiscard]] const UPowerDeviceInfo* deviceForSerial(std::string_view serial) const;
 
 private:
   struct TrackedDevice {

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -236,6 +236,12 @@ namespace StringUtils {
     std::ranges::transform(s, s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   }
 
+  [[nodiscard]] inline bool equalsInsensitive(std::string_view lhs, std::string_view rhs) {
+    return std::ranges::equal(lhs, rhs, [](unsigned char a, unsigned char b) {
+      return std::tolower(a) == std::tolower(b);
+    });
+  }
+
   [[nodiscard]] inline bool containsInsensitive(std::string_view haystack, std::string_view needle) {
     if (haystack.empty() || needle.empty()) {
       return false;


### PR DESCRIPTION
Some bluetooth devices (e.g. PlayStation 5 Controller) do not report battery stats over Bluetooth, but from UPower. So if the serial of a UPower device matches the address of a Bluetooth device, we use the former's battery percent.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
