### PR TITLE
feat(widgets/notification): Keep notification widget visible when the user clicks it to open the panel

### DIFF
--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -629,6 +629,8 @@ void Application::initPanelManagerAndPanels() {
   m_panelManager.setPanelClosedCallback([this]() {
     m_overviewLauncherCapture.sync();
     m_bar.reevaluateAutoHide();
+    // Widgets that stay visible while their panel is open re-evaluate on the next update.
+    m_bar.refresh();
   });
   m_configService.addReloadCallback([this]() {
     m_overviewLauncherCapture.setEnabled(m_configService.config().shell.niriOverviewTypeToLaunchEnabled);

--- a/src/shell/bar/widgets/notification_widget.cpp
+++ b/src/shell/bar/widgets/notification_widget.cpp
@@ -33,11 +33,8 @@ void NotificationWidget::create() {
     if (data.button != BTN_LEFT) {
       return;
     }
-    // If the user clicked the widget to open the panel, keep the widget visible so it can be clicked again to close the
-    // panel.
-    auto& panelManager = PanelManager::instance();
-    m_meClickedToOpenThePanel =
-        !(panelManager.isOpenPanel("control-center") && panelManager.isActivePanelContext("notifications"));
+    // Latch so the widget stays clickable while the panel this click opened is up.
+    m_openedPanelByClick = true;
     requestPanelToggle("control-center", "notifications");
   });
 
@@ -93,15 +90,10 @@ void NotificationWidget::refreshIndicatorState() {
   const bool dndEnabled = (m_manager != nullptr) && m_manager->doNotDisturb();
 
   if (Node* rootNode = root(); rootNode != nullptr) {
-    bool panelStillOpen = false;
-    if (m_meClickedToOpenThePanel) {
-      auto& panelManager = PanelManager::instance();
-      panelStillOpen = panelManager.isOpenPanel("control-center") && panelManager.isActivePanelContext("notifications");
-      if (!panelStillOpen) {
-        m_meClickedToOpenThePanel = false;
-      }
+    if (m_openedPanelByClick) {
+      m_openedPanelByClick = PanelManager::instance().isOpenPanel("control-center");
     }
-    const bool showWidget = panelStillOpen || !m_hideWhenNoUnread || hasNotifications;
+    const bool showWidget = m_openedPanelByClick || !m_hideWhenNoUnread || hasNotifications;
     rootNode->setVisible(showWidget);
     rootNode->setParticipatesInLayout(showWidget);
   }

--- a/src/shell/bar/widgets/notification_widget.cpp
+++ b/src/shell/bar/widgets/notification_widget.cpp
@@ -3,6 +3,7 @@
 #include "notification/notification_manager.h"
 #include "render/scene/input_area.h"
 #include "render/scene/node.h"
+#include "shell/panel/panel_manager.h"
 #include "ui/builders.h"
 #include "ui/palette.h"
 #include "ui/style.h"
@@ -32,6 +33,11 @@ void NotificationWidget::create() {
     if (data.button != BTN_LEFT) {
       return;
     }
+    // If the user clicked the widget to open the panel, keep the widget visible so it can be clicked again to close the
+    // panel.
+    auto& panelManager = PanelManager::instance();
+    m_meClickedToOpenThePanel =
+        !(panelManager.isOpenPanel("control-center") && panelManager.isActivePanelContext("notifications"));
     requestPanelToggle("control-center", "notifications");
   });
 
@@ -87,7 +93,15 @@ void NotificationWidget::refreshIndicatorState() {
   const bool dndEnabled = (m_manager != nullptr) && m_manager->doNotDisturb();
 
   if (Node* rootNode = root(); rootNode != nullptr) {
-    const bool showWidget = !m_hideWhenNoUnread || hasNotifications;
+    bool panelStillOpen = false;
+    if (m_meClickedToOpenThePanel) {
+      auto& panelManager = PanelManager::instance();
+      panelStillOpen = panelManager.isOpenPanel("control-center") && panelManager.isActivePanelContext("notifications");
+      if (!panelStillOpen) {
+        m_meClickedToOpenThePanel = false;
+      }
+    }
+    const bool showWidget = panelStillOpen || !m_hideWhenNoUnread || hasNotifications;
     rootNode->setVisible(showWidget);
     rootNode->setParticipatesInLayout(showWidget);
   }

--- a/src/shell/bar/widgets/notification_widget.h
+++ b/src/shell/bar/widgets/notification_widget.h
@@ -24,5 +24,5 @@ private:
   bool m_hideWhenNoUnread = false;
   bool m_hasNotifications = false;
   bool m_dndEnabled = false;
-  bool m_meClickedToOpenThePanel = false;
+  bool m_openedPanelByClick = false;
 };

--- a/src/shell/bar/widgets/notification_widget.h
+++ b/src/shell/bar/widgets/notification_widget.h
@@ -24,4 +24,5 @@ private:
   bool m_hideWhenNoUnread = false;
   bool m_hasNotifications = false;
   bool m_dndEnabled = false;
+  bool m_meClickedToOpenThePanel = false;
 };


### PR DESCRIPTION
## Summary

When auto-hide is on, the notification widget will now remain visible when the user clicks it to open the panel, and as long as the panel is still open in the "notifications" page. This allows the user to click the widget again to close the panel without having to move the mouse.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
