### PR TITLE
fix(pipewire): fix audio spectrum receiving silent audio samples 

### DIFF
--- a/src/pipewire/pipewire_spectrum.cpp
+++ b/src/pipewire/pipewire_spectrum.cpp
@@ -167,9 +167,9 @@ bool PipeWireSpectrum::Stream::start() {
   }
 
   auto* props = pw_properties_new(
-      PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Monitor", PW_KEY_MEDIA_NAME, "Noctalia Spectrum",
+      PW_KEY_MEDIA_TYPE, "Audio", PW_KEY_MEDIA_CATEGORY, "Capture", PW_KEY_MEDIA_NAME, "Noctalia Spectrum",
       PW_KEY_APP_NAME, "Noctalia Spectrum", PW_KEY_STREAM_MONITOR, "true", PW_KEY_STREAM_CAPTURE_SINK, "true",
-      PW_KEY_TARGET_OBJECT, m_targetObject.c_str(), PW_KEY_NODE_PASSIVE, "true", nullptr
+      PW_KEY_MEDIA_ROLE, "Music", PW_KEY_TARGET_OBJECT, m_targetObject.c_str(), PW_KEY_NODE_PASSIVE, "true", nullptr
   );
   if (props == nullptr) {
     kLog.warn("failed to create spectrum stream properties");


### PR DESCRIPTION
## Summary

Changed `PW_KEY_MEDIA_CATEGORY` and added the missing `PW_KEY_MEDIA_ROLE` on the audio capture stream so it autoconnects and receives real audio samples instead of silence.

## Motivation

The audio spectrum visualizer was not working on my system (`PipeWire 1.6.7`, `libpipewire 1.6.7`). The stream connected successfully, but every captured sample returned as `0`, causing the visualizer to show no activity.

According to the PipeWire documentation, autoconnecting streams require the media type, category, and role properties to be set together for proper connection behavior. The stream was missing `PW_KEY_MEDIA_ROLE`, and `PW_KEY_MEDIA_CATEGORY` was set to `"Monitor"` instead of `"Capture"`, matching the properties used in the PipeWire audio capture example.

Ref: https://docs.pipewire.org/audio-capture_8c-example.html#_a33

## Type of Change

- [x] Bug fix

## Testing
Tested locally on `PipeWire 1.6.7` / `libpipewire 1.6.7`.
