### PR TITLE
New options to handle border and shadows across supported elements

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1089,6 +1089,7 @@
         "background": "Background",
         "battery": "Battery",
         "behavior": "Behavior",
+        "borders": "Borders",
         "brightness": "Brightness",
         "built-in": "Built-In",
         "calendar": "Calendar",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1473,6 +1473,18 @@
           "description": "Draw outlines around buttons throughout the shell",
           "label": "Button Borders"
         },
+        "input-borders": {
+          "description": "Draw outlines around text fields and other inputs throughout the shell",
+          "label": "Input Borders"
+        },
+        "popup-borders": {
+          "description": "Draw outlines around popups and dropdowns",
+          "label": "Popup Borders"
+        },
+        "popup-shadows": {
+          "description": "Draw drop shadows behind popups and dropdowns",
+          "label": "Popup Shadows"
+        },
         "community-palette": {
           "description": "Choose a palette from the community catalog",
           "label": "Community Palette",

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -364,8 +364,11 @@ void Application::initStyleThemeAndWayland() {
     const float corner = m_configService.config().shell.cornerRadiusScale;
     const bool cornerChanged =
         std::isfinite(lastCornerRadiusScale) && std::abs(corner - lastCornerRadiusScale) > 1.0e-4f;
-    Style::setCornerRadiusScale(corner);
+    Style::setCornerRadiusScale(m_configService.config().shell.cornerRadiusScale);
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
+    Style::setInputBordersEnabled(m_configService.config().shell.inputBorders);
+    Style::setPopupBordersEnabled(m_configService.config().shell.popupBorders);
+    Style::setPopupShadowsEnabled(m_configService.config().shell.popupShadows);
     lastCornerRadiusScale = corner;
     if (cornerChanged) {
       m_notificationToast.requestLayout();

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -364,7 +364,7 @@ void Application::initStyleThemeAndWayland() {
     const float corner = m_configService.config().shell.cornerRadiusScale;
     const bool cornerChanged =
         std::isfinite(lastCornerRadiusScale) && std::abs(corner - lastCornerRadiusScale) > 1.0e-4f;
-    Style::setCornerRadiusScale(m_configService.config().shell.cornerRadiusScale);
+    Style::setCornerRadiusScale(corner);
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
     Style::setInputBordersEnabled(m_configService.config().shell.inputBorders);
     Style::setPopupBordersEnabled(m_configService.config().shell.popupBorders);

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -961,6 +961,9 @@ struct ShellConfig {
 
   float cornerRadiusScale = 1.0f;
   bool buttonBorders = true;
+  bool inputBorders = true;
+  bool popupBorders = true;
+  bool popupShadows = true;
   std::string fontFamily = "sans-serif";
   std::string lang; // empty = auto-detect from $LC_ALL/$LC_MESSAGES/$LANG
   std::string timeFormat = "{:%H:%M}";

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1367,6 +1367,9 @@ namespace noctalia::config::schema {
     static const Schema<ShellConfig> s = {
         field(&ShellConfig::cornerRadiusScale, "corner_radius_scale", kCornerRadiusScaleRange),
         field(&ShellConfig::buttonBorders, "button_borders"),
+        field(&ShellConfig::inputBorders, "input_borders"),
+        field(&ShellConfig::popupBorders, "popup_borders"),
+        field(&ShellConfig::popupShadows, "popup_shadows"),
         // font_family is trimmed; empty falls back to sans-serif.
         custom<ShellConfig>(
             "font_family",

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -437,7 +437,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
     }
     auto widget = std::make_unique<ScreenshotWidget>(
         output, std::move(barGlyph), *m_screenshots, m_configService, m_platform, *m_renderContext,
-        m_configService.config().shell.shadow, barPosition, customImageFor(wc)
+        barPosition, customImageFor(wc)
     );
     widget->setContentScale(contentScale);
     return widget;
@@ -581,7 +581,6 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .taskbarMaxWidth = static_cast<float>(wc != nullptr ? wc->getDouble("taskbar_max_width", 8192.0) : 8192.0),
         .barPosition = barPosition,
         .barName = barName,
-        .shadowConfig = m_config.shell.shadow,
     };
     if (wc != nullptr) {
       const std::string placement = wc->getString("workspace_label_placement", "corner");

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -436,8 +436,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
       barGlyph = "screenshot";
     }
     auto widget = std::make_unique<ScreenshotWidget>(
-        output, std::move(barGlyph), *m_screenshots, m_configService, m_platform, *m_renderContext,
-        barPosition, customImageFor(wc)
+        output, std::move(barGlyph), *m_screenshots, m_configService, m_platform, *m_renderContext, barPosition,
+        customImageFor(wc)
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/screenshot_widget.cpp
+++ b/src/shell/bar/widgets/screenshot_widget.cpp
@@ -241,7 +241,7 @@ void ScreenshotWidget::openCaptureMenu() {
   if (m_menuPopup == nullptr) {
     m_menuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), m_renderContext);
   }
-  // Popups now read shadow config globally via Style::popupShadowsEnabled() + ConfigService
+  m_menuPopup->setShadowConfig(m_configService.config().shell.shadow);
   const auto options = outputOptions();
   m_menuPopup->setOnActivate([this, options](const ContextMenuControlEntry& entry) {
     if (entry.id == 1) {

--- a/src/shell/bar/widgets/screenshot_widget.cpp
+++ b/src/shell/bar/widgets/screenshot_widget.cpp
@@ -113,8 +113,8 @@ ScreenshotWidget::ScreenshotWidget(
     CompositorPlatform& platform, RenderContext& renderContext, std::string barPosition, WidgetCustomImage customImage
 )
     : m_barGlyphId(std::move(barGlyphId)), m_output(output), m_screenshots(screenshots), m_configService(configService),
-      m_platform(platform), m_renderContext(renderContext),
-      m_barPosition(std::move(barPosition)), m_customImage(std::move(customImage)) {}
+      m_platform(platform), m_renderContext(renderContext), m_barPosition(std::move(barPosition)),
+      m_customImage(std::move(customImage)) {}
 
 ScreenshotWidget::~ScreenshotWidget() = default;
 

--- a/src/shell/bar/widgets/screenshot_widget.cpp
+++ b/src/shell/bar/widgets/screenshot_widget.cpp
@@ -110,11 +110,10 @@ namespace {
 
 ScreenshotWidget::ScreenshotWidget(
     wl_output* output, std::string barGlyphId, ScreenshotService& screenshots, ConfigService& configService,
-    CompositorPlatform& platform, RenderContext& renderContext, const ShellConfig::ShadowConfig& shadow,
-    std::string barPosition, WidgetCustomImage customImage
+    CompositorPlatform& platform, RenderContext& renderContext, std::string barPosition, WidgetCustomImage customImage
 )
     : m_barGlyphId(std::move(barGlyphId)), m_output(output), m_screenshots(screenshots), m_configService(configService),
-      m_platform(platform), m_renderContext(renderContext), m_shadowConfig(shadow),
+      m_platform(platform), m_renderContext(renderContext),
       m_barPosition(std::move(barPosition)), m_customImage(std::move(customImage)) {}
 
 ScreenshotWidget::~ScreenshotWidget() = default;
@@ -242,7 +241,7 @@ void ScreenshotWidget::openCaptureMenu() {
   if (m_menuPopup == nullptr) {
     m_menuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), m_renderContext);
   }
-  m_menuPopup->setShadowConfig(m_shadowConfig);
+  // Popups now read shadow config globally via Style::popupShadowsEnabled() + ConfigService
   const auto options = outputOptions();
   m_menuPopup->setOnActivate([this, options](const ContextMenuControlEntry& entry) {
     if (entry.id == 1) {

--- a/src/shell/bar/widgets/screenshot_widget.h
+++ b/src/shell/bar/widgets/screenshot_widget.h
@@ -21,8 +21,8 @@ class ScreenshotWidget : public Widget {
 public:
   ScreenshotWidget(
       wl_output* output, std::string barGlyphId, ScreenshotService& screenshots, ConfigService& configService,
-      CompositorPlatform& platform, RenderContext& renderContext, const ShellConfig::ShadowConfig& shadow,
-      std::string barPosition = "top", WidgetCustomImage customImage = {}
+      CompositorPlatform& platform, RenderContext& renderContext, std::string barPosition = "top",
+      WidgetCustomImage customImage = {}
   );
   ~ScreenshotWidget() override;
 

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1959,7 +1959,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
   if (m_contextMenuPopup == nullptr) {
     m_contextMenuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), *renderContext);
   }
-  // Popups now read shadow config globally via Style::popupShadowsEnabled() + ConfigService
+  m_contextMenuPopup->setShadowConfig(m_configService.config().shell.shadow);
   m_contextMenuPopup->setOnActivate([this, entryActions, entryAppName, entryWorkingDir,
                                      entryTerminal](const ContextMenuControlEntry& entry) {
     if (entry.id >= 0) {

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -185,7 +185,7 @@ TaskbarWidget::TaskbarWidget(
       m_occupiedColor(m_configOptions.occupiedColor), m_emptyColor(m_configOptions.emptyColor),
       m_urgentColor(m_configOptions.urgentColor), m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth),
       m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth), m_barPosition(std::move(m_configOptions.barPosition)),
-      m_barName(std::move(m_configOptions.barName)), m_shadowConfig(m_configOptions.shadowConfig) {
+      m_barName(std::move(m_configOptions.barName)) {
   syncWorkspaceGroupingCapability();
   buildDesktopIconIndex();
 }
@@ -1959,7 +1959,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
   if (m_contextMenuPopup == nullptr) {
     m_contextMenuPopup = std::make_unique<ContextMenuPopup>(m_platform.wayland(), *renderContext);
   }
-  m_contextMenuPopup->setShadowConfig(m_shadowConfig);
+  // Popups now read shadow config globally via Style::popupShadowsEnabled() + ConfigService
   m_contextMenuPopup->setOnActivate([this, entryActions, entryAppName, entryWorkingDir,
                                      entryTerminal](const ContextMenuControlEntry& entry) {
     if (entry.id >= 0) {

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -50,7 +50,6 @@ struct TaskbarWidgetOptions {
   float taskbarMaxWidth = 8192.0f;
   std::string barPosition;
   std::string barName;
-  ShellConfig::ShadowConfig shadowConfig;
 };
 
 class TaskbarWidget : public Widget {
@@ -151,7 +150,6 @@ private:
   float m_taskbarMaxWidth = 8192.0;
   std::string m_barPosition;
   std::string m_barName;
-  ShellConfig::ShadowConfig m_shadowConfig;
   bool m_rebuildPending = true;
   bool m_vertical = false;
   float m_containerWidth = 0.0f;

--- a/src/shell/dock/dock_context_menu.cpp
+++ b/src/shell/dock/dock_context_menu.cpp
@@ -316,7 +316,7 @@ namespace shell::dock {
       aH = halfCell * 2;
     }
 
-    const auto menuChrome = popup_chrome::computeGeometry(kMenuWidth, menuHeight, config.config().shell.shadow);
+    const auto menuChrome = popup_chrome::computeGeometry(kMenuWidth, menuHeight, config.config().shell.shadow, Style::popupShadowsEnabled());
     PopupSurfaceConfig popupCfg{
         .anchorX = aX,
         .anchorY = aY,
@@ -378,9 +378,11 @@ namespace shell::dock {
 
       menuPtr->sceneRoot = std::make_unique<Node>();
       menuPtr->sceneRoot->setSize(fw, fh);
-      (void)popup_chrome::addShadow(
-          *menuPtr->sceneRoot, menuPtr->chrome, config.config().shell.shadow, Style::scaledRadiusLg()
-      );
+      if (Style::popupShadowsEnabled()) {
+        (void)popup_chrome::addShadow(
+            *menuPtr->sceneRoot, menuPtr->chrome, config.config().shell.shadow, Style::scaledRadiusLg()
+        );
+      }
 
       auto ctrl = std::make_unique<ContextMenuControl>();
       ctrl->setMenuWidth(menuPtr->chrome.contentWidth);

--- a/src/shell/dock/dock_context_menu.cpp
+++ b/src/shell/dock/dock_context_menu.cpp
@@ -316,7 +316,9 @@ namespace shell::dock {
       aH = halfCell * 2;
     }
 
-    const auto menuChrome = popup_chrome::computeGeometry(kMenuWidth, menuHeight, config.config().shell.shadow, Style::popupShadowsEnabled());
+    const auto menuChrome = popup_chrome::computeGeometry(
+        kMenuWidth, menuHeight, config.config().shell.shadow, Style::popupShadowsEnabled()
+    );
     PopupSurfaceConfig popupCfg{
         .anchorX = aX,
         .anchorY = aY,

--- a/src/shell/settings/config_export_dialog_popup.cpp
+++ b/src/shell/settings/config_export_dialog_popup.cpp
@@ -298,7 +298,7 @@ namespace settings {
     const float panelH = std::ceil(pref.height + pad * 2.0f);
     const ShellConfig::ShadowConfig shadow =
         config() != nullptr ? config()->config().shell.shadow : ShellConfig::ShadowConfig{};
-    const auto geo = popup_chrome::computeGeometry(panelW, panelH, shadow);
+    const auto geo = popup_chrome::computeGeometry(panelW, panelH, shadow, Style::popupShadowsEnabled());
     const float maxOuterHeight =
         m_parentHeight > 0 ? std::max(1.0f, static_cast<float>(m_parentHeight) - (kParentMargin * m_scale)) : 1.0e6f;
     const std::uint32_t nextHeight =

--- a/src/shell/settings/settings_popup_layout.cpp
+++ b/src/shell/settings/settings_popup_layout.cpp
@@ -1,6 +1,7 @@
 #include "shell/settings/settings_popup_layout.h"
 
 #include "ui/popup_chrome.h"
+#include "ui/style.h"
 
 #include <algorithm>
 
@@ -15,7 +16,7 @@ namespace settings::popup_layout {
       return panelW;
     }
 
-    const auto probe = popup_chrome::computeGeometry(panelW, panelW, shadow);
+    const auto probe = popup_chrome::computeGeometry(panelW, panelW, shadow, Style::popupShadowsEnabled());
     const float chromeW = static_cast<float>(probe.surfaceWidth) - panelW;
     const float fitPanelW = std::max(1.0f, static_cast<float>(parentWidth) - (parentMarginLogical * scale) - chromeW);
     const float maxPanelW = std::min(fitPanelW, maxLogical * scale);
@@ -26,7 +27,9 @@ namespace settings::popup_layout {
 
   std::pair<std::uint32_t, std::uint32_t>
   surfaceSizeForContent(float contentWidth, float contentHeight, const ShellConfig::ShadowConfig& shadow) {
-    const auto geo = popup_chrome::computeGeometry(std::max(1.0f, contentWidth), std::max(1.0f, contentHeight), shadow);
+    const auto geo = popup_chrome::computeGeometry(
+        std::max(1.0f, contentWidth), std::max(1.0f, contentHeight), shadow, Style::popupShadowsEnabled()
+    );
     return {geo.surfaceWidth, geo.surfaceHeight};
   }
 

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -502,6 +502,21 @@ namespace settings {
         ToggleSetting{cfg.shell.buttonBorders}, "button outline border flat minimal"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.input-borders.label"),
+        tr("settings.schema.appearance.input-borders.description"), {"shell", "input_borders"},
+        ToggleSetting{cfg.shell.inputBorders}, "input text box field outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-borders.label"),
+        tr("settings.schema.appearance.popup-borders.description"), {"shell", "popup_borders"},
+        ToggleSetting{cfg.shell.popupBorders}, "popup menu dropdown outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-shadows.label"),
+        tr("settings.schema.appearance.popup-shadows.description"), {"shell", "popup_shadows"},
+        ToggleSetting{cfg.shell.popupShadows}, "popup menu dropdown drop shadow depth"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-colorize.label"),
         tr("settings.schema.appearance.app-icon-colorize.description"), {"shell", "app_icon_colorize"},
         ToggleSetting{cfg.shell.appIconColorize}, "tint all application icons"

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -490,51 +490,6 @@ namespace settings {
         tr("settings.schema.appearance.pure-black-dark.description"), {"theme", "pure_black_dark"},
         ToggleSetting{cfg.theme.pureBlackDark}, "oled amoled true black background contrast"
     ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.corner-roundness.label"),
-        tr("settings.schema.appearance.corner-roundness.description"), {"shell", "corner_radius_scale"},
-        sliderFor(cfg.shell.cornerRadiusScale, noctalia::config::schema::kCornerRadiusScaleRange, false),
-        "rounded corners radius"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.button-borders.label"),
-        tr("settings.schema.appearance.button-borders.description"), {"shell", "button_borders"},
-        ToggleSetting{cfg.shell.buttonBorders}, "button outline border flat minimal"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.input-borders.label"),
-        tr("settings.schema.appearance.input-borders.description"), {"shell", "input_borders"},
-        ToggleSetting{cfg.shell.inputBorders}, "input text box field outline border flat minimal"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-borders.label"),
-        tr("settings.schema.appearance.popup-borders.description"), {"shell", "popup_borders"},
-        ToggleSetting{cfg.shell.popupBorders}, "popup menu dropdown outline border flat minimal"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.popup-shadows.label"),
-        tr("settings.schema.appearance.popup-shadows.description"), {"shell", "popup_shadows"},
-        ToggleSetting{cfg.shell.popupShadows}, "popup menu dropdown drop shadow depth"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-colorize.label"),
-        tr("settings.schema.appearance.app-icon-colorize.description"), {"shell", "app_icon_colorize"},
-        ToggleSetting{cfg.shell.appIconColorize}, "tint all application icons"
-    ));
-    {
-      const SettingVisibility colorizeOn = [](const Config& c) { return c.shell.appIconColorize; };
-      ShellConfig colorizeShell = cfg.shell;
-      colorizeShell.appIconColorize = true;
-      const ColorSpec pickerColor =
-          cfg.shell.appIconColor.value_or(*effectiveShellAppIconColorizationTint(colorizeShell));
-      auto e = makeEntry(
-          SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-color.label"),
-          tr("settings.schema.appearance.app-icon-color.description"), {"shell", "app_icon_color"},
-          colorSpecPicker(pickerColor), "color role dock tray application icons"
-      );
-      e.visibleWhen = colorizeOn;
-      entries.push_back(std::move(e));
-    }
     {
       SettingControl fontFamilyControl =
           TextSetting{.value = cfg.shell.fontFamily, .placeholder = "sans-serif", .browseFileExtensions = {}};
@@ -559,6 +514,31 @@ namespace settings {
         "locale translation", true
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.corner-roundness.label"),
+        tr("settings.schema.appearance.corner-roundness.description"), {"shell", "corner_radius_scale"},
+        sliderFor(cfg.shell.cornerRadiusScale, noctalia::config::schema::kCornerRadiusScaleRange, false),
+        "rounded corners radius"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-colorize.label"),
+        tr("settings.schema.appearance.app-icon-colorize.description"), {"shell", "app_icon_colorize"},
+        ToggleSetting{cfg.shell.appIconColorize}, "tint all application icons"
+    ));
+    {
+      const SettingVisibility colorizeOn = [](const Config& c) { return c.shell.appIconColorize; };
+      ShellConfig colorizeShell = cfg.shell;
+      colorizeShell.appIconColorize = true;
+      const ColorSpec pickerColor =
+          cfg.shell.appIconColor.value_or(*effectiveShellAppIconColorizationTint(colorizeShell));
+      auto e = makeEntry(
+          SettingsSection::Appearance, "interface", tr("settings.schema.appearance.app-icon-color.label"),
+          tr("settings.schema.appearance.app-icon-color.description"), {"shell", "app_icon_color"},
+          colorSpecPicker(pickerColor), "color role dock tray application icons"
+      );
+      e.visibleWhen = colorizeOn;
+      entries.push_back(std::move(e));
+    }
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "accessibility", tr("settings.schema.appearance.ui-scale.label"),
         tr("settings.schema.appearance.ui-scale.description"), {"accessibility", "ui_scale"},
         sliderFor(cfg.accessibility.uiScale, noctalia::config::schema::kScaleRange, false), "size scale text panels"
@@ -579,6 +559,21 @@ namespace settings {
         sliderFor(cfg.shell.animation.speed, noctalia::config::schema::kAnimationSpeedRange, false), "motion"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "borders", tr("settings.schema.appearance.button-borders.label"),
+        tr("settings.schema.appearance.button-borders.description"), {"shell", "button_borders"},
+        ToggleSetting{cfg.shell.buttonBorders}, "button outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "borders", tr("settings.schema.appearance.input-borders.label"),
+        tr("settings.schema.appearance.input-borders.description"), {"shell", "input_borders"},
+        ToggleSetting{cfg.shell.inputBorders}, "input text box field outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "borders", tr("settings.schema.appearance.popup-borders.label"),
+        tr("settings.schema.appearance.popup-borders.description"), {"shell", "popup_borders"},
+        ToggleSetting{cfg.shell.popupBorders}, "popup menu dropdown outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "effects", tr("settings.schema.shared.shadow-direction.label"),
         tr("settings.schema.appearance.global-shadow-direction.description"), {"shell", "shadow", "direction"},
         enumSelect(kShadowDirections, cfg.shell.shadow.direction), "shadow direction"
@@ -587,6 +582,11 @@ namespace settings {
         SettingsSection::Appearance, "effects", tr("settings.schema.shared.shadow-alpha.label"),
         tr("settings.schema.appearance.global-shadow-alpha.description"), {"shell", "shadow", "alpha"},
         sliderFor(cfg.shell.shadow.alpha, noctalia::config::schema::kUnitRange, false), "shadow opacity", true
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "effects", tr("settings.schema.appearance.popup-shadows.label"),
+        tr("settings.schema.appearance.popup-shadows.description"), {"shell", "popup_shadows"},
+        ToggleSetting{cfg.shell.popupShadows}, "popup menu dropdown drop shadow depth"
     ));
 
     // Wallpaper

--- a/src/shell/settings/settings_sheet_popup.cpp
+++ b/src/shell/settings/settings_sheet_popup.cpp
@@ -373,7 +373,7 @@ namespace settings {
 
     float panelW = m_minWidth * m_scale;
     if (m_parentWidth > 0) {
-      const auto probe = popup_chrome::computeGeometry(panelW, panelW, shadow);
+      const auto probe = popup_chrome::computeGeometry(panelW, panelW, shadow, Style::popupShadowsEnabled());
       const float chromeW = static_cast<float>(probe.surfaceWidth) - panelW;
       const float fitPanelW = std::max(1.0f, static_cast<float>(m_parentWidth) - (kParentMargin * m_scale) - chromeW);
       const float maxPanelW = std::min(fitPanelW, m_maxWidth * m_scale);
@@ -410,7 +410,7 @@ namespace settings {
       rootH = std::max(rootH, fillH);
     }
     const float panelH = std::ceil(rootH + pad * 2.0f);
-    const auto geo = popup_chrome::computeGeometry(panelW, panelH, shadow);
+    const auto geo = popup_chrome::computeGeometry(panelW, panelH, shadow, Style::popupShadowsEnabled());
     const float maxOuterHeight =
         m_parentHeight > 0 ? std::max(1.0f, static_cast<float>(m_parentHeight) - (kParentMargin * m_scale)) : 1.0e6f;
     const std::uint32_t nextHeight =

--- a/src/shell/tray/tray_menu.cpp
+++ b/src/shell/tray/tray_menu.cpp
@@ -693,8 +693,9 @@ void TrayMenu::ensureSurface() {
   });
   inst->surface->setDismissedCallback([this]() { close(); });
 
-  const auto chrome =
-      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled());
+  const auto chrome = popup_chrome::computeGeometry(
+      menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled()
+  );
   PopupPlacement placement{};
   if (const auto bar = resolveTrayBarConfig(m_config, m_wayland, output); bar.has_value()) {
     placement = popupPlacementForBar(*bar, anchorX, anchorY, contentScale());
@@ -795,8 +796,9 @@ void TrayMenu::resizeMainSurfaceToEntries() {
     return;
   }
 
-  const auto chrome =
-      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled());
+  const auto chrome = popup_chrome::computeGeometry(
+      menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled()
+  );
   const auto desiredWidth = chrome.surfaceWidth;
   const auto desiredHeight = chrome.surfaceHeight;
   if (m_instance->surface->width() == desiredWidth && m_instance->surface->height() == desiredHeight) {
@@ -1118,7 +1120,8 @@ void TrayMenu::openSubmenuAtLevel(std::size_t levelIndex, std::int32_t parentEnt
   const auto subGap = std::max(1, static_cast<std::int32_t>(std::lround(4.0f * scale)));
 
   const auto chrome = popup_chrome::computeGeometry(
-      menuWidth(), static_cast<float>(submenuHeightPx(level.entries)), popupShadowConfig(m_config), Style::popupShadowsEnabled()
+      menuWidth(), static_cast<float>(submenuHeightPx(level.entries)), popupShadowConfig(m_config),
+      Style::popupShadowsEnabled()
   );
 
   const auto* wlOutput = m_wayland->findOutputByWl(parentMenu->output);

--- a/src/shell/tray/tray_menu.cpp
+++ b/src/shell/tray/tray_menu.cpp
@@ -694,7 +694,7 @@ void TrayMenu::ensureSurface() {
   inst->surface->setDismissedCallback([this]() { close(); });
 
   const auto chrome =
-      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config));
+      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled());
   PopupPlacement placement{};
   if (const auto bar = resolveTrayBarConfig(m_config, m_wayland, output); bar.has_value()) {
     placement = popupPlacementForBar(*bar, anchorX, anchorY, contentScale());
@@ -796,7 +796,7 @@ void TrayMenu::resizeMainSurfaceToEntries() {
   }
 
   const auto chrome =
-      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config));
+      popup_chrome::computeGeometry(menuWidth(), static_cast<float>(surfaceHeightPx()), popupShadowConfig(m_config), Style::popupShadowsEnabled());
   const auto desiredWidth = chrome.surfaceWidth;
   const auto desiredHeight = chrome.surfaceHeight;
   if (m_instance->surface->width() == desiredWidth && m_instance->surface->height() == desiredHeight) {
@@ -878,9 +878,11 @@ void TrayMenu::buildScene(MenuInstance& inst, uint32_t width, uint32_t height) {
 
   inst.sceneRoot = std::make_unique<Node>();
   inst.sceneRoot->setSize(w, h);
-  (void)popup_chrome::addShadow(
-      *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
-  );
+  if (Style::popupShadowsEnabled()) {
+    (void)popup_chrome::addShadow(
+        *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
+    );
+  }
 
   std::vector<ContextMenuControlEntry> entries;
   entries.reserve(m_entries.size());
@@ -1116,7 +1118,7 @@ void TrayMenu::openSubmenuAtLevel(std::size_t levelIndex, std::int32_t parentEnt
   const auto subGap = std::max(1, static_cast<std::int32_t>(std::lround(4.0f * scale)));
 
   const auto chrome = popup_chrome::computeGeometry(
-      menuWidth(), static_cast<float>(submenuHeightPx(level.entries)), popupShadowConfig(m_config)
+      menuWidth(), static_cast<float>(submenuHeightPx(level.entries)), popupShadowConfig(m_config), Style::popupShadowsEnabled()
   );
 
   const auto* wlOutput = m_wayland->findOutputByWl(parentMenu->output);
@@ -1230,9 +1232,11 @@ void TrayMenu::buildSubmenuScene(std::size_t levelIndex, MenuInstance& inst, uin
 
   inst.sceneRoot = std::make_unique<Node>();
   inst.sceneRoot->setSize(w, h);
-  (void)popup_chrome::addShadow(
-      *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
-  );
+  if (Style::popupShadowsEnabled()) {
+    (void)popup_chrome::addShadow(
+        *inst.sceneRoot, inst.chrome, popupShadowConfig(m_config), Style::scaledRadiusLg(contentScale())
+    );
+  }
 
   if (levelIndex >= m_submenuLevels.size()) {
     return;

--- a/src/ui/controls/box.cpp
+++ b/src/ui/controls/box.cpp
@@ -139,7 +139,7 @@ void Box::setPanelStyle(bool showBorder) {
   syncStyle();
 }
 
-void Box::setDialogStyle() { setPanelStyle(/*showBorder=*/true); }
+void Box::setDialogStyle() { setPanelStyle(Style::popupBordersEnabled()); }
 
 void Box::setCardStyle(float scale, float fillOpacity, bool showBorder) {
   setFill(colorSpecFromRole(ColorRole::SurfaceVariant, fillOpacity));

--- a/src/ui/controls/box.h
+++ b/src/ui/controls/box.h
@@ -35,9 +35,9 @@ public:
   void setFlatStyle();
   void setCardStyle(float scale = 1.0f, float fillOpacity = 1.0f, bool showBorder = true);
   void setPanelStyle(bool showBorder = true);
-  // Dialog/popup background. Like the panel style but always carries a subtle
-  // outline so the dialog separates from the parent surface it floats over,
-  // independent of the [shell.panel].borders toggle.
+  // Dialog/popup background. Like the panel style but carries a subtle
+  // outline based on the [shell].popup_borders toggle, so the dialog
+  // separates from the parent surface it floats over.
   void setDialogStyle();
 
   void setSize(float width, float height) override;

--- a/src/ui/controls/context_menu.cpp
+++ b/src/ui/controls/context_menu.cpp
@@ -217,10 +217,8 @@ void ContextMenuControl::rebuild(Renderer& renderer) {
   addChild(
       ui::box({
           .configure = [this](Box& bg) {
-            bg.setCardStyle(m_contentScale);
+            bg.setCardStyle(m_contentScale, 1.0f, Style::popupBordersEnabled());
             bg.setRadius(Style::scaledRadiusLg(m_contentScale));
-            bg.setFill(colorSpecFromRole(ColorRole::SurfaceVariant));
-            bg.setBorder(colorSpecFromRole(ColorRole::Outline), Style::borderWidth * m_contentScale);
             bg.setFrameSize(width(), height());
           },
       })

--- a/src/ui/controls/context_menu_popup.cpp
+++ b/src/ui/controls/context_menu_popup.cpp
@@ -42,8 +42,7 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
   const std::size_t maxVisible =
       request.maxVisible > 0 ? request.maxVisible : std::max<std::size_t>(1, request.entries.size());
   const float menuHeight = ContextMenuControl::preferredHeight(request.entries, maxVisible);
-  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
-  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, effectiveShadow);
+  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig, Style::popupShadowsEnabled());
   m_scrollState = {};
   m_scrollView = nullptr;
   m_menu = nullptr;
@@ -121,8 +120,9 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
 
     self->m_sceneRoot = std::make_unique<Node>();
     self->m_sceneRoot->setSize(fw, fh);
-    const auto effectiveShadow2 = Style::popupShadowsEnabled() ? self->m_shadowConfig : std::nullopt;
-    (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, effectiveShadow2, Style::scaledRadiusLg());
+    if (Style::popupShadowsEnabled()) {
+      (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, self->m_shadowConfig, Style::scaledRadiusLg());
+    }
 
     auto scrollView = std::make_unique<ScrollView>();
     scrollView->setPosition(chrome.contentX(), chrome.contentY());

--- a/src/ui/controls/context_menu_popup.cpp
+++ b/src/ui/controls/context_menu_popup.cpp
@@ -42,7 +42,8 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
   const std::size_t maxVisible =
       request.maxVisible > 0 ? request.maxVisible : std::max<std::size_t>(1, request.entries.size());
   const float menuHeight = ContextMenuControl::preferredHeight(request.entries, maxVisible);
-  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig, Style::popupShadowsEnabled());
+  const auto chrome =
+      popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig, Style::popupShadowsEnabled());
   m_scrollState = {};
   m_scrollView = nullptr;
   m_menu = nullptr;

--- a/src/ui/controls/context_menu_popup.cpp
+++ b/src/ui/controls/context_menu_popup.cpp
@@ -42,7 +42,8 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
   const std::size_t maxVisible =
       request.maxVisible > 0 ? request.maxVisible : std::max<std::size_t>(1, request.entries.size());
   const float menuHeight = ContextMenuControl::preferredHeight(request.entries, maxVisible);
-  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, m_shadowConfig);
+  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
+  const auto chrome = popup_chrome::computeGeometry(request.menuWidth, menuHeight, effectiveShadow);
   m_scrollState = {};
   m_scrollView = nullptr;
   m_menu = nullptr;
@@ -120,7 +121,8 @@ void ContextMenuPopup::open(ContextMenuPopupRequest request) {
 
     self->m_sceneRoot = std::make_unique<Node>();
     self->m_sceneRoot->setSize(fw, fh);
-    (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, self->m_shadowConfig, Style::scaledRadiusLg());
+    const auto effectiveShadow2 = Style::popupShadowsEnabled() ? self->m_shadowConfig : std::nullopt;
+    (void)popup_chrome::addShadow(*self->m_sceneRoot, chrome, effectiveShadow2, Style::scaledRadiusLg());
 
     auto scrollView = std::make_unique<ScrollView>();
     scrollView->setPosition(chrome.contentX(), chrome.contentY());

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -362,6 +362,7 @@ Input::Input() {
     updateDisplayText();
     applyVisualState();
   });
+  m_inputBordersConn = Style::inputBordersChanged().connect([this] { applyVisualState(); });
 }
 
 Input::~Input() {

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -1388,6 +1388,13 @@ void Input::applyVisualState() {
         : (focused ? resolveColorSpec(focusRingColorSpec())
                    : (inputHovered ? resolved(ColorRole::Hover) : resolved(ColorRole::Outline)));
 
+    float resolvedBorderWidth = 0.0f;
+    if (focused) {
+      resolvedBorderWidth = Style::focusRingWidth;
+    } else if (Style::inputBordersEnabled()) {
+      resolvedBorderWidth = Style::borderWidth;
+    }
+
     m_background->setStyle(
         RoundedRectStyle{
             .fill = fill,
@@ -1395,7 +1402,7 @@ void Input::applyVisualState() {
             .fillMode = FillMode::Solid,
             .radius = Style::scaledRadius(m_frameRadius, chromeScale),
             .softness = 1.0f,
-            .borderWidth = focused ? Style::focusRingWidth : Style::borderWidth,
+            .borderWidth = resolvedBorderWidth,
         }
     );
   } else if (m_background != nullptr) {

--- a/src/ui/controls/input.h
+++ b/src/ui/controls/input.h
@@ -238,6 +238,7 @@ private:
   float m_lastPrimaryPressY = 0.0f;
   bool m_hasLastPrimaryPress = false;
   Signal<>::ScopedConnection m_paletteConn;
+  Signal<>::ScopedConnection m_inputBordersConn;
 
   // Detects synchronous self-destruction from user callbacks (onSubmit/onKeyEvent
   // can close a dialog that owns this Input). handleKey takes a weak_ptr to it and

--- a/src/ui/controls/select.cpp
+++ b/src/ui/controls/select.cpp
@@ -353,6 +353,13 @@ void Select::applyVisualState() {
   m_triggerGlyph->setColor(triggerText);
   m_triggerGlyph->setRotation(m_caretProgress * std::numbers::pi_v<float>);
 
+  float resolvedBorderWidth = 0.0f;
+  if (triggerFocused) {
+    resolvedBorderWidth = Style::focusRingWidth;
+  } else if (Style::inputBordersEnabled()) {
+    resolvedBorderWidth = Style::borderWidth;
+  }
+
   m_triggerBackground->setStyle(
       RoundedRectStyle{
           .fill = triggerBg,
@@ -360,7 +367,7 @@ void Select::applyVisualState() {
           .fillMode = FillMode::Solid,
           .radius = Style::scaledRadiusMd(),
           .softness = 1.0f,
-          .borderWidth = triggerFocused ? Style::focusRingWidth : Style::borderWidth,
+          .borderWidth = resolvedBorderWidth,
       }
   );
 }

--- a/src/ui/controls/select.cpp
+++ b/src/ui/controls/select.cpp
@@ -92,6 +92,7 @@ Select::Select() {
 
   applyVisualState();
   m_paletteConn = paletteChanged().connect([this] { applyVisualState(); });
+  m_inputBordersConn = Style::inputBordersChanged().connect([this] { applyVisualState(); });
 }
 
 Select::~Select() {

--- a/src/ui/controls/select.h
+++ b/src/ui/controls/select.h
@@ -84,6 +84,7 @@ private:
   std::vector<ColorSwatchPreview> m_optionSwatchPreviews;
   bool m_notifyOnReselect = false;
   Signal<>::ScopedConnection m_paletteConn;
+  Signal<>::ScopedConnection m_inputBordersConn;
 
   std::function<void(std::size_t, std::string_view)> m_onSelectionChanged;
 };

--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -98,7 +98,8 @@ void SelectDropdownPopup::openSelectDropdown(const DropdownRequest& request, Dro
   m_viewportHeight = static_cast<float>(visibleCount) * m_optionHeight + kMenuPadding * 2.0f;
   m_totalHeight = static_cast<float>(m_options.size()) * m_optionHeight;
   m_scrollOffset = 0.0f;
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig);
+  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
 
   ensureHoveredIndexVisible();
 
@@ -227,12 +228,13 @@ bool SelectDropdownPopup::isSelectDropdownOpen() const { return m_surface != nul
 void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
   m_sceneRoot = std::make_unique<Node>();
   m_optionViews.clear();
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig);
+  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
   const float menuX = chrome.contentX();
   const float menuY = chrome.contentY();
   const float radius = Style::scaledRadiusMd();
 
-  (void)popup_chrome::addShadow(*m_sceneRoot, chrome, m_shadowConfig, radius);
+  (void)popup_chrome::addShadow(*m_sceneRoot, chrome, effectiveShadow, radius);
 
   auto bg = std::make_unique<RectNode>();
   bg->setStyle(
@@ -242,7 +244,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
           .fillMode = FillMode::Solid,
           .radius = radius,
           .softness = 1.0f,
-          .borderWidth = Style::borderWidth,
+          .borderWidth = Style::popupBordersEnabled() ? Style::borderWidth : 0.0f,
       }
   );
   auto* bgNode = static_cast<RectNode*>(m_sceneRoot->addChild(std::move(bg)));
@@ -353,7 +355,7 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
 
   auto scrollbar = std::make_unique<Scrollbar>();
   scrollbar->setOnScrollChanged([this](float offset) { setScrollOffset(offset); });
-  const float scrollbarX = menuX + m_menuWidth - Style::scrollbarWidth - Style::borderWidth;
+  const float scrollbarX = menuX + m_menuWidth - Style::scrollbarWidth - (Style::popupBordersEnabled() ? Style::borderWidth : 0.0f);
   scrollbar->setPosition(scrollbarX, menuY + kMenuPadding);
   scrollbar->update(contentViewport, m_totalHeight, m_scrollOffset);
   m_scrollbar = static_cast<Scrollbar*>(m_sceneRoot->addChild(std::move(scrollbar)));
@@ -721,7 +723,8 @@ bool SelectDropdownPopup::ownsSurface(wl_surface* surface) const noexcept {
 }
 
 bool SelectDropdownPopup::containsPopupContent(float localX, float localY) const noexcept {
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig);
+  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
   return localX >= chrome.contentX()
       && localY >= chrome.contentY()
       && localX < chrome.contentRight()

--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -98,7 +98,8 @@ void SelectDropdownPopup::openSelectDropdown(const DropdownRequest& request, Dro
   m_viewportHeight = static_cast<float>(visibleCount) * m_optionHeight + kMenuPadding * 2.0f;
   m_totalHeight = static_cast<float>(m_options.size()) * m_optionHeight;
   m_scrollOffset = 0.0f;
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
+  const auto chrome =
+      popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
 
   ensureHoveredIndexVisible();
 
@@ -227,7 +228,8 @@ bool SelectDropdownPopup::isSelectDropdownOpen() const { return m_surface != nul
 void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
   m_sceneRoot = std::make_unique<Node>();
   m_optionViews.clear();
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
+  const auto chrome =
+      popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
   const float menuX = chrome.contentX();
   const float menuY = chrome.contentY();
   const float radius = Style::scaledRadiusMd();
@@ -355,7 +357,8 @@ void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
 
   auto scrollbar = std::make_unique<Scrollbar>();
   scrollbar->setOnScrollChanged([this](float offset) { setScrollOffset(offset); });
-  const float scrollbarX = menuX + m_menuWidth - Style::scrollbarWidth - (Style::popupBordersEnabled() ? Style::borderWidth : 0.0f);
+  const float scrollbarX =
+      menuX + m_menuWidth - Style::scrollbarWidth - (Style::popupBordersEnabled() ? Style::borderWidth : 0.0f);
   scrollbar->setPosition(scrollbarX, menuY + kMenuPadding);
   scrollbar->update(contentViewport, m_totalHeight, m_scrollOffset);
   m_scrollbar = static_cast<Scrollbar*>(m_sceneRoot->addChild(std::move(scrollbar)));
@@ -723,7 +726,8 @@ bool SelectDropdownPopup::ownsSurface(wl_surface* surface) const noexcept {
 }
 
 bool SelectDropdownPopup::containsPopupContent(float localX, float localY) const noexcept {
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
+  const auto chrome =
+      popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
   return localX >= chrome.contentX()
       && localY >= chrome.contentY()
       && localX < chrome.contentRight()

--- a/src/ui/controls/select_dropdown_popup.cpp
+++ b/src/ui/controls/select_dropdown_popup.cpp
@@ -98,8 +98,7 @@ void SelectDropdownPopup::openSelectDropdown(const DropdownRequest& request, Dro
   m_viewportHeight = static_cast<float>(visibleCount) * m_optionHeight + kMenuPadding * 2.0f;
   m_totalHeight = static_cast<float>(m_options.size()) * m_optionHeight;
   m_scrollOffset = 0.0f;
-  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
 
   ensureHoveredIndexVisible();
 
@@ -228,13 +227,14 @@ bool SelectDropdownPopup::isSelectDropdownOpen() const { return m_surface != nul
 void SelectDropdownPopup::buildScene(const DropdownRequest& request) {
   m_sceneRoot = std::make_unique<Node>();
   m_optionViews.clear();
-  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
   const float menuX = chrome.contentX();
   const float menuY = chrome.contentY();
   const float radius = Style::scaledRadiusMd();
 
-  (void)popup_chrome::addShadow(*m_sceneRoot, chrome, effectiveShadow, radius);
+  if (Style::popupShadowsEnabled()) {
+    (void)popup_chrome::addShadow(*m_sceneRoot, chrome, m_shadowConfig, radius);
+  }
 
   auto bg = std::make_unique<RectNode>();
   bg->setStyle(
@@ -723,8 +723,7 @@ bool SelectDropdownPopup::ownsSurface(wl_surface* surface) const noexcept {
 }
 
 bool SelectDropdownPopup::containsPopupContent(float localX, float localY) const noexcept {
-  const auto effectiveShadow = Style::popupShadowsEnabled() ? m_shadowConfig : std::nullopt;
-  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, effectiveShadow);
+  const auto chrome = popup_chrome::computeGeometry(m_menuWidth, m_viewportHeight, m_shadowConfig, Style::popupShadowsEnabled());
   return localX >= chrome.contentX()
       && localY >= chrome.contentY()
       && localX < chrome.contentRight()

--- a/src/ui/dialogs/dialog_popup_host.cpp
+++ b/src/ui/dialogs/dialog_popup_host.cpp
@@ -29,7 +29,10 @@ namespace {
       | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X
       | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
 
-  ShellConfig::ShadowConfig popupShadowConfig(ConfigService* config) {
+  std::optional<ShellConfig::ShadowConfig> popupShadowConfig(ConfigService* config) {
+    if (!Style::popupShadowsEnabled()) {
+      return std::nullopt;
+    }
     return config != nullptr ? config->config().shell.shadow : ShellConfig::ShadowConfig{};
   }
 
@@ -495,10 +498,12 @@ void DialogPopupHost::syncSceneGeometryFromSurface() {
   const float panelW = m_chrome.contentWidth;
   const float panelH = m_chrome.contentHeight;
   if (m_panelShadow != nullptr) {
-    const ShellConfig::ShadowConfig shadow = popupShadowConfig(m_config);
-    const auto offset = shadowDirectionOffset(shadow.direction);
-    m_panelShadow->setPosition(panelX + static_cast<float>(offset.x), panelY + static_cast<float>(offset.y));
-    m_panelShadow->setFrameSize(panelW, panelH);
+    const auto shadow = popupShadowConfig(m_config);
+    if (shadow) {
+      const auto offset = shadowDirectionOffset(shadow->direction);
+      m_panelShadow->setPosition(panelX + static_cast<float>(offset.x), panelY + static_cast<float>(offset.y));
+      m_panelShadow->setFrameSize(panelW, panelH);
+    }
   }
   if (m_bgNode != nullptr) {
     m_bgNode->setPosition(panelX, panelY);

--- a/src/ui/dialogs/dialog_popup_host.cpp
+++ b/src/ui/dialogs/dialog_popup_host.cpp
@@ -110,8 +110,9 @@ bool DialogPopupHost::openPopup(std::uint32_t width, std::uint32_t height) {
   // grab serial it rejects). Running cancel() there would destroy this popup mid-initialization.
   surface->setDismissedCallback([this]() { DeferredCall::callLater([this]() { cancel(); }); });
 
-  m_chrome =
-      popup_chrome::computeGeometry(static_cast<float>(width), static_cast<float>(height), popupShadowConfig(m_config), Style::popupShadowsEnabled());
+  m_chrome = popup_chrome::computeGeometry(
+      static_cast<float>(width), static_cast<float>(height), popupShadowConfig(m_config), Style::popupShadowsEnabled()
+  );
   PopupSurfaceConfig popupConfig = defaultPopupConfig(*parentContext, width, height);
   popup_chrome::applyToConfig(
       popupConfig, m_chrome,
@@ -166,7 +167,8 @@ bool DialogPopupHost::openPopupAsChild(PopupSurfaceConfig config, const XdgPopup
   surface->setDismissedCallback([this]() { DeferredCall::callLater([this]() { cancel(); }); });
 
   m_chrome = popup_chrome::computeGeometry(
-      static_cast<float>(config.width), static_cast<float>(config.height), popupShadowConfig(m_config), Style::popupShadowsEnabled()
+      static_cast<float>(config.width), static_cast<float>(config.height), popupShadowConfig(m_config),
+      Style::popupShadowsEnabled()
   );
   popup_chrome::applyToConfig(
       config, m_chrome,
@@ -425,7 +427,8 @@ void DialogPopupHost::buildScene(std::uint32_t width, std::uint32_t height) {
   m_sceneRoot = std::make_unique<Node>();
   m_sceneRoot->setAnimationManager(&m_animations);
   if (Style::popupShadowsEnabled()) {
-    m_panelShadow = popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl());
+    m_panelShadow =
+        popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl());
   }
 
   auto bg = ui::box({

--- a/src/ui/dialogs/dialog_popup_host.cpp
+++ b/src/ui/dialogs/dialog_popup_host.cpp
@@ -29,10 +29,7 @@ namespace {
       | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X
       | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
 
-  std::optional<ShellConfig::ShadowConfig> popupShadowConfig(ConfigService* config) {
-    if (!Style::popupShadowsEnabled()) {
-      return std::nullopt;
-    }
+  ShellConfig::ShadowConfig popupShadowConfig(ConfigService* config) {
     return config != nullptr ? config->config().shell.shadow : ShellConfig::ShadowConfig{};
   }
 
@@ -114,7 +111,7 @@ bool DialogPopupHost::openPopup(std::uint32_t width, std::uint32_t height) {
   surface->setDismissedCallback([this]() { DeferredCall::callLater([this]() { cancel(); }); });
 
   m_chrome =
-      popup_chrome::computeGeometry(static_cast<float>(width), static_cast<float>(height), popupShadowConfig(m_config));
+      popup_chrome::computeGeometry(static_cast<float>(width), static_cast<float>(height), popupShadowConfig(m_config), Style::popupShadowsEnabled());
   PopupSurfaceConfig popupConfig = defaultPopupConfig(*parentContext, width, height);
   popup_chrome::applyToConfig(
       popupConfig, m_chrome,
@@ -169,7 +166,7 @@ bool DialogPopupHost::openPopupAsChild(PopupSurfaceConfig config, const XdgPopup
   surface->setDismissedCallback([this]() { DeferredCall::callLater([this]() { cancel(); }); });
 
   m_chrome = popup_chrome::computeGeometry(
-      static_cast<float>(config.width), static_cast<float>(config.height), popupShadowConfig(m_config)
+      static_cast<float>(config.width), static_cast<float>(config.height), popupShadowConfig(m_config), Style::popupShadowsEnabled()
   );
   popup_chrome::applyToConfig(
       config, m_chrome,
@@ -427,7 +424,9 @@ void DialogPopupHost::buildScene(std::uint32_t width, std::uint32_t height) {
   (void)height;
   m_sceneRoot = std::make_unique<Node>();
   m_sceneRoot->setAnimationManager(&m_animations);
-  m_panelShadow = popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl());
+  if (Style::popupShadowsEnabled()) {
+    m_panelShadow = popup_chrome::addShadow(*m_sceneRoot, m_chrome, popupShadowConfig(m_config), Style::scaledRadiusXl());
+  }
 
   auto bg = ui::box({
       .configure = [](Box& box) { box.setDialogStyle(); },
@@ -497,13 +496,11 @@ void DialogPopupHost::syncSceneGeometryFromSurface() {
   const float panelY = m_chrome.contentY();
   const float panelW = m_chrome.contentWidth;
   const float panelH = m_chrome.contentHeight;
-  if (m_panelShadow != nullptr) {
+  if (m_panelShadow != nullptr && Style::popupShadowsEnabled()) {
     const auto shadow = popupShadowConfig(m_config);
-    if (shadow) {
-      const auto offset = shadowDirectionOffset(shadow->direction);
-      m_panelShadow->setPosition(panelX + static_cast<float>(offset.x), panelY + static_cast<float>(offset.y));
-      m_panelShadow->setFrameSize(panelW, panelH);
-    }
+    const auto offset = shadowDirectionOffset(shadow.direction);
+    m_panelShadow->setPosition(panelX + static_cast<float>(offset.x), panelY + static_cast<float>(offset.y));
+    m_panelShadow->setFrameSize(panelW, panelH);
   }
   if (m_bgNode != nullptr) {
     m_bgNode->setPosition(panelX, panelY);

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -6,6 +6,9 @@ namespace {
 
   float g_cornerRadiusScale = 1.0f;
   bool g_buttonBordersEnabled = true;
+  bool g_inputBordersEnabled = true;
+  bool g_popupBordersEnabled = true;
+  bool g_popupShadowsEnabled = true;
 
 } // namespace
 
@@ -29,6 +32,15 @@ namespace Style {
     static Signal<> signal;
     return signal;
   }
+
+  bool inputBordersEnabled() noexcept { return g_inputBordersEnabled; }
+  void setInputBordersEnabled(bool enabled) { g_inputBordersEnabled = enabled; }
+
+  bool popupBordersEnabled() noexcept { return g_popupBordersEnabled; }
+  void setPopupBordersEnabled(bool enabled) { g_popupBordersEnabled = enabled; }
+
+  bool popupShadowsEnabled() noexcept { return g_popupShadowsEnabled; }
+  void setPopupShadowsEnabled(bool enabled) { g_popupShadowsEnabled = enabled; }
 
   float scaledRadius(float radius, float localScale) noexcept { return radius * localScale * g_cornerRadiusScale; }
 

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -34,7 +34,19 @@ namespace Style {
   }
 
   bool inputBordersEnabled() noexcept { return g_inputBordersEnabled; }
-  void setInputBordersEnabled(bool enabled) { g_inputBordersEnabled = enabled; }
+
+  void setInputBordersEnabled(bool enabled) {
+    if (g_inputBordersEnabled == enabled) {
+      return;
+    }
+    g_inputBordersEnabled = enabled;
+    inputBordersChanged().emit();
+  }
+
+  Signal<>& inputBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
 
   bool popupBordersEnabled() noexcept { return g_popupBordersEnabled; }
   void setPopupBordersEnabled(bool enabled) { g_popupBordersEnabled = enabled; }

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -71,6 +71,15 @@ namespace Style {
   void setButtonBordersEnabled(bool enabled);
   Signal<>& buttonBordersChanged();
 
+  [[nodiscard]] bool inputBordersEnabled() noexcept;
+  void setInputBordersEnabled(bool enabled);
+
+  [[nodiscard]] bool popupBordersEnabled() noexcept;
+  void setPopupBordersEnabled(bool enabled);
+
+  [[nodiscard]] bool popupShadowsEnabled() noexcept;
+  void setPopupShadowsEnabled(bool enabled);
+
   [[nodiscard]] float scaledRadius(float radius, float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusSm(float localScale = 1.0f) noexcept;
   [[nodiscard]] float scaledRadiusMd(float localScale = 1.0f) noexcept;

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -73,6 +73,7 @@ namespace Style {
 
   [[nodiscard]] bool inputBordersEnabled() noexcept;
   void setInputBordersEnabled(bool enabled);
+  Signal<>& inputBordersChanged();
 
   [[nodiscard]] bool popupBordersEnabled() noexcept;
   void setPopupBordersEnabled(bool enabled);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Extended support for border and shadow toggles by adding new options, shown in the screenshot

<img width="1100" height="700" alt="image" src="https://github.com/user-attachments/assets/980e659b-0328-4e0f-8051-b1a0876e501b" />


## Motivation

<!-- What problem does this solve? -->
Currently, button border only affects the clickable button boxes and doesn't affect the input, dropdown and popup boxes. Also that disabling shadows currently doesn't affect the popups where their shadows are hardcoded. So added two new border toggles that affects the said areas, and a new shadow toggle that affects the popups.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [x] New feature

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just build debug` to ensure no compilation errors were caught. Tested the options manually, video showcase in the below section 

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
https://github.com/user-attachments/assets/588abb3b-8bd8-4938-a3f4-3756f26ac1b7


## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I'm still not exactly sure if you guys intended for it this way. But I'm open to suggestions if needed any changes in the option structure. 