### PR TITLE
fix(pipewire): dont override volume set by other apps

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -1322,17 +1322,7 @@ void PipeWireService::onNodeParam(
 
   float candidateVol = resolvedVolume(parsed);
   if (candidateVol >= 0.0f) {
-    if (!nd.applicationBinary.empty()) {
-      const auto prefIt = m_userAppVolumes.find(nd.applicationBinary);
-      if (prefIt != m_userAppVolumes.end() && std::abs(candidateVol - prefIt->second) > kVolumeWriteGuardEpsilon) {
-        nd.volume = prefIt->second;
-        setNodeVolume(nd.id, prefIt->second);
-      } else {
-        mergeIncomingVolumes(nd, parsed);
-      }
-    } else {
-      mergeIncomingVolumes(nd, parsed);
-    }
+    mergeIncomingVolumes(nd, parsed);
   }
 
   recomputeEffectiveMute(nd);
@@ -1722,16 +1712,6 @@ void PipeWireService::applyVolumePropsFromDict(NodeData& nd, const spa_dict* pro
       candidate = std::clamp(*maybeChannelmixVolume, 0.0f, 1.5f);
     } else if (const auto maybeVolume = parseFloat(dictGet(props, "volume")); maybeVolume.has_value()) {
       candidate = std::clamp(*maybeVolume, 0.0f, 1.5f);
-    }
-
-    if (!nd.applicationBinary.empty()) {
-      const auto prefIt = m_userAppVolumes.find(nd.applicationBinary);
-      if (prefIt != m_userAppVolumes.end()
-          && candidate >= 0.0f
-          && std::abs(candidate - prefIt->second) > kVolumeWriteGuardEpsilon) {
-        setNodeVolume(nd.id, prefIt->second);
-        candidate = prefIt->second;
-      }
     }
 
     if (candidate >= 0.0f && !shouldRejectVolumeWrite(nd, candidate)) {


### PR DESCRIPTION
## Summary

Do set re-apply node volume in case another volume is received via onNodeParam.

## Motivation

Fixes a bug that prevents the user from changing the volume in any app other than Noctalia. (#3483)

What has been happening:
1. user sets app volume to 50% in Noctalia -> `m_userAppVolumes["firefox"] = 0.50`, spa channelVolumes written
2. pipewire echoes the props back -> onNodeParam sees a different value (e.g. from pavucontrol or another mixer changing it to 70%)
3. the echo is rejected, setNodeVolume is called with 0.50 -> rewrites node volume back to 50% and re-stores the map
4. loop: every subsequent props echo from pipewire triggers a re-clamp to the user-set volume

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3483

## Testing

I've conducted the following manual tests.

Test 1:
1. Changed volume in Noctalia for a YouTube video's Firefox tab.
2. Confirmed that volume indeed changes.
3. Changed volume of the same video via YT volume slider.
4. Confirmed that volume indeed changes. (previously broken)
5. Confirmed that the volume set via YT volume slider is also reflected on the Noctalia slider.

Test 2 (done for both input & output device):
1. Changed volume in Noctalia for an output device.
2. Confirmed that volume indeed changes.
3. Confirmed that volume slider in pavucontrol is updated.
4. Changed volume of the same output device via pavucontrol (previously broken, the slider would be stuck)
5. Confirmed that volume indeed changes. (previously broken)
6. Confirmed that the volume set via pavucontrol is also reflected on the Noctalia slider.

Test 3 (done for input/output devices & apps as well):
1. Muted an output device in Noctalia.
2. Confirmed that audio is indeed muted.
3. Confirm that mute state in pavucontrol is updated.
4. Changed mute state from pavucontrol.
5. Confirmed that audio is indeed unmuted.
6. Confirmed that the mute state set via pavucontrol is also reflected on the Noctalia slider.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

First contribution, so please review extremely carefully. My understanding of the codebase is very limited, although I have experience with PipeWire specifically.

Explanation of changes:

`onNodeParam`:
- removed `m_userAppVolumes` look-up and `setNodeVolume` call
- now it just calls `mergeIncomingVolumes`. updating mixer bars without re-applying volumes

`applyVolumePropsFromDict`:
- removed the enforcement block that overrides candidate with the stored preference
- echoed props still correctly update `nd.volume` and `nd.swMute` (needed to update our UI state)