### PR TITLE
feat(wallpaper): allow disabling all wallpaper transition effect

### DIFF
--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1408,7 +1408,7 @@ namespace noctalia::config::schema {
         colorSpecField(&WallpaperConfig::fillColor, "fill_color", /*alwaysEmit=*/true),
         enumArrayField(
             &WallpaperConfig::transitions, "transition", kWallpaperTransitions,
-            std::optional<WallpaperTransition>{WallpaperTransition::Fade}
+            std::optional<WallpaperTransition>{}
         ),
         field(&WallpaperConfig::transitionDurationMs, "transition_duration", kWallpaperTransitionDurationRange),
         field(&WallpaperConfig::edgeSmoothness, "edge_smoothness", kUnitRange),

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -715,7 +715,6 @@ namespace settings {
       for (const auto& t : cfg.wallpaper.transitions) {
         transitions.selectedValues.emplace_back(enumToKey(kWallpaperTransitions, t));
       }
-      transitions.requireAtLeastOne = true;
       entries.push_back(makeEntry(
           SettingsSection::Wallpaper, "transition", tr("settings.schema.wallpaper.transitions.label"),
           tr("settings.schema.wallpaper.transitions.description"), {"wallpaper", "transition"}, std::move(transitions),

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -1417,6 +1417,13 @@ Wallpaper::redirectActiveTransition(WallpaperInstance& instance, const std::stri
 void Wallpaper::startTransition(WallpaperInstance& instance) {
   const auto& wpConfig = m_config->config().wallpaper;
 
+  if (wpConfig.transitions.empty()) {
+    instance.transitioning = true;
+    instance.transitionDirection = WallpaperTransitionDirection::Forward;
+    finishTransition(instance);
+    return;
+  }
+
   float aspectRatio = 1.777f;
   if (instance.surface->height() > 0) {
     aspectRatio = static_cast<float>(instance.surface->width()) / static_cast<float>(instance.surface->height());


### PR DESCRIPTION
## Summary

This PR lets you disable all wallpaper transition effect just by deselecting all the effect.

## Motivation

Previously, at least one transition effect was always required. Geistmensch from discord server had a request to let us disable the all transition effect and this makes switching instant.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Built successfully with `ninja -C build-debug`. Manually tested: deselecting all transitions in Settings -> Wallpaper -> Transition Effects give instant wallpaper changes with no animation.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/71ad01f2-9b09-43ba-a8fe-432b71fe0009

> The transition is instant with all effect disabled and even transition duration is set high it won't read it. Its just there was lag during video recording.

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I self-reviewed the changes.
- [x] I will update end-user documentation after merge.
- [x] I checked for new warnings or errors.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
