### PR TITLE
fix(input): don't drop wheel detent events; keep one wheel notch at one step

### DIFF
--- a/src/render/scene/input_area.cpp
+++ b/src/render/scene/input_area.cpp
@@ -14,6 +14,10 @@ namespace {
   // step deliberately rather than racing the finger.
   constexpr float kScrollUnitsPerStep = 20.0f;
 
+  bool isWheelSource(std::uint32_t axisSource) noexcept {
+    return axisSource == WL_POINTER_AXIS_SOURCE_WHEEL || axisSource == WL_POINTER_AXIS_SOURCE_WHEEL_TILT;
+  }
+
 } // namespace
 
 InputArea::InputArea() : Node(NodeType::Base) {}
@@ -213,9 +217,13 @@ bool InputArea::dispatchAxis(
     return false;
   }
 
-  // Quantize scroll into whole detent steps. Wheel events carry detents in
-  // axisLines and cross the threshold immediately; continuous sources
+  // Quantize scroll into whole detent steps. Wheel sources are capped at one
+  // step per frame: a ratcheted wheel emits one frame per notch, so the notch
+  // the user feels stays one step even when the compositor scales the delta
+  // (niri's scroll-factor), while free-spinning hi-res wheels emit sub-detent
+  // frames that must first accrue to a full detent. Continuous sources
   // (touchpads) accrue axisValue until a detent-equivalent is reached.
+  // Scrolling content stays on scrollDelta() and keeps the scaling.
   float axisSteps = 0.0f;
   if (axis < m_scrollStepAccum.size()) {
     float& accum = m_scrollStepAccum[axis];
@@ -226,6 +234,9 @@ bool InputArea::dispatchAxis(
     accum += detentDelta;
     axisSteps = std::trunc(accum);
     accum -= axisSteps;
+    if (isWheelSource(axisSource)) {
+      axisSteps = std::clamp(axisSteps, -1.0f, 1.0f);
+    }
   }
 
   return m_onAxis(

--- a/src/render/scene/input_area.h
+++ b/src/render/scene/input_area.h
@@ -42,9 +42,12 @@ public:
     }
 
     // Whole wheel-detent steps accumulated by the InputArea (positive = scroll
-    // down). Continuous sources (touchpads, hi-res wheels) emit a step only
-    // once a full detent-equivalent has accrued — use this instead of
-    // scrollDelta() for discrete stepping (volume, workspace cycling, ...).
+    // down). Wheel sources yield at most one step per frame, so a ratcheted
+    // notch is one step regardless of compositor scaling while a free-spinning
+    // hi-res wheel still has to accrue a full detent; continuous sources
+    // (touchpads) emit a step only once a full detent-equivalent has accrued —
+    // use this instead of scrollDelta() for discrete stepping (volume,
+    // workspace cycling, ...).
     [[nodiscard]] float scrollSteps() const noexcept { return axisSteps; }
   };
 

--- a/src/wayland/wayland_seat.cpp
+++ b/src/wayland/wayland_seat.cpp
@@ -7,7 +7,6 @@
 #include <clocale>
 #include <cstring>
 #include <linux/input-event-codes.h>
-#include <ranges>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <xkbcommon/xkbcommon-compose.h>
@@ -56,7 +55,8 @@ namespace {
 
   constexpr Logger kLog("seat");
   constexpr float kAxisValue120PerStep = 120.0f;
-  constexpr float kLegacyWheelAxisUnitsPerStep = 10.0f;
+  // libinput reports one wheel detent as 15 degrees of rotation.
+  constexpr float kLegacyWheelAxisUnitsPerStep = 15.0f;
 
 } // namespace
 
@@ -320,18 +320,31 @@ void WaylandSeat::handlePointerAxis(
     void* data, wl_pointer* /*pointer*/, std::uint32_t time, std::uint32_t axis, std::int32_t value
 ) {
   auto* self = static_cast<WaylandSeat*>(data);
-  self->m_pendingPointerEvents.push_back(
-      PointerEvent{
-          .type = PointerEvent::Type::Axis,
-          .surface = self->m_lastPointerSurface,
-          .sx = self->m_hasPointerPosition ? self->m_lastPointerX : 0.0,
-          .sy = self->m_hasPointerPosition ? self->m_lastPointerY : 0.0,
-          .time = time,
-          .axis = axis,
-          .axisSource = self->m_pendingAxisSource,
-          .axisValue = wl_fixed_to_double(value),
-      }
-  );
+  PointerEvent event{
+      .type = PointerEvent::Type::Axis,
+      .surface = self->m_lastPointerSurface,
+      .sx = self->m_hasPointerPosition ? self->m_lastPointerX : 0.0,
+      .sy = self->m_hasPointerPosition ? self->m_lastPointerY : 0.0,
+      .time = time,
+      .axis = axis,
+      .axisSource = self->m_pendingAxisSource,
+      .axisValue = wl_fixed_to_double(value),
+  };
+
+  // axis_discrete/axis_value120 arrive before the axis event they describe, and
+  // the protocol couples each of them to exactly one axis event of the same
+  // axis within the frame. Claim whatever was stashed for this axis.
+  if (axis < self->m_pendingAxisDetents.size()) {
+    AxisDetent& detent = self->m_pendingAxisDetents[axis];
+    if (detent.valid) {
+      event.axisDiscrete = detent.discrete;
+      event.axisValue120 = detent.value120;
+      event.axisLines = detent.lines;
+      detent = {};
+    }
+  }
+
+  self->m_pendingPointerEvents.push_back(event);
 }
 
 void WaylandSeat::handlePointerAxisSource(void* data, wl_pointer* /*pointer*/, std::uint32_t axisSource) {
@@ -343,14 +356,14 @@ void WaylandSeat::handlePointerAxisDiscrete(
     void* data, wl_pointer* /*pointer*/, std::uint32_t axis, std::int32_t discrete
 ) {
   auto* self = static_cast<WaylandSeat*>(data);
-  for (auto& pendingEvent : std::views::reverse(self->m_pendingPointerEvents)) {
-    if (pendingEvent.type == PointerEvent::Type::Axis && pendingEvent.axis == axis) {
-      pendingEvent.axisDiscrete = discrete;
-      if (pendingEvent.axisLines == 0.0f) {
-        pendingEvent.axisLines = static_cast<float>(discrete);
-      }
-      return;
-    }
+  if (axis >= self->m_pendingAxisDetents.size()) {
+    return;
+  }
+  AxisDetent& detent = self->m_pendingAxisDetents[axis];
+  detent.valid = true;
+  detent.discrete = discrete;
+  if (detent.lines == 0.0f) {
+    detent.lines = static_cast<float>(discrete);
   }
 }
 
@@ -358,13 +371,13 @@ void WaylandSeat::handlePointerAxisValue120(
     void* data, wl_pointer* /*pointer*/, std::uint32_t axis, std::int32_t value120
 ) {
   auto* self = static_cast<WaylandSeat*>(data);
-  for (auto& pendingEvent : std::views::reverse(self->m_pendingPointerEvents)) {
-    if (pendingEvent.type == PointerEvent::Type::Axis && pendingEvent.axis == axis) {
-      pendingEvent.axisValue120 = value120;
-      pendingEvent.axisLines = static_cast<float>(value120) / kAxisValue120PerStep;
-      return;
-    }
+  if (axis >= self->m_pendingAxisDetents.size()) {
+    return;
   }
+  AxisDetent& detent = self->m_pendingAxisDetents[axis];
+  detent.valid = true;
+  detent.value120 = value120;
+  detent.lines = static_cast<float>(value120) / kAxisValue120PerStep;
 }
 
 void WaylandSeat::handlePointerFrame(void* data, wl_pointer* /*pointer*/) {
@@ -372,6 +385,8 @@ void WaylandSeat::handlePointerFrame(void* data, wl_pointer* /*pointer*/) {
   std::vector<PointerEvent> events = std::move(self->m_pendingPointerEvents);
   self->m_pendingPointerEvents.clear();
   self->m_pendingAxisSource = 0;
+  // Detents never carry across a frame; drop any the compositor left uncoupled.
+  self->m_pendingAxisDetents.fill({});
 
   if (!self->m_pointerEventCallback) {
     return;

--- a/src/wayland/wayland_seat.h
+++ b/src/wayland/wayland_seat.h
@@ -2,6 +2,7 @@
 
 #include "core/input/key_modifiers.h"
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -160,6 +161,15 @@ private:
   PointerEventCallback m_pointerEventCallback;
   std::vector<PointerEvent> m_pendingPointerEvents;
   std::uint32_t m_pendingAxisSource = 0;
+  // Detent info for an axis, received ahead of the axis event it belongs to.
+  struct AxisDetent {
+    bool valid = false;
+    std::int32_t discrete = 0;
+    std::int32_t value120 = 0;
+    float lines = 0.0f;
+  };
+  // Indexed by wl_pointer axis (vertical, horizontal).
+  std::array<AxisDetent, 2> m_pendingAxisDetents{};
   wl_surface* m_lastPointerSurface = nullptr;
   std::uint32_t m_pointerEnterSerial = 0;
   double m_lastPointerX = 0.0;


### PR DESCRIPTION
## Summary

Two commits fixing wheel scrolling on discrete steppers (volume, brightness,
workspaces, ...), which currently apply 2–3 steps per wheel notch on
compositors that scale scroll deltas:

1. **`fix(input): don't drop wheel detent events in the seat handlers`** — the
   bug. `handlePointerAxisDiscrete()`/`handlePointerAxisValue120()` search the
   pending event queue *backwards* for the axis event to annotate, but the
   protocol guarantees the detent event is **followed** by its coupled axis
   event, so the search never matches and the detent is always discarded. The
   detent is now stashed per axis and claimed by the next axis event of that
   axis; leftovers are cleared at the frame boundary. Also fixes the legacy
   wheel fallback unit: `kLegacyWheelAxisUnitsPerStep` was 10.0, but libinput
   reports one detent as 15 degrees.

2. **`fix(input): cap wheel scrollSteps() at one step per frame`** — a design
   call, separable from 1. With the seat fixed, `scrollSteps()` sees the
   compositor's real detent count — which is not 1 per notch under a scroll
   factor (niri at 1.6 honestly reports alternating 1/2 detents per notch,
   giving an alternating 5%/10% volume pattern). A wheel notch is a hardware
   detent the user feels exactly once, so wheel sources are now capped at one
   step per frame. Free-spinning hi-res wheels emit sub-detent frames and
   still accrue to a full detent first; touchpads keep accumulating as before;
   scrolling content is untouched (it uses `scrollDelta()`, so a compositor
   scroll-factor still speeds up scroll views and scrollbars).

If you'd rather have `scrollSteps()` report the compositor's scaled detent
count faithfully, commit 1 on its own is still a strict improvement — happy to
drop commit 2.

## Motivation

Since 53c98d38b (`fix(input): quantize touch pad scroll into wheel-detent
steps`), one wheel notch on the volume widget changes the volume by 10–15%
with a configured 5% scroll step. The regression is not in the widgets — the
new quantizer is the first consumer that multiplies by the reported magnitude,
which exposed the two seat-level flaws above (the pre-53c98d38b widget code
only ever looked at the scroll direction, masking both).

Raw events captured with a minimal client binding `wl_seat` v5 (as Noctalia
does), niri 26.04 with `scroll-factor 1.6`, one physical notch per frame:

```
  axis_source src=0                  (WL_POINTER_AXIS_SOURCE_WHEEL)
  axis_DISCRETE axis=0 discrete=1    <-- arrives BEFORE the axis event
  axis        axis=0 value=24.000    <-- 15.0 (libinput detent) * 1.6
FRAME ---
```

The `axis_discrete` line always precedes its `axis` line — per spec: *"each
axis_discrete event is always followed by exactly one axis event with the same
axis number within the same wl_pointer.frame"* — so the backwards search can
never find its target. With the detent dropped, the legacy fallback divides
24.0 by 10.0 → 2.4 detents per notch → the accumulator emits 2–3 steps:

| Notch | accum before | steps | volume delta (5% step) |
|-------|--------------|-------|------------------------|
| 1     | 0.0          | 2     | 10%                    |
| 2     | 0.4          | 2     | 10%                    |
| 3     | 0.8          | 3     | 15%                    |

Note: `handlePointerAxisValue120()` has the same ordering flaw. It is
unreachable today (`kSeatVersion = 5`; `axis_value120` is v8+) but becomes
live the moment the seat version is bumped, so it is fixed alongside.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None — analysis and fix in one go; the full event captures are above.

## Testing

- Verified the event ordering with a minimal `wl_seat` v5 client against
  niri 26.04 (dump excerpt above).
- Replayed the measured event sequences through the exact final
  `dispatchAxis()` logic in a standalone harness: ratcheted wheel at
  scroll-factor 1.6 and 1.0 → exactly 1 step per notch; hi-res free-spin
  (0.25 lines/frame) → 1 step per 4 frames; direction reversal resets the
  accumulator; touchpad path byte-identical to before.
- Built and ran the shell on CachyOS / niri 26.04 (AMD RX 9070 XT), daily use:
  volume, brightness, workspaces, taskbar, calendar, settings sliders and
  number inputs step once per notch; settings/control-center/notification
  scroll views still follow the compositor scroll-factor; horizontal tilt
  unchanged.
- Both commits build independently with zero warnings; `meson test`: 40/40 OK
  at each commit. clang-format clean.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Only tested on Niri 26.04 — that is the compositor I run. The seat-level fix
is compositor-independent protocol handling, but a confirmation on Hyprland or
Sway (both send `axis_discrete` on `wl_seat` v5) would be welcome.

## Screenshots / Videos

Input-behavior change only, nothing visual to show. The raw event captures in
Motivation stand in for a recording.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- The two commits are deliberately separable — see Summary. Dropping commit 2
  keeps commit 1 a strict improvement.
- Reviewer heads-up: with the seat fix, scroll views and scrollbars receive
  the compositor's *true* detent count. Users running a compositor
  scroll-factor were getting an inflated 2.4x line rate from the broken legacy
  fallback, so panel scrolling will feel somewhat slower for them after this —
  that is the compositor setting being honored, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
