### PR TITLE
feat(plugins): add hover callbacks and interactive row/column nodes.

### DIFF
--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -1,5 +1,6 @@
 #include "ui/ui_tree_reconciler.h"
 
+#include "core/input/keybind_matcher.h"
 #include "core/log.h"
 #include "render/core/color.h"
 #include "render/core/renderer.h"
@@ -29,6 +30,7 @@
 #include <charconv>
 #include <cmath>
 #include <format>
+#include <functional>
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <unordered_set>
@@ -300,14 +302,24 @@ namespace ui {
       return std::nullopt;
     }
 
+    InputArea* inputAreaFromSlot(Node* node) { return dynamic_cast<InputArea*>(node); }
+
     // The Node that a control's children reconcile into. Flex containers host
-    // their children directly; a ScrollView hosts them in its inner content
-    // Flex. Any other control returns nullptr — it cannot have children.
+    // their children directly; a wrapped Flex hosts them in its inner Flex; a
+    // ScrollView hosts them in its inner content Flex. Any other control
+    // returns nullptr — it cannot have children.
     Node* childContainer(const std::string& type, Node* node) {
       if (node == nullptr) {
         return nullptr;
       }
-      if (type == "column" || type == "row" || type == "drag_source" || type == "drop_zone") {
+      if (type == "column" || type == "row") {
+        if (auto* inputArea = inputAreaFromSlot(node)) {
+          const auto& kids = inputArea->children();
+          return kids.empty() ? nullptr : kids.front().get();
+        }
+        return node;
+      }
+      if (type == "drag_source" || type == "drop_zone") {
         return node;
       }
       if (type == "scroll") {
@@ -341,36 +353,103 @@ namespace ui {
       return nullptr;
     }
 
-    InputArea* inputAreaFromSlot(Node* node) { return dynamic_cast<InputArea*>(node); }
+    // A callback prop with an empty name counts as unset. Callback wiring is
+    // change-detected against the slot's empty-string default, so an empty
+    // name would never wire a handler — but it WOULD create a wrapper that
+    // swallows clicks/hover meant for ancestors and sits in tab order dead.
+    const std::string* callbackProp(const UiTreeNode& node, const char* key) {
+      const std::string* name = strProp(node, key);
+      return name != nullptr && !name->empty() ? name : nullptr;
+    }
 
-    // box/image get an InputArea wrapper only when clickable (see createControl).
-    // If a reconcile flips that need, the existing node can't be reused — its
-    // structure no longer matches — so it must be rebuilt like a type change.
+    // Box/image and row/column get an InputArea wrapper only when clickable (see
+    // createControl). If a reconcile flips that need, the existing node can't
+    // be reused — its structure no longer matches — so it must be rebuilt like
+    // a type change.
     bool clickableWrapMismatch(const UiTreeNode& want, Node* node) {
-      if (want.type != "box" && want.type != "image") {
+      if (want.type != "box" && want.type != "image" && want.type != "row" && want.type != "column") {
         return false;
       }
-      const bool wantsWrapper = strProp(want, "onClick") != nullptr || strProp(want, "onHover") != nullptr;
+      const bool wantsWrapper = callbackProp(want, "onClick") != nullptr || callbackProp(want, "onHover") != nullptr;
       const bool hasWrapper = inputAreaFromSlot(node) != nullptr;
       return wantsWrapper != hasWrapper;
     }
 
+    // InputArea never self-sizes; box/image mirror explicit sizes, but a
+    // content-sized flex needs its child measurement forwarded.
+    class ClickWrap final : public InputArea {
+    protected:
+      LayoutSize doMeasure(Renderer& renderer, const LayoutConstraints& constraints) override {
+        if (!children().empty()) {
+          const LayoutSize measured = children().front()->measure(renderer, constraints);
+          setSize(measured.width, measured.height);
+          return measured;
+        }
+        return InputArea::doMeasure(renderer, constraints);
+      }
+
+      void doArrange(Renderer& renderer, const LayoutRect& rect) override {
+        setPosition(rect.x, rect.y);
+        setSize(rect.width, rect.height);
+        if (!children().empty()) {
+          children().front()->arrange(
+              renderer, LayoutRect{.x = 0.0f, .y = 0.0f, .width = rect.width, .height = rect.height}
+          );
+        }
+      }
+    };
+
     std::unique_ptr<Node> wrapClickable(std::unique_ptr<Node> control, bool acceptClicks) {
-      auto inputArea = std::make_unique<InputArea>();
+      auto inputArea = std::make_unique<ClickWrap>();
       // A hover-only wrapper must not swallow clicks meant for ancestors.
       inputArea->setAcceptedButtons(acceptClicks ? InputArea::buttonMask(BTN_LEFT) : 0);
+      if (acceptClicks) {
+        inputArea->setFocusable(true);
+      }
       inputArea->addChild(std::move(control));
       return inputArea;
+    }
+
+    void wireWrapperActivation(InputArea* inputArea, const std::function<void()>& sink) {
+      // A wrapper created hover-only starts with an empty button mask.
+      inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
+      inputArea->setOnClick([sink](const InputArea::PointerData&) { sink(); });
+      inputArea->setFocusable(true);
+      inputArea->setOnKeyDown([sink](const InputArea::KeyData& key) {
+        if (key.pressed && KeybindMatcher::matches(KeybindAction::Validate, key.sym, key.modifiers)) {
+          sink();
+        }
+      });
+    }
+
+    // Wrapper input handlers deviate from the retain-absent-props default:
+    // when onClick/onHover disappears while the other callback keeps the
+    // wrapper alive, the stale handler must go with it — a retained one would
+    // leave an invisible node that swallows clicks and sits in tab order as a
+    // keyboard-activatable ghost.
+    void clearWrapperActivation(InputArea* inputArea) {
+      inputArea->setAcceptedButtons(0);
+      inputArea->setFocusable(false);
+      inputArea->setOnClick(nullptr);
+      inputArea->setOnKeyDown(nullptr);
+      // setOnClick(fn) auto-selects the pointer cursor; drop it with the click.
+      inputArea->setCursorShape(0);
+    }
+
+    void clearWrapperHover(InputArea* inputArea) {
+      inputArea->setOnEnter(nullptr);
+      inputArea->setOnLeave(nullptr);
     }
 
     // Known prop keys per control type — an unknown prop is a loud skip, not a
     // silent no-op, so typos in plugin code surface immediately.
     const std::unordered_set<std::string>& knownProps(const std::string& type) {
       static const std::unordered_set<std::string> kCommon = {"width", "height", "flexGrow", "opacity", "visible"};
-      static const std::unordered_set<std::string> kFlex = {
-          "width", "height",  "flexGrow", "opacity", "visible", "gap",         "padding",  "paddingH", "paddingV",
-          "align", "justify", "fill",     "radius",  "border",  "borderWidth", "minWidth", "minHeight"
-      };
+      static const std::unordered_set<std::string> kFlex = {"width",     "height",  "flexGrow",    "opacity",
+                                                            "visible",   "gap",     "padding",     "paddingH",
+                                                            "paddingV",  "align",   "justify",     "fill",
+                                                            "radius",    "border",  "borderWidth", "minWidth",
+                                                            "minHeight", "onClick", "onHover"};
       static const std::unordered_set<std::string> kBox = {"width",       "height",   "flexGrow", "opacity",
                                                            "visible",     "fill",     "radius",   "border",
                                                            "borderWidth", "softness", "onClick",  "onHover"};
@@ -484,7 +563,7 @@ namespace ui {
     Node* node = nullptr;
     std::string callbackName;        // last-wired button onClick / control onChange target
     std::string rightCallbackName;   // last-wired button onRightClick target
-    std::string hoverCallbackName;   // last-wired onHover target (button/box/image)
+    std::string hoverCallbackName;   // last-wired onHover target (button/box/image/row/column)
     std::string submitCallbackName;  // last-wired input onSubmit target
     std::string dragEndCallbackName; // last-wired slider onDragEnd target
     std::string imagePath;           // last-applied resolved image source
@@ -549,12 +628,18 @@ namespace ui {
       auto flex = std::make_unique<Flex>();
       flex->setDirection(FlexDirection::Vertical);
       flex->setAlign(FlexAlign::Stretch);
+      if (callbackProp(desired, "onClick") != nullptr || callbackProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::move(flex), callbackProp(desired, "onClick") != nullptr);
+      }
       return flex;
     }
     if (desired.type == "row") {
       auto flex = std::make_unique<Flex>();
       flex->setDirection(FlexDirection::Horizontal);
       flex->setAlign(FlexAlign::Stretch);
+      if (callbackProp(desired, "onClick") != nullptr || callbackProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::move(flex), callbackProp(desired, "onClick") != nullptr);
+      }
       return flex;
     }
     if (desired.type == "drag_source") {
@@ -570,8 +655,8 @@ namespace ui {
       return zone;
     }
     if (desired.type == "box") {
-      if (strProp(desired, "onClick") != nullptr || strProp(desired, "onHover") != nullptr) {
-        return wrapClickable(std::make_unique<Box>(), strProp(desired, "onClick") != nullptr);
+      if (callbackProp(desired, "onClick") != nullptr || callbackProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::make_unique<Box>(), callbackProp(desired, "onClick") != nullptr);
       }
       return std::make_unique<Box>();
     }
@@ -582,8 +667,8 @@ namespace ui {
       return std::make_unique<Glyph>();
     }
     if (desired.type == "image") {
-      if (strProp(desired, "onClick") != nullptr || strProp(desired, "onHover") != nullptr) {
-        return wrapClickable(std::make_unique<Image>(), strProp(desired, "onClick") != nullptr);
+      if (callbackProp(desired, "onClick") != nullptr || callbackProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::make_unique<Image>(), callbackProp(desired, "onClick") != nullptr);
       }
       return std::make_unique<Image>();
     }
@@ -829,7 +914,10 @@ namespace ui {
         || desired.type == "row"
         || desired.type == "drag_source"
         || desired.type == "drop_zone") {
-      auto* flex = static_cast<Flex*>(node);
+      auto* flex = controlFromSlot<Flex>(node);
+      if (flex == nullptr) {
+        return;
+      }
       if (desired.type == "drop_zone") {
         auto* zone = static_cast<DropZone*>(node);
         const std::string* direction = strProp(desired, "direction");
@@ -911,6 +999,45 @@ namespace ui {
           flex->setMaxHeight(scaled(*height));
         }
       }
+      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
+        if (*onClick != slot.callbackName) {
+          slot.callbackName = *onClick;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name});
+              }
+            });
+          }
+        }
+      } else if (!slot.callbackName.empty()) {
+        slot.callbackName.clear();
+        if (auto* inputArea = inputAreaFromSlot(node)) {
+          clearWrapperActivation(inputArea);
+        }
+      }
+      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
+        if (*onHover != slot.hoverCallbackName) {
+          slot.hoverCallbackName = *onHover;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "true"});
+              }
+            });
+            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "false"});
+              }
+            });
+          }
+        }
+      } else if (!slot.hoverCallbackName.empty()) {
+        slot.hoverCallbackName.clear();
+        if (auto* inputArea = inputAreaFromSlot(node)) {
+          clearWrapperHover(inputArea);
+        }
+      }
       return;
     }
 
@@ -938,33 +1065,43 @@ namespace ui {
       if (auto* inputArea = inputAreaFromSlot(node)) {
         inputArea->setSize(boxWidth, boxHeight);
       }
-      if (const std::string* onClick = strProp(desired, "onClick");
-          onClick != nullptr && *onClick != slot.callbackName) {
-        slot.callbackName = *onClick;
+      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
+        if (*onClick != slot.callbackName) {
+          slot.callbackName = *onClick;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name});
+              }
+            });
+          }
+        }
+      } else if (!slot.callbackName.empty()) {
+        slot.callbackName.clear();
         if (auto* inputArea = inputAreaFromSlot(node)) {
-          // A wrapper created hover-only starts with an empty button mask.
-          inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
-          inputArea->setOnClick([this, name = slot.callbackName](const InputArea::PointerData&) {
-            if (m_sink) {
-              m_sink(ControlCallback{name});
-            }
-          });
+          clearWrapperActivation(inputArea);
         }
       }
-      if (const std::string* onHover = strProp(desired, "onHover");
-          onHover != nullptr && *onHover != slot.hoverCallbackName) {
-        slot.hoverCallbackName = *onHover;
+      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
+        if (*onHover != slot.hoverCallbackName) {
+          slot.hoverCallbackName = *onHover;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "true"});
+              }
+            });
+            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "false"});
+              }
+            });
+          }
+        }
+      } else if (!slot.hoverCallbackName.empty()) {
+        slot.hoverCallbackName.clear();
         if (auto* inputArea = inputAreaFromSlot(node)) {
-          inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
-            if (m_sink) {
-              m_sink(ControlCallback{name, "true"});
-            }
-          });
-          inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
-            if (m_sink) {
-              m_sink(ControlCallback{name, "false"});
-            }
-          });
+          clearWrapperHover(inputArea);
         }
       }
       return;
@@ -1072,33 +1209,43 @@ namespace ui {
           }
         }
       }
-      if (const std::string* onClick = strProp(desired, "onClick");
-          onClick != nullptr && *onClick != slot.callbackName) {
-        slot.callbackName = *onClick;
+      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
+        if (*onClick != slot.callbackName) {
+          slot.callbackName = *onClick;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name});
+              }
+            });
+          }
+        }
+      } else if (!slot.callbackName.empty()) {
+        slot.callbackName.clear();
         if (auto* inputArea = inputAreaFromSlot(node)) {
-          // A wrapper created hover-only starts with an empty button mask.
-          inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
-          inputArea->setOnClick([this, name = slot.callbackName](const InputArea::PointerData&) {
-            if (m_sink) {
-              m_sink(ControlCallback{name});
-            }
-          });
+          clearWrapperActivation(inputArea);
         }
       }
-      if (const std::string* onHover = strProp(desired, "onHover");
-          onHover != nullptr && *onHover != slot.hoverCallbackName) {
-        slot.hoverCallbackName = *onHover;
+      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
+        if (*onHover != slot.hoverCallbackName) {
+          slot.hoverCallbackName = *onHover;
+          if (auto* inputArea = inputAreaFromSlot(node)) {
+            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "true"});
+              }
+            });
+            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
+              if (m_sink) {
+                m_sink(ControlCallback{name, "false"});
+              }
+            });
+          }
+        }
+      } else if (!slot.hoverCallbackName.empty()) {
+        slot.hoverCallbackName.clear();
         if (auto* inputArea = inputAreaFromSlot(node)) {
-          inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
-            if (m_sink) {
-              m_sink(ControlCallback{name, "true"});
-            }
-          });
-          inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
-            if (m_sink) {
-              m_sink(ControlCallback{name, "false"});
-            }
-          });
+          clearWrapperHover(inputArea);
         }
       }
       return;

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -350,14 +350,15 @@ namespace ui {
       if (want.type != "box" && want.type != "image") {
         return false;
       }
-      const bool wantsWrapper = strProp(want, "onClick") != nullptr;
+      const bool wantsWrapper = strProp(want, "onClick") != nullptr || strProp(want, "onHover") != nullptr;
       const bool hasWrapper = inputAreaFromSlot(node) != nullptr;
       return wantsWrapper != hasWrapper;
     }
 
-    std::unique_ptr<Node> wrapClickable(std::unique_ptr<Node> control) {
+    std::unique_ptr<Node> wrapClickable(std::unique_ptr<Node> control, bool acceptClicks) {
       auto inputArea = std::make_unique<InputArea>();
-      inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
+      // A hover-only wrapper must not swallow clicks meant for ancestors.
+      inputArea->setAcceptedButtons(acceptClicks ? InputArea::buttonMask(BTN_LEFT) : 0);
       inputArea->addChild(std::move(control));
       return inputArea;
     }
@@ -372,7 +373,7 @@ namespace ui {
       };
       static const std::unordered_set<std::string> kBox = {"width",       "height",   "flexGrow", "opacity",
                                                            "visible",     "fill",     "radius",   "border",
-                                                           "borderWidth", "softness", "onClick"};
+                                                           "borderWidth", "softness", "onClick",  "onHover"};
       static const std::unordered_set<std::string> kLabel = {"width",      "height",   "flexGrow", "opacity",
                                                              "visible",    "text",     "fontSize", "color",
                                                              "fontWeight", "maxWidth", "maxLines", "textAlign",
@@ -381,17 +382,17 @@ namespace ui {
                                                              "visible", "name",   "size",     "color"};
       static const std::unordered_set<std::string> kImage = {"width",   "height",      "flexGrow", "opacity",
                                                              "visible", "path",        "radius",   "fit",
-                                                             "border",  "borderWidth", "onClick"};
+                                                             "border",  "borderWidth", "onClick",  "onHover"};
       static const std::unordered_set<std::string> kSeparator = {"width",   "height",  "flexGrow",
                                                                  "opacity", "visible", "thickness",
                                                                  "color",   "spacing", "orientation"};
       static const std::unordered_set<std::string> kProgress = {"width",    "height", "flexGrow", "opacity", "visible",
                                                                 "progress", "fill",   "track",    "radius"};
-      static const std::unordered_set<std::string> kButton = {"width",      "height",  "flexGrow",     "opacity",
-                                                              "visible",    "text",    "glyph",        "fontSize",
-                                                              "glyphSize",  "variant", "contentAlign", "enabled",
-                                                              "selected",   "onClick", "onRightClick", "tooltip",
-                                                              "controlSize"};
+      static const std::unordered_set<std::string> kButton = {"width",       "height",  "flexGrow",     "opacity",
+                                                              "visible",     "text",    "glyph",        "fontSize",
+                                                              "glyphSize",   "variant", "contentAlign", "enabled",
+                                                              "selected",    "onClick", "onRightClick", "tooltip",
+                                                              "controlSize", "onHover"};
       static const std::unordered_set<std::string> kGraph = {"width",   "height",    "flexGrow",   "opacity",
                                                              "visible", "values",    "values2",    "color",
                                                              "color2",  "lineWidth", "fillOpacity"};
@@ -483,6 +484,7 @@ namespace ui {
     Node* node = nullptr;
     std::string callbackName;        // last-wired button onClick / control onChange target
     std::string rightCallbackName;   // last-wired button onRightClick target
+    std::string hoverCallbackName;   // last-wired onHover target (button/box/image)
     std::string submitCallbackName;  // last-wired input onSubmit target
     std::string dragEndCallbackName; // last-wired slider onDragEnd target
     std::string imagePath;           // last-applied resolved image source
@@ -568,8 +570,8 @@ namespace ui {
       return zone;
     }
     if (desired.type == "box") {
-      if (strProp(desired, "onClick") != nullptr) {
-        return wrapClickable(std::make_unique<Box>());
+      if (strProp(desired, "onClick") != nullptr || strProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::make_unique<Box>(), strProp(desired, "onClick") != nullptr);
       }
       return std::make_unique<Box>();
     }
@@ -580,8 +582,8 @@ namespace ui {
       return std::make_unique<Glyph>();
     }
     if (desired.type == "image") {
-      if (strProp(desired, "onClick") != nullptr) {
-        return wrapClickable(std::make_unique<Image>());
+      if (strProp(desired, "onClick") != nullptr || strProp(desired, "onHover") != nullptr) {
+        return wrapClickable(std::make_unique<Image>(), strProp(desired, "onClick") != nullptr);
       }
       return std::make_unique<Image>();
     }
@@ -940,9 +942,27 @@ namespace ui {
           onClick != nullptr && *onClick != slot.callbackName) {
         slot.callbackName = *onClick;
         if (auto* inputArea = inputAreaFromSlot(node)) {
+          // A wrapper created hover-only starts with an empty button mask.
+          inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
           inputArea->setOnClick([this, name = slot.callbackName](const InputArea::PointerData&) {
             if (m_sink) {
               m_sink(ControlCallback{name});
+            }
+          });
+        }
+      }
+      if (const std::string* onHover = strProp(desired, "onHover");
+          onHover != nullptr && *onHover != slot.hoverCallbackName) {
+        slot.hoverCallbackName = *onHover;
+        if (auto* inputArea = inputAreaFromSlot(node)) {
+          inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+            if (m_sink) {
+              m_sink(ControlCallback{name, "true"});
+            }
+          });
+          inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
+            if (m_sink) {
+              m_sink(ControlCallback{name, "false"});
             }
           });
         }
@@ -1056,9 +1076,27 @@ namespace ui {
           onClick != nullptr && *onClick != slot.callbackName) {
         slot.callbackName = *onClick;
         if (auto* inputArea = inputAreaFromSlot(node)) {
+          // A wrapper created hover-only starts with an empty button mask.
+          inputArea->setAcceptedButtons(InputArea::buttonMask(BTN_LEFT));
           inputArea->setOnClick([this, name = slot.callbackName](const InputArea::PointerData&) {
             if (m_sink) {
               m_sink(ControlCallback{name});
+            }
+          });
+        }
+      }
+      if (const std::string* onHover = strProp(desired, "onHover");
+          onHover != nullptr && *onHover != slot.hoverCallbackName) {
+        slot.hoverCallbackName = *onHover;
+        if (auto* inputArea = inputAreaFromSlot(node)) {
+          inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+            if (m_sink) {
+              m_sink(ControlCallback{name, "true"});
+            }
+          });
+          inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
+            if (m_sink) {
+              m_sink(ControlCallback{name, "false"});
             }
           });
         }
@@ -1159,6 +1197,20 @@ namespace ui {
       // retained Button. An empty text routes to InputArea::clearTooltip().
       const std::string* tooltip = strProp(desired, "tooltip");
       button->setTooltip(tooltip != nullptr ? *tooltip : "");
+      if (const std::string* onHover = strProp(desired, "onHover");
+          onHover != nullptr && *onHover != slot.hoverCallbackName) {
+        slot.hoverCallbackName = *onHover;
+        button->setOnEnter([this, name = slot.hoverCallbackName]() {
+          if (m_sink) {
+            m_sink(ControlCallback{name, "true"});
+          }
+        });
+        button->setOnLeave([this, name = slot.hoverCallbackName]() {
+          if (m_sink) {
+            m_sink(ControlCallback{name, "false"});
+          }
+        });
+      }
       if (const std::string* onClick = strProp(desired, "onClick");
           onClick != nullptr && *onClick != slot.callbackName) {
         slot.callbackName = *onClick;

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -612,6 +612,9 @@ namespace ui {
 
   void UiTreeReconciler::reset() {
     m_dragDropController->cancel();
+    // The host tree is gone, so any hover it was reporting has ended. The slots
+    // still name it; the Nodes they point at are already freed.
+    closeHover();
     m_rootSlots.clear();
   }
 
@@ -779,6 +782,13 @@ namespace ui {
         slot.node = parent.addChild(std::move(control));
         slots.push_back(std::move(slot));
       }
+
+      for (const auto& leftover : detached) {
+        if (!leftover.used && subtreeOwnsHover(leftover.slot)) {
+          closeHover();
+          break;
+        }
+      }
     }
 
     // Apply props and recurse. With a sequence mismatch slots were rebuilt above
@@ -806,6 +816,93 @@ namespace ui {
       }
     }
     return structureChanged;
+  }
+
+  void UiTreeReconciler::syncWrapperCallbacks(Slot& slot, const UiTreeNode& desired, Node* node) {
+    InputArea* inputArea = inputAreaFromSlot(node);
+    if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
+      if (*onClick != slot.callbackName) {
+        slot.callbackName = *onClick;
+        if (inputArea != nullptr) {
+          wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
+            if (m_sink) {
+              m_sink(ControlCallback{name});
+            }
+          });
+        }
+      }
+    } else if (!slot.callbackName.empty()) {
+      slot.callbackName.clear();
+      if (inputArea != nullptr) {
+        clearWrapperActivation(inputArea);
+      }
+    }
+    if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
+      if (*onHover != slot.hoverCallbackName) {
+        releaseHover(slot.hoverCallbackName);
+        slot.hoverCallbackName = *onHover;
+        if (inputArea != nullptr) {
+          inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
+            openHover(name);
+          });
+          inputArea->setOnLeave([this, name = slot.hoverCallbackName]() { releaseHover(name); });
+        }
+      }
+    } else if (!slot.hoverCallbackName.empty()) {
+      releaseHover(slot.hoverCallbackName);
+      slot.hoverCallbackName.clear();
+      if (inputArea != nullptr) {
+        clearWrapperHover(inputArea);
+      }
+    }
+  }
+
+  // Hover is state the plugin mirrors, so every "true" owes a "false". Exactly
+  // one InputArea is hovered at a time, so one live callback name is enough to
+  // close the hover when its node is dropped, rewired, or reset away — none of
+  // which reach the dispatcher's leave path, because that only tracks areas
+  // still in the scene.
+  void UiTreeReconciler::openHover(const std::string& name) {
+    if (m_hoveredCallback == name) {
+      return;
+    }
+    closeHover();
+    m_hoveredCallback = name;
+    if (m_sink) {
+      m_sink(ControlCallback{name, "true"});
+    }
+  }
+
+  void UiTreeReconciler::closeHover() {
+    if (m_hoveredCallback.empty()) {
+      return;
+    }
+    const std::string name = std::exchange(m_hoveredCallback, std::string{});
+    if (m_sink) {
+      m_sink(ControlCallback{name, "false"});
+    }
+  }
+
+  // Closes the hover only if `name` is the one currently reporting it.
+  void UiTreeReconciler::releaseHover(const std::string& name) {
+    if (!name.empty() && name == m_hoveredCallback) {
+      closeHover();
+    }
+  }
+
+  bool UiTreeReconciler::subtreeOwnsHover(const Slot& slot) const {
+    if (m_hoveredCallback.empty()) {
+      return false;
+    }
+    if (slot.hoverCallbackName == m_hoveredCallback) {
+      return true;
+    }
+    for (const Slot& child : slot.children) {
+      if (subtreeOwnsHover(child)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   void UiTreeReconciler::applyProps(Slot& slot, const UiTreeNode& desired, Renderer& renderer) {
@@ -999,45 +1096,7 @@ namespace ui {
           flex->setMaxHeight(scaled(*height));
         }
       }
-      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
-        if (*onClick != slot.callbackName) {
-          slot.callbackName = *onClick;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name});
-              }
-            });
-          }
-        }
-      } else if (!slot.callbackName.empty()) {
-        slot.callbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperActivation(inputArea);
-        }
-      }
-      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
-        if (*onHover != slot.hoverCallbackName) {
-          slot.hoverCallbackName = *onHover;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "true"});
-              }
-            });
-            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "false"});
-              }
-            });
-          }
-        }
-      } else if (!slot.hoverCallbackName.empty()) {
-        slot.hoverCallbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperHover(inputArea);
-        }
-      }
+      syncWrapperCallbacks(slot, desired, node);
       return;
     }
 
@@ -1065,45 +1124,7 @@ namespace ui {
       if (auto* inputArea = inputAreaFromSlot(node)) {
         inputArea->setSize(boxWidth, boxHeight);
       }
-      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
-        if (*onClick != slot.callbackName) {
-          slot.callbackName = *onClick;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name});
-              }
-            });
-          }
-        }
-      } else if (!slot.callbackName.empty()) {
-        slot.callbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperActivation(inputArea);
-        }
-      }
-      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
-        if (*onHover != slot.hoverCallbackName) {
-          slot.hoverCallbackName = *onHover;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "true"});
-              }
-            });
-            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "false"});
-              }
-            });
-          }
-        }
-      } else if (!slot.hoverCallbackName.empty()) {
-        slot.hoverCallbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperHover(inputArea);
-        }
-      }
+      syncWrapperCallbacks(slot, desired, node);
       return;
     }
 
@@ -1209,45 +1230,7 @@ namespace ui {
           }
         }
       }
-      if (const std::string* onClick = callbackProp(desired, "onClick"); onClick != nullptr) {
-        if (*onClick != slot.callbackName) {
-          slot.callbackName = *onClick;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            wireWrapperActivation(inputArea, [this, name = slot.callbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name});
-              }
-            });
-          }
-        }
-      } else if (!slot.callbackName.empty()) {
-        slot.callbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperActivation(inputArea);
-        }
-      }
-      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
-        if (*onHover != slot.hoverCallbackName) {
-          slot.hoverCallbackName = *onHover;
-          if (auto* inputArea = inputAreaFromSlot(node)) {
-            inputArea->setOnEnter([this, name = slot.hoverCallbackName](const InputArea::PointerData&) {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "true"});
-              }
-            });
-            inputArea->setOnLeave([this, name = slot.hoverCallbackName]() {
-              if (m_sink) {
-                m_sink(ControlCallback{name, "false"});
-              }
-            });
-          }
-        }
-      } else if (!slot.hoverCallbackName.empty()) {
-        slot.hoverCallbackName.clear();
-        if (auto* inputArea = inputAreaFromSlot(node)) {
-          clearWrapperHover(inputArea);
-        }
-      }
+      syncWrapperCallbacks(slot, desired, node);
       return;
     }
 
@@ -1344,19 +1327,21 @@ namespace ui {
       // retained Button. An empty text routes to InputArea::clearTooltip().
       const std::string* tooltip = strProp(desired, "tooltip");
       button->setTooltip(tooltip != nullptr ? *tooltip : "");
-      if (const std::string* onHover = strProp(desired, "onHover");
-          onHover != nullptr && *onHover != slot.hoverCallbackName) {
-        slot.hoverCallbackName = *onHover;
-        button->setOnEnter([this, name = slot.hoverCallbackName]() {
-          if (m_sink) {
-            m_sink(ControlCallback{name, "true"});
-          }
-        });
-        button->setOnLeave([this, name = slot.hoverCallbackName]() {
-          if (m_sink) {
-            m_sink(ControlCallback{name, "false"});
-          }
-        });
+      // Like the wrapper controls, hover handlers clear on removal instead of
+      // being retained: a stale one keeps firing and keeps the Button's
+      // InputArea enabled for a callback the tree no longer declares.
+      if (const std::string* onHover = callbackProp(desired, "onHover"); onHover != nullptr) {
+        if (*onHover != slot.hoverCallbackName) {
+          releaseHover(slot.hoverCallbackName);
+          slot.hoverCallbackName = *onHover;
+          button->setOnEnter([this, name = slot.hoverCallbackName]() { openHover(name); });
+          button->setOnLeave([this, name = slot.hoverCallbackName]() { releaseHover(name); });
+        }
+      } else if (!slot.hoverCallbackName.empty()) {
+        releaseHover(slot.hoverCallbackName);
+        slot.hoverCallbackName.clear();
+        button->setOnEnter(nullptr);
+        button->setOnLeave(nullptr);
       }
       if (const std::string* onClick = strProp(desired, "onClick");
           onClick != nullptr && *onClick != slot.callbackName) {

--- a/src/ui/ui_tree_reconciler.h
+++ b/src/ui/ui_tree_reconciler.h
@@ -90,6 +90,17 @@ namespace ui {
     bool
     syncChildren(Node& parent, std::vector<Slot>& slots, const std::vector<UiTreeNode>& desired, Renderer& renderer);
     void applyProps(Slot& slot, const UiTreeNode& desired, Renderer& renderer);
+    // onClick/onHover wiring shared by the InputArea-wrapped controls
+    // (row/column/box/image).
+    void syncWrapperCallbacks(Slot& slot, const UiTreeNode& desired, Node* node);
+    // Hover is state the plugin mirrors, so every "true" owes a "false". The
+    // dispatcher only delivers leave to areas still in the scene, so the
+    // reconciler tracks the callback currently reporting hover and closes it
+    // itself when that node is dropped, rewired, or reset away.
+    void openHover(const std::string& name);
+    void closeHover();
+    void releaseHover(const std::string& name);
+    [[nodiscard]] bool subtreeOwnsHover(const Slot& slot) const;
     [[nodiscard]] std::unique_ptr<Node> createControl(const UiTreeNode& desired);
 
     CallbackSink m_sink;
@@ -100,6 +111,8 @@ namespace ui {
     FontWeight m_defaultFontWeight; // initialized in the ctor (opaque enum here)
     bool m_compactControls = false;
     bool m_dragDropEnabled = false;
+    // Callback name currently reporting hover; empty when nothing is hovered.
+    std::string m_hoveredCallback;
     std::unique_ptr<DragDropController> m_dragDropController;
     std::vector<Slot> m_rootSlots;
   };

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <print>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Satisfies the AsyncTextureCache link dependency pulled in by the Image
@@ -472,7 +473,10 @@ int main() {
         area->dispatchPress(5.0f, 5.0f, BTN_LEFT, false);
       }
       ok = expect(
-               fired.empty() && area != nullptr && area->acceptedButtons() == 0 && !area->focusable()
+               fired.empty()
+                   && area != nullptr
+                   && area->acceptedButtons() == 0
+                   && !area->focusable()
                    && area->cursorShape() == 0,
                "emptied onClick clears the wrapper's activation"
            )
@@ -539,6 +543,142 @@ int main() {
                "removing onClick rebuilds flex without wrapper"
            )
           && ok;
+    }
+  }
+
+  // Hover state a plugin mirrors must stay balanced: a hovered node dropped by a
+  // reconcile is destroyed without the dispatcher ever sending leave, so the
+  // reconciler emits the closing "false" itself.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<std::pair<std::string, std::string>> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) {
+      fired.emplace_back(cb.fn, cb.arg1);
+    });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("column");
+    ui::UiTreeNode chip = makeNode("box");
+    chip.key = "a";
+    chip.props.emplace("onHover", std::string("chipHover"));
+    tree.children.push_back(chip);
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* column = dynamic_cast<Flex*>(host.children().front().get());
+    auto* chipArea = column != nullptr && !column->children().empty()
+        ? dynamic_cast<InputArea*>(column->children()[0].get())
+        : nullptr;
+    ok = expect(chipArea != nullptr, "hovered-drop fixture built a wrapped box") && ok;
+    if (chipArea != nullptr) {
+      chipArea->dispatchEnter(0.0f, 0.0f);
+    }
+    ok = expect(fired.size() == 1 && fired.front().second == "true", "hover enter reported before the drop") && ok;
+
+    // A retained hovered node is not a drop — nothing more fires.
+    fired.clear();
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(fired.empty(), "retaining a hovered node emits no hover callback") && ok;
+
+    tree.children.clear();
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(
+             fired.size() == 1 && fired.front().first == "chipHover" && fired.front().second == "false",
+             "dropping a hovered node emits the closing onHover false"
+         )
+        && ok;
+  }
+
+  // The same balance holds for the other two ways a hover ends without the
+  // dispatcher: the callback is rewired or dropped, and the whole host tree is
+  // torn down and reset out from under the reconciler.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::vector<std::pair<std::string, std::string>> fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) {
+      fired.emplace_back(cb.fn, cb.arg1);
+    });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("box");
+    tree.props.emplace("onHover", std::string("first"));
+    (void)reconciler.reconcile(host, tree, renderer);
+    auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+    ok = expect(area != nullptr, "rewire fixture built a wrapped box") && ok;
+    if (area != nullptr) {
+      area->dispatchEnter(0.0f, 0.0f);
+    }
+    fired.clear();
+
+    // Rewiring while hovered closes the old callback; the new one opens on the
+    // next enter, which the dispatcher will deliver against the retained node.
+    tree.props["onHover"] = std::string("second");
+    (void)reconciler.reconcile(host, tree, renderer);
+    ok = expect(
+             fired.size() == 1 && fired.front().first == "first" && fired.front().second == "false",
+             "rewiring onHover while hovered closes the old callback"
+         )
+        && ok;
+
+    fired.clear();
+    if (area != nullptr) {
+      area->dispatchEnter(0.0f, 0.0f);
+    }
+    ok = expect(fired.size() == 1 && fired.front().first == "second", "the rewired callback opens on re-enter") && ok;
+
+    // A host tree torn down and reset away leaves slots naming a hover whose
+    // Nodes are already freed — reset() must still close it.
+    fired.clear();
+    reconciler.reset();
+    ok = expect(
+             fired.size() == 1 && fired.front().first == "second" && fired.front().second == "false",
+             "reset closes a hover left open by a torn-down tree"
+         )
+        && ok;
+
+    fired.clear();
+    reconciler.reset();
+    ok = expect(fired.empty(), "a second reset has no hover left to close") && ok;
+  }
+
+  // Button hover callbacks clear on removal rather than being retained, and an
+  // empty callback name counts as unset.
+  {
+    ui::UiTreeReconciler reconciler;
+    std::string fired;
+    reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) {
+      fired = cb.fn + "/" + cb.arg1;
+    });
+    Flex host;
+
+    ui::UiTreeNode tree = makeNode("column");
+    ui::UiTreeNode button = makeNode("button");
+    button.props.emplace("text", std::string("Go"));
+    button.props.emplace("onHover", std::string("hover"));
+    tree.children.push_back(button);
+    (void)reconciler.reconcile(host, tree, renderer);
+
+    auto* column = dynamic_cast<Flex*>(host.children().front().get());
+    auto* control = column != nullptr ? dynamic_cast<Button*>(column->children()[0].get()) : nullptr;
+    auto* area = control != nullptr ? control->inputArea() : nullptr;
+    ok = expect(area != nullptr, "hover button built") && ok;
+    if (area != nullptr) {
+      area->dispatchEnter(0.0f, 0.0f);
+      ok = expect(fired == "hover/true", "button onHover enter reaches the sink") && ok;
+      area->dispatchLeave();
+      ok = expect(fired == "hover/false", "button onHover leave reaches the sink") && ok;
+
+      tree.children[0].props.erase("onHover");
+      (void)reconciler.reconcile(host, tree, renderer);
+      fired.clear();
+      area->dispatchEnter(0.0f, 0.0f);
+      area->dispatchLeave();
+      ok = expect(fired.empty(), "dropped button onHover stops firing") && ok;
+
+      tree.children[0].props.emplace("onHover", std::string());
+      (void)reconciler.reconcile(host, tree, renderer);
+      area->dispatchEnter(0.0f, 0.0f);
+      area->dispatchLeave();
+      ok = expect(fired.empty(), "an empty button onHover name wires nothing") && ok;
     }
   }
 

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -324,6 +324,224 @@ int main() {
     ok = expect(dynamic_cast<Box*>(unwrapped) != nullptr, "box unwrapped after onClick removed") && ok;
   }
 
+  // Clickable row and column containers preserve the Flex as the wrapped child,
+  // forward its content measurement, and route pointer callbacks.
+  for (const char* type : {"row", "column"}) {
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onClick", std::string("activate"));
+      tree.children.push_back(makeLabel("First"));
+      tree.children.push_back(makeLabel("Second"));
+      (void)reconciler.reconcile(host, tree, renderer);
+
+      Node* root = host.children().empty() ? nullptr : host.children().front().get();
+      auto* area = dynamic_cast<InputArea*>(root);
+      auto* inner =
+          area != nullptr && !area->children().empty() ? dynamic_cast<Flex*>(area->children().front().get()) : nullptr;
+      ok = expect(dynamic_cast<Flex*>(root) == nullptr, "clickable container is not a bare Flex") && ok;
+      ok = expect(area != nullptr, "clickable container is an InputArea") && ok;
+      ok = expect(inner != nullptr && inner->children().size() == 2, "labels reconcile into inner Flex") && ok;
+
+      LayoutSize innerSize{};
+      LayoutSize wrappedSize{};
+      if (area != nullptr && inner != nullptr) {
+        innerSize = inner->measure(renderer, LayoutConstraints::unconstrained());
+        wrappedSize = area->measure(renderer, LayoutConstraints::unconstrained());
+      }
+      ok = expect(
+               innerSize.width == wrappedSize.width
+                   && innerSize.height == wrappedSize.height
+                   && innerSize.width > 0.0f
+                   && innerSize.height > 0.0f,
+               "clickable container forwards content measurement"
+           )
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onClick", std::string("activate"));
+      tree.props.emplace("width", 120.0);
+      tree.props.emplace("height", 36.0);
+      tree.children.push_back(makeLabel("Sized"));
+      (void)reconciler.reconcile(host, tree, renderer);
+
+      auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+      auto* inner =
+          area != nullptr && !area->children().empty() ? dynamic_cast<Flex*>(area->children().front().get()) : nullptr;
+      LayoutSize measured{};
+      if (area != nullptr) {
+        measured = area->measure(renderer, LayoutConstraints::unconstrained());
+      }
+      ok = expect(
+               inner != nullptr
+                   && inner->minWidth() == 120.0f
+                   && inner->maxWidth() == 120.0f
+                   && inner->minHeight() == 36.0f
+                   && inner->maxHeight() == 36.0f
+                   && measured.width == 120.0f
+                   && measured.height == 36.0f,
+               "clickable container preserves explicit size"
+           )
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onClick", std::string("activate"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      auto* clickable = dynamic_cast<InputArea*>(host.children().front().get());
+      ok = expect(
+               clickable != nullptr
+                   && clickable->acceptedButtons() == InputArea::buttonMask(BTN_LEFT)
+                   && clickable->focusable(),
+               "clickable container accepts left clicks and is focusable"
+           )
+          && ok;
+
+      // Validate matching uses the application's global keybind matcher, which this test does not configure.
+    }
+
+    // Hover-only wrappers start with an empty button mask and never take
+    // focus. (The retained-node route to the same state — onClick removed
+    // while onHover stays — is covered by the clearing test above.)
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onHover", std::string("hover"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      auto* hoverOnly = dynamic_cast<InputArea*>(host.children().front().get());
+      ok = expect(
+               hoverOnly != nullptr && hoverOnly->acceptedButtons() == 0 && !hoverOnly->focusable(),
+               "hover-only container does not accept clicks or take focus"
+           )
+          && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::string fired;
+      reconciler.setCallbackSink([&fired](const ui::UiTreeReconciler::ControlCallback& cb) { fired = cb.fn; });
+      Flex host;
+
+      // Explicit size: dispatchPress hit-tests the point against the wrapper's
+      // bounds, and an empty content-sized container measures 0x0.
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onClick", std::string("first"));
+      tree.props.emplace("width", 40.0);
+      tree.props.emplace("height", 20.0);
+      (void)reconciler.reconcile(host, tree, renderer);
+      auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+      if (area != nullptr) {
+        (void)area->measure(renderer, LayoutConstraints::unconstrained());
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, true);
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, false);
+      }
+      ok = expect(fired == "first", "click dispatch reaches the first container callback") && ok;
+
+      tree.props["onClick"] = std::string("second");
+      (void)reconciler.reconcile(host, tree, renderer);
+      fired.clear();
+      if (area != nullptr) {
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, true);
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, false);
+      }
+      ok = expect(fired == "second", "reconciled container callback replaces the old click callback") && ok;
+
+      // onClick emptied while onHover keeps the wrapper alive: wrapper input
+      // handlers clear on removal (deviating from the retain-absent-props
+      // default) — a retained one would leave an invisible click-swallowing,
+      // keyboard-activatable node. The wrapper drops mask, focus, and handler.
+      tree.props["onClick"] = std::string();
+      tree.props.emplace("onHover", std::string("h"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      fired.clear();
+      if (area != nullptr) {
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, true);
+        area->dispatchPress(5.0f, 5.0f, BTN_LEFT, false);
+      }
+      ok = expect(
+               fired.empty() && area != nullptr && area->acceptedButtons() == 0 && !area->focusable()
+                   && area->cursorShape() == 0,
+               "emptied onClick clears the wrapper's activation"
+           )
+          && ok;
+    }
+
+    // An empty callback name is "unset": wiring is change-detected against the
+    // slot's empty default, so it could never fire — wrapping anyway would
+    // swallow ancestor clicks/hover and add a dead tab stop.
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onClick", std::string());
+      tree.props.emplace("onHover", std::string());
+      (void)reconciler.reconcile(host, tree, renderer);
+      Node* node = host.children().empty() ? nullptr : host.children().front().get();
+      ok = expect(dynamic_cast<Flex*>(node) != nullptr, "empty callback names leave the container unwrapped") && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      std::string callbackName;
+      std::string callbackArg;
+      reconciler.setCallbackSink([&](const ui::UiTreeReconciler::ControlCallback& cb) {
+        callbackName = cb.fn;
+        callbackArg = cb.arg1;
+      });
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      tree.props.emplace("onHover", std::string("hover"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      auto* area = dynamic_cast<InputArea*>(host.children().front().get());
+      if (area != nullptr) {
+        area->dispatchEnter(0.0f, 0.0f);
+        ok = expect(callbackName == "hover" && callbackArg == "true", "container hover enter reaches the sink") && ok;
+        area->dispatchLeave();
+      }
+      ok = expect(callbackName == "hover" && callbackArg == "false", "container hover leave reaches the sink") && ok;
+    }
+
+    {
+      ui::UiTreeReconciler reconciler;
+      Flex host;
+
+      ui::UiTreeNode tree = makeNode(type);
+      (void)reconciler.reconcile(host, tree, renderer);
+      Node* bare = host.children().empty() ? nullptr : host.children().front().get();
+      ok = expect(dynamic_cast<Flex*>(bare) != nullptr, "bare row/column remains a plain Flex") && ok;
+
+      tree.props.emplace("onClick", std::string("activate"));
+      (void)reconciler.reconcile(host, tree, renderer);
+      Node* wrapped = host.children().empty() ? nullptr : host.children().front().get();
+      ok =
+          expect(wrapped != bare && dynamic_cast<InputArea*>(wrapped) != nullptr, "adding onClick rebuilds flex") && ok;
+
+      tree.props.erase("onClick");
+      (void)reconciler.reconcile(host, tree, renderer);
+      Node* unwrapped = host.children().empty() ? nullptr : host.children().front().get();
+      ok = expect(
+               unwrapped != wrapped && dynamic_cast<Flex*>(unwrapped) != nullptr,
+               "removing onClick rebuilds flex without wrapper"
+           )
+          && ok;
+    }
+  }
+
   // Interactive controls build and apply their value props.
   {
     ui::UiTreeReconciler reconciler;


### PR DESCRIPTION
## Summary

Adds `onHover("true"/"false")` callbacks to button, box, and image nodes,
plus `onClick`/`onHover` callbacks to row and column nodes. Clickable
row/column containers preserve natural and explicit sizing. Clickable
wrappers enter the tab order and activate by pointer or the Validate
keybind.

## Motivation

Migrating our taskbar chips from buttons to box/row containers surfaced two
gaps, `ui.box` supports `onClick` but is a leaf, so it can't host the
chip's label, and rows/columns (which can) accept no interaction props at
all. Hover isn't exposed on any node, so per-item hover behavior (expand
the hovered workspace's window group) had no host support either.

## Type of Change

- [x] New feature

## Related Issue

#3355

## Testing

- Built from source on NixOS (both commits on `main` @ 4bf957f4c), full
  shell run.
- `meson test ui_tree_reconciler` OK. New coverage: wrapped row/column
  child reconciliation, content-sized and explicit-size measurement,
  click/hover dispatch, click callback rewiring and clearing, hover-only
  wrapper button masks and focusability, wrap toggling, empty callback
  names.
- Exercised live by a niri taskbar plugin: `ui.row`+`ui.label` workspace
  chips (click switches workspace, hover expands that workspace's window
  group) and `ui.image` window tiles (click focuses, hover cue). Hover-only
  wrappers pass clicks through to ancestors.
- `just format` (clang-format 22)  no diff.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="206" height="37" alt="image" src="https://github.com/user-attachments/assets/5b6e4d5e-ebec-4f62-a646-5b6f858dac47" />

idle

<img width="276" height="47" alt="image" src="https://github.com/user-attachments/assets/6c9fb876-b61d-4590-a0eb-341d0679a5a2" />

on hover

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- For wrapper props, empty callback names count as unset. Removing
  `onClick` while `onHover` keeps the wrapper alive clears its click
  handler, button mask, focusability, keyboard handler, and cursor.
- Container `onHover` fires only while its wrapper is the innermost hovered
  input area; an interactive descendant becomes the hover target instead.
- Keyboard-focused containers do not yet draw a visual focus state.
- After merge, document `onClick`/`onHover` for row, column, box, image,
  and button nodes.

Disclaimer: AI-assisted tooling was used.