### PR TITLE
Improvements for border, shadow toggles and widget spacing configurations

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -993,6 +993,10 @@
           "empty": "No settings match the current filters.",
           "groups": {
             "grouping": "Grouping",
+            "network": {
+              "ethernet": "Ethernet",
+              "wifi": "Wi-Fi"
+            },
             "presentation": "Presentation",
             "runtime": "Runtime",
             "taskbar": {
@@ -1501,6 +1505,18 @@
         "global-shadow-direction": {
           "description": "Direction the shadow is cast from surfaces"
         },
+        "input-borders": {
+          "description": "Draw outlines around text inputs and dropdowns",
+          "label": "Input Borders"
+        },
+        "popup-borders": {
+          "description": "Draw outlines around floating menus, dialogs, and tooltips",
+          "label": "Popup Borders"
+        },
+        "popup-shadows": {
+          "description": "Cast shadows from floating menus, dialogs, and tooltips",
+          "label": "Popup Shadows"
+        },
         "language": {
           "description": "Override automatic locale detection",
           "label": "Language"
@@ -1508,6 +1524,10 @@
         "palette-source": {
           "description": "Where to derive the color palette from",
           "label": "Palette Source"
+        },
+        "pure-black-context-menus": {
+          "description": "Force context menus to have a pure black background",
+          "label": "Pure Black Context Menus"
         },
         "pure-black-dark": {
           "description": "Anchor dark surfaces to true black, preventing banding on OLED panels (dark mode only)",
@@ -1704,6 +1724,10 @@
         "widget-icon-color": {
           "description": "Overrides the widget color for icons on this bar; fixed hex colors are also supported",
           "label": "Widget Icon Color"
+        },
+        "widget-icon-spacing": {
+          "description": "Space between icons and text within bar widgets",
+          "label": "Widget Icon Spacing"
         },
         "widget-spacing": {
           "description": "Space between bar widgets",
@@ -3098,6 +3122,15 @@
           "description": "Color role used for empty workspaces; fixed hex colors are also supported",
           "label": "Empty Color"
         },
+        "ethernet-custom-image": {
+          "description": "Path to a custom image for ethernet; leave empty to use the icon glyph",
+          "dialog-title": "Select custom image",
+          "label": "Custom image"
+        },
+        "ethernet-custom-image-colorize": {
+          "description": "Tint the custom image with the widget Icon Color setting",
+          "label": "Colorize custom image"
+        },
         "focused-color": {
           "description": "Color role used for the focused workspace; fixed hex colors are also supported",
           "label": "Focused Color"
@@ -3125,6 +3158,14 @@
           "label": "Glyph",
           "sysmon-description": "Custom icon glyph; leave empty to use the icon for the selected stat",
           "volume-description": "Custom icon glyph; leave empty to use the built-in dynamic icons"
+        },
+        "wifi-glyph": {
+          "description": "Custom icon glyph for Wi-Fi",
+          "label": "Wi-Fi Glyph"
+        },
+        "ethernet-glyph": {
+          "description": "Custom icon glyph for Ethernet",
+          "label": "Ethernet Glyph"
         },
         "group-by-workspace": {
           "description": "Group taskbar icons into workspace capsules when compositor data is available",
@@ -3208,8 +3249,16 @@
           "label": "Icon Size"
         },
         "icon-spacing": {
-          "description": "Spacing between privacy indicator icons in pixels",
-          "label": "Icon Spacing"
+          "description": "Spacing between the icon and text in pixels",
+          "label": "Icon Spacing",
+          "privacy-description": "Spacing between privacy indicator icons in pixels",
+          "network-description": "Spacing between the network icon and its label",
+          "sysmon-description": "Spacing between the system monitor icon and its label",
+          "custom-button-description": "Spacing between the custom button's icon and label (or padding when there is no text)"
+        },
+        "label-spacing": {
+          "description": "Spacing between the main label and the strength percentage in pixels",
+          "label": "Label Spacing"
         },
         "inactive-color": {
           "description": "Color used for inactive privacy indicators; fixed hex colors are also supported",
@@ -3269,6 +3318,15 @@
         "middle-command": {
           "description": "Shell command run when middle-clicking this button. When set, middle-click opens this command instead of widget settings.",
           "label": "Middle Click Command"
+        },
+        "minimal-hover-highlight": {
+          "description": "Show a hover background on minimal workspace labels",
+          "label": "Hover Highlight"
+        },
+        "minimal-spacing": {
+          "description": "Spacing between minimal workspace labels",
+          "label": "Minimal Spacing",
+          "workspaces-description": "Padding around workspace labels in the minimal style"
         },
         "min-length": {
           "description": "Minimum widget length in pixels",
@@ -3392,6 +3450,10 @@
           "description": "Show current temperature text",
           "label": "Show Temperature"
         },
+        "show-signal-strength": {
+          "description": "Show Wi-Fi signal strength percentage",
+          "label": "Show Signal Strength"
+        },
         "show-vpn-label": {
           "description": "Show VPN label instead of interface label next to the icon",
           "label": "Show VPN Label"
@@ -3407,6 +3469,10 @@
         "show-workspace-label": {
           "description": "Show the small workspace tag on grouped taskbar capsules; turn off for icon-only groups",
           "label": "Workspace Capsule Label"
+        },
+        "spacing": {
+          "description": "Space between elements within this widget",
+          "label": "Widget Spacing"
         },
         "stat": {
           "description": "System statistic to display",
@@ -3452,6 +3518,19 @@
         "width": {
           "description": "Widget width in pixels",
           "label": "Width"
+        },
+        "wifi-custom-image": {
+          "description": "Path to a custom image for Wi-Fi; leave empty to use the icon glyph",
+          "dialog-title": "Select custom image",
+          "label": "Custom image"
+        },
+        "wifi-custom-image-colorize": {
+          "description": "Tint the custom image with the widget Icon Color setting",
+          "label": "Colorize custom image"
+        },
+        "wifi-show-strength": {
+          "description": "Show the current strength of the Wi-Fi in percentage",
+          "label": "Show Strength"
         },
         "window-title-max-width": {
           "description": "Maximum width in pixels for window titles",

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -365,6 +365,12 @@ void Application::initStyleThemeAndWayland() {
         std::isfinite(lastCornerRadiusScale) && std::abs(corner - lastCornerRadiusScale) > 1.0e-4f;
     Style::setCornerRadiusScale(corner);
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
+    Style::setInputBordersEnabled(m_configService.config().shell.inputBorders);
+    Style::setPopupBordersEnabled(m_configService.config().shell.popupBorders);
+    Style::setPopupShadowsEnabled(m_configService.config().shell.popupShadows);
+    Style::setPureBlackContextMenusEnabled(
+        m_configService.config().theme.pureBlackDark && m_configService.config().theme.pureBlackContextMenus
+    );
     lastCornerRadiusScale = corner;
     if (cornerChanged) {
       m_notificationToast.requestLayout();

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -78,6 +78,7 @@ struct BarMonitorOverride {
   std::optional<std::int32_t> marginOppositeEdge; // extra reserved space on the inward side of the bar
   std::optional<std::int32_t> padding;            // main-axis padding from bar edges to start/end sections
   std::optional<std::int32_t> widgetSpacing;      // gap between widgets within a section
+  std::optional<float> widgetIconSpacing;         // gap between icon and label within a widget
   std::optional<bool> shadow;                     // use the global shell shadow on this bar
   std::optional<bool> contactShadow;              // dark gradient between attached panel and bar
   std::optional<std::int32_t> panelOverlap;       // logical px the attached panel overlaps the bar edge (seam tuning)
@@ -139,6 +140,9 @@ struct BarConfig {
   std::int32_t marginOppositeEdge = 0; // extra reserved space on the inward side of the bar
   std::int32_t padding = 14;           // main-axis padding from bar edges to start/end sections
   std::int32_t widgetSpacing = 6;      // gap between widgets within a section
+  // Gap between icon and label in widgets that show both (logical px, before content scale).
+  // Unset inherits the default Style::spaceXs (4px).
+  std::optional<float> widgetIconSpacing;
   bool shadow = true;                  // use the global shell shadow
   bool contactShadow = false;          // dark gradient between attached panel and bar
   // Logical px the attached panel overlaps the bar edge so their seam is hidden. The ideal value depends on the
@@ -960,6 +964,9 @@ struct ShellConfig {
 
   float cornerRadiusScale = 1.0f;
   bool buttonBorders = true;
+  bool inputBorders = true;             // border on input entry boxes and dropdown option boxes
+  bool popupBorders = true;             // border on context menus and inner windows
+  bool popupShadows = true;             // shadows for context menus and inner windows
   std::string fontFamily = "sans-serif";
   std::string lang; // empty = auto-detect from $LC_ALL/$LC_MESSAGES/$LANG
   std::string timeFormat = "{:%H:%M}";
@@ -1361,6 +1368,7 @@ struct ThemeConfig {
   std::string wallpaperScheme = "m3-content";
   ThemeMode mode = ThemeMode::Dark;
   bool pureBlackDark = false;
+  bool pureBlackContextMenus = false; // extend pure black to context menu backgrounds
   TemplatesConfig templates;
 
   bool operator==(const ThemeConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1096,6 +1096,7 @@ namespace noctalia::config::schema {
         field(&ThemeConfig::wallpaperScheme, "wallpaper_scheme"),
         enumField(&ThemeConfig::mode, "mode", kThemeModes),
         field(&ThemeConfig::pureBlackDark, "pure_black_dark"),
+        field(&ThemeConfig::pureBlackContextMenus, "pure_black_context_menus"),
         subTable(&ThemeConfig::templates, "templates", templatesSchema()),
     };
     return s;
@@ -1365,6 +1366,9 @@ namespace noctalia::config::schema {
     static const Schema<ShellConfig> s = {
         field(&ShellConfig::cornerRadiusScale, "corner_radius_scale", kCornerRadiusScaleRange),
         field(&ShellConfig::buttonBorders, "button_borders"),
+        field(&ShellConfig::inputBorders, "input_borders"),
+        field(&ShellConfig::popupBorders, "popup_borders"),
+        field(&ShellConfig::popupShadows, "popup_shadows"),
         // font_family is trimmed; empty falls back to sans-serif.
         custom<ShellConfig>(
             "font_family",
@@ -2014,6 +2018,7 @@ namespace noctalia::config::schema {
         field(&BarConfig::marginOppositeEdge, "margin_opposite_edge"),
         field(&BarConfig::padding, "padding"),
         field(&BarConfig::widgetSpacing, "widget_spacing"),
+        optionalFloatField(&BarConfig::widgetIconSpacing, "widget_icon_spacing"),
         field(&BarConfig::shadow, "shadow"),
         field(&BarConfig::contactShadow, "contact_shadow"),
         field(&BarConfig::panelOverlap, "panel_overlap", kBarPanelOverlapRange),
@@ -2085,6 +2090,7 @@ namespace noctalia::config::schema {
         optionalIntField(&BarMonitorOverride::marginOppositeEdge, "margin_opposite_edge"),
         optionalIntField(&BarMonitorOverride::padding, "padding"),
         optionalIntField(&BarMonitorOverride::widgetSpacing, "widget_spacing"),
+        optionalFloatField(&BarMonitorOverride::widgetIconSpacing, "widget_icon_spacing"),
         optionalFloatField(&BarMonitorOverride::scale, "scale", kBarScaleRange),
         optionalBoolField(&BarMonitorOverride::shadow, "shadow"),
         optionalBoolField(&BarMonitorOverride::contactShadow, "contact_shadow"),

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2149,12 +2149,13 @@ void Bar::populateWidgets(BarInstance& instance) {
     const float contentScale = resolveWidgetContentScale(instance.barConfig.scale, wcPtr, "widget." + name + ".scale");
     auto widget = m_widgetFactory->create(
         name, instance.output, contentScale, instance.barConfig.position, instance.barConfig.name,
-        static_cast<float>(instance.barConfig.widgetSpacing)
+        static_cast<float>(instance.barConfig.widgetSpacing), instance.barConfig.shadow
     );
     if (widget == nullptr) {
       return;
     }
     widget->setConfigName(name);
+    widget->setWidgetIconSpacing(instance.barConfig.widgetIconSpacing);
     if (wcPtr != nullptr) {
       widget->setAnchor(wcPtr->getBool("anchor", false));
       widget->setNonInteractive(!wcPtr->getBool("interactive", true));
@@ -2212,10 +2213,11 @@ void Bar::populateWidgets(BarInstance& instance) {
   // Prepend a red "debug" pill to the end section if running a debug build
   auto debugWidget = m_widgetFactory->create(
       "debug_indicator", instance.output, instance.barConfig.scale, instance.barConfig.position,
-      instance.barConfig.name, static_cast<float>(instance.barConfig.widgetSpacing)
+      instance.barConfig.name, static_cast<float>(instance.barConfig.widgetSpacing), instance.barConfig.shadow
   );
   if (debugWidget != nullptr) {
     debugWidget->setConfigName("debug_indicator");
+    debugWidget->setWidgetIconSpacing(instance.barConfig.widgetIconSpacing);
     debugWidget->setLabelFontWeight(labelFontWeight);
     debugWidget->setLabelFontFamily(barFontFamily);
     debugWidget->create();

--- a/src/shell/bar/widget.cpp
+++ b/src/shell/bar/widget.cpp
@@ -100,6 +100,16 @@ void Widget::setUpdateCallback(UpdateCallback callback) { m_updateCallback = std
 
 void Widget::setRedrawCallback(RedrawCallback callback) { m_redrawCallback = std::move(callback); }
 
+float Widget::iconTextSpacing() const noexcept {
+  if (m_localIconSpacing.has_value()) {
+    return *m_localIconSpacing * m_contentScale;
+  }
+  if (m_widgetIconSpacing.has_value()) {
+    return *m_widgetIconSpacing * m_contentScale;
+  }
+  return Style::spaceXs * m_contentScale;
+}
+
 void Widget::setFrameTickRequestCallback(FrameTickRequestCallback callback) {
   m_frameTickRequestCallback = std::move(callback);
 }

--- a/src/shell/bar/widget.h
+++ b/src/shell/bar/widget.h
@@ -66,6 +66,8 @@ public:
   void setPanelToggleCallback(PanelToggleCallback callback);
   void setContentScale(float scale) noexcept { m_contentScale = scale; }
   [[nodiscard]] float contentScale() const noexcept { return m_contentScale; }
+  void setWidgetIconSpacing(std::optional<float> spacing) noexcept { m_widgetIconSpacing = spacing; }
+  [[nodiscard]] float iconTextSpacing() const noexcept;
   void setLabelFontWeight(FontWeight fontWeight) noexcept { m_labelFontWeight = fontWeight; }
   [[nodiscard]] FontWeight labelFontWeight() const noexcept { return m_labelFontWeight; }
   void setLabelFontFamily(std::string family) noexcept { m_labelFontFamily = std::move(family); }
@@ -91,6 +93,8 @@ public:
   // Outermost node for flex layout / anchor alignment (capsule shell when enabled).
   [[nodiscard]] Node* layoutBoundsNode() const noexcept { return m_capsuleShell != nullptr ? m_capsuleShell : root(); }
   [[nodiscard]] float resolvedBarCapsuleRadius(float width, float height) const noexcept;
+  
+  void setLocalIconSpacing(std::optional<float> spacing) noexcept { m_localIconSpacing = spacing; }
 
   // Whether the bar should paint the decorative capsule for this frame (spec enabled + visible ink).
   [[nodiscard]] virtual bool shouldShowBarCapsule() const;
@@ -128,6 +132,8 @@ protected:
   WidgetBarCapsuleSpec m_barCapsuleSpec{};
   std::optional<ColorSpec> m_widgetForeground;
   std::optional<ColorSpec> m_widgetIconColor;
+  std::optional<float> m_localIconSpacing;
+  std::optional<float> m_widgetIconSpacing;
   bool m_nonInteractive = false;
   Node* m_capsuleShell = nullptr;
   Box* m_capsuleBox = nullptr;

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -119,7 +119,7 @@ WidgetFactory::~WidgetFactory() = default;
 
 std::unique_ptr<Widget> WidgetFactory::create(
     const std::string& name, wl_output* output, float contentScale, const std::string& barPosition,
-    const std::string& barName, float widgetSpacing
+    const std::string& barName, float widgetSpacing, bool shadowEnabled
 ) const {
   // Resolve: if name matches a [widget.<name>] entry, use its type + settings.
   // Otherwise treat the name itself as the widget type with default settings.
@@ -268,6 +268,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .scrollDownCommand = trimSetting("scroll_down_command"),
         .customImage = customImageFor(wc),
     });
+    if (wc != nullptr && wc->hasSetting("icon_spacing")) {
+      widget->setLocalIconSpacing(static_cast<float>(wc->getInt("icon_spacing", 6)));
+    }
     widget->setContentScale(contentScale);
     return widget;
   }
@@ -346,7 +349,32 @@ std::unique_ptr<Widget> WidgetFactory::create(
   if (type == "network") {
     const bool showLabel = wc != nullptr ? wc->getBool("show_label", true) : true;
     const bool showVpnLabel = wc != nullptr ? wc->getBool("show_vpn_label", false) : false;
-    auto widget = std::make_unique<NetworkWidget>(m_network, m_sysmon, output, showLabel, showVpnLabel);
+    const bool wifiShowStrength = wc != nullptr ? wc->getBool("wifi_show_strength", false) : false;
+
+    WidgetCustomImage wifiImg;
+    std::string wifiGlyph;
+    if (wc != nullptr) {
+      wifiImg.path = wc->getString("wifi_custom_image");
+      wifiImg.colorize = wc->getBool("wifi_custom_image_colorize", false);
+      wifiGlyph = wc->getString("wifi_glyph");
+    }
+    
+    WidgetCustomImage ethImg;
+    std::string ethGlyph;
+    if (wc != nullptr) {
+      ethImg.path = wc->getString("ethernet_custom_image");
+      ethImg.colorize = wc->getBool("ethernet_custom_image_colorize", false);
+      ethGlyph = wc->getString("ethernet_glyph");
+    }
+
+    const float labelSpacing = static_cast<float>(wc != nullptr ? wc->getInt("label_spacing", 4) : 4);
+    auto widget = std::make_unique<NetworkWidget>(
+        m_network, m_sysmon, output, showLabel, showVpnLabel, wifiShowStrength, labelSpacing,
+        wifiGlyph, wifiImg, ethGlyph, ethImg
+    );
+    if (wc != nullptr && wc->hasSetting("icon_spacing")) {
+      widget->setLocalIconSpacing(static_cast<float>(wc->getInt("icon_spacing", 6)));
+    }
     widget->setContentScale(contentScale);
     return widget;
   }
@@ -434,7 +462,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     }
     auto widget = std::make_unique<ScreenshotWidget>(
         output, std::move(barGlyph), *m_screenshots, m_configService, m_platform, *m_renderContext,
-        m_configService.config().shell.shadow, barPosition, customImageFor(wc)
+        m_configService.config().shell.shadow, shadowEnabled, barPosition, customImageFor(wc)
     );
     widget->setContentScale(contentScale);
     return widget;
@@ -528,6 +556,9 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .customImage = customImageFor(wc),
     };
     auto widget = std::make_unique<SysmonWidget>(m_sysmon, m_configService, std::move(options));
+    if (wc != nullptr && wc->hasSetting("icon_spacing")) {
+      widget->setLocalIconSpacing(static_cast<float>(wc->getInt("icon_spacing", 6)));
+    }
     widget->setContentScale(contentScale);
     return widget;
   }
@@ -608,6 +639,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         ),
         .inlineEntryGap = widgetSpacing,
         .matchAdjacentSpacing = wc != nullptr ? wc->getBool("match_adjacent_spacing", false) : false,
+        .widgetSpacing = static_cast<float>(wc != nullptr ? wc->getDouble("spacing", 4.0) : 4.0),
     };
     auto widget = std::make_unique<TrayWidget>(m_configService, m_tray, std::move(options));
     widget->setContentScale(contentScale);
@@ -690,6 +722,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .activePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("active_pill_size", 2.2) : 2.2),
         .inactivePillSize = static_cast<float>(wc != nullptr ? wc->getDouble("inactive_pill_size", 1.0) : 1.0),
         .minimal = workspaceStyle == "minimal",
+        .minimalSpacing = static_cast<float>(wc != nullptr ? wc->getDouble("minimal_spacing", 4.0) : 4.0),
+        .minimalHoverHighlight = wc != nullptr ? wc->getBool("minimal_hover_highlight", true) : true,
         .focusedPill = workspaceStyle == "focus_hint",
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
     };

--- a/src/shell/bar/widget_factory.h
+++ b/src/shell/bar/widget_factory.h
@@ -44,8 +44,8 @@ public:
   ~WidgetFactory();
 
   [[nodiscard]] std::unique_ptr<Widget> create(
-      const std::string& name, wl_output* output, float contentScale = 1.0f, const std::string& barPosition = "top",
-      const std::string& barName = "default", float widgetSpacing = 6.0f
+      const std::string& name, wl_output* output, float contentScale, const std::string& barPosition,
+      const std::string& barName, float widgetSpacing, bool shadowEnabled
   ) const;
 
 private:

--- a/src/shell/bar/widgets/active_window_widget.cpp
+++ b/src/shell/bar/widgets/active_window_widget.cpp
@@ -103,7 +103,7 @@ void ActiveWindowWidget::doLayout(Renderer& renderer, float containerWidth, floa
     m_icon->setVisible(showIcon);
     m_title->setVisible(showTitle);
     applyTitleScrollMode(showTitle);
-    const float spacing = showIcon && showTitle ? Style::spaceXs : 0.0f;
+    const float spacing = showIcon && showTitle ? iconTextSpacing() : 0.0f;
     const float iconWidth = showIcon ? m_icon->width() : 0.0f;
     const float labelMaxWidth = showTitle ? std::max(0.0f, maxLength - iconWidth - spacing) : 0.0f;
     m_title->setMaxWidth(labelMaxWidth);

--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -155,7 +155,7 @@ void BatteryWidget::layoutGraphicMode(Renderer& renderer) {
   const float termW = std::round(kGraphicTerminalWidth * scale);
   const float termH = std::round(kGraphicTerminalHeight * scale);
   const float cornerR = std::round(kGraphicCornerRadius * scale);
-  const float labelGap = Style::spaceXs * m_contentScale;
+  const float labelGap = iconTextSpacing();
   const float stateGap = std::round(Style::spaceXs * 0.5f * m_contentScale);
   const bool showLabel = m_overlayLabel != nullptr && m_showLabel;
   const bool showStateGlyph = m_overlayGlyph != nullptr && m_overlayGlyph->visible();
@@ -266,7 +266,7 @@ void BatteryWidget::layoutGlyphMode(Renderer& renderer, float /*containerWidth*/
     } else {
       const float h = std::max(m_glyph->height(), m_label->height());
       m_glyph->setPosition(0.0f, std::round((h - m_glyph->height()) * 0.5f));
-      m_label->setPosition(m_glyph->width() + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
+      m_label->setPosition(m_glyph->width() + iconTextSpacing(), std::round((h - m_label->height()) * 0.5f));
       rootNode->setSize(m_label->x() + m_label->width(), h);
     }
   } else {

--- a/src/shell/bar/widgets/bluetooth_widget.cpp
+++ b/src/shell/bar/widgets/bluetooth_widget.cpp
@@ -103,7 +103,7 @@ void BluetoothWidget::doLayout(Renderer& renderer, float /*containerWidth*/, flo
     m_label->measure(renderer);
     if (m_label->width() > 0.0f) {
       contentHeight = std::max(contentHeight, m_label->height());
-      m_label->setPosition(m_glyph->width() + Style::spaceXs, std::round((contentHeight - m_label->height()) * 0.5f));
+      m_label->setPosition(m_glyph->width() + iconTextSpacing(), std::round((contentHeight - m_label->height()) * 0.5f));
       totalWidth = m_label->x() + m_label->width();
     }
   }

--- a/src/shell/bar/widgets/brightness_widget.cpp
+++ b/src/shell/bar/widgets/brightness_widget.cpp
@@ -98,7 +98,7 @@ void BrightnessWidget::doLayout(Renderer& renderer, float containerWidth, float 
     m_glyph->setPosition(0.0f, std::round((h - m_glyph->height()) * 0.5f));
     float totalWidth = m_glyph->width();
     if (labelVisible) {
-      m_label->setPosition(m_glyph->width() + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
+      m_label->setPosition(m_glyph->width() + iconTextSpacing(), std::round((h - m_label->height()) * 0.5f));
       totalWidth = m_label->x() + m_label->width();
     }
     rootNode->setSize(totalWidth, h);

--- a/src/shell/bar/widgets/custom_button_widget.cpp
+++ b/src/shell/bar/widgets/custom_button_widget.cpp
@@ -131,7 +131,8 @@ void CustomButtonWidget::doLayout(Renderer& renderer, float containerWidth, floa
   const bool showGlyph = !showImage && m_glyph != nullptr && !m_glyphName.empty();
   const bool showIcon = showImage || showGlyph;
   const bool showLabel = !m_labelText.empty();
-  const float spacing = (showIcon && showLabel) ? Style::spaceXs * m_contentScale : 0.0f;
+  const float spacing = (showIcon && showLabel) ? iconTextSpacing() : 0.0f;
+  const float padding = (showIcon && !showLabel) ? std::round(iconTextSpacing() / 2.0f) : 0.0f;
 
   if (m_glyph != nullptr) {
     m_glyph->setVisible(showGlyph);
@@ -173,9 +174,11 @@ void CustomButtonWidget::doLayout(Renderer& renderer, float containerWidth, floa
       }
       width = std::max(width, m_label->width());
       height += m_label->height();
+    } else {
+      height += padding * 2.0f;
     }
 
-    float y = 0.0f;
+    float y = padding;
     if (showImage) {
       m_image->setPosition(std::round((width - m_image->width()) * 0.5f), y);
       y += m_image->height() + spacing;
@@ -205,9 +208,11 @@ void CustomButtonWidget::doLayout(Renderer& renderer, float containerWidth, floa
     }
     width += m_label->width();
     height = std::max(height, m_label->height());
+  } else {
+    width += padding * 2.0f;
   }
 
-  float x = 0.0f;
+  float x = padding;
   if (showImage) {
     m_image->setPosition(x, std::round((height - m_image->height()) * 0.5f));
     x += m_image->width() + spacing;

--- a/src/shell/bar/widgets/debug_indicator_widget.cpp
+++ b/src/shell/bar/widgets/debug_indicator_widget.cpp
@@ -15,7 +15,7 @@ void DebugIndicatorWidget::create() {
       {
           .out = &m_container,
           .align = FlexAlign::Center,
-          .gap = Style::spaceXs * m_contentScale,
+          .gap = iconTextSpacing() * m_contentScale,
       },
       ui::glyph({
           .out = &m_glyph,
@@ -42,7 +42,7 @@ void DebugIndicatorWidget::doLayout(Renderer& renderer, float containerWidth, fl
   }
 
   const bool isVertical = containerHeight > containerWidth;
-  m_container->setGap(Style::spaceXs * m_contentScale);
+  m_container->setGap(iconTextSpacing() * m_contentScale);
   m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
   m_glyph->setColor(colorSpecFromRole(ColorRole::Error));
   m_label->setVisible(!isVertical);

--- a/src/shell/bar/widgets/keyboard_layout_widget.cpp
+++ b/src/shell/bar/widgets/keyboard_layout_widget.cpp
@@ -419,7 +419,7 @@ void KeyboardLayoutWidget::doLayout(Renderer& renderer, float containerWidth, fl
     }
     root()->setSize(w, y);
   } else {
-    const float spacing = Style::spaceXs;
+    const float spacing = iconTextSpacing() * m_contentScale;
     float x = 0.0f;
     const float iconH = showIcon ? (m_image != nullptr ? m_image->height() : m_glyph->height()) : 0.0f;
     const float labelH = m_showLabel ? m_label->height() : 0.0f;

--- a/src/shell/bar/widgets/lock_keys_widget.cpp
+++ b/src/shell/bar/widgets/lock_keys_widget.cpp
@@ -89,8 +89,7 @@ void LockKeysWidget::doLayout(Renderer& renderer, float containerWidth, float co
     return;
   }
 
-  constexpr float kSpacing = Style::spaceXs;
-  const float spacing = kSpacing * m_contentScale;
+  const float spacing = iconTextSpacing() * m_contentScale;
   float x = 0.0f;
   float y = 0.0f;
   float h = 0.0f;

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -136,7 +136,7 @@ void MediaWidget::doLayout(Renderer& renderer, float containerWidth, float conta
   applyTitleScrollMode(showLabel);
 
   const float leadingWidth = showArtSlot ? artSize : (showEmptyGlyph ? m_emptyGlyph->width() : 0.0f);
-  const float spacing = showLabel && leadingWidth > 0.0f ? Style::spaceXs : 0.0f;
+  const float spacing = showLabel && leadingWidth > 0.0f ? iconTextSpacing() : 0.0f;
   const float labelMaxWidth = showLabel ? std::max(0.0f, maxLength - leadingWidth - spacing) : 0.0f;
   m_label->setMaxWidth(labelMaxWidth);
   m_label->measure(renderer);

--- a/src/shell/bar/widgets/network_widget.cpp
+++ b/src/shell/bar/widgets/network_widget.cpp
@@ -9,6 +9,8 @@
 #include "ui/builders.h"
 #include "ui/palette.h"
 #include "ui/style.h"
+#include "ui/controls/image.h"
+#include "shell/bar/widget_custom_image.h"
 
 #include <chrono>
 #include <linux/input-event-codes.h>
@@ -58,9 +60,13 @@ namespace {
 } // namespace
 
 NetworkWidget::NetworkWidget(
-    INetworkService* network, SystemMonitorService* monitor, wl_output* /*output*/, bool showLabel, bool showVpnLabel
+    INetworkService* network, SystemMonitorService* monitor, wl_output* /*output*/, bool showLabel, bool showVpnLabel,
+    bool wifiShowStrength, float labelSpacing, std::string wifiGlyphId, WidgetCustomImage wifiCustomImage,
+    std::string ethernetGlyphId, WidgetCustomImage ethernetCustomImage
 )
-    : m_network(network), m_monitor(monitor), m_showLabel(showLabel), m_showVpnLabel(showVpnLabel) {}
+    : m_network(network), m_monitor(monitor), m_showLabel(showLabel), m_showVpnLabel(showVpnLabel),
+      m_wifiShowStrength(wifiShowStrength), m_labelSpacing(labelSpacing), m_wifiGlyphId(std::move(wifiGlyphId)), m_wifiCustomImage(std::move(wifiCustomImage)),
+      m_ethernetGlyphId(std::move(ethernetGlyphId)), m_ethernetCustomImage(std::move(ethernetCustomImage)) {}
 
 void NetworkWidget::create() {
   auto area = std::make_unique<InputArea>();
@@ -105,6 +111,9 @@ void NetworkWidget::create() {
       kTooltipRefreshInterval
   );
 
+  if (m_wifiCustomImage.enabled() || m_ethernetCustomImage.enabled()) {
+    area->addChild(ui::image({.out = &m_image, .fit = ImageFit::Contain}));
+  }
   area->addChild(
       ui::glyph({
           .out = &m_glyph,
@@ -135,49 +144,93 @@ void NetworkWidget::create() {
           .fontFamily = labelFontFamily(),
       })
   );
+  
+  area->addChild(
+      ui::label({
+          .out = &m_strengthLabel,
+          .fontSize = Style::fontSizeBody * m_contentScale,
+          .fontWeight = labelFontWeight(),
+          .fontFamily = labelFontFamily(),
+          .visible = false,
+      })
+  );
 
   setRoot(std::move(area));
 }
 
 void NetworkWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {
   auto* rootNode = root();
-  if (m_glyph == nullptr || rootNode == nullptr) {
+  if ((m_glyph == nullptr && m_image == nullptr) || rootNode == nullptr) {
     return;
   }
   m_isVertical = containerHeight > containerWidth;
   syncState(renderer);
 
-  m_glyph->measure(renderer);
+  if (m_glyph != nullptr && m_glyph->visible()) {
+    m_glyph->measure(renderer);
+  } else if (m_image != nullptr && m_image->visible()) {
+    // Image sizing is handled by sync
+  }
+
   if (m_label != nullptr) {
     m_label->measure(renderer);
   }
+  if (m_strengthLabel != nullptr) {
+    m_strengthLabel->measure(renderer);
+  }
 
   // Glyph and spinner share one slot; only one is visible.
-  Node* icon =
-      (m_spinner != nullptr && m_spinner->visible()) ? static_cast<Node*>(m_spinner) : static_cast<Node*>(m_glyph);
+  Node* icon = nullptr;
+  if (m_spinner != nullptr && m_spinner->visible()) {
+    icon = static_cast<Node*>(m_spinner);
+  } else if (m_glyph != nullptr && m_glyph->visible()) {
+    icon = static_cast<Node*>(m_glyph);
+  } else if (m_image != nullptr && m_image->visible()) {
+    icon = static_cast<Node*>(m_image);
+  }
+
+  if (icon == nullptr) {
+    return;
+  }
 
   const bool labelVisible = m_label != nullptr && m_label->width() > 0.0f && m_label->visible();
-  if (m_isVertical && labelVisible) {
-    const float w = std::max(icon->width(), m_label->width());
+  const bool strengthVisible = m_strengthLabel != nullptr && m_strengthLabel->width() > 0.0f && m_strengthLabel->visible();
+
+  if (m_isVertical && (labelVisible || strengthVisible)) {
+    // In vertical layout we only show the main label. If strength is the only thing, we show it.
+    Label* visibleLabel = labelVisible ? m_label : m_strengthLabel;
+    const float w = std::max(icon->width(), visibleLabel->width());
     icon->setPosition(std::round((w - icon->width()) * 0.5f), 0.0f);
-    m_label->setPosition(std::round((w - m_label->width()) * 0.5f), icon->height());
-    rootNode->setSize(w, icon->height() + m_label->height());
+    visibleLabel->setPosition(std::round((w - visibleLabel->width()) * 0.5f), icon->height());
+    rootNode->setSize(w, icon->height() + visibleLabel->height());
   } else {
-    const float h = labelVisible ? std::max(icon->height(), m_label->height()) : icon->height();
-    icon->setPosition(0.0f, std::round((h - icon->height()) * 0.5f));
-    float totalWidth = icon->width();
+    float maxH = icon->height();
+    if (labelVisible) maxH = std::max(maxH, m_label->height());
+    if (strengthVisible) maxH = std::max(maxH, m_strengthLabel->height());
+    
+    icon->setPosition(0.0f, std::round((maxH - icon->height()) * 0.5f));
+    float currentX = icon->width();
+    
     if (labelVisible) {
-      m_label->setPosition(icon->width() + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
-      totalWidth = m_label->x() + m_label->width();
+      currentX += iconTextSpacing() * m_contentScale;
+      m_label->setPosition(currentX, std::round((maxH - m_label->height()) * 0.5f));
+      currentX += m_label->width();
     }
-    rootNode->setSize(totalWidth, h);
+    
+    if (strengthVisible) {
+      currentX += (labelVisible ? m_labelSpacing : iconTextSpacing()) * m_contentScale;
+      m_strengthLabel->setPosition(currentX, std::round((maxH - m_strengthLabel->height()) * 0.5f));
+      currentX += m_strengthLabel->width();
+    }
+    
+    rootNode->setSize(currentX, maxH);
   }
 }
 
 void NetworkWidget::doUpdate(Renderer& renderer) { syncState(renderer); }
 
 void NetworkWidget::syncState(Renderer& renderer) {
-  if (m_glyph == nullptr || m_network == nullptr) {
+  if ((m_glyph == nullptr && m_image == nullptr) || m_network == nullptr) {
     return;
   }
 
@@ -190,12 +243,39 @@ void NetworkWidget::syncState(Renderer& renderer) {
   m_lastVertical = m_isVertical;
 
   const bool showSpinner = s.kind == NetworkConnectivity::Wired && s.resolving;
+  const bool isWifi = s.kind == NetworkConnectivity::Wireless;
+  const bool isEth = s.kind == NetworkConnectivity::Wired;
+  
+  WidgetCustomImage currentCustomImage;
+  std::string currentGlyphId;
+  if (isWifi) {
+    currentCustomImage = m_wifiCustomImage;
+    currentGlyphId = m_wifiGlyphId;
+  } else if (isEth) {
+    currentCustomImage = m_ethernetCustomImage;
+    currentGlyphId = m_ethernetGlyphId;
+  }
 
-  m_glyph->setVisible(!showSpinner);
-  m_glyph->setGlyph(network_glyphs::glyphForState(s));
-  m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
-  m_glyph->setColor(widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
-  m_glyph->measure(renderer);
+  if (currentCustomImage.enabled()) {
+    if (m_glyph != nullptr) {
+      m_glyph->setVisible(false);
+    }
+    if (m_image != nullptr) {
+      m_image->setVisible(!showSpinner);
+      widget_custom_image::sync(*m_image, renderer, currentCustomImage, m_contentScale, widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
+    }
+  } else {
+    if (m_image != nullptr) {
+      m_image->setVisible(false);
+    }
+    if (m_glyph != nullptr) {
+      m_glyph->setVisible(!showSpinner);
+      m_glyph->setGlyph(!currentGlyphId.empty() ? currentGlyphId : network_glyphs::glyphForState(s));
+      m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
+      m_glyph->setColor(widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
+      m_glyph->measure(renderer);
+    }
+  }
 
   if (m_spinner != nullptr) {
     m_spinner->setVisible(showSpinner);
@@ -207,10 +287,13 @@ void NetworkWidget::syncState(Renderer& renderer) {
     }
   }
 
-  if (m_label != nullptr) {
-    const bool showLabel = m_showLabel;
-    m_label->setVisible(showLabel);
-    if (showLabel) {
+  if (m_label != nullptr && m_strengthLabel != nullptr) {
+    const bool showStrengthText = m_wifiShowStrength && s.kind == NetworkConnectivity::Wireless && s.connected;
+    
+    m_label->setVisible(m_showLabel);
+    m_strengthLabel->setVisible(showStrengthText);
+    
+    if (m_showLabel) {
       std::string text = labelForState(s);
       if (m_showVpnLabel && s.vpnActive) {
         if (std::string vpnName = firstActiveVpnName(m_network->vpnConnections()); !vpnName.empty()) {
@@ -224,6 +307,17 @@ void NetworkWidget::syncState(Renderer& renderer) {
       m_label->setText(text);
       m_label->setColor(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
       m_label->measure(renderer);
+    }
+    
+    if (showStrengthText) {
+      std::string text = std::to_string(s.signalStrength) + "%";
+      if (m_isVertical && text.size() > 3) {
+        text = text.substr(0, 3);
+      }
+      m_strengthLabel->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
+      m_strengthLabel->setText(text);
+      m_strengthLabel->setColor(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
+      m_strengthLabel->measure(renderer);
     }
   }
 

--- a/src/shell/bar/widgets/network_widget.h
+++ b/src/shell/bar/widgets/network_widget.h
@@ -3,11 +3,12 @@
 #include "dbus/network/inetwork_service.h"
 #include "shell/bar/widget.h"
 #include "shell/tooltip/tooltip_content.h"
-
+#include "shell/bar/widget_custom_image.h"
 #include <string>
 #include <vector>
 
 class Glyph;
+class Image;
 class Label;
 class Spinner;
 class SystemMonitorService;
@@ -16,7 +17,9 @@ struct wl_output;
 class NetworkWidget : public Widget {
 public:
   NetworkWidget(
-      INetworkService* network, SystemMonitorService* monitor, wl_output* output, bool showLabel, bool showVpnLabel
+      INetworkService* network, SystemMonitorService* monitor, wl_output* output, bool showLabel, bool showVpnLabel,
+      bool wifiShowStrength, float labelSpacing, std::string wifiGlyphId, WidgetCustomImage wifiCustomImage,
+      std::string ethernetGlyphId, WidgetCustomImage ethernetCustomImage
   );
 
   void create() override;
@@ -31,9 +34,17 @@ private:
   SystemMonitorService* m_monitor = nullptr;
   bool m_showLabel = true;
   bool m_showVpnLabel = false;
+  bool m_wifiShowStrength = false;
+  float m_labelSpacing = 4.0f;
+  std::string m_wifiGlyphId;
+  WidgetCustomImage m_wifiCustomImage;
+  std::string m_ethernetGlyphId;
+  WidgetCustomImage m_ethernetCustomImage;
   Glyph* m_glyph = nullptr;
+  Image* m_image = nullptr;
   Spinner* m_spinner = nullptr;
   Label* m_label = nullptr;
+  Label* m_strengthLabel = nullptr;
   NetworkState m_lastState;
   bool m_haveLastState = false;
   bool m_isVertical = false;

--- a/src/shell/bar/widgets/plugin_widget.cpp
+++ b/src/shell/bar/widgets/plugin_widget.cpp
@@ -193,7 +193,7 @@ void PluginWidget::create() {
   auto flex = ui::row({
       .out = &m_flex,
       .align = FlexAlign::Center,
-      .gap = Style::spaceXs,
+      .gap = iconTextSpacing() * m_contentScale,
   });
 
   flex->addChild(

--- a/src/shell/bar/widgets/screenshot_widget.cpp
+++ b/src/shell/bar/widgets/screenshot_widget.cpp
@@ -111,10 +111,10 @@ namespace {
 ScreenshotWidget::ScreenshotWidget(
     wl_output* output, std::string barGlyphId, ScreenshotService& screenshots, ConfigService& configService,
     CompositorPlatform& platform, RenderContext& renderContext, const ShellConfig::ShadowConfig& shadow,
-    std::string barPosition, WidgetCustomImage customImage
+    bool shadowEnabled, std::string barPosition, WidgetCustomImage customImage
 )
     : m_barGlyphId(std::move(barGlyphId)), m_output(output), m_screenshots(screenshots), m_configService(configService),
-      m_platform(platform), m_renderContext(renderContext), m_shadowConfig(shadow),
+      m_platform(platform), m_renderContext(renderContext), m_shadowConfig(shadow), m_shadowEnabled(shadowEnabled),
       m_barPosition(std::move(barPosition)), m_customImage(std::move(customImage)) {}
 
 ScreenshotWidget::~ScreenshotWidget() = default;
@@ -242,7 +242,7 @@ void ScreenshotWidget::openCaptureMenu() {
   if (m_menuPopup == nullptr) {
     m_menuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), m_renderContext);
   }
-  m_menuPopup->setShadowConfig(m_shadowConfig);
+  m_menuPopup->setShadowConfig(m_shadowConfig, m_shadowEnabled);
   const auto options = outputOptions();
   m_menuPopup->setOnActivate([this, options](const ContextMenuControlEntry& entry) {
     if (entry.id == 1) {

--- a/src/shell/bar/widgets/screenshot_widget.h
+++ b/src/shell/bar/widgets/screenshot_widget.h
@@ -22,7 +22,7 @@ public:
   ScreenshotWidget(
       wl_output* output, std::string barGlyphId, ScreenshotService& screenshots, ConfigService& configService,
       CompositorPlatform& platform, RenderContext& renderContext, const ShellConfig::ShadowConfig& shadow,
-      std::string barPosition = "top", WidgetCustomImage customImage = {}
+      bool shadowEnabled, std::string barPosition = "top", WidgetCustomImage customImage = {}
   );
   ~ScreenshotWidget() override;
 
@@ -43,6 +43,7 @@ private:
   CompositorPlatform& m_platform;
   RenderContext& m_renderContext;
   ShellConfig::ShadowConfig m_shadowConfig;
+  bool m_shadowEnabled = true;
   std::string m_barPosition;
   WidgetCustomImage m_customImage;
   Glyph* m_glyph = nullptr;

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -461,7 +461,7 @@ void SysmonWidget::doLayout(Renderer& renderer, float containerWidth, float cont
   syncIcon(renderer);
   const float iconW = iconWidth();
   const float iconH = iconHeight();
-  const float gap = Style::spaceXs * m_contentScale;
+  const float gap = iconTextSpacing() * m_contentScale;
   const bool verticalBar = m_isVerticalBar;
 
   if (m_label != nullptr) {

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -422,7 +422,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   // If the title text is too narrow, all it shows is "..." which isn't useful, so we hide it instead.
   const auto metric = renderer.measureText("...", Style::fontSizeCaption * m_contentScale, fontWeight);
   const float minWindowTitleWidth = (metric.right - metric.left) * 2;
-  const float windowTitleGap = Style::spaceXs * m_contentScale;
+  const float windowTitleGap = iconTextSpacing();
   const float windowTitleWidth =
       std::min(m_windowTitleMaxWidth * m_contentScale, std::max(0.0f, maxTileWidth - tileSize - windowTitleGap));
   const bool showWindowTitle = m_showWindowTitle && windowTitleWidth > minWindowTitleWidth;
@@ -1955,7 +1955,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
   if (m_contextMenuPopup == nullptr) {
     m_contextMenuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), *renderContext);
   }
-  m_contextMenuPopup->setShadowConfig(m_shadowConfig);
+  m_contextMenuPopup->setShadowConfig(m_shadowConfig, m_configOptions.shadowEnabled);
   m_contextMenuPopup->setOnActivate([this, entryActions, entryAppName, entryWorkingDir,
                                      entryTerminal](const ContextMenuControlEntry& entry) {
     if (entry.id >= 0) {

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -49,6 +49,7 @@ struct TaskbarWidgetOptions {
   std::string barPosition;
   std::string barName;
   ShellConfig::ShadowConfig shadowConfig;
+  bool shadowEnabled = true;
 };
 
 class TaskbarWidget : public Widget {

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -171,6 +171,7 @@ TrayWidget::TrayWidget(ConfigService& config, TrayService* tray, TrayWidgetOptio
       m_panelGridMode(options.panelGridMode),
       m_panelGridColumns(std::clamp<std::size_t>(options.panelGridColumns, 1U, 5U)),
       m_inlineEntryGap(std::max(0.0f, options.inlineEntryGap)), m_matchAdjacentSpacing(options.matchAdjacentSpacing),
+      m_widgetSpacing(std::max(0.0f, options.widgetSpacing)),
       m_customItemSize(options.customItemSize) {
   auto normalizeTokens = [](std::vector<std::string>& tokens) {
     std::vector<std::string> normalized;
@@ -234,7 +235,7 @@ std::string TrayWidget::resolveFromTrayThemePath(std::string_view themePath, std
 
 float TrayWidget::resolvedInlineEntryGap() const {
   if (!m_matchAdjacentSpacing) {
-    return m_inlineEntryGap;
+    return m_widgetSpacing * m_contentScale;
   }
   const auto& cap = barCapsuleSpec();
   const float pad = cap.enabled ? cap.padding * m_contentScale : 0.0f;

--- a/src/shell/bar/widgets/tray_widget.h
+++ b/src/shell/bar/widgets/tray_widget.h
@@ -29,6 +29,7 @@ struct TrayWidgetOptions {
   std::size_t panelGridColumns = 3;
   float inlineEntryGap = Style::spaceXs;
   bool matchAdjacentSpacing = false;
+  float widgetSpacing = 4.0f;
   std::optional<float> customItemSize;
 };
 
@@ -82,6 +83,7 @@ private:
   std::size_t m_panelGridColumns = 3;
   float m_inlineEntryGap = Style::spaceXs;
   bool m_matchAdjacentSpacing = false;
+  float m_widgetSpacing = 4.0f;
   std::optional<float> m_customItemSize;
   bool m_appIconColorizeDirty = false;
 

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -132,7 +132,7 @@ void VolumeWidget::doLayout(Renderer& renderer, float containerWidth, float cont
     }
     float totalWidth = iconW;
     if (labelVisible) {
-      m_label->setPosition(iconW + Style::spaceXs, std::round((h - m_label->height()) * 0.5f));
+      m_label->setPosition(iconW + iconTextSpacing(), std::round((h - m_label->height()) * 0.5f));
       totalWidth = m_label->x() + m_label->width();
     }
     rootNode->setSize(totalWidth, h);

--- a/src/shell/bar/widgets/weather_widget.cpp
+++ b/src/shell/bar/widgets/weather_widget.cpp
@@ -61,7 +61,7 @@ void WeatherWidget::doLayout(Renderer& renderer, float containerWidth, float con
   m_label->setColor(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)));
   m_label->measure(renderer);
 
-  const float spacing = m_label->text().empty() ? 0.0f : (Style::spaceXs * m_contentScale);
+  const float spacing = m_label->text().empty() ? 0.0f : iconTextSpacing();
   if (m_isVertical) {
     const float contentWidth = std::max(m_glyph->width(), m_label->width());
     m_glyph->setPosition(std::round((contentWidth - m_glyph->width()) * 0.5f), 0.0f);

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -77,6 +77,7 @@ WorkspacesWidget::WorkspacesWidget(
       m_hideWhenEmpty(options.hideWhenEmpty), m_pillScale(options.pillScale),
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
+      m_minimalSpacing(options.minimalSpacing), m_minimalHoverHighlight(options.minimalHoverHighlight),
       m_focusedPill(options.focusedPill), m_focusedOutputOnly(options.focusedOutputOnly),
       m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor) {
   buildDesktopIconIndex();
@@ -427,7 +428,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
   }
 
   const float gap = kWorkspaceGap * m_contentScale;
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = m_minimal ? (Style::fontSizeBody * m_contentScale) : Style::fontSizeMini * m_contentScale;
   const float pillHeight = std::round(kWorkspacePillDefaultHeight * m_contentScale * m_pillScale);
   const FontWeight configuredFontWeight = labelFontWeight();
 
@@ -454,7 +455,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
   }
 
   const float baseSize = std::round(pillHeight);
-  const float padding = m_minimal ? (Style::spaceXs * m_contentScale) : (baseSize * 0.6f);
+  const float padding = m_minimal ? (m_minimalSpacing * m_contentScale) : (baseSize * 0.6f);
   float maxLabelHeight = labelFontSize;
 
   for (std::size_t i = 0; i < entries.size(); ++i) {
@@ -591,6 +592,10 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
       setWorkspaceClickHandler(*area, ws);
 
       area->setOnEnter([this, areaPtr](const InputArea::PointerData&) {
+        if (m_minimal && !m_minimalHoverHighlight) {
+          return;
+        }
+
         const auto itemIt = std::ranges::find(m_items, areaPtr, &Item::area);
         if (itemIt == m_items.end() || itemIt->exiting) {
           return;
@@ -625,6 +630,10 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
       });
 
       area->setOnLeave([this, areaPtr]() {
+        if (m_minimal && !m_minimalHoverHighlight) {
+          return;
+        }
+
         if (m_hoveredArea != areaPtr) {
           return;
         }
@@ -792,7 +801,7 @@ void WorkspacesWidget::ensureItemLabel(Renderer& renderer, Item& item, const Wor
     return;
   }
 
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = m_minimal ? (Style::fontSizeBody * m_contentScale) : Style::fontSizeMini * m_contentScale;
   item.text = static_cast<Label*>(item.area->addChild(
       ui::label({
           .text = item.label,
@@ -810,10 +819,10 @@ void WorkspacesWidget::recalculateItemMetrics(
     Renderer& renderer, Item& item, const Workspace& workspace, std::size_t displayIndex
 ) {
   const std::string label = workspaceLabel(workspace, displayIndex);
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = m_minimal ? (Style::fontSizeBody * m_contentScale) : Style::fontSizeMini * m_contentScale;
   const float pillHeight = std::round(kWorkspacePillDefaultHeight * m_contentScale * m_pillScale);
   const float baseSize = std::round(pillHeight);
-  const float padding = m_minimal ? (Style::spaceXs * m_contentScale) : (baseSize * 0.6f);
+  const float padding = m_minimal ? (m_minimalSpacing * m_contentScale) : (baseSize * 0.6f);
   const FontWeight configuredFontWeight = labelFontWeight();
 
   item.label = label;
@@ -1123,7 +1132,7 @@ void WorkspacesWidget::applyItemLayout(Item& it) {
   }
 
   const float iconSize = focusedPillIconSize();
-  const float iconGap = Style::spaceXs * m_contentScale;
+  const float iconGap = iconTextSpacing();
 
   if (m_isVertical) {
     const float textHeight = showText ? it.text->height() : 0.0f;
@@ -1283,7 +1292,7 @@ float WorkspacesWidget::focusedPillDotSize() const noexcept {
 float WorkspacesWidget::focusedPillActiveMainAxisSize(
     float textWidth, float textHeight, bool showLabel, bool hasIcon, float baseSize, float padding
 ) const noexcept {
-  const float iconGap = Style::spaceXs * m_contentScale;
+  const float iconGap = iconTextSpacing();
   const float iconReserve = hasIcon ? focusedPillIconSize() + iconGap : 0.0f;
   const float minActive = workspaceMainAxisMinWidth(baseSize, true);
   if (!showLabel && iconReserve <= 0.0f) {

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -40,6 +40,8 @@ public:
     float activePillSize = 2.2f;
     float inactivePillSize = 1.0f;
     bool minimal = false;
+    float minimalSpacing = 4.0f;
+    bool minimalHoverHighlight = true;
     bool focusedPill = false;
     bool focusedOutputOnly = false;
   };
@@ -150,6 +152,8 @@ private:
   float m_activePillSize = 2.2f;
   float m_inactivePillSize = 1.0f;
   bool m_minimal = false;
+  float m_minimalSpacing = 4.0f;
+  bool m_minimalHoverHighlight = true;
   bool m_focusedPill = false;
   bool m_focusedOutputOnly = false;
   bool m_wasFocusedOutput = true;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -492,6 +492,11 @@ namespace settings {
         ToggleSetting{cfg.theme.pureBlackDark}, "oled amoled true black background contrast"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "theme", tr("settings.schema.appearance.pure-black-context-menus.label"),
+        tr("settings.schema.appearance.pure-black-context-menus.description"), {"theme", "pure_black_context_menus"},
+        ToggleSetting{cfg.theme.pureBlackContextMenus}, "oled amoled true black background context menu popup"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "interface", tr("settings.schema.appearance.corner-roundness.label"),
         tr("settings.schema.appearance.corner-roundness.description"), {"shell", "corner_radius_scale"},
         sliderFor(cfg.shell.cornerRadiusScale, noctalia::config::schema::kCornerRadiusScaleRange, false),
@@ -501,6 +506,21 @@ namespace settings {
         SettingsSection::Appearance, "interface", tr("settings.schema.appearance.button-borders.label"),
         tr("settings.schema.appearance.button-borders.description"), {"shell", "button_borders"},
         ToggleSetting{cfg.shell.buttonBorders}, "button outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.input-borders.label"),
+        tr("settings.schema.appearance.input-borders.description"), {"shell", "input_borders"},
+        ToggleSetting{cfg.shell.inputBorders}, "input outline border flat minimal textbox inputbox"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-borders.label"),
+        tr("settings.schema.appearance.popup-borders.description"), {"shell", "popup_borders"},
+        ToggleSetting{cfg.shell.popupBorders}, "popup outline border flat minimal context menu"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-shadows.label"),
+        tr("settings.schema.appearance.popup-shadows.description"), {"shell", "popup_shadows"},
+        ToggleSetting{cfg.shell.popupShadows}, "popup shadow depth context menu window"
     ));
     entries.push_back(makeEntry(
         SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-colorize.label"),
@@ -2862,6 +2882,11 @@ namespace settings {
           SliderSetting{bar.widgetSpacing, 0.0f, 32.0f, 1.0f, true}, "gap"
       ));
       entries.push_back(makeEntry(
+          section, "widgets", tr("settings.schema.bar.widget-icon-spacing.label"),
+          tr("settings.schema.bar.widget-icon-spacing.description"), path("widget_icon_spacing"),
+          SliderSetting{bar.widgetIconSpacing.value_or(6.0f), 0.0f, 32.0f, 1.0f, true}, "icon text gap"
+      ));
+      entries.push_back(makeEntry(
           section, "widgets", tr("settings.schema.bar.widget-color.label"),
           tr("settings.schema.bar.widget-color.description"), path("color"), colorSpecPicker(bar.widgetColor, true),
           "color foreground", true
@@ -3197,6 +3222,11 @@ namespace settings {
             section, "widgets", tr("settings.schema.bar.widget-spacing.label"),
             tr("settings.schema.bar.widget-spacing.description"), monitorPath("widget_spacing"),
             SliderSetting{ovr.widgetSpacing.value_or(bar.widgetSpacing), 0.0f, 32.0f, 1.0f, true}, "gap"
+        ));
+        entries.push_back(makeEntry(
+            section, "widgets", tr("settings.schema.bar.widget-icon-spacing.label"),
+            tr("settings.schema.bar.widget-icon-spacing.description"), monitorPath("widget_icon_spacing"),
+            SliderSetting{ovr.widgetIconSpacing.value_or(bar.widgetIconSpacing.value_or(6.0f)), 0.0f, 32.0f, 1.0f, true}, "icon text gap"
         ));
         entries.push_back(makeEntry(
             section, "widgets", tr("settings.schema.bar.widget-color.label"),

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -773,6 +773,7 @@ namespace settings {
       add(stringSpec("custom_image", ""));
       add(boolSpec("custom_image_colorize", false));
     } else if (type == "custom_button") {
+      add(intSpec("icon_spacing", 6, 0.0, 48.0, 1.0));
       add(glyphSpec("glyph", "heart"));
       add(stringSpec("custom_image", ""));
       add(boolSpec("custom_image_colorize", false));
@@ -829,11 +830,28 @@ namespace settings {
       add(boolSpec("hide_when_no_media", false));
     } else if (type == "network") {
       add(boolSpec("show_label", true));
+      add(intSpec("icon_spacing", 6, 0.0, 48.0, 1.0));
+      {
+        auto labelSpacing = intSpec("label_spacing", 4, 0.0, 48.0, 1.0);
+        labelSpacing.visibleWhen = WidgetSettingVisibility{"show_label", {"true"}};
+        add(std::move(labelSpacing));
+      }
       {
         auto vpnName = boolSpec("show_vpn_label", false);
         vpnName.visibleWhen = WidgetSettingVisibility{"show_label", {"true"}};
         add(std::move(vpnName));
       }
+
+      auto wifiGroup = "network.wifi";
+      add(withGroup(boolSpec("wifi_show_strength", false), wifiGroup));
+      add(withGroup(glyphSpec("wifi_glyph", ""), wifiGroup));
+      add(withGroup(stringSpec("wifi_custom_image", ""), wifiGroup));
+      add(withGroup(boolSpec("wifi_custom_image_colorize", false), wifiGroup));
+
+      auto ethGroup = "network.ethernet";
+      add(withGroup(glyphSpec("ethernet_glyph", ""), ethGroup));
+      add(withGroup(stringSpec("ethernet_custom_image", ""), ethGroup));
+      add(withGroup(boolSpec("ethernet_custom_image_colorize", false), ethGroup));
     } else if (type == "notifications") {
       add(boolSpec("hide_when_no_unread", false));
     } else if (type == "privacy") {
@@ -853,6 +871,7 @@ namespace settings {
       add(intSpec("length", 20, 0.0, 400.0, 1.0));
     } else if (type == "sysmon") {
       add(selectSpec("stat", "cpu_usage", sysmonStats));
+      add(intSpec("icon_spacing", 6, 0.0, 48.0, 1.0));
       {
         auto glyph = glyphSpec("glyph", "");
         glyph.descriptionKey = "settings.widgets.settings.glyph.sysmon-description";
@@ -1004,6 +1023,13 @@ namespace settings {
       add(stringListSpec("hidden"));
       add(stringListSpec("pinned"));
       add(boolSpec("match_adjacent_spacing", false));
+      {
+        auto traySpacing = doubleSpec("spacing", 4.0, 0.0, 32.0, 1.0);
+        WidgetSettingVisibility customSpacingOnly;
+        customSpacingOnly.all = {WidgetSettingVisibilityCondition{"match_adjacent_spacing", {"false"}}};
+        traySpacing.visibleWhen = customSpacingOnly;
+        add(std::move(traySpacing));
+      }
       add(boolSpec("drawer", false));
       {
         const WidgetSettingVisibility drawerOn{"drawer", {"true"}};
@@ -1041,6 +1067,8 @@ namespace settings {
     } else if (type == "workspaces") {
       WidgetSettingVisibility pillStyleOnly;
       pillStyleOnly.all = {WidgetSettingVisibilityCondition{"style", {"regular"}}};
+      WidgetSettingVisibility minimalStyleOnly;
+      minimalStyleOnly.all = {WidgetSettingVisibilityCondition{"style", {"minimal"}}};
       for (auto& spec : commonSpecs) {
         if (spec.schema.key == "capsule_radius") {
           spec.descriptionKey = "settings.widgets.settings.capsule-radius.workspaces-description";
@@ -1091,6 +1119,17 @@ namespace settings {
         inactivePillSize.descriptionKey = "settings.widgets.settings.inactive-pill-size.workspaces-description";
         inactivePillSize.visibleWhen = pillStyleOnly;
         add(std::move(inactivePillSize));
+      }
+      {
+        auto minimalSpacing = withGroup(doubleSpec("minimal_spacing", 4.0, 0.0, 64.0, 1.0), "workspaces.pills");
+        minimalSpacing.descriptionKey = "settings.widgets.settings.minimal-spacing.workspaces-description";
+        minimalSpacing.visibleWhen = minimalStyleOnly;
+        add(std::move(minimalSpacing));
+      }
+      {
+        auto hoverHighlight = withGroup(boolSpec("minimal_hover_highlight", true), "workspaces.pills");
+        hoverHighlight.visibleWhen = minimalStyleOnly;
+        add(std::move(hoverHighlight));
       }
 
       // Colors: the focused/occupied/empty palette and which monitor gets the focused treatment.

--- a/src/shell/tray/tray_menu.cpp
+++ b/src/shell/tray/tray_menu.cpp
@@ -878,9 +878,11 @@ void TrayMenu::buildScene(MenuInstance& inst, uint32_t width, uint32_t height) {
 
   inst.sceneRoot = std::make_unique<Node>();
   inst.sceneRoot->setSize(w, h);
-  (void)popup_chrome::addShadow(
-      *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
-  );
+  if (Style::popupShadowsEnabled()) {
+    (void)popup_chrome::addShadow(
+        *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
+    );
+  }
 
   std::vector<ContextMenuControlEntry> entries;
   entries.reserve(m_entries.size());
@@ -1230,9 +1232,11 @@ void TrayMenu::buildSubmenuScene(std::size_t levelIndex, MenuInstance& inst, uin
 
   inst.sceneRoot = std::make_unique<Node>();
   inst.sceneRoot->setSize(w, h);
-  (void)popup_chrome::addShadow(
-      *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
-  );
+  if (Style::popupShadowsEnabled()) {
+    (void)popup_chrome::addShadow(
+        *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
+    );
+  }
 
   if (levelIndex >= m_submenuLevels.size()) {
     return;

--- a/src/ui/controls/context_menu.cpp
+++ b/src/ui/controls/context_menu.cpp
@@ -217,10 +217,18 @@ void ContextMenuControl::rebuild(Renderer& renderer) {
   addChild(
       ui::box({
           .configure = [this](Box& bg) {
-            bg.setCardStyle(m_contentScale);
+            bg.setCardStyle(m_contentScale, 1.0f, Style::popupBordersEnabled());
             bg.setRadius(Style::scaledRadiusLg(m_contentScale));
-            bg.setFill(colorSpecFromRole(ColorRole::SurfaceVariant));
-            bg.setBorder(colorSpecFromRole(ColorRole::Outline), Style::borderWidth * m_contentScale);
+            if (Style::pureBlackContextMenusEnabled() && !isResolvedLightTheme()) {
+              bg.setFill(ColorSpec{.role = std::nullopt, .fixed = rgba(0.0f, 0.0f, 0.0f, 1.0f)});
+            } else {
+              bg.setFill(colorSpecFromRole(ColorRole::SurfaceVariant));
+            }
+            if (Style::popupBordersEnabled()) {
+              bg.setBorder(colorSpecFromRole(ColorRole::Outline), Style::borderWidth * m_contentScale);
+            } else {
+              bg.clearBorder();
+            }
             bg.setFrameSize(width(), height());
           },
       })

--- a/src/ui/controls/context_menu_popup.cpp
+++ b/src/ui/controls/context_menu_popup.cpp
@@ -42,7 +42,7 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
   const std::size_t maxVisible =
       request.maxVisible > 0 ? request.maxVisible : std::max<std::size_t>(1, request.entries.size());
   const float menuHeight = ContextMenuControl::preferredHeight(request.entries, maxVisible);
-  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig);
+  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig, m_shadowEnabled);
   m_scrollState = {};
   m_scrollView = nullptr;
   m_menu = nullptr;
@@ -120,7 +120,7 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
 
     self->m_sceneRoot = std::make_unique<Node>();
     self->m_sceneRoot->setSize(fw, fh);
-    (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, self->m_shadowConfig, Style::scaledRadiusLg());
+    (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, self->m_shadowConfig, Style::scaledRadiusLg(), 1.0f, self->m_shadowEnabled && Style::popupShadowsEnabled());
 
     auto scrollView = std::make_unique<ScrollView>();
     scrollView->setPosition(chrome.contentX(), chrome.contentY());
@@ -225,11 +225,12 @@ void ContextMenuPopup::setOnActivate(std::function<void(const ContextMenuControl
 
 void ContextMenuPopup::setOnDismissed(std::function<void()> callback) { m_onDismissed = std::move(callback); }
 
-void ContextMenuPopup::setShadowConfig(const ShellConfig::ShadowConfig& shadow) {
-  if (m_shadowConfig == shadow) {
+void ContextMenuPopup::setShadowConfig(const ShellConfig::ShadowConfig& shadow, bool shadowEnabled) {
+  if (m_shadowConfig == shadow && m_shadowEnabled == shadowEnabled) {
     return;
   }
   m_shadowConfig = shadow;
+  m_shadowEnabled = shadowEnabled;
   if (isOpen()) {
     close();
   }

--- a/src/ui/controls/context_menu_popup.h
+++ b/src/ui/controls/context_menu_popup.h
@@ -52,7 +52,7 @@ public:
 
   void setOnActivate(std::function<void(const ContextMenuControlEntry&)> callback);
   void setOnDismissed(std::function<void()> callback);
-  void setShadowConfig(const ShellConfig::ShadowConfig& shadow);
+  void setShadowConfig(const ShellConfig::ShadowConfig& shadow, bool shadowEnabled = true);
 
   bool onPointerEvent(const PointerEvent& event);
   void onKeyboardEvent(const KeyboardEvent& event);
@@ -82,6 +82,7 @@ private:
   std::function<void(const ContextMenuControlEntry&)> m_onActivate;
   std::function<void()> m_onDismissed;
   ShellConfig::ShadowConfig m_shadowConfig;
+  bool m_shadowEnabled = true;
 
   // Parent layer surface (e.g. a bar) whose keyboard interactivity is flipped to
   // OnDemand while the menu is open so the grabbing popup inherits keyboard

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -1395,7 +1395,7 @@ void Input::applyVisualState() {
             .fillMode = FillMode::Solid,
             .radius = Style::scaledRadius(m_frameRadius, chromeScale),
             .softness = 1.0f,
-            .borderWidth = focused ? Style::focusRingWidth : Style::borderWidth,
+            .borderWidth = focused ? Style::focusRingWidth : (Style::inputBordersEnabled() ? Style::borderWidth : 0.0f),
         }
     );
   } else if (m_background != nullptr) {

--- a/src/ui/controls/select.cpp
+++ b/src/ui/controls/select.cpp
@@ -360,7 +360,7 @@ void Select::applyVisualState() {
           .fillMode = FillMode::Solid,
           .radius = Style::scaledRadiusMd(),
           .softness = 1.0f,
-          .borderWidth = triggerFocused ? Style::focusRingWidth : Style::borderWidth,
+          .borderWidth = (triggerFocused || Style::inputBordersEnabled()) ? (triggerFocused ? Style::focusRingWidth : Style::borderWidth) : 0.0f,
       }
   );
 }

--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -232,7 +232,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
   const float menuY = chrome.contentY();
   const float radius = Style::scaledRadiusMd();
 
-  (void)popup_chrome::addShadow(*m_sceneRoot, chrome, m_shadowConfig, radius);
+  (void)popup_chrome::addShadow(*m_sceneRoot, chrome, m_shadowConfig, radius, 1.0f, Style::popupShadowsEnabled());
 
   auto bg = std::make_unique<RectNode>();
   bg->setStyle(
@@ -242,7 +242,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
           .fillMode = FillMode::Solid,
           .radius = radius,
           .softness = 1.0f,
-          .borderWidth = Style::borderWidth,
+          .borderWidth = Style::popupBordersEnabled() ? Style::borderWidth : 0.0f,
       }
   );
   auto* bgNode = static_cast<RectNode*>(m_sceneRoot->addChild(std::move(bg)));
@@ -267,7 +267,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
 
   const bool hasIndicators = !request.indicatorColors.empty();
   const float indicatorSize = hasIndicators ? std::round(request.fontSize) : 0.0f;
-  const float indicatorBorder = hasIndicators ? 1.5f : 0.0f;
+  const float indicatorBorder = hasIndicators && Style::inputBordersEnabled() ? 1.5f : 0.0f;
 
   for (std::size_t i = 0; i < m_options.size(); ++i) {
     const float rowY = static_cast<float>(i) * m_optionHeight;
@@ -353,7 +353,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
 
   auto scrollbar = std::make_unique<Scrollbar>();
   scrollbar->setOnScrollChanged([this](float offset) { setScrollOffset(offset); });
-  const float scrollbarX = menuX + m_menuWidth - Style::scrollbarWidth - Style::borderWidth;
+  const float scrollbarX = menuX + m_menuWidth - Style::scrollbarWidth - (Style::inputBordersEnabled() ? Style::borderWidth : 0.0f);
   scrollbar->setPosition(scrollbarX, menuY + kMenuPadding);
   scrollbar->update(contentViewport, m_totalHeight, m_scrollOffset);
   m_scrollbar = static_cast<Scrollbar*>(m_sceneRoot->addChild(std::move(scrollbar)));

--- a/src/ui/dialogs/dialog_popup_host.cpp
+++ b/src/ui/dialogs/dialog_popup_host.cpp
@@ -424,10 +424,10 @@ void DialogPopupHost::buildScene(std::uint32_t width, std::uint32_t height) {
   (void)height;
   m_sceneRoot = std::make_unique<Node>();
   m_sceneRoot->setAnimationManager(&m_animations);
-  m_panelShadow = popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl());
+  m_panelShadow = popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl(), 1.0f, Style::popupShadowsEnabled());
 
   auto bg = ui::box({
-      .configure = [](Box& box) { box.setDialogStyle(); },
+      .configure = [](Box& box) { box.setPanelStyle(Style::popupBordersEnabled()); },
   });
   m_bgNode = static_cast<Box*>(m_sceneRoot->addChild(std::move(bg)));
 

--- a/src/ui/popup_chrome.cpp
+++ b/src/ui/popup_chrome.cpp
@@ -95,9 +95,9 @@ namespace popup_chrome {
 
   RectNode* addShadow(
       Node& parent, const Geometry& geometry, const ShellConfig::ShadowConfig& shadow, float radius,
-      float backgroundOpacity
+      float backgroundOpacity, bool componentShadow
   ) {
-    if (!shell::surface_shadow::enabled(true, shadow)) {
+    if (!shell::surface_shadow::enabled(componentShadow, shadow)) {
       return nullptr;
     }
 

--- a/src/ui/popup_chrome.h
+++ b/src/ui/popup_chrome.h
@@ -56,7 +56,7 @@ namespace popup_chrome {
   void setContentInputRegion(PopupSurface& surface, const Geometry& geometry);
   [[nodiscard]] RectNode* addShadow(
       Node& parent, const Geometry& geometry, const ShellConfig::ShadowConfig& shadow, float radius,
-      float backgroundOpacity = 1.0f
+      float backgroundOpacity = 1.0f, bool componentShadow = true
   );
 
 } // namespace popup_chrome

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -6,6 +6,10 @@ namespace {
 
   float g_cornerRadiusScale = 1.0f;
   bool g_buttonBordersEnabled = true;
+  bool g_inputBordersEnabled = true;
+  bool g_popupBordersEnabled = true;
+  bool g_popupShadowsEnabled = true;
+  bool g_pureBlackContextMenusEnabled = false;
 
 } // namespace
 
@@ -26,6 +30,66 @@ namespace Style {
   }
 
   Signal<>& buttonBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
+
+  bool inputBordersEnabled() noexcept { return g_inputBordersEnabled; }
+
+  void setInputBordersEnabled(bool enabled) {
+    if (g_inputBordersEnabled == enabled) {
+      return;
+    }
+    g_inputBordersEnabled = enabled;
+    inputBordersChanged().emit();
+  }
+
+  Signal<>& inputBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
+
+  bool popupBordersEnabled() noexcept { return g_popupBordersEnabled; }
+
+  void setPopupBordersEnabled(bool enabled) {
+    if (g_popupBordersEnabled == enabled) {
+      return;
+    }
+    g_popupBordersEnabled = enabled;
+    popupBordersChanged().emit();
+  }
+
+  Signal<>& popupBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
+
+  bool popupShadowsEnabled() noexcept { return g_popupShadowsEnabled; }
+
+  void setPopupShadowsEnabled(bool enabled) {
+    if (g_popupShadowsEnabled == enabled) {
+      return;
+    }
+    g_popupShadowsEnabled = enabled;
+    popupShadowsChanged().emit();
+  }
+
+  Signal<>& popupShadowsChanged() {
+    static Signal<> signal;
+    return signal;
+  }
+
+  bool pureBlackContextMenusEnabled() noexcept { return g_pureBlackContextMenusEnabled; }
+
+  void setPureBlackContextMenusEnabled(bool enabled) {
+    if (g_pureBlackContextMenusEnabled == enabled) {
+      return;
+    }
+    g_pureBlackContextMenusEnabled = enabled;
+    pureBlackContextMenusChanged().emit();
+  }
+
+  Signal<>& pureBlackContextMenusChanged() {
     static Signal<> signal;
     return signal;
   }

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -71,6 +71,22 @@ namespace Style {
   void setButtonBordersEnabled(bool enabled);
   Signal<>& buttonBordersChanged();
 
+  [[nodiscard]] bool inputBordersEnabled() noexcept;
+  void setInputBordersEnabled(bool enabled);
+  Signal<>& inputBordersChanged();
+
+  [[nodiscard]] bool popupBordersEnabled() noexcept;
+  void setPopupBordersEnabled(bool enabled);
+  Signal<>& popupBordersChanged();
+
+  [[nodiscard]] bool popupShadowsEnabled() noexcept;
+  void setPopupShadowsEnabled(bool enabled);
+  Signal<>& popupShadowsChanged();
+
+  [[nodiscard]] bool pureBlackContextMenusEnabled() noexcept;
+  void setPureBlackContextMenusEnabled(bool enabled);
+  Signal<>& pureBlackContextMenusChanged();
+
   [[nodiscard]] float scaledRadius(float radius, float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusSm(float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusMd(float localScale = 1.0f) noexcept;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Introduces a comprehensive set of new UI styling options for popups and menus, alongside significant layout and spacing refinements for several widgets.

**Theme & UI Styling Enhancements:**
- Added `popup_borders`, `popup_shadows`, `input_borders`, and `pure_black_context_menus` toggles to the Theme configuration schema.
- Integrated these new styling toggles globally, ensuring that context menus, select dropdowns, dialogs, input fields, and right-click tray menus fully respect the border and shadow configurations.
- Added proper localization for these new settings in `en.json`

**Widget Layout & Spacing Overhauls:**
- Overhauled the `icon_spacing` hierarchy across widgets: widgets now seamlessly fall back to the global bar spacing config while correctly applying widget-specific overrides if configured.
- Modified the **Custom Button** widget's layout calculation to dynamically apply padding (`icon_spacing / 2`) on both sides when text is hidden, ensuring the icon stays perfectly centered.
- Refactored the **Network** widget's internal layout to decouple the signal strength text from the main label spacing, introducing a dedicated `label_spacing` property for tighter visual control.

## Motivation

To expand Noctalia's customizability by giving users control over aesthetic elements like borders and shadows for all popups and inputs, while simultaneously fixing layout inconsistencies in widget padding (Network, Custom Button) to ensure a more polished and predictable design across the bar.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Built locally via `just build debug` and verified widget spacing fallback behaviors, custom button centering, and the new popup styling configurations propagating correctly across context menus and the settings UI.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Note on widget spacing: The Custom Button is intentionally the only widget that explicitly pads at half the value of the spacing when no text is present to ensure better visual centering.