### PR TITLE
noctalia.scm: Simplify STB header dependencies.

### DIFF
--- a/noctalia.scm
+++ b/noctalia.scm
@@ -22,7 +22,6 @@
   #:use-module (guix git-download)
   ;; Guix build systems
   #:use-module (guix build-system meson)
-  #:use-module (guix build-system gnu)
   ;; Guix packages
   #:use-module (gnu packages cpp)
   #:use-module (gnu packages curl)
@@ -43,29 +42,6 @@
   #:use-module (gnu packages stb)
   #:use-module (gnu packages xdisorg)
   #:use-module (gnu packages xml))
-
-;; guix distributes stb headers under include/stb_x.h, but noctalia
-;; expects them in include/stb/stb_x.h
-(define* (wrap-stb-header stb-package name #:key deprecated?)
-  (package
-   (inherit stb-package)
-   (arguments
-    (list
-     #:modules '((guix build utils))
-     #:builder
-     #~(begin
-         (use-modules (guix build utils))
-         (let ((headers-dir #$(file-append (this-package-input "stb")
-                                           (if deprecated? "/deprecated" "")))
-               (lib (string-join (string-split #$name #\-) "_"))
-               (out #$output))
-           (install-file (string-append headers-dir "/" lib ".h")
-                         (string-append out "/include/stb/"))
-           #t))))))
-(define stb-image-resize2-wrapped
-  (wrap-stb-header stb-image-resize2 "stb-image-resize2"))
-(define stb-image-write-wrapped
-  (wrap-stb-header stb-image-write "stb-image-write"))
 
 (define wayland-protocols-1.48
   (package
@@ -107,7 +83,10 @@
                    ;; /bin/sh doesn't exist in the build environment.
                    (substitute* "tests/process_test.cpp"
                      (("/bin/(sh)" _ cmd)
-                      (which cmd))))))))
+                      (which cmd)))
+                   ;; Adjust import paths for STB headers packaged in Guix.
+                   (substitute* (find-files "." "\\.cpp$|^meson\\.build$")
+                     (("\\bstb/stb_") "stb_")))))))
     (native-inputs
      (list pkg-config))
     (inputs
@@ -133,8 +112,8 @@
            pipewire
            polkit
            sdbus-c++
-           stb-image-resize2-wrapped
-           stb-image-write-wrapped
+           stb-image-resize2
+           stb-image-write
            tomlplusplus
            wayland
            wayland-protocols-1.48

--- a/noctalia.scm
+++ b/noctalia.scm
@@ -7,7 +7,7 @@
 ;;; (channel
 ;;;   (name 'noctalia)
 ;;;   (url "https://github.com/noctalia-dev/noctalia")
-;;;   (branch "v5"))
+;;;   (branch "main"))
 ;;; --8<---------------cut here---------------end--------------->8---
 ;;;
 ;;; It provides this (noctalia) module with the noctalia-git package.


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This is a change to the Guix package.  It adjusts import paths in the source instead of wrapping STB header packages and simplifies the package definitions.

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

```bash
guix build -f noctalia.scm
```

And check functionality of the built `/gnu/store/…-noctalia-git-latest/bin/noctalia`.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
