### PR TITLE
feat(battery): add display content options and none display mode

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2986,6 +2986,9 @@
         "net-tx": "Network TX",
         "none": "None",
         "on-hover": "On Hover",
+        "percent": "Percent",
+        "time": "Time",
+        "rate": "Rate",
         "output": "Output",
         "ram-percent": "RAM Percent",
         "ram-used": "RAM Used",
@@ -3116,8 +3119,12 @@
           "label": "Display"
         },
         "display-mode": {
-          "description": "Render the battery as a graphical shape or a Tabler glyph",
+          "description": "Choose None for label-obly, or a graphical shape or Tabler glyph",
           "label": "Display Mode"
+        },
+        "display-content": {
+          "description": "Choose what information to display in the battery label",
+          "label": "Display Content"
         },
         "drawer": {
           "description": "Show a tray button in the bar and open items in a panel",
@@ -3424,10 +3431,6 @@
         "show-label": {
           "description": "Show text next to the icon",
           "label": "Show Label"
-        },
-        "show-time-remaining": {
-          "description": "Show the estimated time remaining until the battery is empty or full",
-          "label": "Show Time Remaining"
         },
         "show-num-lock": {
           "description": "Show Num Lock state",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3425,6 +3425,10 @@
           "description": "Show text next to the icon",
           "label": "Show Label"
         },
+        "show-time-remaining": {
+          "description": "Show the estimated time remaining until the battery is empty or full",
+          "label": "Show Time Remaining"
+        },
         "show-num-lock": {
           "description": "Show Num Lock state",
           "label": "Show Num Lock"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2986,12 +2986,11 @@
         "net-tx": "Network TX",
         "none": "None",
         "on-hover": "On Hover",
-        "percent": "Percent",
-        "time": "Time",
-        "rate": "Rate",
         "output": "Output",
+        "percent": "Percent",
         "ram-percent": "RAM Percent",
         "ram-used": "RAM Used",
+        "rate": "Rate",
         "regular": "Regular",
         "screenshot-primary-fullscreen": "Fullscreen",
         "screenshot-primary-region": "Region",
@@ -3000,6 +2999,7 @@
         "swap-percent": "Swap Percent",
         "text": "Text",
         "text-only": "Text Only",
+        "time": "Time",
         "workspace-label-centered": "Centered",
         "workspace-label-corner": "Corner",
         "workspace-label-inside": "Inside Pill"
@@ -3119,12 +3119,8 @@
           "label": "Display"
         },
         "display-mode": {
-          "description": "Choose None for label-obly, or a graphical shape or Tabler glyph",
+          "description": "Render the battery as a graphical shape, a Tabler glyph, or label only",
           "label": "Display Mode"
-        },
-        "display-content": {
-          "description": "Choose what information to display in the battery label",
-          "label": "Display Content"
         },
         "drawer": {
           "description": "Show a tray button in the bar and open items in a panel",
@@ -3287,6 +3283,10 @@
         "label": {
           "description": "Optional static text shown on this button",
           "label": "Label"
+        },
+        "label-content": {
+          "description": "What the battery label shows: charge percentage, time remaining, or power draw",
+          "label": "Label Content"
         },
         "label-min-width": {
           "description": "Minimum label width in pixels to prevent resizing",
@@ -3634,8 +3634,10 @@
       "day": "{count} day",
       "day-plural": "{count} days",
       "hour": "{count} hour",
+      "hour-compact": "{count}h",
       "hour-plural": "{count} hours",
       "minute": "{count} minute",
+      "minute-compact": "{count}m",
       "minute-plural": "{count} minutes",
       "month": "{count} month",
       "month-plural": "{count} months",

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -38,50 +38,58 @@ namespace {
     }
     return nullptr;
   }
-  std::string formatShortDuration(std::int64_t seconds) {
-    if (seconds <= 0)
-      return {};
-    const auto hrs = seconds / 3600;
-    const auto mins = (seconds % 3600) / 60;
-    if (hrs > 0 && mins > 0)
-      return std::format("{}h {}m", hrs, mins);
-    if (hrs > 0)
-      return std::format("{}h", hrs);
-    if (mins > 0)
-      return std::format("{}m", mins);
-    return "< 1m";
+
+  std::string formatCompactDuration(std::int64_t seconds) {
+    const auto hours = seconds / 3600;
+    const auto minutes = (seconds % 3600) / 60;
+    const std::string hourText = i18n::tr("time.units.hour-compact", "count", hours);
+    const std::string minuteText = i18n::tr("time.units.minute-compact", "count", minutes);
+    if (hours > 0 && minutes > 0) {
+      return i18n::tr("time.duration.two-parts", "first", hourText, "second", minuteText);
+    }
+    if (hours > 0) {
+      return hourText;
+    }
+    if (minutes > 0) {
+      return minuteText;
+    }
+    return i18n::tr("time.duration.less-than-minute");
   }
+
 } // namespace
 
 BatteryWidget::BatteryWidget(UPowerService* upower, Options options)
     : m_upower(upower), m_deviceSelector(std::move(options.deviceSelector)),
       m_warningThreshold(options.warningThreshold), m_warningColor(options.warningColor),
-      m_displayMode(options.displayMode), m_showLabel(options.showLabel), m_hideWhenPlugged(options.hideWhenPlugged),
-      m_hideWhenFull(options.hideWhenFull), m_displayContent(options.displayContent) {}
+      m_displayMode(options.displayMode), m_labelContent(options.labelContent), m_showLabel(options.showLabel),
+      m_hideWhenPlugged(options.hideWhenPlugged), m_hideWhenFull(options.hideWhenFull) {}
 
-std::string BatteryWidget::buildLabelText(int pct, const UPowerState& s) const {
-  switch (m_displayContent) {
-  case BatteryDisplayContent::Time: {
-    std::string timeText;
-    if (s.state == BatteryState::Discharging && s.timeToEmpty > 0)
-      timeText = formatShortDuration(s.timeToEmpty);
-    else if (s.state == BatteryState::Charging && s.timeToFull > 0)
-      timeText = formatShortDuration(s.timeToFull);
-    if (!timeText.empty()) {
-      return timeText;
+// Vertical bars are too narrow for time or rate text, so they always show the bare percentage; the
+// tooltip carries the full detail. Time and rate are only known while the battery is actively charging
+// or discharging, and the percentage stands in whenever the selected content has no value to show.
+std::string BatteryWidget::buildLabelText(int pct, const UPowerState& state) const {
+  if (m_isVertical) {
+    return std::to_string(pct);
+  }
+
+  switch (m_labelContent) {
+  case BatteryLabelContent::Time:
+    if (state.state == BatteryState::Discharging && state.timeToEmpty > 0) {
+      return formatCompactDuration(state.timeToEmpty);
+    }
+    if (state.state == BatteryState::Charging && state.timeToFull > 0) {
+      return formatCompactDuration(state.timeToFull);
     }
     break;
-  }
-  case BatteryDisplayContent::Rate: {
-    if (s.energyRate > 0.0) {
-      return std::format("{:.1f} W", s.energyRate);
+  case BatteryLabelContent::Rate:
+    if (state.energyRate > 0.0) {
+      return std::format("{:.1f} W", state.energyRate);
     }
     break;
-  }
-  case BatteryDisplayContent::Percent:
+  case BatteryLabelContent::Percent:
     break;
   }
-  return m_isVertical ? std::format("{}", pct) : std::format("{}%", pct);
+  return std::format("{}%", pct);
 }
 
 void BatteryWidget::create() {
@@ -400,7 +408,10 @@ void BatteryWidget::syncState(Renderer& renderer) {
       || s.state == BatteryState::FullyCharged
       || s.state == BatteryState::PendingCharge;
 
+  const bool hasVisibleContent = m_displayMode != BatteryDisplayMode::None || m_showLabel;
+
   const bool showWidget = s.isPresent
+      && hasVisibleContent
       && !(m_hideWhenPlugged && isPluggedIn)
       && !(m_hideWhenFull && (s.state == BatteryState::FullyCharged || s.state == BatteryState::PendingCharge));
 
@@ -491,7 +502,6 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_label->setColor(fgColor);
       m_label->measure(renderer);
     }
-
   } else if (m_displayMode == BatteryDisplayMode::None) {
     const ColorSpec normalFgColor = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
     const ColorSpec fgColor = isWarning ? m_warningColor : normalFgColor;
@@ -500,7 +510,6 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
       m_label->setText(buildLabelText(pct, s));
       m_label->setColor(fgColor);
-      m_label->setVisible(true);
       m_label->measure(renderer);
     }
   }

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <format>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -43,11 +44,11 @@ namespace {
     const auto hrs = seconds / 3600;
     const auto mins = (seconds % 3600) / 60;
     if (hrs > 0 && mins > 0)
-      return std::to_string(hrs) + "h " + std::to_string(mins) + "m";
+      return std::format("{}h {}m", hrs, mins);
     if (hrs > 0)
-      return std::to_string(hrs) + "h";
+      return std::format("{}h", hrs);
     if (mins > 0)
-      return std::to_string(mins) + "m";
+      return std::format("{}m", mins);
     return "< 1m";
   }
 } // namespace
@@ -59,7 +60,7 @@ BatteryWidget::BatteryWidget(UPowerService* upower, Options options)
       m_hideWhenFull(options.hideWhenFull), m_showTimeRemaining(options.showTimeRemaining) {}
 
 std::string BatteryWidget::buildLabelText(int pct, const UPowerState& s) const {
-  std::string base = m_isVertical ? std::to_string(pct) : std::to_string(pct) + "%";
+  std::string base = m_isVertical ? std::format("{}", pct) : std::format("{}%", pct);
   if (!m_showTimeRemaining) {
     return base;
   }
@@ -68,7 +69,7 @@ std::string BatteryWidget::buildLabelText(int pct, const UPowerState& s) const {
     timeText = formatShortDuration(s.timeToEmpty);
   else if (s.state == BatteryState::Charging && s.timeToFull > 0)
     timeText = formatShortDuration(s.timeToFull);
-  return timeText.empty() ? base : base + " " + timeText;
+  return timeText.empty() ? base : std::format("{} ({})", base, timeText);
 }
 
 void BatteryWidget::create() {

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -37,14 +37,39 @@ namespace {
     }
     return nullptr;
   }
-
+  std::string formatShortDuration(std::int64_t seconds) {
+    if (seconds <= 0)
+      return {};
+    const auto hrs = seconds / 3600;
+    const auto mins = (seconds % 3600) / 60;
+    if (hrs > 0 && mins > 0)
+      return std::to_string(hrs) + "h " + std::to_string(mins) + "m";
+    if (hrs > 0)
+      return std::to_string(hrs) + "h";
+    if (mins > 0)
+      return std::to_string(mins) + "m";
+    return "< 1m";
+  }
 } // namespace
 
 BatteryWidget::BatteryWidget(UPowerService* upower, Options options)
     : m_upower(upower), m_deviceSelector(std::move(options.deviceSelector)),
       m_warningThreshold(options.warningThreshold), m_warningColor(options.warningColor),
       m_displayMode(options.displayMode), m_showLabel(options.showLabel), m_hideWhenPlugged(options.hideWhenPlugged),
-      m_hideWhenFull(options.hideWhenFull) {}
+      m_hideWhenFull(options.hideWhenFull), m_showTimeRemaining(options.showTimeRemaining) {}
+
+std::string BatteryWidget::buildLabelText(int pct, const UPowerState& s) const {
+  std::string base = m_isVertical ? std::to_string(pct) : std::to_string(pct) + "%";
+  if (!m_showTimeRemaining) {
+    return base;
+  }
+  std::string timeText;
+  if (s.state == BatteryState::Discharging && s.timeToEmpty > 0)
+    timeText = formatShortDuration(s.timeToEmpty);
+  else if (s.state == BatteryState::Charging && s.timeToFull > 0)
+    timeText = formatShortDuration(s.timeToFull);
+  return timeText.empty() ? base : base + " " + timeText;
+}
 
 void BatteryWidget::create() {
   auto container = std::make_unique<InputArea>();
@@ -386,7 +411,7 @@ void BatteryWidget::syncState(Renderer& renderer) {
 
     // Graphic mode label
     if (m_overlayLabel != nullptr && m_showLabel) {
-      m_overlayLabel->setText(m_isVertical ? std::to_string(pct) : std::to_string(pct) + "%");
+      m_overlayLabel->setText(buildLabelText(pct, s));
       m_overlayLabel->setColor(fgColor);
       m_overlayLabel->measure(renderer);
     }
@@ -420,7 +445,7 @@ void BatteryWidget::syncState(Renderer& renderer) {
 
     if (m_label != nullptr && m_showLabel) {
       m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
-      m_label->setText(m_isVertical ? std::to_string(pct) : std::to_string(pct) + "%");
+      m_label->setText(buildLabelText(pct, s));
       m_label->setColor(fgColor);
       m_label->measure(renderer);
     }

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -57,19 +57,31 @@ BatteryWidget::BatteryWidget(UPowerService* upower, Options options)
     : m_upower(upower), m_deviceSelector(std::move(options.deviceSelector)),
       m_warningThreshold(options.warningThreshold), m_warningColor(options.warningColor),
       m_displayMode(options.displayMode), m_showLabel(options.showLabel), m_hideWhenPlugged(options.hideWhenPlugged),
-      m_hideWhenFull(options.hideWhenFull), m_showTimeRemaining(options.showTimeRemaining) {}
+      m_hideWhenFull(options.hideWhenFull), m_displayContent(options.displayContent) {}
 
 std::string BatteryWidget::buildLabelText(int pct, const UPowerState& s) const {
-  std::string base = m_isVertical ? std::format("{}", pct) : std::format("{}%", pct);
-  if (!m_showTimeRemaining) {
-    return base;
+  switch (m_displayContent) {
+  case BatteryDisplayContent::Time: {
+    std::string timeText;
+    if (s.state == BatteryState::Discharging && s.timeToEmpty > 0)
+      timeText = formatShortDuration(s.timeToEmpty);
+    else if (s.state == BatteryState::Charging && s.timeToFull > 0)
+      timeText = formatShortDuration(s.timeToFull);
+    if (!timeText.empty()) {
+      return timeText;
+    }
+    break;
   }
-  std::string timeText;
-  if (s.state == BatteryState::Discharging && s.timeToEmpty > 0)
-    timeText = formatShortDuration(s.timeToEmpty);
-  else if (s.state == BatteryState::Charging && s.timeToFull > 0)
-    timeText = formatShortDuration(s.timeToFull);
-  return timeText.empty() ? base : std::format("{} ({})", base, timeText);
+  case BatteryDisplayContent::Rate: {
+    if (s.energyRate > 0.0) {
+      return std::format("{:.1f} W", s.energyRate);
+    }
+    break;
+  }
+  case BatteryDisplayContent::Percent:
+    break;
+  }
+  return m_isVertical ? std::format("{}", pct) : std::format("{}%", pct);
 }
 
 void BatteryWidget::create() {
@@ -81,8 +93,10 @@ void BatteryWidget::create() {
 
   if (m_displayMode == BatteryDisplayMode::Graphic) {
     createGraphicMode();
-  } else {
+  } else if (m_displayMode == BatteryDisplayMode::Glyph) {
     createGlyphMode();
+  } else {
+    createLabelOnlyMode();
   }
 }
 
@@ -152,6 +166,20 @@ void BatteryWidget::createGlyphMode() {
   );
 }
 
+void BatteryWidget::createLabelOnlyMode() {
+  auto* container = static_cast<InputArea*>(root());
+
+  container->addChild(
+      ui::label({
+          .out = &m_label,
+          .fontSize = Style::fontSizeBody * m_contentScale,
+          .fontWeight = labelFontWeight(),
+          .fontFamily = labelFontFamily(),
+          .visible = m_showLabel,
+      })
+  );
+}
+
 void BatteryWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
   if (rootNode == nullptr) {
@@ -162,8 +190,10 @@ void BatteryWidget::doLayout(Renderer& renderer, float containerWidth, float con
 
   if (m_displayMode == BatteryDisplayMode::Graphic) {
     layoutGraphicMode(renderer);
-  } else {
+  } else if (m_displayMode == BatteryDisplayMode::Glyph) {
     layoutGlyphMode(renderer, containerWidth, containerHeight);
+  } else {
+    layoutLabelOnlyMode(renderer, containerWidth, containerHeight);
   }
 }
 
@@ -296,6 +326,17 @@ void BatteryWidget::layoutGlyphMode(Renderer& renderer, float /*containerWidth*/
   } else {
     rootNode->setSize(m_glyph->width(), m_glyph->height());
   }
+}
+
+void BatteryWidget::layoutLabelOnlyMode(Renderer& renderer, float /*containerWidth*/, float /*containerHeight*/) {
+  auto* rootNode = root();
+  if (m_label == nullptr || rootNode == nullptr) {
+    return;
+  }
+
+  m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
+  m_label->measure(renderer);
+  rootNode->setSize(m_label->width(), m_label->height());
 }
 
 void BatteryWidget::updateFillGeometry() {
@@ -433,7 +474,7 @@ void BatteryWidget::syncState(Renderer& renderer) {
     if (m_overlayGlyph != nullptr) {
       m_overlayGlyph->setVisible(stateGlyph != nullptr);
     }
-  } else {
+  } else if (m_displayMode == BatteryDisplayMode::Glyph) {
     const ColorSpec normalFgColor = widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface));
     const ColorSpec fgColor = isWarning ? m_warningColor : normalFgColor;
 
@@ -448,6 +489,18 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
       m_label->setText(buildLabelText(pct, s));
       m_label->setColor(fgColor);
+      m_label->measure(renderer);
+    }
+
+  } else if (m_displayMode == BatteryDisplayMode::None) {
+    const ColorSpec normalFgColor = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
+    const ColorSpec fgColor = isWarning ? m_warningColor : normalFgColor;
+
+    if (m_label != nullptr && m_showLabel) {
+      m_label->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
+      m_label->setText(buildLabelText(pct, s));
+      m_label->setColor(fgColor);
+      m_label->setVisible(true);
       m_label->measure(renderer);
     }
   }

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -24,6 +24,7 @@ public:
     bool showLabel = true;
     bool hideWhenPlugged = false;
     bool hideWhenFull = false;
+    bool showTimeRemaining = false;
   };
 
   BatteryWidget(UPowerService* upower, Options options);
@@ -51,6 +52,8 @@ private:
   bool m_showLabel = true;
   bool m_hideWhenPlugged = false;
   bool m_hideWhenFull = false;
+  bool m_showTimeRemaining = false;
+  [[nodiscard]] std::string buildLabelText(int pct, const UPowerState& s) const;
 
   // Glyph mode nodes
   Glyph* m_glyph = nullptr;

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -13,7 +13,7 @@ class Glyph;
 class Label;
 
 enum class BatteryDisplayMode : std::uint8_t { None, Graphic, Glyph };
-enum class BatteryDisplayContent : std::uint8_t { Percent, Time, Rate };
+enum class BatteryLabelContent : std::uint8_t { Percent, Time, Rate };
 
 class BatteryWidget : public Widget {
 public:
@@ -22,7 +22,7 @@ public:
     int warningThreshold = 0;
     ColorSpec warningColor = colorSpecFromRole(ColorRole::Error);
     BatteryDisplayMode displayMode = BatteryDisplayMode::Glyph;
-    BatteryDisplayContent displayContent = BatteryDisplayContent::Percent;
+    BatteryLabelContent labelContent = BatteryLabelContent::Percent;
     bool showLabel = true;
     bool hideWhenPlugged = false;
     bool hideWhenFull = false;
@@ -39,6 +39,7 @@ private:
   [[nodiscard]] bool needsFrameTick() const override;
   void syncState(Renderer& renderer);
   void updateFillGeometry();
+  [[nodiscard]] std::string buildLabelText(int pct, const UPowerState& state) const;
 
   void createGraphicMode();
   void createGlyphMode();
@@ -52,11 +53,10 @@ private:
   int m_warningThreshold = 0;
   ColorSpec m_warningColor;
   BatteryDisplayMode m_displayMode = BatteryDisplayMode::Glyph;
+  BatteryLabelContent m_labelContent = BatteryLabelContent::Percent;
   bool m_showLabel = true;
   bool m_hideWhenPlugged = false;
   bool m_hideWhenFull = false;
-  BatteryDisplayContent m_displayContent = BatteryDisplayContent::Percent;
-  [[nodiscard]] std::string buildLabelText(int pct, const UPowerState& s) const;
 
   // Glyph mode nodes
   Glyph* m_glyph = nullptr;

--- a/src/shell/bar/widgets/battery_widget.h
+++ b/src/shell/bar/widgets/battery_widget.h
@@ -12,7 +12,8 @@ class Box;
 class Glyph;
 class Label;
 
-enum class BatteryDisplayMode : std::uint8_t { Graphic, Glyph };
+enum class BatteryDisplayMode : std::uint8_t { None, Graphic, Glyph };
+enum class BatteryDisplayContent : std::uint8_t { Percent, Time, Rate };
 
 class BatteryWidget : public Widget {
 public:
@@ -21,10 +22,10 @@ public:
     int warningThreshold = 0;
     ColorSpec warningColor = colorSpecFromRole(ColorRole::Error);
     BatteryDisplayMode displayMode = BatteryDisplayMode::Glyph;
+    BatteryDisplayContent displayContent = BatteryDisplayContent::Percent;
     bool showLabel = true;
     bool hideWhenPlugged = false;
     bool hideWhenFull = false;
-    bool showTimeRemaining = false;
   };
 
   BatteryWidget(UPowerService* upower, Options options);
@@ -41,8 +42,10 @@ private:
 
   void createGraphicMode();
   void createGlyphMode();
+  void createLabelOnlyMode();
   void layoutGraphicMode(Renderer& renderer);
   void layoutGlyphMode(Renderer& renderer, float containerWidth, float containerHeight);
+  void layoutLabelOnlyMode(Renderer& renderer, float containerWidth, float containerHeight);
 
   UPowerService* m_upower = nullptr;
   std::string m_deviceSelector = "auto";
@@ -52,7 +55,7 @@ private:
   bool m_showLabel = true;
   bool m_hideWhenPlugged = false;
   bool m_hideWhenFull = false;
-  bool m_showTimeRemaining = false;
+  BatteryDisplayContent m_displayContent = BatteryDisplayContent::Percent;
   [[nodiscard]] std::string buildLabelText(int pct, const UPowerState& s) const;
 
   // Glyph mode nodes

--- a/src/shell/bar/widgets/battery_widget_definition.cpp
+++ b/src/shell/bar/widgets/battery_widget_definition.cpp
@@ -35,32 +35,37 @@ batteryWidgetDefinition() {
               field<&Options::showLabel>({
                   .key = "show_label",
               }),
+              field<&Options::labelContent>({
+                  .key = "label_content",
+                  .choices =
+                      {
+                          {
+                              .value = BatteryLabelContent::Percent,
+                              .configValue = "percent",
+                              .labelKey = "settings.widgets.options.percent",
+                          },
+                          {
+                              .value = BatteryLabelContent::Time,
+                              .configValue = "time",
+                              .labelKey = "settings.widgets.options.time",
+                          },
+                          {
+                              .value = BatteryLabelContent::Rate,
+                              .configValue = "rate",
+                              .labelKey = "settings.widgets.options.rate",
+                          },
+                      },
+                  .presentation =
+                      settings::WidgetSettingPresentation{
+                          .visibleWhen = settings::WidgetSettingVisibility{"show_label", {"true"}},
+                          .horizontalBarOnly = true,
+                      },
+              }),
               field<&Options::hideWhenPlugged>({
                   .key = "hide_when_plugged",
               }),
               field<&Options::hideWhenFull>({
                   .key = "hide_when_full",
-              }),
-              field<&Options::displayContent>({
-                  .key = "display_content",
-                  .choices =
-                      {
-                          {
-                              .value = BatteryDisplayContent::Percent,
-                              .configValue = "percent",
-                              .labelKey = "settings.widgets.options.percent",
-                          },
-                          {
-                              .value = BatteryDisplayContent::Time,
-                              .configValue = "time",
-                              .labelKey = "settings.widgets.options.time",
-                          },
-                          {
-                              .value = BatteryDisplayContent::Rate,
-                              .configValue = "rate",
-                              .labelKey = "settings.widgets.options.rate",
-                          },
-                      },
               }),
               field<&Options::deviceSelector>({
                   .key = "device",

--- a/src/shell/bar/widgets/battery_widget_definition.cpp
+++ b/src/shell/bar/widgets/battery_widget_definition.cpp
@@ -36,6 +36,9 @@ batteryWidgetDefinition() {
               field<&Options::hideWhenFull>({
                   .key = "hide_when_full",
               }),
+              field<&Options::showTimeRemaining>({
+                  .key = "show_time_remaining",
+              }),
               field<&Options::deviceSelector>({
                   .key = "device",
                   .presentation =

--- a/src/shell/bar/widgets/battery_widget_definition.cpp
+++ b/src/shell/bar/widgets/battery_widget_definition.cpp
@@ -16,6 +16,11 @@ batteryWidgetDefinition() {
                   .choices =
                       {
                           {
+                              .value = BatteryDisplayMode::None,
+                              .configValue = "none",
+                              .labelKey = "settings.widgets.options.none",
+                          },
+                          {
                               .value = BatteryDisplayMode::Glyph,
                               .configValue = "glyph",
                               .labelKey = "settings.widgets.options.glyph",
@@ -36,8 +41,26 @@ batteryWidgetDefinition() {
               field<&Options::hideWhenFull>({
                   .key = "hide_when_full",
               }),
-              field<&Options::showTimeRemaining>({
-                  .key = "show_time_remaining",
+              field<&Options::displayContent>({
+                  .key = "display_content",
+                  .choices =
+                      {
+                          {
+                              .value = BatteryDisplayContent::Percent,
+                              .configValue = "percent",
+                              .labelKey = "settings.widgets.options.percent",
+                          },
+                          {
+                              .value = BatteryDisplayContent::Time,
+                              .configValue = "time",
+                              .labelKey = "settings.widgets.options.time",
+                          },
+                          {
+                              .value = BatteryDisplayContent::Rate,
+                              .configValue = "rate",
+                              .labelKey = "settings.widgets.options.rate",
+                          },
+                      },
               }),
               field<&Options::deviceSelector>({
                   .key = "device",

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -697,6 +697,7 @@ namespace settings {
         add(std::move(color2));
       }
     } else if (type == "battery") {
+
       for (auto& spec : batteryWidgetDefinition().presentedSettingSpecs()) {
         add(std::move(spec));
       }

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -697,7 +697,6 @@ namespace settings {
         add(std::move(color2));
       }
     } else if (type == "battery") {
-
       for (auto& spec : batteryWidgetDefinition().presentedSettingSpecs()) {
         add(std::move(spec));
       }


### PR DESCRIPTION
## Summary

Adds a Display Content dropdown (Percent/Time/Rate) replacing the old `show_time_remaining` boolean, and a `None` in Display mode that hides the battery glyph/graphic entirely, showing only the label text.

## Motivation

Users no longer need to hover over the battery widget to see how long until battery runs out or time to full charge. 

## Type of Change

- [x] New feature

## Related Issue

Closes #3394  

## Testing

- Ran `just format` & `just build`, completed with no errors
- Tested in debug mode with all three `display_mode` options (None/Glyph/Graphic)
- Display content on Time shows `"2h 20m"` during discharge/charge; falls back to percentage when unavailable
- Display Content on Rate shows `"15.3 W"` during discharge/charge; falls back to percentage when unavailable
- Display Content on Percent shows `"79%"` 
- Display Mode on None hides glyph/graphic entirely, shows label text only. If show label is off, nothing is visible.
- Dropdown controls appear correctly in Battery widget settings:- Display Mode (None/Glyph/Graphic) and Display Content (Percent/Time/Rate)
- Tooltip shows full details (percentage, time, rate, health) regardless of display mode or content setting
- `show_time_remaining` no longer appears in settings (removed)

## Manual Coverage

- [x] Tested on Niri

## Screenshots / Videos


https://github.com/user-attachments/assets/d0c646d0-bf3d-4661-8808-68cfa8fdbc33


## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
