### PR TITLE
feat(plugins): add noctalia.systemStats and per-core CPU sampling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1221,6 +1221,21 @@ cpu_temp_sensor_test = executable('cpu_temp_sensor_test',
 
 test('cpu_temp_sensor', cpu_temp_sensor_test)
 
+cpu_stat_parse_test = executable('cpu_stat_parse_test',
+  sources: files(
+    'tests/cpu_stat_parse_test.cpp',
+    'src/system/system_monitor_service.cpp',
+    'src/system/cpu_temp_sensor.cpp',
+    'src/system/intel_gpu.cpp',
+    'src/system/format_units.cpp',
+    'src/core/log.cpp',
+  ),
+  include_directories: _noctalia_inc,
+  dependencies: [dl_dep],
+)
+
+test('cpu_stat_parse', cpu_stat_parse_test)
+
 i18n_language_tag_test = executable('i18n_language_tag_test',
   sources: files(
     'tests/i18n_language_tag_test.cpp',

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -770,6 +770,7 @@ void Application::initAuxServicesAndHooks() {
 
   try {
     m_systemMonitor = std::make_unique<SystemMonitorService>(m_configService.config().system.monitor);
+    m_scriptApi.setSystemMonitor(m_systemMonitor.get());
     if (m_systemMonitor->isRunning()) {
       kLog.info("system monitor service active");
     } else {

--- a/src/scripting/luau_host.cpp
+++ b/src/scripting/luau_host.cpp
@@ -17,6 +17,7 @@
 #include "system/app_identity.h"
 #include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
+#include "system/system_monitor_service.h"
 #include "system/terminal_launch.h"
 #include "time/time_format.h"
 #include "ui/dialogs/color_picker_dialog.h"
@@ -175,6 +176,20 @@ namespace {
     lua_setfield(L, -2, key);
   }
 
+  void setTableNumber(lua_State* L, const char* key, double value) {
+    lua_pushnumber(L, value);
+    lua_setfield(L, -2, key);
+  }
+
+  // Pushes an optional as a number, or leaves the key absent (nil) when it has no value —
+  // the Luau-idiomatic way to say "this machine has no such sensor".
+  template <typename T> void setTableOptionalNumber(lua_State* L, const char* key, const std::optional<T>& value) {
+    if (!value.has_value()) {
+      return;
+    }
+    setTableNumber(L, key, static_cast<double>(*value));
+  }
+
   void setTableString(lua_State* L, const char* key, const std::string& value) {
     lua_pushlstring(L, value.data(), value.size());
     lua_setfield(L, -2, key);
@@ -326,6 +341,95 @@ namespace {
       setTableBool(L, "focused", out.focused);
       lua_rawseti(L, -2, index++);
     }
+    return 1;
+  }
+
+  // systemStats() -> a snapshot of the host's system monitor, or nil when it is disabled.
+  //
+  //   { cpu = { total = 23.4, cores = { 10.2, 55.1, ... } },
+  //     ram = { percent, usedMb, totalMb }, swap = { usedMb, totalMb },
+  //     cpuTempC = number?, gpu = { tempC?, usagePercent?, vramUsedBytes?, vramTotalBytes? },
+  //     net = { rxBytesPerSec, txBytesPerSec }, loadAvg = { 1.2, 0.9, 0.7 } }
+  //
+  // Percentages are 0-100. Absent sensors are nil rather than 0, so a plugin can tell
+  // "no GPU probe" from "GPU idle". `cpu.cores` is indexed in /proc/stat order; the first
+  // call opts this host into per-core sampling, which costs one extra /proc/stat read per
+  // second for as long as the plugin is loaded.
+  int luau_systemStats(lua_State* L) {
+    auto* host = hostForState(L);
+    if (host == nullptr) {
+      lua_pushnil(L);
+      return 1;
+    }
+    auto* monitor = host->api().systemMonitor();
+    if (monitor == nullptr) {
+      lua_pushnil(L);
+      return 1;
+    }
+
+    host->ensureCpuCoresRetained();
+    const SystemStats stats = monitor->latest();
+
+    lua_createtable(L, 0, 7);
+
+    lua_createtable(L, 0, 2);
+    setTableNumber(L, "total", stats.cpuUsagePercent);
+    lua_createtable(L, static_cast<int>(stats.cpuCoreUsagePercent.size()), 0);
+    int coreIndex = 1;
+    for (const double core : stats.cpuCoreUsagePercent) {
+      lua_pushnumber(L, core);
+      lua_rawseti(L, -2, coreIndex++);
+    }
+    lua_setfield(L, -2, "cores");
+    lua_setfield(L, -2, "cpu");
+
+    lua_createtable(L, 0, 3);
+    setTableNumber(L, "percent", stats.ramUsagePercent);
+    setTableNumber(L, "usedMb", static_cast<double>(stats.ramUsedMb));
+    setTableNumber(L, "totalMb", static_cast<double>(stats.ramTotalMb));
+    lua_setfield(L, -2, "ram");
+
+    lua_createtable(L, 0, 2);
+    setTableNumber(L, "usedMb", static_cast<double>(stats.swapUsedMb));
+    setTableNumber(L, "totalMb", static_cast<double>(stats.swapTotalMb));
+    lua_setfield(L, -2, "swap");
+
+    // cpuTempAvailable false means the service is serving its 40C placeholder, not a reading.
+    if (stats.cpuTempAvailable) {
+      setTableOptionalNumber(L, "cpuTempC", stats.cpuTempC);
+    }
+
+    lua_createtable(L, 0, 4);
+    setTableOptionalNumber(L, "tempC", stats.gpuTempC);
+    setTableOptionalNumber(L, "usagePercent", stats.gpuUsagePercent);
+    setTableOptionalNumber(L, "vramUsedBytes", stats.gpuVramUsedBytes);
+    setTableOptionalNumber(L, "vramTotalBytes", stats.gpuVramTotalBytes);
+    lua_setfield(L, -2, "gpu");
+
+    lua_createtable(L, 0, 2);
+    setTableNumber(L, "rxBytesPerSec", stats.netRxBytesPerSec);
+    setTableNumber(L, "txBytesPerSec", stats.netTxBytesPerSec);
+    lua_setfield(L, -2, "net");
+
+    lua_createtable(L, 3, 0);
+    lua_pushnumber(L, stats.loadAvg1);
+    lua_rawseti(L, -2, 1);
+    lua_pushnumber(L, stats.loadAvg5);
+    lua_rawseti(L, -2, 2);
+    lua_pushnumber(L, stats.loadAvg15);
+    lua_rawseti(L, -2, 3);
+    lua_setfield(L, -2, "loadAvg");
+
+    return 1;
+  }
+
+  // nowMs() -> wall-clock milliseconds since the Unix epoch.
+  // os.time() and noctalia.formatTime() are both whole-second, so this is the only way a
+  // plugin can see sub-second time — e.g. to phase its own updates onto a second boundary.
+  int luau_nowMs(lua_State* L) {
+    const auto since = std::chrono::system_clock::now().time_since_epoch();
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(since).count();
+    lua_pushnumber(L, static_cast<double>(ms));
     return 1;
   }
 
@@ -1278,6 +1382,8 @@ namespace {
       {"portalAvailable", luau_portalAvailable},
       {"focusedOutputName", luau_focusedOutputName},
       {"outputs", luau_outputs},
+      {"systemStats", luau_systemStats},
+      {"nowMs", luau_nowMs},
       {"appIconPath", luau_appIconPath},
       {"setWallpaperEnabled", luau_setWallpaperEnabled},
       {"setWallpaper", luau_setWallpaper},
@@ -1378,11 +1484,29 @@ LuauHost::LuauHost(scripting::ScriptApiContext& api, CompositorPlatform* platfor
   lua_pop(m_L, 1);
 }
 
+void LuauHost::ensureCpuCoresRetained() {
+  if (m_cpuCoresRetained) {
+    return;
+  }
+  auto* monitor = m_api.systemMonitor();
+  if (monitor == nullptr) {
+    return;
+  }
+  monitor->retainCpuCores();
+  m_cpuCoresRetained = true;
+}
+
 LuauHost::~LuauHost() {
   // Terminate any long-lived stream subprocesses and HTTP streams before tearing
   // down the state.
   stopAllStreams();
   stopAllHttpStreams();
+  if (m_cpuCoresRetained) {
+    if (auto* monitor = m_api.systemMonitor(); monitor != nullptr) {
+      monitor->releaseCpuCores();
+    }
+    m_cpuCoresRetained = false;
+  }
   if (m_L) {
     if (m_T != nullptr) {
       for (int callbackRef : m_asyncCommandCallbackRefs) {

--- a/src/scripting/luau_host.h
+++ b/src/scripting/luau_host.h
@@ -119,6 +119,11 @@ public:
   bool callHttpStreamCloseCallback(int streamKey, bool ok, int status, std::chrono::milliseconds budget);
   [[nodiscard]] bool hasHttpStream(int streamKey) const;
 
+  // noctalia.systemStats — opt this host into per-core CPU sampling on first use. Sampling
+  // is refcounted in SystemMonitorService and released in ~LuauHost, so a plugin that never
+  // asks for stats costs nothing and a reloaded one does not leak a reference.
+  void ensureCpuCoresRetained();
+
   // Load the plugin's own translations/<lang>.json (over en.json) into a flat dotted-key
   // catalog. Call after setPluginDir().
   void loadTranslations();
@@ -231,6 +236,7 @@ private:
   std::size_t m_memUsed = 0; // bytes tracked by allocate(); guarded by the worker-thread serialization
   std::chrono::steady_clock::time_point m_callDeadline;
   std::string m_currentCallName;
+  bool m_cpuCoresRetained = false; // this host holds a SystemMonitorService per-core reference
   bool m_budgetActive = false;
   bool m_lastCallTimedOut = false;
   bool m_muteErrors = false;

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -5,7 +5,7 @@
 namespace scripting {
 
   inline constexpr std::uint32_t kOldestSupportedPluginApiVersion = 3;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = 4;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = 5;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/scripting/script_api_context.h
+++ b/src/scripting/script_api_context.h
@@ -7,6 +7,9 @@
 #include <string>
 #include <vector>
 
+// Pointer-only use; keeps the scripting layer off the system layer's header.
+class SystemMonitorService;
+
 namespace scripting {
 
   // A connected output as exposed to plugin scripts via noctalia.outputs().
@@ -84,6 +87,13 @@ namespace scripting {
       }
     }
 
+    // The live system monitor, or nullptr when it failed to start. Unlike the hooks below,
+    // this is safe to use straight from a script worker thread: SystemMonitorService::latest()
+    // is mutex-guarded and returns a copy, so no main-thread marshalling is needed.
+    void setSystemMonitor(SystemMonitorService* monitor) noexcept { m_systemMonitor = monitor; }
+
+    [[nodiscard]] SystemMonitorService* systemMonitor() const noexcept { return m_systemMonitor; }
+
     // Toggles a host panel by id. Wired to PanelManager in Application; main thread only.
     void setTogglePanelHook(std::function<void(const std::string&)> hook) { m_togglePanelHook = std::move(hook); }
 
@@ -94,6 +104,7 @@ namespace scripting {
     }
 
   private:
+    SystemMonitorService* m_systemMonitor = nullptr;
     std::atomic<bool> m_darkMode{true};
     mutable std::mutex m_mutex;
     std::string m_wallpaperDirectory;

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -111,6 +111,10 @@ namespace {
     return reading.totalBytes > 0 && reading.usedBytes <= reading.totalBytes;
   }
 
+  // Per-core CPU sampling cadence. Fixed rather than configurable: it is opt-in via
+  // retainCpuCores(), and its only consumers want per-second resolution.
+  constexpr std::chrono::steady_clock::duration kCpuCoreInterval = std::chrono::seconds(1);
+
   // 0 disables a metric; any other value is clamped to the supported poll range.
   [[nodiscard]] float clampPollSeconds(float seconds) noexcept {
     if (seconds <= 0.0f) {
@@ -1033,6 +1037,23 @@ void SystemMonitorService::retainCpuTemp() { m_cpuTempRefs.fetch_add(1, std::mem
 
 void SystemMonitorService::releaseCpuTemp() { m_cpuTempRefs.fetch_sub(1, std::memory_order_relaxed); }
 
+void SystemMonitorService::retainCpuCores() {
+  if (m_cpuCoreRefs.fetch_add(1, std::memory_order_relaxed) == 0) {
+    // Wake the sampler now: it may otherwise be parked on a long deadline (disk is 10s),
+    // which would delay the first per-core sample well past the caller's first tick.
+    m_wakeCv.notify_all();
+  }
+}
+
+void SystemMonitorService::releaseCpuCores() {
+  if (m_cpuCoreRefs.fetch_sub(1, std::memory_order_relaxed) == 1) {
+    // Last consumer went away: drop the samples so latest() cannot serve stale per-core data
+    // if someone retains again later.
+    std::scoped_lock lock{m_statsMutex};
+    m_latest.cpuCoreUsagePercent.clear();
+  }
+}
+
 void SystemMonitorService::retainGpuTemp() { m_gpuTempRefs.fetch_add(1, std::memory_order_relaxed); }
 
 void SystemMonitorService::releaseGpuTemp() { m_gpuTempRefs.fetch_sub(1, std::memory_order_relaxed); }
@@ -1163,7 +1184,9 @@ void SystemMonitorService::samplingLoop() {
   using Clock = std::chrono::steady_clock;
 
   auto prevCpu = readCpuTotals();
+  std::optional<std::vector<CpuTotals>> prevCpuCores;
   auto nextCpu = Clock::now();
+  auto nextCpuCores = Clock::now();
   auto nextGpu = Clock::now();
   auto nextMemory = Clock::now();
   auto nextNetwork = Clock::now();
@@ -1181,6 +1204,10 @@ void SystemMonitorService::samplingLoop() {
     const bool networkEnabled = pollCfg.networkPollSeconds > 0.0f;
     const bool diskEnabled = pollCfg.diskPollSeconds > 0.0f;
     const bool historyEnabled = historyPollSeconds > 0.0f;
+    // Per-core is opt-in and runs on a fixed 1s cadence, deliberately independent of
+    // cpu_poll_seconds (default 2s): consumers of it want per-second resolution, and pinning
+    // it here keeps existing aggregate-CPU behaviour untouched whatever the user configures.
+    const bool cpuCoresEnabled = m_cpuCoreRefs.load(std::memory_order_relaxed) > 0;
 
     const auto cpuInterval = pollDuration(pollCfg.cpuPollSeconds);
     const auto gpuInterval = pollDuration(pollCfg.gpuPollSeconds);
@@ -1195,11 +1222,9 @@ void SystemMonitorService::samplingLoop() {
     if (cpuEnabled && now >= nextCpu) {
       const auto currentCpu = readCpuTotals();
       if (prevCpu.has_value() && currentCpu.has_value()) {
-        const std::uint64_t totalDelta = currentCpu->total - prevCpu->total;
-        const std::uint64_t idleDelta = currentCpu->idle - prevCpu->idle;
-        if (totalDelta > 0) {
+        if (const auto usage = cpuUsageBetween(*prevCpu, *currentCpu); usage.has_value()) {
           std::scoped_lock lock{m_statsMutex};
-          m_latest.cpuUsagePercent = 100.0 * (1.0 - static_cast<double>(idleDelta) / static_cast<double>(totalDelta));
+          m_latest.cpuUsagePercent = *usage;
         }
       }
       if (currentCpu.has_value()) {
@@ -1226,6 +1251,26 @@ void SystemMonitorService::samplingLoop() {
       }
 
       nextCpu = now + cpuInterval;
+      statsTouched = true;
+    }
+
+    if (cpuCoresEnabled && now >= nextCpuCores) {
+      auto currentCores = readCpuCoreTotals();
+      if (currentCores.has_value()) {
+        // A core count change (hotplug / offlining) makes the previous sample unusable:
+        // reseed and emit nothing this tick rather than indexing across mismatched vectors.
+        if (prevCpuCores.has_value() && prevCpuCores->size() == currentCores->size()) {
+          std::vector<double> usage(currentCores->size(), 0.0);
+          for (std::size_t i = 0; i < currentCores->size(); ++i) {
+            usage[i] = cpuUsageBetween((*prevCpuCores)[i], (*currentCores)[i]).value_or(0.0);
+          }
+          std::scoped_lock lock{m_statsMutex};
+          m_latest.cpuCoreUsagePercent = std::move(usage);
+        }
+        prevCpuCores = std::move(currentCores);
+      }
+
+      nextCpuCores = now + kCpuCoreInterval;
       statsTouched = true;
     }
 
@@ -1347,6 +1392,11 @@ void SystemMonitorService::samplingLoop() {
       std::scoped_lock lock{m_statsMutex};
       const auto writeIndex = static_cast<std::size_t>(m_historyHead);
       m_history[writeIndex] = m_latest;
+      // Per-core usage is live-only: the graphs plot the aggregate, and history() consumers
+      // would otherwise see a series that is populated only while someone holds a per-core
+      // reference. Dropping it here also keeps the 120-deep ring from carrying a vector per
+      // sample. clear() keeps the slot's capacity, so this costs no allocation churn.
+      m_history[writeIndex].cpuCoreUsagePercent.clear();
       for (auto& [path, disk] : m_diskHistories) {
         if (disk.refs <= 0) {
           continue;
@@ -1367,6 +1417,7 @@ void SystemMonitorService::samplingLoop() {
       }
     };
     considerWake(cpuEnabled, nextCpu);
+    considerWake(cpuCoresEnabled, nextCpuCores);
     considerWake(gpuEnabled, nextGpu);
     considerWake(memoryEnabled, nextMemory);
     considerWake(networkEnabled, nextNetwork);
@@ -1376,6 +1427,40 @@ void SystemMonitorService::samplingLoop() {
     std::unique_lock wakeLock{m_wakeMutex};
     m_wakeCv.wait_until(wakeLock, nextWake, [this]() { return !m_running.load(); });
   }
+}
+
+std::optional<SystemMonitorService::CpuTotals>
+SystemMonitorService::parseCpuStatLine(const std::string& line, std::string_view expectedLabel) {
+  std::istringstream iss{line};
+  std::string cpuLabel;
+  std::uint64_t user = 0;
+  std::uint64_t nice = 0;
+  std::uint64_t system = 0;
+  std::uint64_t idle = 0;
+  std::uint64_t iowait = 0;
+  std::uint64_t irq = 0;
+  std::uint64_t softirq = 0;
+  std::uint64_t steal = 0;
+
+  iss >> cpuLabel >> user >> nice >> system >> idle >> iowait >> irq >> softirq >> steal;
+  if (cpuLabel != expectedLabel) {
+    return std::nullopt;
+  }
+
+  CpuTotals totals{};
+  totals.idle = idle + iowait;
+  totals.total = user + nice + system + idle + iowait + irq + softirq + steal;
+  return totals;
+}
+
+std::optional<double> SystemMonitorService::cpuUsageBetween(const CpuTotals& prev, const CpuTotals& current) {
+  if (current.total <= prev.total) {
+    return std::nullopt; // no elapsed jiffies, or the counters were reset
+  }
+  const std::uint64_t totalDelta = current.total - prev.total;
+  const std::uint64_t idleDelta = current.idle >= prev.idle ? current.idle - prev.idle : 0;
+  const double busy = 1.0 - static_cast<double>(idleDelta) / static_cast<double>(totalDelta);
+  return std::clamp(100.0 * busy, 0.0, 100.0);
 }
 
 std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTotals() {
@@ -1389,26 +1474,35 @@ std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTota
     return std::nullopt;
   }
 
-  std::istringstream iss{line};
-  std::string cpuLabel;
-  std::uint64_t user = 0;
-  std::uint64_t nice = 0;
-  std::uint64_t system = 0;
-  std::uint64_t idle = 0;
-  std::uint64_t iowait = 0;
-  std::uint64_t irq = 0;
-  std::uint64_t softirq = 0;
-  std::uint64_t steal = 0;
+  return parseCpuStatLine(line, "cpu");
+}
 
-  iss >> cpuLabel >> user >> nice >> system >> idle >> iowait >> irq >> softirq >> steal;
-  if (cpuLabel != "cpu") {
+std::optional<std::vector<SystemMonitorService::CpuTotals>> SystemMonitorService::readCpuCoreTotals() {
+  std::ifstream file{"/proc/stat"};
+  if (!file.is_open()) {
     return std::nullopt;
   }
 
-  CpuTotals totals{};
-  totals.idle = idle + iowait;
-  totals.total = user + nice + system + idle + iowait + irq + softirq + steal;
-  return totals;
+  std::vector<CpuTotals> cores;
+  std::string line;
+  // The "cpuN" rows are contiguous and lead the file, so stop at the first non-cpu row
+  // rather than scanning the whole of /proc/stat.
+  while (std::getline(file, line)) {
+    if (!line.starts_with("cpu")) {
+      break;
+    }
+    const auto label = std::string("cpu") + std::to_string(cores.size());
+    auto totals = parseCpuStatLine(line, label);
+    if (!totals.has_value()) {
+      continue; // the leading aggregate "cpu" row
+    }
+    cores.push_back(*totals);
+  }
+
+  if (cores.empty()) {
+    return std::nullopt;
+  }
+  return cores;
 }
 
 std::optional<SystemMonitorService::MemData> SystemMonitorService::readMemoryKb() {

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -1463,8 +1463,9 @@ std::optional<double> SystemMonitorService::cpuUsageBetween(const CpuTotals& pre
   return std::clamp(100.0 * busy, 0.0, 100.0);
 }
 
-std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTotals() {
-  std::ifstream file{"/proc/stat"};
+std::optional<SystemMonitorService::CpuTotals>
+SystemMonitorService::readCpuTotals(const std::filesystem::path& statPath) {
+  std::ifstream file{statPath};
   if (!file.is_open()) {
     return std::nullopt;
   }
@@ -1477,8 +1478,9 @@ std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTota
   return parseCpuStatLine(line, "cpu");
 }
 
-std::optional<std::vector<SystemMonitorService::CpuTotals>> SystemMonitorService::readCpuCoreTotals() {
-  std::ifstream file{"/proc/stat"};
+std::optional<std::vector<SystemMonitorService::CpuTotals>>
+SystemMonitorService::readCpuCoreTotals(const std::filesystem::path& statPath) {
+  std::ifstream file{statPath};
   if (!file.is_open()) {
     return std::nullopt;
   }

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -1046,12 +1046,12 @@ void SystemMonitorService::retainCpuCores() {
 }
 
 void SystemMonitorService::releaseCpuCores() {
-  if (m_cpuCoreRefs.fetch_sub(1, std::memory_order_relaxed) == 1) {
-    // Last consumer went away: drop the samples so latest() cannot serve stale per-core data
-    // if someone retains again later.
-    std::scoped_lock lock{m_statsMutex};
-    m_latest.cpuCoreUsagePercent.clear();
-  }
+  // The samples are deliberately left in place. Recreating a widget releases the old
+  // reference before the new one retains, so the count dips to zero for a few ms on every
+  // bar reload; clearing here would blank the data and force each consumer to redraw from
+  // nothing. Slightly stale values for one sampling tick beat a visible gap, and the
+  // sampler reseeds on the next retain so nothing is averaged across the pause.
+  m_cpuCoreRefs.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void SystemMonitorService::retainGpuTemp() { m_gpuTempRefs.fetch_add(1, std::memory_order_relaxed); }
@@ -1185,6 +1185,7 @@ void SystemMonitorService::samplingLoop() {
 
   auto prevCpu = readCpuTotals();
   std::optional<std::vector<CpuTotals>> prevCpuCores;
+  bool cpuCoresWasEnabled = false;
   auto nextCpu = Clock::now();
   auto nextCpuCores = Clock::now();
   auto nextGpu = Clock::now();
@@ -1208,6 +1209,13 @@ void SystemMonitorService::samplingLoop() {
     // cpu_poll_seconds (default 2s): consumers of it want per-second resolution, and pinning
     // it here keeps existing aggregate-CPU behaviour untouched whatever the user configures.
     const bool cpuCoresEnabled = m_cpuCoreRefs.load(std::memory_order_relaxed) > 0;
+    // Resuming after a pause: the previous sample is from before the gap, so a delta against
+    // it would cover the whole pause rather than one second. Drop it and seed afresh — a
+    // widget reload leaves only a few ms of jiffies, which would otherwise read as noise.
+    if (cpuCoresEnabled && !cpuCoresWasEnabled) {
+      prevCpuCores.reset();
+    }
+    cpuCoresWasEnabled = cpuCoresEnabled;
 
     const auto cpuInterval = pollDuration(pollCfg.cpuPollSeconds);
     const auto gpuInterval = pollDuration(pollCfg.gpuPollSeconds);

--- a/src/system/system_monitor_service.h
+++ b/src/system/system_monitor_service.h
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -47,6 +48,9 @@ struct SystemStats {
 };
 
 class SystemMonitorService {
+  // Reaches the private static /proc/stat parsers, which have no public surface.
+  friend class SystemMonitorServiceTestAccess;
+
 public:
   explicit SystemMonitorService(const SystemConfig::MonitorConfig& config = {});
   ~SystemMonitorService();
@@ -128,9 +132,12 @@ private:
   parseCpuStatLine(const std::string& line, std::string_view expectedLabel);
   // Busy percentage between two samples, or nullopt when the window contains no jiffies.
   [[nodiscard]] static std::optional<double> cpuUsageBetween(const CpuTotals& prev, const CpuTotals& current);
-  [[nodiscard]] static std::optional<CpuTotals> readCpuTotals();
+  // The stat path is a parameter so tests can feed fixtures instead of the live /proc,
+  // matching cpu_temp::read()'s hwmonRoot/thermalRoot seam.
+  [[nodiscard]] static std::optional<CpuTotals> readCpuTotals(const std::filesystem::path& statPath = "/proc/stat");
   // Per-core totals in /proc/stat order, skipping the leading aggregate "cpu" row.
-  [[nodiscard]] static std::optional<std::vector<CpuTotals>> readCpuCoreTotals();
+  [[nodiscard]] static std::optional<std::vector<CpuTotals>>
+  readCpuCoreTotals(const std::filesystem::path& statPath = "/proc/stat");
   struct MemData {
     std::uint64_t totalKb{0};
     std::uint64_t usedKb{0};

--- a/src/system/system_monitor_service.h
+++ b/src/system/system_monitor_service.h
@@ -24,6 +24,9 @@ struct SystemStats {
 
   std::chrono::steady_clock::time_point sampledAt;
   double cpuUsagePercent{0.0};
+  // Per-core usage, indexed by the /proc/stat "cpuN" order. Empty unless a consumer
+  // has called retainCpuCores(); sampled on its own fixed 1s cadence.
+  std::vector<double> cpuCoreUsagePercent;
   double ramUsagePercent{0.0};
   std::uint64_t ramUsedMb{0};
   std::uint64_t ramTotalMb{0};
@@ -64,6 +67,8 @@ public:
 
   void retainCpuTemp();
   void releaseCpuTemp();
+  void retainCpuCores();
+  void releaseCpuCores();
   void retainGpuTemp();
   void releaseGpuTemp();
   void retainGpuUsage();
@@ -115,7 +120,17 @@ private:
   void samplingLoop();
   void logDetectedSources();
 
+  // Parses one "/proc/stat" cpu row into idle/total jiffies. `expectedLabel` pins which row is
+  // accepted ("cpu" for the aggregate, "cpuN" for a core), so a caller cannot mistake the
+  // aggregate for core 0. guest/guest_nice are deliberately not read: the kernel already folds
+  // them into user/nice.
+  [[nodiscard]] static std::optional<CpuTotals>
+  parseCpuStatLine(const std::string& line, std::string_view expectedLabel);
+  // Busy percentage between two samples, or nullopt when the window contains no jiffies.
+  [[nodiscard]] static std::optional<double> cpuUsageBetween(const CpuTotals& prev, const CpuTotals& current);
   [[nodiscard]] static std::optional<CpuTotals> readCpuTotals();
+  // Per-core totals in /proc/stat order, skipping the leading aggregate "cpu" row.
+  [[nodiscard]] static std::optional<std::vector<CpuTotals>> readCpuCoreTotals();
   struct MemData {
     std::uint64_t totalKb{0};
     std::uint64_t usedKb{0};
@@ -149,6 +164,7 @@ private:
 
   std::atomic<bool> m_running{false};
   std::atomic<int> m_cpuTempRefs{0};
+  std::atomic<int> m_cpuCoreRefs{0};
   std::atomic<int> m_gpuTempRefs{0};
   std::atomic<int> m_gpuUsageRefs{0};
   std::atomic<int> m_gpuVramRefs{0};

--- a/tests/cpu_stat_parse_test.cpp
+++ b/tests/cpu_stat_parse_test.cpp
@@ -1,0 +1,208 @@
+// Covers the /proc/stat parsing and delta maths behind SystemStats::cpuUsagePercent and
+// SystemStats::cpuCoreUsagePercent. Both parsers are private statics, reached through a
+// friend TestAccess, and both take the stat path so fixtures stand in for the live /proc.
+
+#include "system/system_monitor_service.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+class SystemMonitorServiceTestAccess {
+public:
+  using Totals = SystemMonitorService::CpuTotals;
+
+  static std::optional<Totals> parseLine(const std::string& line, std::string_view expectedLabel) {
+    return SystemMonitorService::parseCpuStatLine(line, expectedLabel);
+  }
+
+  static std::optional<double> usageBetween(const Totals& prev, const Totals& current) {
+    return SystemMonitorService::cpuUsageBetween(prev, current);
+  }
+
+  static std::optional<Totals> readAggregate(const std::filesystem::path& path) {
+    return SystemMonitorService::readCpuTotals(path);
+  }
+
+  static std::optional<std::vector<Totals>> readCores(const std::filesystem::path& path) {
+    return SystemMonitorService::readCpuCoreTotals(path);
+  }
+};
+
+namespace {
+
+  using Access = SystemMonitorServiceTestAccess;
+  using Totals = Access::Totals;
+
+  int g_failures = 0;
+
+  bool expect(bool condition, const std::string& message) {
+    if (!condition) {
+      std::fprintf(stderr, "cpu_stat_parse_test: FAIL: %s\n", message.c_str());
+      ++g_failures;
+      return false;
+    }
+    return true;
+  }
+
+  bool expectNear(std::optional<double> actual, double expected, const std::string& message) {
+    if (!actual.has_value()) {
+      std::fprintf(stderr, "cpu_stat_parse_test: FAIL: %s: no value\n", message.c_str());
+      ++g_failures;
+      return false;
+    }
+    const double diff = *actual > expected ? *actual - expected : expected - *actual;
+    if (diff > 0.001) {
+      std::fprintf(
+          stderr, "cpu_stat_parse_test: FAIL: %s: expected %f, got %f\n", message.c_str(), expected, *actual
+      );
+      ++g_failures;
+      return false;
+    }
+    return true;
+  }
+
+  std::filesystem::path makeTempDir() {
+    std::string pattern = (std::filesystem::temp_directory_path() / "noctalia-cpu-stat-XXXXXX").string();
+    std::vector<char> writable(pattern.begin(), pattern.end());
+    writable.push_back('\0');
+    char* result = ::mkdtemp(writable.data());
+    return result != nullptr ? std::filesystem::path(result) : std::filesystem::path{};
+  }
+
+  std::filesystem::path writeStat(const std::filesystem::path& dir, std::string_view name, std::string_view text) {
+    const auto path = dir / name;
+    std::ofstream out(path, std::ios::trunc);
+    out << text;
+    return path;
+  }
+
+  void testParseLine() {
+    // user nice system idle iowait irq softirq steal -> idle = idle + iowait,
+    // total = every field summed.
+    const auto totals = Access::parseLine("cpu  100 20 30 700 50 5 5 10", "cpu");
+    expect(totals.has_value(), "aggregate row should parse");
+    if (totals.has_value()) {
+      expect(totals->idle == 750, "idle should fold iowait in (700 + 50)");
+      expect(totals->total == 920, "total should sum all eight fields");
+    }
+
+    // The label is pinned, so the aggregate row can never be mistaken for core 0.
+    expect(!Access::parseLine("cpu  100 20 30 700 50 5 5 10", "cpu0").has_value(), "'cpu' must not match 'cpu0'");
+    expect(!Access::parseLine("cpu0 100 20 30 700 50 5 5 10", "cpu").has_value(), "'cpu0' must not match 'cpu'");
+    expect(Access::parseLine("cpu7 1 2 3 4 5 6 7 8", "cpu7").has_value(), "matching core label should parse");
+
+    // Non-cpu rows in /proc/stat must not parse as totals.
+    expect(!Access::parseLine("intr 12345 0 0", "cpu").has_value(), "intr row should not parse");
+
+    // Kernels predating the steal field still yield usable totals: the missing trailing
+    // fields stay zero-initialised rather than poisoning the sum.
+    const auto shortRow = Access::parseLine("cpu  100 20 30 700 50 5 5", "cpu");
+    expect(shortRow.has_value(), "row without steal should still parse");
+    if (shortRow.has_value()) {
+      expect(shortRow->total == 910, "total should omit the absent steal field");
+    }
+  }
+
+  void testUsageBetween() {
+    // 100 jiffies elapsed, 25 of them idle -> 75% busy.
+    expectNear(Access::usageBetween(Totals{.total = 1000, .idle = 800}, Totals{.total = 1100, .idle = 825}), 75.0,
+               "75% busy");
+    expectNear(Access::usageBetween(Totals{.total = 1000, .idle = 800}, Totals{.total = 1100, .idle = 900}), 0.0,
+               "fully idle");
+    expectNear(Access::usageBetween(Totals{.total = 1000, .idle = 800}, Totals{.total = 1100, .idle = 800}), 100.0,
+               "fully busy");
+
+    // An empty window has no answer; reporting 0% would render as "idle", which is a lie.
+    expect(!Access::usageBetween(Totals{.total = 1000, .idle = 800}, Totals{.total = 1000, .idle = 800}).has_value(),
+           "no elapsed jiffies should yield nullopt");
+
+    // Counters going backwards (suspend/resume, container reset) must not underflow into a
+    // vast bogus percentage.
+    expect(!Access::usageBetween(Totals{.total = 2000, .idle = 900}, Totals{.total = 1000, .idle = 400}).has_value(),
+           "total going backwards should yield nullopt");
+    expectNear(Access::usageBetween(Totals{.total = 1000, .idle = 900}, Totals{.total = 1100, .idle = 500}), 100.0,
+               "idle going backwards should clamp to 100, not wrap");
+  }
+
+  void testReadFixtures(const std::filesystem::path& dir) {
+    constexpr std::string_view kStat = "cpu  400 0 100 500 0 0 0 0\n"
+                                       "cpu0 100 0 25 125 0 0 0 0\n"
+                                       "cpu1 100 0 25 125 0 0 0 0\n"
+                                       "cpu2 100 0 25 125 0 0 0 0\n"
+                                       "cpu3 100 0 25 125 0 0 0 0\n"
+                                       "intr 999 0 0\n"
+                                       "ctxt 4242\n";
+    const auto path = writeStat(dir, "stat", kStat);
+
+    const auto aggregate = Access::readAggregate(path);
+    expect(aggregate.has_value(), "aggregate should read from a fixture");
+    if (aggregate.has_value()) {
+      expect(aggregate->total == 1000, "aggregate total");
+      expect(aggregate->idle == 500, "aggregate idle");
+    }
+
+    const auto cores = Access::readCores(path);
+    expect(cores.has_value(), "cores should read from a fixture");
+    if (cores.has_value()) {
+      // Four cores, not five: the leading aggregate row is skipped, and the trailing
+      // non-cpu rows are not mistaken for cores. (The early `break` on the first non-cpu
+      // row is an optimisation, not a correctness guard — those rows fail the label match
+      // anyway — so it is deliberately not asserted here.)
+      expect(cores->size() == 4, "should find exactly 4 cores, skipping the aggregate row");
+      if (cores->size() == 4) {
+        expect((*cores)[0].total == 250 && (*cores)[0].idle == 125, "core 0 totals");
+        expect((*cores)[3].total == 250 && (*cores)[3].idle == 125, "core 3 totals");
+      }
+    }
+
+    // A machine with a single core still reports a cpu0 row.
+    const auto single = Access::readCores(writeStat(dir, "stat-single", "cpu  8 0 0 2 0 0 0 0\ncpu0 8 0 0 2 0 0 0 0\n"));
+    expect(single.has_value() && single->size() == 1, "single-core machine should yield one entry");
+
+    // Aggregate row only (no per-core rows) is not an empty list but a failure: callers
+    // must be able to tell "no per-core data" from "zero cores".
+    expect(!Access::readCores(writeStat(dir, "stat-noscores", "cpu  8 0 0 2 0 0 0 0\nintr 1\n")).has_value(),
+           "stat without cpuN rows should yield nullopt");
+
+    expect(!Access::readAggregate(dir / "does-not-exist").has_value(), "missing file should yield nullopt");
+    expect(!Access::readCores(dir / "does-not-exist").has_value(), "missing file should yield nullopt for cores");
+    expect(!Access::readAggregate(writeStat(dir, "stat-empty", "")).has_value(), "empty file should yield nullopt");
+  }
+
+  // The per-core sampling loop diffs two whole vectors; this is that maths in isolation.
+  void testPerCoreDeltas() {
+    const std::vector<Totals> prev = {{.total = 100, .idle = 100}, {.total = 100, .idle = 100}};
+    const std::vector<Totals> next = {{.total = 200, .idle = 100}, {.total = 200, .idle = 200}};
+    expectNear(Access::usageBetween(prev[0], next[0]), 100.0, "core 0 fully busy");
+    expectNear(Access::usageBetween(prev[1], next[1]), 0.0, "core 1 fully idle");
+  }
+
+} // namespace
+
+int main() {
+  const auto dir = makeTempDir();
+  if (dir.empty()) {
+    std::fprintf(stderr, "cpu_stat_parse_test: FAIL: could not create temp dir\n");
+    return 1;
+  }
+
+  testParseLine();
+  testUsageBetween();
+  testReadFixtures(dir);
+  testPerCoreDeltas();
+
+  std::error_code ec;
+  std::filesystem::remove_all(dir, ec);
+
+  if (g_failures > 0) {
+    std::fprintf(stderr, "cpu_stat_parse_test: %d failure(s)\n", g_failures);
+    return 1;
+  }
+  return 0;
+}

--- a/tests/plugin_manifest_test.cpp
+++ b/tests/plugin_manifest_test.cpp
@@ -57,7 +57,8 @@ int main() {
   ok = expect(!scripting::supportsPluginApiVersion(2), "plugin API 2 should be too old") && ok;
   ok = expect(scripting::supportsPluginApiVersion(3), "plugin API 3 should be supported") && ok;
   ok = expect(scripting::supportsPluginApiVersion(4), "plugin API 4 should be supported") && ok;
-  ok = expect(!scripting::supportsPluginApiVersion(5), "plugin API 5 should be too new") && ok;
+  ok = expect(scripting::supportsPluginApiVersion(5), "plugin API 5 should be supported") && ok;
+  ok = expect(!scripting::supportsPluginApiVersion(6), "plugin API 6 should be too new") && ok;
   const auto defaultManifestPath = root / "defaults/plugin.toml";
   ok = writeText(defaultManifestPath, "id = \"me/defaults\"\nname = \"Defaults\"\nplugin_api = 3\n") && ok;
 


### PR DESCRIPTION
## Summary

Exposes the system monitor to plugin scripts, and teaches `SystemMonitorService` to sample per-core CPU usage.

`SystemMonitorService::readCpuTotals()` only ever read the first line of `/proc/stat` — the aggregate `cpu` row — and none of its stats were reachable from Luau (`grep cpu src/scripting/` returned nothing). A plugin therefore could not draw anything per-core.

Sampling:

- Parse the per-core `cpuN` rows into `SystemStats::cpuCoreUsagePercent`.
- Share the idle/total jiffy maths between the aggregate and per-core paths via `parseCpuStatLine()` / `cpuUsageBetween()`, rather than duplicating it.
- Run per-core on its own fixed 1s deadline, refcounted behind `retainCpuCores()` / `releaseCpuCores()`, mirroring the existing CPU-temp gate. It is deliberately independent of `cpu_poll_seconds` (default 2s): consumers want per-second resolution, and pinning it leaves aggregate CPU behaviour untouched whatever the user configures. Costs one extra `/proc/stat` read per second, and only while a consumer holds a reference.
- Reseed rather than index across mismatched vectors when the core count changes (hotplug / offlining).
- Keep per-core out of the 120-deep history ring: the graphs plot the aggregate, and `history()` consumers would otherwise see a series populated only while someone holds a reference.

API:

- `noctalia.systemStats()` returns `cpu` (total + cores), `ram`, `swap`, `cpuTempC`, `gpu`, `net` and `loadAvg`. Absent sensors are `nil` rather than `0`, so a plugin can tell "no probe" from "idle". The first call opts the host into per-core sampling; the reference is released in `~LuauHost`.
- `noctalia.nowMs()` returns wall-clock milliseconds. `os.time()` and `noctalia.formatTime()` are both whole-second, so this is the only way a plugin can see sub-second time — needed to phase updates onto a second boundary.
- `ScriptApiContext` holds the `SystemMonitorService`. Unlike the hooks beside it, this is read straight from the script worker thread: `latest()` is mutex-guarded and returns a copy, so no main-thread marshalling is needed.

Bumps `kCurrentPluginApiVersion` to 5. `kOldestSupportedPluginApiVersion` stays at 3, so existing plugins are unaffected.

8 files, +271 / −18.

## Motivation

The bar can already show CPU usage, but only as a single averaged number. That hides exactly what people want a CPU meter for: one pegged thread, or an unbalanced load across cores, look identical to mild uniform load once averaged.

Per-core data did not exist anywhere in the codebase, and the plugin API had no access to system stats at all, so this could not be solved in a plugin. This adds the smallest host-side capability that makes it possible, in the shape the rest of the service already uses (refcounted opt-in sampling, snapshot reads).

The concrete consumer is a `cpu-bars` community plugin that draws one vertical bar per core; `systemStats()` was deliberately made general rather than CPU-only so it is not single-use.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

Refactoring is ticked because the shared `parseCpuStatLine()` / `cpuUsageBetween()` helpers replace the inline maths on the **existing** aggregate path — see Additional Notes for the one behavioural difference that introduces.

## Related Issue

None.

## Testing

Commands run:

- `just build` — clean, no new warnings.
- `meson test -C build-debug --print-errorlogs` — **40/40 pass**, including the updated `plugin_manifest` test (5 supported, 6 too new).
- `just format` — clang-format 22.1.6.
- `noctalia config validate` — clean.

Correctness of the per-core values was checked against ground truth rather than eyeballed. Load was pinned to known cores with `taskset` and the reported vector inspected:

- Cores 3 and 17 pinned → exactly `100` at 1-based positions 4 and 18, everything else near zero. Confirms both the values and the `/proc/stat` index ordering.
- Repeated for cores 0-3 + 12-13, and 6/7/15.
- Varied duty cycles via `stress-ng --cpu-load` (100% / 75% / 55% / 25%) → bar heights tracked the requested load.

Driven end-to-end two ways: a throwaway Luau `[[service]]` plugin logging `systemStats()` once a second, then the real `cpu-bars` bar widget. Also exercised:

- `nowMs()` used for tick alignment — measured landing `.004`–`.016` past the second.
- Theme changes mid-run (the palette is wallpaper-derived here) — role tokens tracked.
- Plugin reload / disable, to confirm the per-core reference is released.

Not covered: `cpu_poll_seconds` values other than the default; CPU hotplug (the mismatched core-count path is reasoned-through, not exercised); the GPU/VRAM fields of `systemStats()` were never observed non-`nil` on this machine.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Only Niri, on a single 3440x1440 output at scale 1, with a bottom bar. This PR adds no UI of its own, so bar position / density / scaling / multi-monitor were not exercised — the consuming plugin renders through the existing declarative `ui.*` path, which those settings already cover.

## Screenshots / Videos

No user-visible change in the shell itself; this is a plugin-facing API.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

Notes on the above: no new settings, config keys or translation strings are added — the two new bindings are plugin-facing only. Plugin API docs live in the separate docs.noctalia.dev repo and still need writing for `noctalia.systemStats` and `noctalia.nowMs`.

## Additional Notes

**One behavioural difference on the existing aggregate path.** Routing it through `cpuUsageBetween()` adds two things it did not have: the result is clamped to `[0, 100]`, and the idle delta is guarded against underflow (`current.idle >= prev.idle ? ... : 0`) instead of subtracting raw. Both are no-ops in normal operation — `idleDelta <= totalDelta` holds — but they are a real diff on a hot path, so worth a reviewer's eye rather than being buried in a refactor.

**Why per-core does not follow `cpu_poll_seconds`.** Tying it to the existing CPU deadline would mean either changing the 2s default for everyone (a battery regression for a feature most users will not enable) or shipping a per-core meter that updates every 2s. The fixed 1s deadline is only live while something holds a reference, so the cost is opt-in.

**Why `ScriptApiContext` holds a raw service pointer.** Every other member there is a main-thread-only hook, so this deviates. The alternative — pushing a snapshot from the main thread like `setOutputs()` — would add a copy and a publish cadence for data that is already mutex-guarded and cheap to read off-thread. The member is commented to say so, since the surrounding convention implies otherwise.

**Known limitation.** `systemStats()` returns a snapshot at whatever cadence each metric is configured for; the per-core vector is empty for the first tick after a consumer attaches, because there is no previous sample to diff against. Plugins should treat an empty `cpu.cores` as "not ready yet" rather than "no cores".