### PR TITLE
fix(pipewire): show app streams with node.target in Application Volumes

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -696,7 +696,7 @@ namespace {
     if (!nd.linkGroup.empty() || nd.nodePassive) {
       return false;
     }
-    if (!nd.targetObject.empty() && !isQemuStreamNode(nd)) {
+    if (!nd.targetObject.empty() && nd.applicationName.empty() && !isQemuStreamNode(nd)) {
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary

`isProgramOutputNode` excluded every Stream/Output/Audio node that had
`target.object` set, except QEMU. apps like Sober (Roblox via SDL)
set `node.target` to route audio to a specific sink, so they never
appeared in the Application Volumes section.

The fix only skips nodes with `target.object` when `applicationName` is
also empty. apps carry a name, while loopback/filter endpoints
have no identity and stay filtered.

## Motivation

Sober's audio stream was invisible in the audio panel. The same pattern
(node.target + Stream/Output/Audio) likely affects other apps.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

see #3186 for Telegram

## Testing

- `just build` (debug): succeeds, no new warnings.
- Manual: on Niri with PipeWire 1.6.7 / WirePlumber 0.5.15, Sober's
  audio stream previously did not appear in Application Volumes. After
  the fix it shows up.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="518" height="118" alt="image" src="https://github.com/user-attachments/assets/41b17e1d-3bfc-48cd-a5b4-f7602261b4b7" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Tested on Sober only. Telegram #3186 has the same root cause
but was not tested.