### PR TITLE
Minor Minimal Style Workspace Improvements

### DIFF
--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -35,7 +35,9 @@ namespace {
   constexpr float kWorkspacePillDefaultHeight = Style::baseGlyphSize;
   constexpr float kWorkspaceAnimDurationMs = static_cast<float>(Style::animNormal);
 
-  float workspaceLabelFontSize(bool minimal) { return minimal ? Style::fontSizeBody : Style::fontSizeMini; }
+  [[nodiscard]] constexpr float workspaceLabelFontSize(bool minimal) {
+    return minimal ? Style::fontSizeBody : Style::fontSizeMini;
+  }
 
   [[nodiscard]] FontWeight workspaceFontWeight(FontWeight baseWeight, bool minimal, bool active) {
     if (minimal && active) {
@@ -704,9 +706,10 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
     m_container->setFrameSize(total, m_indicatorHeight);
   }
 
-  ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
-  hoverFill.alpha = 0.0f;
-  if (!m_minimal || m_barCapsuleSpec.hoverHighlight) {
+  // Only minimal style draws the translucent per-item hover overlay.
+  if (m_minimal && barCapsuleSpec().hoverHighlight) {
+    ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
+    hoverFill.alpha = 0.0f;
     m_hoverOverlay = static_cast<Box*>(m_container->addChild(
         ui::box({
             .fill = hoverFill,
@@ -718,6 +721,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
         })
     ));
   }
+
   if (needsAnimation) {
     startAnimation();
   } else {
@@ -1184,9 +1188,6 @@ void WorkspacesWidget::updateHoverOverlay() {
   Item& hoveredItem = *hoveredIt;
 
   if (!m_minimal) {
-    if (m_hoverOverlay != nullptr) {
-      m_hoverOverlay->setVisible(false);
-    }
     for (auto& item : m_items) {
       if (&item == &hoveredItem) {
         if (item.indicator != nullptr) {

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -35,6 +35,8 @@ namespace {
   constexpr float kWorkspacePillDefaultHeight = Style::baseGlyphSize;
   constexpr float kWorkspaceAnimDurationMs = static_cast<float>(Style::animNormal);
 
+  float workspaceLabelFontSize(bool minimal) { return minimal ? Style::fontSizeBody : Style::fontSizeMini; }
+
   [[nodiscard]] FontWeight workspaceFontWeight(FontWeight baseWeight, bool minimal, bool active) {
     if (minimal && active) {
       return static_cast<FontWeight>(static_cast<int>(baseWeight) + 200);
@@ -431,7 +433,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
   }
 
   const float gap = kWorkspaceGap * m_contentScale;
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = workspaceLabelFontSize(m_minimal) * m_contentScale;
   const float pillHeight = std::round(kWorkspacePillDefaultHeight * m_contentScale * m_pillScale);
   const FontWeight configuredFontWeight = labelFontWeight();
 
@@ -704,17 +706,18 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
 
   ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
   hoverFill.alpha = 0.0f;
-  m_hoverOverlay = static_cast<Box*>(m_container->addChild(
-      ui::box({
-          .fill = hoverFill,
-          .visible = false,
-          .configure = [](Box& box) {
-            box.setParticipatesInLayout(false);
-            box.setHitTestVisible(false);
-          },
-      })
-  ));
-
+  if (!m_minimal || m_barCapsuleSpec.hoverHighlight) {
+    m_hoverOverlay = static_cast<Box*>(m_container->addChild(
+        ui::box({
+            .fill = hoverFill,
+            .visible = false,
+            .configure = [](Box& box) {
+              box.setParticipatesInLayout(false);
+              box.setHitTestVisible(false);
+            },
+        })
+    ));
+  }
   if (needsAnimation) {
     startAnimation();
   } else {
@@ -796,7 +799,7 @@ void WorkspacesWidget::ensureItemLabel(Renderer& renderer, Item& item, const Wor
     return;
   }
 
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = workspaceLabelFontSize(m_minimal) * m_contentScale;
   item.text = static_cast<Label*>(item.area->addChild(
       ui::label({
           .text = item.label,
@@ -814,7 +817,7 @@ void WorkspacesWidget::recalculateItemMetrics(
     Renderer& renderer, Item& item, const Workspace& workspace, std::size_t displayIndex
 ) {
   const std::string label = workspaceLabel(workspace, displayIndex);
-  const float labelFontSize = Style::fontSizeMini * m_contentScale;
+  const float labelFontSize = workspaceLabelFontSize(m_minimal) * m_contentScale;
   const float pillHeight = std::round(kWorkspacePillDefaultHeight * m_contentScale * m_pillScale);
   const float baseSize = std::round(pillHeight);
   const float padding = m_minimal ? (Style::spaceXs * m_contentScale) : (baseSize * 0.6f);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Fixed the font sizing and hover highlight handling for `workspaces` widget minimal style

## Motivation

<!-- What problem does this solve? -->
Re-using the mini-sized fonts from the pills makes the font feel too small for minimal styled workspace widget where there's no pill background. Now it respect the global content scaling and uses the default font size of all widgets. Also, have noticed that it doesn't respect the global hover highlight toggle by default, so made it such that it respects that toggle now for minimal style 

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just build debug` to ensure no compilation errors were caught. Tested the debug build manually and have tested different content scaling values to ensure the minimal style workspaces follow them correctly. Also that hovering over the elements inside the minimal style workspaces widget respects the hover highlight toggle.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
| Before | After |
|--------|-------|
| <img width="1049" height="556" alt="Before" src="https://github.com/user-attachments/assets/21529fdc-3061-427d-895b-2553920939da" /> | <img width="1024" height="560" alt="After" src="https://github.com/user-attachments/assets/81fdecc5-3747-4d42-80b8-ab965ebb691b" /> |


## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files 
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.