### PR TITLE
widgets/volume: add effects profile glyph overrides

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2930,6 +2930,12 @@
         "ram": "RAM",
         "temp": "Temperature"
       },
+      "map-placeholders": {
+        "effects-profile-name": "Profile name",
+        "glyph-name": "Glyph name",
+        "label": "Label",
+        "layout-name": "Layout name"
+      },
       "options": {
         "always": "Always",
         "auto": "Auto",
@@ -3110,6 +3116,10 @@
         "enable-scroll": {
           "description": "Allow mouse wheel and trackpad scroll actions on this widget",
           "label": "Enable Scroll"
+        },
+        "effects-profile-glyphs": {
+          "description": "Map EasyEffects profile names to icon glyphs",
+          "label": "Effects Profile Glyphs"
         },
         "focused-color": {
           "description": "Color role used for the focused workspace; fixed hex colors are also supported",

--- a/example.toml
+++ b/example.toml
@@ -477,6 +477,9 @@ battery_low_percent_threshold = 0   # set to e.g. 15 to enable battery_under_thr
 # network_speed_unit = "mb"          # auto | kb | mb
 # network_speed_compact = true       # show "1.2M" instead of "1.2 MB/s"
 
+# [widget.volume.effects_profile_glyphs]
+# eq_desktop = "device-speaker"
+
 # [widget.keyboard_layout]
 # display                 = "short"    # "short" (e.g. "DE") or "full" (full layout name)
 # show_icon               = true

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -633,9 +633,12 @@ std::unique_ptr<Widget> WidgetFactory::create(
         : colorSpecFromRole(ColorRole::Error);
     std::string glyphOverride = wc != nullptr ? wc->getString("glyph", "") : std::string{};
     std::string muteGlyphOverride = wc != nullptr ? wc->getString("mute_glyph", "") : std::string{};
+    auto effectsProfileGlyphs =
+        wc != nullptr ? wc->getStringMap("effects_profile_glyphs") : std::unordered_map<std::string, std::string>{};
     auto widget = std::make_unique<VolumeWidget>(
         m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep, muteColor,
-        std::move(glyphOverride), std::move(muteGlyphOverride), customImageFor(wc), enableScroll
+        std::move(glyphOverride), std::move(muteGlyphOverride), std::move(effectsProfileGlyphs), customImageFor(wc),
+        enableScroll
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -24,12 +24,14 @@ namespace {
 VolumeWidget::VolumeWidget(
     PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* /*output*/,
     bool showLabel, VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
-    std::string muteGlyphOverride, WidgetCustomImage customImage, bool enableScroll
+    std::string muteGlyphOverride, std::unordered_map<std::string, std::string> effectsProfileGlyphs,
+    WidgetCustomImage customImage, bool enableScroll
 )
     : m_audio(audio), m_easyEffects(easyEffects), m_config(config), m_showLabel(showLabel),
       m_enableScroll(enableScroll), m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target),
       m_muteColor(muteColor), m_glyphOverride(std::move(glyphOverride)),
-      m_muteGlyphOverride(std::move(muteGlyphOverride)), m_customImage(std::move(customImage)) {}
+      m_muteGlyphOverride(std::move(muteGlyphOverride)), m_effectsProfileGlyphs(std::move(effectsProfileGlyphs)),
+      m_customImage(std::move(customImage)) {}
 
 void VolumeWidget::create() {
   auto area = std::make_unique<InputArea>();
@@ -168,7 +170,7 @@ void VolumeWidget::syncState(Renderer& renderer) {
 
   if (m_target == VolumeWidgetTarget::Output) {
     kLog.debug(
-        "sync vol {:.6f} muted {} glyph {} node {}", volume, muted, glyphName(volume, muted),
+        "sync vol {:.6f} muted {} glyph {} node {}", volume, muted, glyphName(volume, muted, effectsProfile),
         node != nullptr ? node->id : 0
     );
   }
@@ -179,7 +181,7 @@ void VolumeWidget::syncState(Renderer& renderer) {
         muted ? m_muteColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface))
     );
   } else {
-    m_glyph->setGlyph(glyphName(volume, muted));
+    m_glyph->setGlyph(glyphName(volume, muted, effectsProfile));
     m_glyph->setGlyphSize(Style::baseGlyphSize * m_contentScale);
     m_glyph->setColor(muted ? m_muteColor : widgetIconColorOr(colorSpecFromRole(ColorRole::OnSurface)));
     m_glyph->measure(renderer);
@@ -218,12 +220,18 @@ void VolumeWidget::syncState(Renderer& renderer) {
   requestRedraw();
 }
 
-std::string VolumeWidget::glyphName(float volume, bool muted) const {
+std::string VolumeWidget::glyphName(float volume, bool muted, const std::string& effectsProfile) const {
   const char* dynamicGlyph = audioVolumeGlyph(volume, muted, m_target == VolumeWidgetTarget::Input);
   const std::string_view muteGlyph = m_target == VolumeWidgetTarget::Input ? "microphone-mute" : "volume-mute";
   const bool usingMuteGlyph = std::string_view{dynamicGlyph} == muteGlyph;
   if (usingMuteGlyph && !m_muteGlyphOverride.empty()) {
     return m_muteGlyphOverride;
+  }
+  if (!usingMuteGlyph && !effectsProfile.empty()) {
+    const auto profileGlyph = m_effectsProfileGlyphs.find(effectsProfile);
+    if (profileGlyph != m_effectsProfileGlyphs.end() && !profileGlyph->second.empty()) {
+      return profileGlyph->second;
+    }
   }
   if (!usingMuteGlyph && !m_glyphOverride.empty()) {
     return m_glyphOverride;

--- a/src/shell/bar/widgets/volume_widget.h
+++ b/src/shell/bar/widgets/volume_widget.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 
 struct Config;
 class EasyEffectsService;
@@ -24,7 +25,8 @@ public:
   VolumeWidget(
       PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* output, bool showLabel,
       VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
-      std::string muteGlyphOverride, WidgetCustomImage customImage = {}, bool enableScroll = true
+      std::string muteGlyphOverride, std::unordered_map<std::string, std::string> effectsProfileGlyphs,
+      WidgetCustomImage customImage = {}, bool enableScroll = true
   );
 
   void create() override;
@@ -33,7 +35,7 @@ private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void syncState(Renderer& renderer);
-  [[nodiscard]] std::string glyphName(float volume, bool muted) const;
+  [[nodiscard]] std::string glyphName(float volume, bool muted, const std::string& effectsProfile = {}) const;
 
   PipeWireService* m_audio = nullptr;
   EasyEffectsService* m_easyEffects = nullptr;
@@ -45,6 +47,7 @@ private:
   ColorSpec m_muteColor;
   std::string m_glyphOverride;
   std::string m_muteGlyphOverride;
+  std::unordered_map<std::string, std::string> m_effectsProfileGlyphs;
   WidgetCustomImage m_customImage;
   Glyph* m_glyph = nullptr;
   Image* m_image = nullptr;

--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -1611,18 +1611,26 @@ namespace settings {
         case WidgetControlKind::StringList:
           ctx.makeListBlock(*panel, entry, ListSetting{.items = settingValueAsStringList(value)});
           break;
-        case WidgetControlKind::StringMap:
+        case WidgetControlKind::StringMap: {
+          const bool customLabels = spec.schema.key == "custom_labels";
           ctx.makeStringMapBlock(
               *panel, entry,
               StringMapSetting{
                   .entries = widgetConfig != nullptr ? widgetConfig->getStringMap(spec.schema.key)
                                                      : std::unordered_map<std::string, std::string>{},
-                  .suggestedKeys = ctx.keyboardLayoutNames,
-                  .keyPlaceholder = "Layout name",
-                  .valuePlaceholder = "Label",
+                  .suggestedKeys = customLabels ? ctx.keyboardLayoutNames : std::vector<std::string>{},
+                  .keyPlaceholder = i18n::tr(
+                      customLabels ? "settings.widgets.map-placeholders.layout-name"
+                                   : "settings.widgets.map-placeholders.effects-profile-name"
+                  ),
+                  .valuePlaceholder = i18n::tr(
+                      customLabels ? "settings.widgets.map-placeholders.label"
+                                   : "settings.widgets.map-placeholders.glyph-name"
+                  ),
               }
           );
           break;
+        }
         case WidgetControlKind::Select: {
           SelectSetting selectSetting;
           const std::string selectedValue = settingValueAsString(value);

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -1047,6 +1047,7 @@ namespace settings {
         add(std::move(glyph));
       }
       add(glyphSpec("mute_glyph", ""));
+      add(stringMapSpec("effects_profile_glyphs"));
       add(stringSpec("custom_image", ""));
       add(boolSpec("custom_image_colorize", false));
       add(boolSpec("enable_scroll", true));


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Manual Coverage
- [x] Tested on Hyprland

## Checklist
- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
