### PR TITLE
feat(media-widget): add mouse side buttons for prev/next track

### DIFF
--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -33,7 +33,7 @@ MediaWidget::MediaWidget(
 
 void MediaWidget::create() {
   auto area = std::make_unique<InputArea>();
-  area->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
+  area->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT, BTN_SIDE, BTN_EXTRA, BTN_BACK, BTN_FORWARD}));
   area->setOnEnter([this](const InputArea::PointerData&) {
     applyTitleScrollMode(m_label != nullptr && m_label->visible());
     this->requestUpdate();
@@ -47,8 +47,24 @@ void MediaWidget::create() {
       requestPanelToggle("control-center", "media");
       return;
     }
-    if (data.button == BTN_RIGHT && m_mpris != nullptr) {
+    if (m_mpris == nullptr) {
+      return;
+    }
+    // Mice report the thumb buttons as either SIDE/EXTRA or BACK/FORWARD.
+    switch (data.button) {
+    case BTN_RIGHT:
       m_mpris->playPauseActive();
+      break;
+    case BTN_SIDE:
+    case BTN_BACK:
+      m_mpris->previousActive();
+      break;
+    case BTN_EXTRA:
+    case BTN_FORWARD:
+      m_mpris->nextActive();
+      break;
+    default:
+      break;
     }
   });
   m_area = area.get();


### PR DESCRIPTION
## Summary

Adds mouse side-button support to the media widget: BTN_SIDE triggers previous track, BTN_EXTRA triggers next track, always apply to the active media source displayed on the widget. Left-click (open control center) and right-click (play/pause) are unchanged.

## Motivation

Media playback control (prev/next) currently requires opening the control center or using a keyboard shortcut. Mouse side buttons are a natural gesture for me, similar to browser back/forward. Inspired by the GNOME Shell extension media-controls (https://github.com/sakithb/media-controls), which offers the same behavior.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Built with `meson compile -C build-debug`, clean build, no new warnings.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/702d034b-0180-4913-beb5-d241d69e9a74


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.