### PR TITLE
feat(window-switcher): dismiss on outside click

### DIFF
--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -374,6 +374,10 @@ void Application::initInputDispatch() {
       m_lockScreen.onPointerEvent(event);
       return;
     }
+    if (m_windowSwitcher.isActive()) {
+      (void)m_windowSwitcher.onPointerEvent(event);
+      return;
+    }
     if (m_colorPickerDialogPopup.onPointerEvent(event)) {
       return;
     }
@@ -403,8 +407,6 @@ void Application::initInputDispatch() {
     if (m_bar.onPointerEvent(event))
       return;
     if (m_dock.onPointerEvent(event))
-      return;
-    if (m_windowSwitcher.onPointerEvent(event))
       return;
     if (m_panelManager.onPointerEvent(event))
       return;

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -375,8 +375,13 @@ void Application::initInputDispatch() {
       return;
     }
     if (m_windowSwitcher.isActive()) {
-      (void)m_windowSwitcher.onPointerEvent(event);
-      return;
+      if (m_windowSwitcher.onPointerEvent(event)) {
+        return;
+      }
+      if (event.type == PointerEvent::Type::Button || event.type == PointerEvent::Type::Axis) {
+        return;
+      }
+      // Enter/Leave/Motion fall through so other surfaces' hover state stays in sync.
     }
     if (m_colorPickerDialogPopup.onPointerEvent(event)) {
       return;

--- a/src/shell/switcher/window_switcher.cpp
+++ b/src/shell/switcher/window_switcher.cpp
@@ -911,9 +911,19 @@ bool WindowSwitcher::onPointerEvent(const PointerEvent& event) {
       target->pointerInside = true;
     }
     if (!onTarget && !target->pointerInside) {
+      if (event.state == 1) {
+        hide();
+      }
       return false;
     }
     const bool pressed = (event.state == 1);
+    if (pressed
+        && event.surface == target->surface->wlSurface()
+        && (target->inputDispatcher.hoveredArea() == nullptr
+            || target->inputDispatcher.hoveredArea() == target->input)) {
+      hide();
+      return true;
+    }
     return target->inputDispatcher.pointerButton(
         static_cast<float>(event.sx), static_cast<float>(event.sy), event.button, pressed
     );

--- a/src/shell/switcher/window_switcher.cpp
+++ b/src/shell/switcher/window_switcher.cpp
@@ -907,18 +907,19 @@ bool WindowSwitcher::onPointerEvent(const PointerEvent& event) {
     }
     return false;
   case PointerEvent::Type::Button: {
+    const bool pressed = (event.state == 1);
     if (onTarget) {
       target->pointerInside = true;
     }
     if (!onTarget && !target->pointerInside) {
-      if (event.state == 1) {
+      if (pressed) {
         hide();
+        return true;
       }
       return false;
     }
-    const bool pressed = (event.state == 1);
     if (pressed
-        && event.surface == target->surface->wlSurface()
+        && onTarget
         && (target->inputDispatcher.hoveredArea() == nullptr
             || target->inputDispatcher.hoveredArea() == target->input)) {
       hide();


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Clicking outside the window switcher now dismisses it, matching the existing outside-click-to-close behavior of other panels (wallpaper selector, launcher, session menu). Previously the only way to cancel was via keyboard (releasing the trigger modifier, or the configured Cancel keybind).

## Motivation

I trigger the switcher from a hot corner / CLI invocation rather than an Alt-Tab-style modifier hold, so there is no "release the modifier" gesture available to me — keyboard Cancel was the only way to close it. This adds mouse parity with the panels that already support outside-click dismissal.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Tested through running the IPC call via keybind, hot corner and terminal:
```bash
noctalia msg window-switcher
```
- Niri 26.04
- noctalia v5.0.0 (v5.0.0-beta.3-62-g5a20c9cf0ecc)

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

Manually verified:
- Click on the dimmed backdrop between/around tiles closes the switcher without activating the selection (same as Cancel).
- Click on a tile still selects/activates normally.
- Click on the other monitor (no switcher there) won't close the switcher, unless you click on a bar/dock widget on the other monitor, that closes the switcher.

## Screenshots / Videos

https://github.com/user-attachments/assets/fa6d69f3-029b-4d71-bdc5-04ba425e31f7.mp4

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
