### PR TITLE
feat: add eye-care reminder service and settings UI configuration

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -694,6 +694,10 @@
       "dbus-disabled": "DBus notifications disabled",
       "desktop-widgets-editor": "Widget editor",
       "desktop-widgets-editor-enabled": "Desktop widget editor is on. Switch to an empty workspace to see the editor overlay.",
+      "eyecare-break-body": "Focus on an object 20 feet away for 20 seconds.",
+      "eyecare-break-finished-body": "Your eyes are rested. You can return to your screen.",
+      "eyecare-break-finished-title": "Break finished",
+      "eyecare-break-title": "Time for a break",
       "greeter-sync": "Noctalia Greeter",
       "greeter-sync-pending": "Waiting for administrator approval to write to the greeter.",
       "greeter-sync-pending-console": "Waiting for administrator approval. Approve the polkit prompt in Noctalia, on a TTY or console, or run pkexec manually.",
@@ -1099,6 +1103,7 @@
         "directories": "Directories",
         "display": "Display",
         "effects": "Effects",
+        "eyecare": "Eye Care",
         "filtering": "Filtering",
         "focus-styling": "Focus Styling",
         "formats": "Formats",
@@ -2465,6 +2470,22 @@
         "weather-unit": {
           "description": "Unit system for weather display",
           "label": "Units"
+        },
+        "eyecare": {
+          "description": "Periodically remind you to take breaks to protect your eyes (20-20-20 rule)",
+          "label": "Eye-Care Reminders"
+        },
+        "eyecare-active-duration": {
+          "description": "Active screen time before triggering a break (minutes)",
+          "label": "Active Duration"
+        },
+        "eyecare-break-duration": {
+          "description": "Required duration for eye-care breaks (seconds)",
+          "label": "Break Duration"
+        },
+        "eyecare-sound": {
+          "description": "Play notification sound when breaks start or finish",
+          "label": "Enable Audio Feedback"
         }
       },
       "shared": {

--- a/meson.build
+++ b/meson.build
@@ -735,6 +735,7 @@ _noctalia_sources = files(
   'src/system/day_night_schedule.cpp',
   'src/system/gamma_service.cpp',
   'src/system/location_service.cpp',
+  'src/system/eyecare_service.cpp',
   'src/capture/screencopy_capture.cpp',
   'src/capture/screencopy_util.cpp',
   'src/capture/screenshot_service.cpp',

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -58,6 +58,7 @@
 #include "system/battery_warning_monitor.h"
 #include "system/dependency_service.h"
 #include "system/desktop_entry_poll_source.h"
+#include "system/eyecare_service.h"
 #include "system/gamma_service.h"
 #include "system/icon_theme_poll_source.h"
 #include "system/location_poll_source.h"
@@ -243,6 +244,7 @@ private:
   HookManager m_hookManager;
   DependencyService m_dependencyService;
   GammaService m_gammaService;
+  EyeCareService m_eyeCareService;
   ScreenshotService m_screenshotService{m_wayland, m_compositorPlatform, m_notificationManager, &m_clipboardService};
   std::unique_ptr<MprisService> m_mprisService;
   std::unique_ptr<PowerProfilesService> m_powerProfilesService;

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1245,6 +1245,17 @@ void Application::initSessionBusServices() {
       m_panelManager.refresh();
     }
   });
+
+  m_eyeCareService.initialize(&m_notificationManager, m_soundPlayer.get(), &m_idleManager);
+  m_eyeCareService.reload(m_configService.config().eyecare);
+  m_configService.addReloadCallback(
+      [this]() {
+        if (m_configService.lastChange().eyecare) {
+          m_eyeCareService.reload(m_configService.config().eyecare);
+        }
+      },
+      "eyecare"
+  );
 }
 
 void Application::startTrayService() {

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -971,6 +971,7 @@ void Application::initWidgetControllersAndCallbacks() {
       }
     }
     m_idleManager.onSecondTick();
+    m_eyeCareService.onSecondTick(m_lockScreen.isActive());
   });
 
   if (m_pipewireService != nullptr) {

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -375,6 +375,7 @@ namespace {
         && a.battery == b.battery
         && a.keybinds == b.keybinds
         && a.nightlight == b.nightlight
+        && a.eyecare == b.eyecare
         && a.location == b.location
         && a.idle == b.idle
         && a.hooks == b.hooks
@@ -718,6 +719,7 @@ ConfigChangeSet computeConfigChangeSet(const Config& prev, const Config& next) {
       .battery = !(prev.battery == next.battery),
       .keybinds = !(prev.keybinds == next.keybinds),
       .nightlight = !(prev.nightlight == next.nightlight),
+      .eyecare = !(prev.eyecare == next.eyecare),
       .location = !(prev.location == next.location),
       .idle = !(prev.idle == next.idle),
       .hooks = !(prev.hooks == next.hooks),

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1177,6 +1177,15 @@ struct NightLightConfig {
   bool operator==(const NightLightConfig&) const = default;
 };
 
+struct EyeCareConfig {
+  bool enabled = false;
+  std::int32_t activeDurationMinutes = 20;
+  std::int32_t breakDurationSeconds = 20;
+  bool enableSound = true;
+
+  bool operator==(const EyeCareConfig&) const = default;
+};
+
 struct LocationConfig {
   // Single source of truth for "where am I". Resolution priority:
   //   auto_locate (IP) -> address (geocoded) -> manual latitude/longitude.
@@ -1466,6 +1475,7 @@ struct Config {
   BatteryConfig battery;
   KeybindsConfig keybinds;
   NightLightConfig nightlight;
+  EyeCareConfig eyecare;
   LocationConfig location;
   IdleConfig idle;
   HooksConfig hooks;
@@ -1497,6 +1507,7 @@ struct ConfigChangeSet {
   bool battery = true;
   bool keybinds = true;
   bool nightlight = true;
+  bool eyecare = true;
   bool location = true;
   bool idle = true;
   bool hooks = true;
@@ -1526,6 +1537,7 @@ struct ConfigChangeSet {
         || battery
         || keybinds
         || nightlight
+        || eyecare
         || location
         || idle
         || hooks

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -171,6 +171,16 @@ namespace noctalia::config::schema {
     return s;
   }
 
+  const Schema<EyeCareConfig>& eyecareSchema() {
+    static const Schema<EyeCareConfig> s = {
+        field(&EyeCareConfig::enabled, "enabled"),
+        field(&EyeCareConfig::activeDurationMinutes, "active_duration_minutes", kEyeCareActiveDurationMinutesRange),
+        field(&EyeCareConfig::breakDurationSeconds, "break_duration_seconds", kEyeCareBreakDurationSecondsRange),
+        field(&EyeCareConfig::enableSound, "enable_sound"),
+    };
+    return s;
+  }
+
   const Schema<LocationConfig>& locationSchema() {
     static const Schema<LocationConfig> s = {
         field(&LocationConfig::autoLocate, "auto_locate"),

--- a/src/config/schema/config_schema.h
+++ b/src/config/schema/config_schema.h
@@ -14,6 +14,7 @@ namespace noctalia::config::schema {
   const Schema<LockscreenConfig>& lockscreenSchema();
   const Schema<SystemConfig>& systemSchema();
   const Schema<NightLightConfig>& nightlightSchema();
+  const Schema<EyeCareConfig>& eyecareSchema();
   const Schema<LocationConfig>& locationSchema();
   const Schema<NotificationConfig>& notificationSchema();
   const Schema<DockConfig>& dockSchema();

--- a/src/config/schema/config_sections.cpp
+++ b/src/config/schema/config_sections.cpp
@@ -60,6 +60,7 @@ namespace noctalia::config::schema {
         t.push_back(makeSection("brightness", &Config::brightness, brightnessSchema()));
         t.push_back(makeSection("battery", &Config::battery, batterySchema()));
         t.push_back(makeSection("nightlight", &Config::nightlight, nightlightSchema()));
+        t.push_back(makeSection("eyecare", &Config::eyecare, eyecareSchema()));
         t.push_back(makeSection("location", &Config::location, locationSchema()));
         t.push_back(makeSection("idle", &Config::idle, idleSchema()));
         t.push_back(makeSection("keybinds", &Config::keybinds, keybindsSchema()));

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -42,4 +42,8 @@ namespace noctalia::config::schema {
   inline constexpr Range<float> kDockInactiveScaleRange{0.1f, 1.0f, 0.05f};
   inline constexpr Range<float> kDockMagnificationScaleRange{1.0f, 2.0f, 0.05f};
 
+  // Eye Care
+  inline constexpr Range<std::int64_t> kEyeCareActiveDurationMinutesRange{1, 120, 1};
+  inline constexpr Range<std::int64_t> kEyeCareBreakDurationSecondsRange{5, 300, 5};
+
 } // namespace noctalia::config::schema

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2370,6 +2370,46 @@ namespace settings {
       entries.push_back(std::move(e));
     }
 
+    const SettingVisibility eyecareOn = [](const Config& c) { return c.eyecare.enabled; };
+    entries.push_back(makeEntry(
+        SettingsSection::Services, "eyecare", tr("settings.schema.services.eyecare.label"),
+        tr("settings.schema.services.eyecare.description"), {"eyecare", "enabled"}, ToggleSetting{cfg.eyecare.enabled},
+        "eyecare 20-20-20 break timer protection"
+    ));
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "eyecare", tr("settings.schema.services.eyecare-active-duration.label"),
+          tr("settings.schema.services.eyecare-active-duration.description"), {"eyecare", "active_duration_minutes"},
+          sliderFor(
+              cfg.eyecare.activeDurationMinutes, noctalia::config::schema::kEyeCareActiveDurationMinutesRange, true
+          ),
+          "eyecare active duration screen time minutes"
+      );
+      e.visibleWhen = eyecareOn;
+      entries.push_back(std::move(e));
+    }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "eyecare", tr("settings.schema.services.eyecare-break-duration.label"),
+          tr("settings.schema.services.eyecare-break-duration.description"), {"eyecare", "break_duration_seconds"},
+          sliderFor(
+              cfg.eyecare.breakDurationSeconds, noctalia::config::schema::kEyeCareBreakDurationSecondsRange, true
+          ),
+          "eyecare break duration rest seconds"
+      );
+      e.visibleWhen = eyecareOn;
+      entries.push_back(std::move(e));
+    }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "eyecare", tr("settings.schema.services.eyecare-sound.label"),
+          tr("settings.schema.services.eyecare-sound.description"), {"eyecare", "enable_sound"},
+          ToggleSetting{cfg.eyecare.enableSound}, "eyecare sound audio chime notification"
+      );
+      e.visibleWhen = eyecareOn;
+      entries.push_back(std::move(e));
+    }
+
     entries.push_back(makeEntry(
         SettingsSection::Services, "audio", tr("settings.schema.services.audio-overdrive.label"),
         tr("settings.schema.services.audio-overdrive.description"), {"audio", "enable_overdrive"},

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -438,6 +438,9 @@ namespace {
     if (section == "nightlight") {
       return schema::writeTable(cfg.nightlight, schema::nightlightSchema());
     }
+    if (section == "eyecare") {
+      return schema::writeTable(cfg.eyecare, schema::eyecareSchema());
+    }
     if (section == "notification") {
       return schema::writeTable(cfg.notification, schema::notificationSchema());
     }

--- a/src/system/eyecare_service.cpp
+++ b/src/system/eyecare_service.cpp
@@ -1,0 +1,125 @@
+#include "system/eyecare_service.h"
+
+#include "core/log.h"
+#include "i18n/i18n.h"
+#include "idle/idle_manager.h"
+#include "notification/notification_manager.h"
+#include "pipewire/sound_player.h"
+
+namespace {
+  constexpr Logger kLog("eyecare");
+}
+
+void EyeCareService::initialize(
+    NotificationManager* notifications, SoundPlayer* soundPlayer, IdleManager* idleManager
+) {
+  m_notifications = notifications;
+  m_soundPlayer = soundPlayer;
+  m_idleManager = idleManager;
+  kLog.info("EyeCareService initialized");
+}
+
+void EyeCareService::reload(const EyeCareConfig& config) {
+  m_config = config;
+  if (!m_config.enabled) {
+    m_activeTime = std::chrono::seconds{0};
+    m_idleTime = std::chrono::seconds{0};
+    m_breakTimer = std::chrono::seconds{0};
+    m_breakElapsed = std::chrono::seconds{0};
+    m_inBreak = false;
+  }
+}
+
+void EyeCareService::onSecondTick(bool lockScreenActive) {
+  if (!m_config.enabled) {
+    return;
+  }
+
+  // System is idle if lockscreen is active or compositor reports session idle
+  const bool isSystemIdle = lockScreenActive || (m_idleManager && m_idleManager->liveIdleSeconds() > 0);
+
+  if (m_inBreak) {
+    m_breakElapsed += std::chrono::seconds{1};
+  }
+
+  if (isSystemIdle) {
+    m_idleTime += std::chrono::seconds{1};
+    if (m_inBreak) {
+      m_breakTimer += std::chrono::seconds{1};
+      if (m_breakTimer >= std::chrono::seconds{m_config.breakDurationSeconds}) {
+        triggerBreakFinished();
+      }
+    } else {
+      // Natural break detection
+      if (m_idleTime >= std::chrono::seconds{m_config.breakDurationSeconds}) {
+        if (m_activeTime.count() > 0) {
+          kLog.info("Natural break detected. Resetting screen time.");
+          m_activeTime = std::chrono::seconds{0};
+        }
+      }
+    }
+  } else {
+    // User is active on the screen
+    m_idleTime = std::chrono::seconds{0};
+
+    if (m_inBreak) {
+      // User active during break. Only abort if the grace period has elapsed.
+      const auto graceThreshold =
+          std::min(std::chrono::seconds{10}, std::chrono::seconds{m_config.breakDurationSeconds});
+      if (m_breakElapsed >= graceThreshold) {
+        m_inBreak = false;
+        m_breakTimer = std::chrono::seconds{0};
+        m_breakElapsed = std::chrono::seconds{0};
+        kLog.info("Break aborted early by user activity.");
+      } else {
+        kLog.debug("User active during break reminder grace period. Ignoring activity.");
+      }
+    } else {
+      m_activeTime += std::chrono::seconds{1};
+      if (m_activeTime >= std::chrono::minutes{m_config.activeDurationMinutes}) {
+        triggerBreakReminder();
+      }
+    }
+  }
+}
+
+void EyeCareService::triggerBreakReminder() {
+  m_inBreak = true;
+  m_breakTimer = std::chrono::seconds{0};
+  m_breakElapsed = std::chrono::seconds{0};
+  m_activeTime = std::chrono::seconds{0}; // Reset to prevent multiple alerts
+
+  kLog.info("Eye care break reminder triggered.");
+
+  if (m_notifications) {
+    m_notifications->addInternal(
+        i18n::tr("notifications.internal.keybind-app"), // Uses "Noctalia" as app name
+        i18n::tr("notifications.internal.eyecare-break-title"), i18n::tr("notifications.internal.eyecare-break-body"),
+        Urgency::Normal, 6000
+    );
+  }
+
+  if (m_config.enableSound && m_soundPlayer) {
+    m_soundPlayer->play("notification");
+  }
+}
+
+void EyeCareService::triggerBreakFinished() {
+  m_inBreak = false;
+  m_breakTimer = std::chrono::seconds{0};
+  m_breakElapsed = std::chrono::seconds{0};
+  m_activeTime = std::chrono::seconds{0};
+
+  kLog.info("Eye care break completed successfully.");
+
+  if (m_notifications) {
+    m_notifications->addInternal(
+        i18n::tr("notifications.internal.keybind-app"), i18n::tr("notifications.internal.eyecare-break-finished-title"),
+        i18n::tr("notifications.internal.eyecare-break-finished-body"), Urgency::Normal, 6000
+    );
+  }
+
+  if (m_config.enableSound && m_soundPlayer) {
+    m_soundPlayer->play("notification");
+  }
+}

--- a/src/system/eyecare_service.h
+++ b/src/system/eyecare_service.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "config/config_types.h"
+
+#include <chrono>
+
+class NotificationManager;
+class SoundPlayer;
+class IdleManager;
+
+class EyeCareService {
+public:
+  EyeCareService() = default;
+
+  void initialize(NotificationManager* notifications, SoundPlayer* soundPlayer, IdleManager* idleManager);
+  void reload(const EyeCareConfig& config);
+  void onSecondTick(bool lockScreenActive);
+
+private:
+  void triggerBreakReminder();
+  void triggerBreakFinished();
+
+  NotificationManager* m_notifications = nullptr;
+  SoundPlayer* m_soundPlayer = nullptr;
+  IdleManager* m_idleManager = nullptr;
+
+  EyeCareConfig m_config;
+
+  std::chrono::seconds m_activeTime{0};
+  std::chrono::seconds m_idleTime{0};
+  std::chrono::seconds m_breakTimer{0};
+  std::chrono::seconds m_breakElapsed{0};
+
+  bool m_inBreak = false;
+};

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -397,6 +397,12 @@ location = "https://example.invalid/bad"
         {"dim", true, 60, "lock", "", "", true},
         {"off", false, 300, "screen_off", "", "", true},
     };
+    c.eyecare = EyeCareConfig{
+        .enabled = true,
+        .activeDurationMinutes = 25,
+        .breakDurationSeconds = 30,
+        .enableSound = false,
+    };
     c.wallpaper.enabled = false;
     c.wallpaper.fillColor = colorSpecFromConfigString("#ff8800");
     c.wallpaper.transitions = {WallpaperTransition::Wipe, WallpaperTransition::Zoom};


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This PR just adds a configurable 20-20-20 Eye Care reminder service, that will integrate with Noctalia's shell and settings panel.
### Key Changes:
* **Eye-Care Service**: Monitors active/idle session states, triggers notifications/audio feedback when breaks start or finish.
* **Config & Validation**: Added the `[eyecare]` block to the schema, with default bounds and validation rules integrated into the test suite.
* **Settings UI**: Registered controls (enabled state, active duration slider, break duration slider, sound toggle) under the **Services** category.
* **Localization**: Added the required translation strings to `en.json`.

<!-- What changed and why? -->

## Motivation
I've recently been facing issues with eye strain, and thought this could be a helpful feature for people. It uses the 20-20-20 rule, where it reminds you every 20 minutes to look somewhere else and take a break for the 20 seconds. It has some customisabillity for the parameters, to adjust break durations, etc. It's my first time contributing to a mainstream open-source project.

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
* Built successfully using `ninja -C build-debug`.
* Ran all unit tests using `meson test -C build-debug` (all 38/38 tests pass, including the config schema roundtrip test).
* Manually tested the UI settings sliders, visibility rules, and service triggers inside a nested Hyprland debug session.
## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
Settings Panel:
<img width="1689" height="431" alt="image" src="https://github.com/user-attachments/assets/1146b26a-34c3-4ecb-b81e-5c2bec579f9e" />

Notification:
<img width="1920" height="1076" alt="image" src="https://github.com/user-attachments/assets/b008b84f-3867-46f3-bb8e-8dc390fba997" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
1st PR here, so there might be some mistakes. I've tried my best, but I know improvements can be made. I'm looking for feedback.