### PR TITLE
`Pure Black` support extended to context menus

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -366,6 +366,7 @@ void Application::initStyleThemeAndWayland() {
         std::isfinite(lastCornerRadiusScale) && std::abs(corner - lastCornerRadiusScale) > 1.0e-4f;
     Style::setCornerRadiusScale(corner);
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
+    Style::setPureBlackDarkEnabled(m_configService.config().theme.pureBlackDark);
     lastCornerRadiusScale = corner;
     if (cornerChanged) {
       m_notificationToast.requestLayout();

--- a/src/ui/controls/context_menu.cpp
+++ b/src/ui/controls/context_menu.cpp
@@ -219,7 +219,11 @@ void ContextMenuControl::rebuild(Renderer& renderer) {
           .configure = [this](Box& bg) {
             bg.setCardStyle(m_contentScale);
             bg.setRadius(Style::scaledRadiusLg(m_contentScale));
-            bg.setFill(colorSpecFromRole(ColorRole::SurfaceVariant));
+            if (Style::pureBlackDarkEnabled() && !isResolvedLightTheme()) {
+              bg.setFill(fixedColorSpec(rgba(0.0f, 0.0f, 0.0f, 1.0f)));
+            } else {
+              bg.setFill(colorSpecFromRole(ColorRole::SurfaceVariant));
+            }
             bg.setBorder(colorSpecFromRole(ColorRole::Outline), Style::borderWidth * m_contentScale);
             bg.setFrameSize(width(), height());
           },

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -6,6 +6,7 @@ namespace {
 
   float g_cornerRadiusScale = 1.0f;
   bool g_buttonBordersEnabled = true;
+  bool g_pureBlackDarkEnabled = false;
 
 } // namespace
 
@@ -29,6 +30,10 @@ namespace Style {
     static Signal<> signal;
     return signal;
   }
+
+  bool pureBlackDarkEnabled() noexcept { return g_pureBlackDarkEnabled; }
+
+  void setPureBlackDarkEnabled(bool enabled) { g_pureBlackDarkEnabled = enabled; }
 
   float scaledRadius(float radius, float localScale) noexcept { return radius * localScale * g_cornerRadiusScale; }
 

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -75,7 +75,6 @@ namespace Style {
   void setPureBlackDarkEnabled(bool enabled);
   // No Signal needed since context menus rebuild on open and don't dynamically listen
 
-
   [[nodiscard]] float scaledRadius(float radius, float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusSm(float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusMd(float localScale = 1.0f) noexcept;

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -71,6 +71,11 @@ namespace Style {
   void setButtonBordersEnabled(bool enabled);
   Signal<>& buttonBordersChanged();
 
+  [[nodiscard]] bool pureBlackDarkEnabled() noexcept;
+  void setPureBlackDarkEnabled(bool enabled);
+  // No Signal needed since context menus rebuild on open and don't dynamically listen
+
+
   [[nodiscard]] float scaledRadius(float radius, float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusSm(float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusMd(float localScale = 1.0f) noexcept;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

`Pure Black` currently works on the bar, templates and panels but not on the context menus. This PR extends the option support to the parts that were not covered like the context menu in the tray and the three-dots menu in settings

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Ran `just build debug` to ensure no build errors were caught with the changes done.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

| Before | After |
|--------|-------|
| <img width="280" height="230" alt="Before 1" src="https://github.com/user-attachments/assets/d5d8373a-5bf1-4bb5-b27c-4a1c8702d1ea" /> | <img width="283" height="212" alt="After 1" src="https://github.com/user-attachments/assets/42e99050-f98c-4fa0-8ba9-0c0e80973d7b" /> |
| <img width="249" height="137" alt="Before 2" src="https://github.com/user-attachments/assets/22aefc7f-9052-48b5-8570-06aaf0dd2b33" /> | <img width="269" height="154" alt="After 2" src="https://github.com/user-attachments/assets/e54bec38-e68b-4698-a282-3e8141ac2148" /> |

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran the relevant build or test commands
- [x] I ran `just format` with clang-format v22+ installed
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration or behavior. It simply extends support.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

Adding to this PR, once this is merged, I'll start working on the following:
- Border and Shadow Toggle improvements
- Refactoring Network widget to accommodate glyph and custom images support separatea for Wi-Fi and Ethernet. Also, adding Signal Strength label option to Wi-Fi.
- Widget Icon Spacing support as they are currently hardcoded with both global and widget setting overrides
- Minimal Workspace Style improvements