### PR TITLE
feat(frame): solid inset border around the output with a rounded desktop hole

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1105,6 +1105,7 @@
         "filtering": "Filtering",
         "focus-styling": "Focus Styling",
         "formats": "Formats",
+        "frame": "Screen Frame",
         "general": "General",
         "greeter": "Greeter",
         "grouping": "Grouping",
@@ -1726,6 +1727,30 @@
         }
       },
       "desktop": {
+        "frame-bleed": {
+          "description": "Extra pixels the frame paints inward, to cover the gap your compositor leaves around windows (niri layout.gaps, Hyprland general:gaps_out)",
+          "label": "Gap Coverage"
+        },
+        "frame-enabled": {
+          "description": "Draw a solid border around the screen with a rounded hole for the desktop; the edge holding a bar uses the bar's own thickness",
+          "label": "Screen Frame"
+        },
+        "frame-match-bar": {
+          "description": "Use the bar's background opacity for the frame so the two read as one surface; turn off to set the frame's opacity separately",
+          "label": "Match Bar"
+        },
+        "frame-opacity": {
+          "description": "Opacity of the frame border",
+          "label": "Frame Opacity"
+        },
+        "frame-radius": {
+          "description": "Corner radius of the frame's inner opening in pixels",
+          "label": "Inner Radius"
+        },
+        "frame-thickness": {
+          "description": "Width of the frame border in pixels, on the edges that do not hold a bar",
+          "label": "Frame Thickness"
+        },
         "hot-corners-bottom-left": {
           "description": "Action when the pointer hits the bottom left corner",
           "label": "Bottom Left Corner"

--- a/meson.build
+++ b/meson.build
@@ -641,6 +641,7 @@ _noctalia_sources = files(
   'src/shell/tooltip/tooltip_manager.cpp',
   'src/shell/hot_corners/hot_corners.cpp',
   'src/shell/screen_corners/screen_corners.cpp',
+  'src/shell/frame/frame.cpp',
   'src/shell/panel/panel_click_shield.cpp',
   'src/wayland/hyprland/focus_grab_service.cpp',
   'src/shell/panel/panel_manager.cpp',
@@ -1527,6 +1528,27 @@ config_path_resolution_test = executable('config_path_resolution_test',
 )
 
 test('config_path_resolution', config_path_resolution_test)
+
+frame_geometry_test = executable('frame_geometry_test',
+  sources: files(
+    'tests/frame_geometry_test.cpp',
+    'src/config/config_types.cpp',
+    'src/render/core/color.cpp',
+    'src/ui/palette.cpp',
+    'src/theme/builtin_palettes.cpp',
+    'src/theme/fixed_palette.cpp',
+    'src/theme/color.cpp',
+    'src/theme/contrast.cpp',
+    'src/core/input/key_chord.cpp',
+  ),
+  include_directories: _noctalia_inc,
+  dependencies: [
+    xkbcommon_dep,
+    tomlplusplus_dep,
+  ],
+)
+
+test('frame_geometry', frame_geometry_test)
 
 config_validate_env = environment()
 config_validate_env.set('NOCTALIA_CONFIG_HOME', meson.current_source_dir() / 'tests/config_validate/config-home')

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -35,6 +35,7 @@
 #include "shell/bar/bar.h"
 #include "shell/desktop/desktop_widgets_controller.h"
 #include "shell/dock/dock.h"
+#include "shell/frame/frame.h"
 #include "shell/hot_corners/hot_corners.h"
 #include "shell/lockscreen/lock_screen.h"
 #include "shell/lockscreen/lockscreen_widgets_controller.h"
@@ -309,6 +310,7 @@ private:
   OsdOverlay m_osdOverlay;
   HotCorners m_hotCorners{this};
   ScreenCorners m_screenCorners;
+  Frame m_frame;
   TrayMenu m_trayMenu;
   Wallpaper m_wallpaper;
   Backdrop m_backdrop;

--- a/src/app/application_events.cpp
+++ b/src/app/application_events.cpp
@@ -74,6 +74,7 @@ void Application::recoverGraphicsAfterReset() {
     m_trayMenu.requestLayout();
     m_settingsWindow.requestRedraw();
     m_screenCorners.requestRedraw();
+    m_frame.requestRedraw();
     requestAllSurfacesRedraw();
     m_graphicsRecoveryAttempts = 0;
     kLog.info("graphics context recovery completed");

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -571,6 +571,9 @@ void Application::reconcileOutputSurfaces() {
   // output set, so re-running it is safe. initialize() only wires dependencies.
   m_backdrop.onOutputChange();
   m_wallpaper.onOutputChange();
+  // Below the bar: the frame paints a rail across the bar's edge too, so the bar and its
+  // widgets must stack above it.
+  m_frame.onOutputChange();
   m_bar.onOutputChange();
   m_dock.onOutputChange();
   m_desktopWidgetsController.onOutputChange();

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -779,6 +779,13 @@ void Application::initNotificationAndOsd() {
 void Application::initBarDockAndLayout() {
   m_trayMenu.initialize(m_wayland, &m_configService, m_trayService.get(), &m_renderContext);
 
+  // Registered before Bar::initialize, which registers the bar's own reload callback.
+  // Reload callbacks run in registration order and each rebuild puts that module's surfaces
+  // back on top of its same-layer siblings, so the frame must rebuild BEFORE the bar — the
+  // bar has to end up above the frame's rails. Enabling a bar changes `bars`, which rebuilds
+  // both; registering the other way round left the newly enabled bar behind the frame.
+  m_configService.addReloadCallback([this]() { m_frame.onConfigReload(); });
+
   m_bar.initialize({
       .platform = m_compositorPlatform,
       .config = m_configService,
@@ -845,6 +852,12 @@ void Application::initBarDockAndLayout() {
       reloadDmenuProviders();
     }
   });
+  // Order matters: these run in registration order, and each rebuild puts that module's
+  // surfaces back on top of its Top-layer siblings. The frame must rebuild after the bar
+  // (registered in Bar::initialize) but before the screen corners — the corner masks are
+  // opaque black, so a translucent frame stacked above them shows the black through and
+  // muddies the corner instead of being cleanly clipped by it. This mirrors the
+  // bottom-to-top order in reconcileOutputSurfaces().
   m_configService.addReloadCallback([this]() { m_screenCorners.onConfigReload(); });
   m_configService.addReloadCallback([this]() { m_hotCorners.onConfigReload(); });
 
@@ -1025,5 +1038,10 @@ void Application::initWidgetControllersAndCallbacks() {
   // the hot-corner trigger zones are built after the bar and dock so they are
   // never occluded by shell chrome on their shared layer.
   m_screenCorners.initialize(m_wayland, &m_configService, &m_renderContext);
+  m_frame.initialize(m_wayland, &m_configService, &m_renderContext);
+  m_frame.setBarStateProviders(
+      [this]() { return m_bar.isVisible(); }, [this]() { return m_bar.reservesLayoutSpace(); }
+  );
+  m_bar.setVisibilityChangedCallback([this]() { m_frame.onBarVisibilityChanged(); });
   m_hotCorners.initialize(m_wayland, &m_configService, &m_renderContext);
 }

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -931,6 +931,30 @@ struct ShellConfig {
     bool operator==(const ScreenCornersConfig&) const = default;
   };
 
+  // Solid inset border around the whole output, with a rounded hole in the middle that the
+  // desktop shows through. Edges that already carry a space-reserving bar reuse the bar's
+  // thickness instead of `thickness`, so the frame reads as one continuous shape with it.
+  // The fill colour is the theme surface role, matching the bar. Opacity is deliberately
+  // opaque by default rather than inherited from the bar: the frame sits against the
+  // wallpaper on three edges, and letting it through reads as a smudge rather than a border.
+  struct FrameConfig {
+    bool enabled = false;
+    std::int32_t thickness = 8; // depth of the border on edges without a bar
+    std::int32_t radius = 12;   // corner radius of the inner hole
+    // Follow the bar's background opacity so the two read as one surface. When set, `opacity`
+    // is ignored; clear it to drive the frame independently.
+    bool matchBar = true;
+    float opacity = 1.0f;
+    // Extra px painted inward past the reserved thickness. Compositors apply their own gap
+    // inside the space we reserve (niri's `layout.gaps`, Hyprland's `general:gaps_out`), which
+    // leaves wallpaper between the frame and the nearest window. We cannot stop that — window
+    // placement belongs to the compositor — but the frame is above the windows, so it can
+    // cover the gap. Set this to the compositor's outer gap.
+    std::int32_t bleed = 0;
+
+    bool operator==(const FrameConfig&) const = default;
+  };
+
   struct MprisConfig {
     std::vector<std::string> blacklist;
 
@@ -1000,6 +1024,7 @@ struct ShellConfig {
   PanelConfig panel;
   LauncherConfig launcher;
   ScreenCornersConfig screenCorners;
+  FrameConfig frame;
   MprisConfig mpris;
   ScreenshotConfig screenshot;
   PrivacyConfig privacy;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1244,6 +1244,18 @@ namespace noctalia::config::schema {
       return s;
     }
 
+    const Schema<ShellConfig::FrameConfig>& shellFrameSchema() {
+      static const Schema<ShellConfig::FrameConfig> s = {
+          field(&ShellConfig::FrameConfig::enabled, "enabled"),
+          field(&ShellConfig::FrameConfig::thickness, "thickness", kFrameThicknessRange),
+          field(&ShellConfig::FrameConfig::radius, "radius", kFrameRadiusRange),
+          field(&ShellConfig::FrameConfig::matchBar, "match_bar"),
+          field(&ShellConfig::FrameConfig::opacity, "opacity", kUnitRange),
+          field(&ShellConfig::FrameConfig::bleed, "bleed", kFrameBleedRange),
+      };
+      return s;
+    }
+
     const Schema<ShellConfig::MprisConfig>& shellMprisSchema() {
       static const Schema<ShellConfig::MprisConfig> s = {
           field(&ShellConfig::MprisConfig::blacklist, "blacklist"),
@@ -1419,6 +1431,7 @@ namespace noctalia::config::schema {
         subTable(&ShellConfig::panel, "panel", shellPanelSchema()),
         subTable(&ShellConfig::launcher, "launcher", shellLauncherSchema()),
         subTable(&ShellConfig::screenCorners, "screen_corners", shellScreenCornersSchema()),
+        subTable(&ShellConfig::frame, "frame", shellFrameSchema()),
         subTable(&ShellConfig::mpris, "mpris", shellMprisSchema()),
         subTable(&ShellConfig::screenshot, "screenshot", shellScreenshotSchema()),
         subTable(&ShellConfig::privacy, "privacy", shellPrivacySchema()),

--- a/src/config/schema/ranges.h
+++ b/src/config/schema/ranges.h
@@ -19,6 +19,9 @@ namespace noctalia::config::schema {
   inline constexpr Range<float> kCornerRadiusScaleRange{0.0f, 2.0f, 0.05f};
   inline constexpr Range<std::int64_t> kControlCenterWidthRange{600, 1200, 10};
   inline constexpr Range<std::int64_t> kScreenCornersSizeRange{1, 100, 1};
+  inline constexpr Range<std::int64_t> kFrameThicknessRange{1, 64, 1};
+  inline constexpr Range<std::int64_t> kFrameRadiusRange{0, 64, 1};
+  inline constexpr Range<std::int64_t> kFrameBleedRange{0, 64, 1};
   inline constexpr Range<std::int64_t> kClipboardHistoryMaxEntriesRange{
       noctalia::config::kClipboardHistoryMinEntries,
       noctalia::config::kClipboardHistoryMaxEntries,

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1713,9 +1713,31 @@ void Bar::syncBarExclusiveZone(BarInstance& instance) {
   instance.surface->setExclusiveZone(zone);
 }
 
+bool Bar::reservesLayoutSpace() const noexcept {
+  return std::ranges::any_of(m_instances, [this](const auto& inst) { return shouldReserveExclusiveZone(*inst); });
+}
+
+void Bar::setVisibilityChangedCallback(std::function<void()> callback) {
+  m_visibilityChangedCallback = std::move(callback);
+}
+
+void Bar::notifyVisibilityChanged() {
+  const bool visible = isVisible();
+  if (visible == m_lastReportedVisible) {
+    return;
+  }
+  m_lastReportedVisible = visible;
+  if (m_visibilityChangedCallback != nullptr) {
+    m_visibilityChangedCallback();
+  }
+}
+
 void Bar::syncBarSurfaceChrome(BarInstance& instance) {
   syncBarExclusiveZone(instance);
   applyBarCompositorBlur(instance);
+  // Every visibility-affecting path funnels through here; gated on an actual transition so an
+  // auto-hide animation does not rebuild dependents on every frame.
+  notifyVisibilityChanged();
 }
 
 std::optional<LayerPopupParentContext> Bar::popupParentContextForSurface(wl_surface* surface) const noexcept {

--- a/src/shell/bar/bar.h
+++ b/src/shell/bar/bar.h
@@ -62,6 +62,9 @@ public:
   void suppressDisplay();
   void unsuppressDisplay();
   [[nodiscard]] bool isVisible() const noexcept;
+  // True while any bar still holds an exclusive zone. Auto-hide keeps the zone and slides out
+  // of it; an IPC hide releases it, and windows expand into the band instead.
+  [[nodiscard]] bool reservesLayoutSpace() const noexcept;
   void onOutputChange();
   void onWorkspaceChanged();
   void scheduleSmartAutoHideReevaluation();
@@ -69,6 +72,10 @@ public:
   void refresh();
   void requestLayout();
   void setAutoHideSuppressionCallback(std::function<bool(const BarInstance&)> callback);
+  // Fired when the bars stop or start being effectively visible. Auto-hide slides the bar out
+  // of an exclusive zone it still holds, so the reserved band empties without any config
+  // change; anything painting around the bar needs to know.
+  void setVisibilityChangedCallback(std::function<void()> callback);
   // Re-run auto-hide after a panel closes so unrelated bars are not left visible.
   void reevaluateAutoHide();
   void setOpenWidgetSettingsCallback(std::function<void(std::string, std::string)> callback);
@@ -130,6 +137,7 @@ private:
   void syncBarAutoHideInputRegion(BarInstance& instance) const;
   void syncBarExclusiveZone(BarInstance& instance);
   void syncBarSurfaceChrome(BarInstance& instance);
+  void notifyVisibilityChanged();
   void clearInstancePointerState(BarInstance& instance);
   [[nodiscard]] bool instanceAcceptsPointerInput(const BarInstance& instance) const noexcept;
   [[nodiscard]] bool shouldReserveExclusiveZone(const BarInstance& instance) const noexcept;
@@ -194,6 +202,8 @@ private:
   std::unordered_map<wl_surface*, BarInstance*> m_surfaceMap;
   BarInstance* m_hoveredInstance = nullptr;
   std::function<bool(const BarInstance&)> m_autoHideSuppressionCallback;
+  std::function<void()> m_visibilityChangedCallback;
+  bool m_lastReportedVisible = true;
   std::function<void(std::string, std::string)> m_openWidgetSettingsCallback;
   Timer m_workspaceRevealDebounce;
   Timer m_workspacePeekHideTimer;

--- a/src/shell/frame/frame.cpp
+++ b/src/shell/frame/frame.cpp
@@ -1,0 +1,379 @@
+#include "shell/frame/frame.h"
+
+#include "config/config_service.h"
+#include "core/ui_phase.h"
+#include "render/core/render_styles.h"
+#include "shell/frame/frame_geometry.h"
+#include "ui/controls/box.h"
+#include "ui/controls/screen_corner.h"
+#include "ui/palette.h"
+#include "wayland/wayland_connection.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+  // Superellipse exponent for the hole's corner wedges; matches ScreenCornerStyle's default.
+  constexpr float kCornerExponent = 4.0f;
+
+  // Reservation strips, in the order the anchors below are indexed.
+  enum Edge : int { EdgeTop = 0, EdgeBottom = 1, EdgeLeft = 2, EdgeRight = 3 };
+
+  constexpr std::uint32_t kEdgeAnchors[4] = {
+      LayerShellAnchor::Top | LayerShellAnchor::Left | LayerShellAnchor::Right,
+      LayerShellAnchor::Bottom | LayerShellAnchor::Left | LayerShellAnchor::Right,
+      LayerShellAnchor::Left | LayerShellAnchor::Top | LayerShellAnchor::Bottom,
+      LayerShellAnchor::Right | LayerShellAnchor::Top | LayerShellAnchor::Bottom,
+  };
+
+  [[nodiscard]] int edgeForPosition(std::string_view position) {
+    if (position == "bottom") {
+      return EdgeBottom;
+    }
+    if (position == "left") {
+      return EdgeLeft;
+    }
+    if (position == "right") {
+      return EdgeRight;
+    }
+    return EdgeTop;
+  }
+
+  bool outputEligible(const WaylandOutput& output) noexcept {
+    return output.done && output.output != nullptr && output.hasUsableGeometry();
+  }
+
+  std::size_t eligibleOutputCount(const WaylandConnection& wayland) {
+    return static_cast<std::size_t>(std::ranges::count_if(wayland.outputs(), outputEligible));
+  }
+
+  // The bar the frame defers to, for fill and for its edge alike. Deliberately independent of
+  // `reserveSpace`: a bar occupies its edge whether or not it displaces windows, so the frame
+  // must neither paint nor reserve there either way. Reservation only decides who owns the band
+  // while the bar is hidden, which is what the bar-owns-band provider answers.
+  [[nodiscard]] const BarConfig* styleBar(const Config& config) {
+    for (const auto& bar : config.bars) {
+      if (bar.enabled) {
+        return &bar;
+      }
+    }
+    return nullptr;
+  }
+
+} // namespace
+
+void Frame::initialize(WaylandConnection& wayland, ConfigService* config, RenderContext* renderContext) {
+  m_wayland = &wayland;
+  m_config = config;
+  m_renderContext = renderContext;
+}
+
+const ShellConfig::FrameConfig& Frame::frameConfig() const { return m_config->config().shell.frame; }
+
+Frame::Insets Frame::holeInsets() const {
+  return frame_geometry::holeInsets(
+      frameConfig(), frame_geometry::styleBar(m_config->config()), barVisible(), barReserves()
+  );
+}
+
+float Frame::fillOpacity() const {
+  return frame_geometry::fillOpacity(frameConfig(), frame_geometry::styleBar(m_config->config()));
+}
+
+void Frame::onConfigReload() {
+  if (m_config == nullptr) {
+    return;
+  }
+
+  const auto& cfg = frameConfig();
+  if (!cfg.enabled) {
+    if (m_lastEnabled) {
+      destroySurfaces();
+      m_lastEnabled = false;
+    }
+    return;
+  }
+
+  // Same layer-shell stacking hazard as the screen corners: the bar and dock share the Top
+  // layer and are stacked by creation order, so recreate whenever either may have been
+  // rebuilt. The bar also feeds our insets, so a bar change is a geometry change for us
+  // regardless.
+  const auto& changed = m_config->lastChange();
+  const bool stackingMayHaveChanged = changed.bars || changed.widgets || changed.dock;
+  const auto insets = holeInsets();
+
+  if (cfg != m_lastConfig
+      || insets != m_lastInsets
+      || m_instances.size() != eligibleOutputCount(*m_wayland)
+      || stackingMayHaveChanged) {
+    destroySurfaces();
+    m_lastEnabled = cfg.enabled;
+    m_lastConfig = cfg;
+    m_lastInsets = insets;
+    ensureSurfaces();
+  }
+}
+
+void Frame::onOutputChange() {
+  if (m_config == nullptr) {
+    return;
+  }
+  const auto& cfg = frameConfig();
+  m_lastEnabled = cfg.enabled;
+  m_lastConfig = cfg;
+  m_lastInsets = holeInsets();
+
+  destroySurfaces();
+  if (!cfg.enabled) {
+    return;
+  }
+  ensureSurfaces();
+}
+
+void Frame::setBarStateProviders(std::function<bool()> visible, std::function<bool()> reserves) {
+  m_barVisibleProvider = std::move(visible);
+  m_barReservesProvider = std::move(reserves);
+}
+
+bool Frame::barVisible() const { return m_barVisibleProvider == nullptr || m_barVisibleProvider(); }
+
+bool Frame::barReserves() const { return m_barReservesProvider == nullptr || m_barReservesProvider(); }
+
+void Frame::onBarVisibilityChanged() {
+  // Scene-only rebuild: the surfaces themselves are unchanged, and recreating them here would
+  // reshuffle the layer-shell stacking on every hide and reveal.
+  for (auto& inst : m_instances) {
+    if (inst->visual == nullptr || inst->builtWidth == 0 || inst->builtHeight == 0) {
+      continue;
+    }
+    UiPhaseScope layoutPhase(UiPhase::Layout);
+    buildFrameScene(*inst, inst->builtWidth, inst->builtHeight);
+    inst->visual->requestRedraw();
+  }
+}
+
+void Frame::requestRedraw() {
+  for (auto& inst : m_instances) {
+    if (inst->visual != nullptr) {
+      inst->visual->requestRedraw();
+    }
+  }
+}
+
+void Frame::ensureSurfaces() {
+  if (m_wayland == nullptr || m_renderContext == nullptr || m_config == nullptr) {
+    return;
+  }
+
+  const auto& cfg = frameConfig();
+  if (!cfg.enabled || !m_instances.empty()) {
+    return;
+  }
+
+  const Insets insets = holeInsets();
+  const BarConfig* bar = styleBar(m_config->config());
+  const int barEdge = bar != nullptr ? edgeForPosition(bar->position) : -1;
+  const std::array<float, 4> edgeInsets{insets.top, insets.bottom, insets.left, insets.right};
+
+  for (const auto& output : m_wayland->outputs()) {
+    if (!outputEligible(output)) {
+      continue;
+    }
+
+    auto inst = std::make_unique<OutputInstance>();
+    inst->output = output.output;
+    inst->fallbackWidth = static_cast<std::uint32_t>(std::max(0, output.effectiveLogicalWidth()));
+    inst->fallbackHeight = static_cast<std::uint32_t>(std::max(0, output.effectiveLogicalHeight()));
+
+    // Reservation strips first, so the visual surface is created last and stays on top of
+    // them. They paint nothing; they exist only to carry an exclusive zone.
+    bool ok = true;
+    for (int edge = 0; edge < 4 && ok; ++edge) {
+      if (edge == barEdge) {
+        continue; // the bar already reserves this edge
+      }
+      const auto depth = static_cast<std::uint32_t>(std::max(0.0f, edgeInsets[static_cast<std::size_t>(edge)]));
+      if (depth == 0) {
+        continue;
+      }
+
+      const bool vertical = edge == EdgeLeft || edge == EdgeRight;
+      auto reservationConfig = LayerSurfaceConfig{
+          .nameSpace = "noctalia-frame-reserve",
+          .layer = LayerShellLayer::Top,
+          .anchor = kEdgeAnchors[edge],
+          .width = vertical ? depth : 0,
+          .height = vertical ? 0 : depth,
+          .exclusiveZone = static_cast<std::int32_t>(depth),
+          .keyboard = LayerShellKeyboard::None,
+          .defaultWidth = vertical ? depth : 0,
+          .defaultHeight = vertical ? 0 : depth,
+      };
+
+      auto& reservation = inst->reservations[edge];
+      reservation = std::make_unique<LayerSurface>(*m_wayland, std::move(reservationConfig));
+      reservation->setRenderContext(m_renderContext);
+      if (!reservation->initialize(output.output)) {
+        ok = false;
+        break;
+      }
+      reservation->setInputRegion({});
+    }
+
+    if (!ok) {
+      continue;
+    }
+
+    // The visual spans the whole output and ignores every exclusive zone, including the
+    // strips above and the bar's, so the rails can paint the space they reserved.
+    auto visualConfig = LayerSurfaceConfig{
+        .nameSpace = "noctalia-frame",
+        .layer = LayerShellLayer::Top,
+        .anchor = LayerShellAnchor::Top | LayerShellAnchor::Bottom | LayerShellAnchor::Left | LayerShellAnchor::Right,
+        .exclusiveZone = -1,
+        .keyboard = LayerShellKeyboard::None,
+    };
+
+    inst->visual = std::make_unique<LayerSurface>(*m_wayland, std::move(visualConfig));
+    inst->visual->setRenderContext(m_renderContext);
+
+    auto* instPtr = inst.get();
+    inst->visual->setConfigureCallback([instPtr](std::uint32_t, std::uint32_t) { instPtr->visual->requestLayout(); });
+    inst->visual->setPrepareFrameCallback([this, instPtr](bool, bool) {
+      auto& target = instPtr->visual->renderTarget();
+      const auto width = target.logicalWidth() == 0 ? instPtr->fallbackWidth : target.logicalWidth();
+      const auto height = target.logicalHeight() == 0 ? instPtr->fallbackHeight : target.logicalHeight();
+      if (width == 0 || height == 0) {
+        return;
+      }
+      if (instPtr->sceneRoot == nullptr || instPtr->builtWidth != width || instPtr->builtHeight != height) {
+        UiPhaseScope layoutPhase(UiPhase::Layout);
+        buildFrameScene(*instPtr, width, height);
+      }
+    });
+
+    if (!inst->visual->initialize(output.output)) {
+      continue;
+    }
+    // Fully click-through: the rails are decoration, and the hole must not swallow clicks
+    // destined for the desktop underneath.
+    inst->visual->setInputRegion({});
+
+    m_instances.push_back(std::move(inst));
+  }
+}
+
+void Frame::destroySurfaces() { m_instances.clear(); }
+
+void Frame::buildFrameScene(OutputInstance& instance, std::uint32_t width, std::uint32_t height) {
+  const auto w = static_cast<float>(width);
+  const auto h = static_cast<float>(height);
+  const Insets insets = holeInsets();
+
+  const auto hole = frame_geometry::paintedHole(w, h, insets, frameConfig().bleed);
+  const float holeX = hole.x;
+  const float holeY = hole.y;
+  const float holeRight = hole.x + hole.width;
+  const float holeBottom = hole.y + hole.height;
+  const float radius = frame_geometry::clampRadius(frameConfig().radius, hole);
+
+  const Color fill = colorForRole(ColorRole::Surface, fillOpacity());
+  const BarConfig* styling = frame_geometry::styleBar(m_config->config());
+  const Color barFill =
+      styling != nullptr ? colorForRole(ColorRole::Surface, std::clamp(styling->backgroundOpacity, 0.0f, 1.0f)) : fill;
+  const auto barEdge = frame_geometry::cededEdge(styling, barVisible());
+
+  auto root = std::make_unique<Node>();
+  root->setSize(w, h);
+
+  // The bar asks the compositor to blur behind it, so its translucent fill lands on a blurred
+  // backdrop and stays flat across a patterned wallpaper. Without the same request our fill
+  // tracks the wallpaper underneath and drifts from the bar's colour.
+  std::vector<InputRect> blurRegion;
+  const auto addBlur = [&](float x, float y, float rw, float rh) {
+    blurRegion.push_back(
+        InputRect{
+            .x = static_cast<int>(std::lround(x)),
+            .y = static_cast<int>(std::lround(y)),
+            .width = static_cast<int>(std::lround(rw)),
+            .height = static_cast<int>(std::lround(rh)),
+        }
+    );
+  };
+
+  const auto addRail = [&](const frame_geometry::Rect& r, const Color& color) {
+    if (r.empty()) {
+      return;
+    }
+    auto rail = std::make_unique<Box>();
+    rail->setFill(color);
+    rail->setSize(r.width, r.height);
+    rail->setParticipatesInLayout(false);
+    rail->setPosition(r.x, r.y);
+    root->addChild(std::move(rail));
+    addBlur(r.x, r.y, r.width, r.height);
+  };
+
+  // Geometry lives in frame_geometry.h so it is unit-testable without a compositor; this is
+  // only the translation into scene nodes. Rails and caps are disjoint by construction, so
+  // nothing double-blends at fractional opacity.
+  for (const auto& rail : frame_geometry::rails(w, h, insets, hole, barEdge)) {
+    addRail(rail, fill);
+  }
+  for (const auto& cap : frame_geometry::endCaps(w, h, insets, barEdge)) {
+    addRail(cap, barFill);
+  }
+
+  if (radius > 0.0f) {
+    // Each wedge fills its square except the rounded quarter facing into the hole, which is
+    // what ScreenCorner's shader already draws.
+    const auto addCorner = [&](float x, float y, ScreenCornerPosition position) {
+      auto corner = std::make_unique<ScreenCorner>();
+      corner->setColor(fill);
+      corner->setCorner(position);
+      corner->setExponent(kCornerExponent);
+      corner->setSize(radius, radius);
+      corner->setParticipatesInLayout(false);
+      corner->setPosition(x, y);
+      root->addChild(std::move(corner));
+
+      // Strip-tessellate the wedge rather than blurring its bounding square, which would
+      // smear a quarter-disc of desktop at each inner corner. Traces the same superellipse
+      // the ScreenCorner shader fills.
+      const bool fromTop = position == ScreenCornerPosition::TopLeft || position == ScreenCornerPosition::TopRight;
+      const bool fromLeft = position == ScreenCornerPosition::TopLeft || position == ScreenCornerPosition::BottomLeft;
+      const int rows = static_cast<int>(std::lround(radius));
+      for (int i = 0; i < rows; ++i) {
+        const float dy = radius - static_cast<float>(i);
+        const float remainder = std::clamp(1.0f - std::pow(dy / radius, kCornerExponent), 0.0f, 1.0f);
+        const float span = radius - (radius * std::pow(remainder, 1.0f / kCornerExponent));
+        if (span < 1.0f) {
+          continue;
+        }
+        const float rowY = fromTop ? y + static_cast<float>(i) : y + radius - 1.0f - static_cast<float>(i);
+        addBlur(fromLeft ? x : x + radius - span, rowY, span, 1.0f);
+      }
+    };
+
+    addCorner(holeX, holeY, ScreenCornerPosition::TopLeft);
+    addCorner(holeRight - radius, holeY, ScreenCornerPosition::TopRight);
+    addCorner(holeRight - radius, holeBottom - radius, ScreenCornerPosition::BottomRight);
+    addCorner(holeX, holeBottom - radius, ScreenCornerPosition::BottomLeft);
+  }
+
+  // Only worth asking the compositor for a blur while something is actually translucent.
+  // Only worth the compositor's work while something is actually translucent.
+  if (fill.a < 0.999f || barFill.a < 0.999f) {
+    instance.visual->setBlurRegion(blurRegion);
+  } else {
+    instance.visual->clearBlurRegion();
+  }
+
+  instance.sceneRoot = std::move(root);
+  instance.builtWidth = width;
+  instance.builtHeight = height;
+  instance.visual->setSceneRoot(instance.sceneRoot.get());
+}

--- a/src/shell/frame/frame.h
+++ b/src/shell/frame/frame.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "config/config_types.h"
+#include "shell/frame/frame_geometry.h"
+#include "wayland/layer_surface.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+class ConfigService;
+class RenderContext;
+class WaylandConnection;
+
+// Draws a solid inset border around each output with a rounded hole in the middle that the
+// desktop shows through.
+//
+// The visual is a single full-output click-through surface rather than one strip per edge:
+// the rounded inner corners straddle two edges, so per-edge surfaces each rounding their own
+// corners meet at a hard angle instead of a continuous arc. Space is reserved by separate
+// zero-visual strips, since a layer surface can only reserve the one edge it is anchored to.
+//
+// The edge carrying a space-reserving bar is inset by the bar's own thickness, not by
+// `thickness` plus it — the bar *is* the frame on that edge, and the hole supplies its inner
+// corners so the two read as one shape.
+class Frame {
+public:
+  Frame() = default;
+  ~Frame() = default;
+
+  Frame(const Frame&) = delete;
+  Frame& operator=(const Frame&) = delete;
+
+  void initialize(WaylandConnection& wayland, ConfigService* config, RenderContext* renderContext);
+  void onOutputChange();
+  void onConfigReload();
+  void requestRedraw();
+  // Auto-hide slides the bar out of a band it still reserves, leaving it empty. Repaint so the
+  // frame covers that band instead of exposing the wallpaper behind it.
+  void onBarVisibilityChanged();
+  // Bar runtime state. Visibility and reservation answer different questions and must stay
+  // separate: the frame cedes the bar's edge while the bar is on screen, and what it paints
+  // once the bar leaves depends on whether the band stayed reserved.
+  void setBarStateProviders(std::function<bool()> visible, std::function<bool()> reserves);
+
+private:
+  // Reserved insets of the hole from each output edge, in logical px.
+  using Insets = frame_geometry::Insets;
+
+  struct OutputInstance {
+    wl_output* output = nullptr;
+    std::unique_ptr<LayerSurface> visual;
+    std::unique_ptr<Node> sceneRoot;
+    // One per edge, in ScreenEdge order; null on the edge a bar already reserves.
+    std::unique_ptr<LayerSurface> reservations[4];
+    // Output size to build against before the compositor's first configure lands, which is
+    // when the render target still reports 0×0.
+    std::uint32_t fallbackWidth = 0;
+    std::uint32_t fallbackHeight = 0;
+    std::uint32_t builtWidth = 0;
+    std::uint32_t builtHeight = 0;
+  };
+
+  [[nodiscard]] const ShellConfig::FrameConfig& frameConfig() const;
+  // Hole insets for an output: the bar's thickness on the bar's edge, `thickness` elsewhere.
+  [[nodiscard]] Insets holeInsets() const;
+  [[nodiscard]] bool barVisible() const;
+  [[nodiscard]] bool barReserves() const;
+  [[nodiscard]] float fillOpacity() const;
+
+  void ensureSurfaces();
+  void destroySurfaces();
+  void buildFrameScene(OutputInstance& instance, std::uint32_t width, std::uint32_t height);
+
+  std::function<bool()> m_barVisibleProvider;
+  std::function<bool()> m_barReservesProvider;
+  WaylandConnection* m_wayland = nullptr;
+  ConfigService* m_config = nullptr;
+  RenderContext* m_renderContext = nullptr;
+  bool m_lastEnabled = false;
+  ShellConfig::FrameConfig m_lastConfig;
+  Insets m_lastInsets;
+  std::vector<std::unique_ptr<OutputInstance>> m_instances;
+};

--- a/src/shell/frame/frame_geometry.h
+++ b/src/shell/frame/frame_geometry.h
@@ -1,0 +1,197 @@
+#pragma once
+
+// Pure geometry for the screen frame, split out so it can be tested without a compositor,
+// a renderer or a live bar. Frame::buildFrameScene is a thin translation of these results
+// into scene nodes; everything that decides *where* the frame paints lives here.
+
+#include "config/config_types.h"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace frame_geometry {
+
+  enum class Edge : int { None = -1, Top = 0, Bottom = 1, Left = 2, Right = 3 };
+
+  struct Insets {
+    float left = 0.0f;
+    float top = 0.0f;
+    float right = 0.0f;
+    float bottom = 0.0f;
+
+    bool operator==(const Insets&) const = default;
+  };
+
+  struct Rect {
+    float x = 0.0f;
+    float y = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+
+    [[nodiscard]] bool empty() const noexcept { return width <= 0.0f || height <= 0.0f; }
+    bool operator==(const Rect&) const = default;
+  };
+
+  [[nodiscard]] inline Edge edgeForPosition(std::string_view position) noexcept {
+    if (position == "bottom") {
+      return Edge::Bottom;
+    }
+    if (position == "left") {
+      return Edge::Left;
+    }
+    if (position == "right") {
+      return Edge::Right;
+    }
+    return Edge::Top;
+  }
+
+  // The bar the frame defers to, for fill and for its edge alike. Deliberately independent of
+  // `reserveSpace`: a bar occupies its edge whether or not it displaces windows.
+  [[nodiscard]] inline const BarConfig* styleBar(const Config& config) noexcept {
+    for (const auto& bar : config.bars) {
+      if (bar.enabled) {
+        return &bar;
+      }
+    }
+    return nullptr;
+  }
+
+  // Reserved insets of the hole from each output edge. The bar's edge takes the bar's own
+  // thickness — never thickness + frame thickness — but only while the band is still the
+  // bar's. Once the bar has gone AND released the band, windows own it and the frame falls
+  // back to its own thickness so the border still closes.
+  [[nodiscard]] inline Insets
+  holeInsets(const ShellConfig::FrameConfig& cfg, const BarConfig* bar, bool barVisible, bool barReserves) noexcept {
+    const auto thickness = static_cast<float>(std::max(0, cfg.thickness));
+    Insets insets{thickness, thickness, thickness, thickness};
+    if (bar == nullptr || (!barVisible && !barReserves)) {
+      return insets;
+    }
+    const auto barThickness = static_cast<float>(std::max(0, bar->thickness));
+    switch (edgeForPosition(bar->position)) {
+    case Edge::Bottom:
+      insets.bottom = barThickness;
+      break;
+    case Edge::Left:
+      insets.left = barThickness;
+      break;
+    case Edge::Right:
+      insets.right = barThickness;
+      break;
+    default:
+      insets.top = barThickness;
+      break;
+    }
+    return insets;
+  }
+
+  // Opacity of the frame fill. Matching the bar does NOT depend on reservation: a bar that
+  // reserves nothing still sits on screen and still has to match.
+  [[nodiscard]] inline float fillOpacity(const ShellConfig::FrameConfig& cfg, const BarConfig* bar) noexcept {
+    if (cfg.matchBar && bar != nullptr) {
+      return std::clamp(bar->backgroundOpacity, 0.0f, 1.0f);
+    }
+    return std::clamp(cfg.opacity, 0.0f, 1.0f);
+  }
+
+  // The edge the frame must not paint over, i.e. the one the bar is currently occupying.
+  [[nodiscard]] inline Edge cededEdge(const BarConfig* bar, bool barVisible) noexcept {
+    return (bar != nullptr && barVisible) ? edgeForPosition(bar->position) : Edge::None;
+  }
+
+  // The hole actually painted around: the reserved hole pulled inward by the bleed, so the
+  // frame covers the gap the compositor leaves between the reserved area and the window.
+  [[nodiscard]] inline Rect paintedHole(float w, float h, const Insets& reserved, int bleed) noexcept {
+    const auto b = static_cast<float>(std::max(0, bleed));
+    const float x = std::clamp(reserved.left + b, 0.0f, w);
+    const float y = std::clamp(reserved.top + b, 0.0f, h);
+    return Rect{
+        x, y, std::max(0.0f, w - reserved.left - reserved.right - (2.0f * b)),
+        std::max(0.0f, h - reserved.top - reserved.bottom - (2.0f * b))
+    };
+  }
+
+  // A radius past half the hole would make the corner arcs self-intersect.
+  [[nodiscard]] inline float clampRadius(int radius, const Rect& hole) noexcept {
+    return std::max(0.0f, std::min({static_cast<float>(radius), hole.width * 0.5f, hole.height * 0.5f}));
+  }
+
+  // The four frame rails: the output minus the bar's reserved band, minus the painted hole.
+  // Disjoint by construction so nothing double-blends at fractional opacity.
+  [[nodiscard]] inline std::array<Rect, 4>
+  rails(float w, float h, const Insets& reserved, const Rect& hole, Edge barEdge) noexcept {
+    float left = 0.0f;
+    float top = 0.0f;
+    float right = w;
+    float bottom = h;
+    switch (barEdge) {
+    case Edge::Bottom:
+      bottom = std::clamp(h - reserved.bottom, 0.0f, h);
+      break;
+    case Edge::Top:
+      top = std::clamp(reserved.top, 0.0f, h);
+      break;
+    case Edge::Left:
+      left = std::clamp(reserved.left, 0.0f, w);
+      break;
+    case Edge::Right:
+      right = std::clamp(w - reserved.right, 0.0f, w);
+      break;
+    default:
+      break;
+    }
+    const float width = std::max(0.0f, right - left);
+    const float holeRight = hole.x + hole.width;
+    const float holeBottom = hole.y + hole.height;
+    return {
+        Rect{left, top, width, hole.y - top},                            // top
+        Rect{left, holeBottom, width, bottom - holeBottom},              // bottom
+        Rect{left, hole.y, hole.x - left, holeBottom - hole.y},          // left
+        Rect{holeRight, hole.y, right - holeRight, holeBottom - hole.y}, // right
+    };
+  }
+
+  // End caps inside the bar's band. Our reservation strips inset the bar on the two edges
+  // perpendicular to it, so it cannot reach the corners; these fill them, in the bar's fill.
+  // Sized by the RESERVED inset, never the painted one — bleeding them further would reach
+  // past the bar's edge and clip its outermost widget.
+  [[nodiscard]] inline std::array<Rect, 2> endCaps(float w, float h, const Insets& reserved, Edge barEdge) noexcept {
+    const float bandTop = std::clamp(reserved.top, 0.0f, h);
+    const float bandBottom = std::clamp(h - reserved.bottom, 0.0f, h);
+    const float bandLeft = std::clamp(reserved.left, 0.0f, w);
+    const float bandRight = std::clamp(w - reserved.right, 0.0f, w);
+    switch (barEdge) {
+    case Edge::Bottom:
+      return {
+          Rect{0.0f, bandBottom, bandLeft, h - bandBottom},
+          Rect{bandRight, bandBottom, w - bandRight, h - bandBottom},
+      };
+    case Edge::Top:
+      return {
+          Rect{0.0f, 0.0f, bandLeft, bandTop},
+          Rect{bandRight, 0.0f, w - bandRight, bandTop},
+      };
+    case Edge::Left:
+      return {
+          Rect{0.0f, 0.0f, bandLeft, bandTop},
+          Rect{0.0f, bandBottom, bandLeft, h - bandBottom},
+      };
+    case Edge::Right:
+      return {
+          Rect{bandRight, 0.0f, w - bandRight, bandTop},
+          Rect{bandRight, bandBottom, w - bandRight, h - bandBottom},
+      };
+    default:
+      return {Rect{}, Rect{}};
+    }
+  }
+
+  [[nodiscard]] inline bool overlaps(const Rect& a, const Rect& b) noexcept {
+    if (a.empty() || b.empty()) {
+      return false;
+    }
+    return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
+  }
+
+} // namespace frame_geometry

--- a/src/shell/screen_corners/screen_corners.cpp
+++ b/src/shell/screen_corners/screen_corners.cpp
@@ -118,7 +118,11 @@ void ScreenCorners::ensureSurfaces() {
     for (int i = 0; i < 4; ++i) {
       auto surfaceConfig = LayerSurfaceConfig{
           .nameSpace = "noctalia-screen-corner",
-          .layer = LayerShellLayer::Top,
+          // Overlay, not Top: these masks model the physical shape of the display, so nothing
+          // the shell draws should ever sit on top of them. On Top they compete with the bar,
+          // dock and frame by creation order, and any partial rebuild silently reorders them —
+          // the frame's end caps end up filling the very corner the mask is carving.
+          .layer = LayerShellLayer::Overlay,
           .anchor = kCornerAnchors[i],
           .width = size,
           .height = size,

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1395,6 +1395,46 @@ namespace settings {
     ));
 
     entries.push_back(makeEntry(
+        SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-enabled.label"),
+        tr("settings.schema.desktop.frame-enabled.description"), {"shell", "frame", "enabled"},
+        ToggleSetting{cfg.shell.frame.enabled}, "frame border matte inset framed"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-thickness.label"),
+        tr("settings.schema.desktop.frame-thickness.description"), {"shell", "frame", "thickness"},
+        sliderFor(cfg.shell.frame.thickness, noctalia::config::schema::kFrameThicknessRange, true),
+        "frame border width thickness"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-radius.label"),
+        tr("settings.schema.desktop.frame-radius.description"), {"shell", "frame", "radius"},
+        sliderFor(cfg.shell.frame.radius, noctalia::config::schema::kFrameRadiusRange, true),
+        "frame border inner radius rounded"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-match-bar.label"),
+        tr("settings.schema.desktop.frame-match-bar.description"), {"shell", "frame", "match_bar"},
+        ToggleSetting{cfg.shell.frame.matchBar}, "frame match bar opacity same colour"
+    ));
+    {
+      // Match Bar drives the fill from the bar's opacity, which leaves this slider inert.
+      auto e = makeEntry(
+          SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-opacity.label"),
+          tr("settings.schema.desktop.frame-opacity.description"), {"shell", "frame", "opacity"},
+          sliderFor(cfg.shell.frame.opacity, noctalia::config::schema::kUnitRange, false),
+          "frame border opacity transparency"
+      );
+      e.visibleWhen = [](const Config& c) { return !c.shell.frame.matchBar; };
+      entries.push_back(std::move(e));
+    }
+    entries.push_back(makeEntry(
+        SettingsSection::Desktop, "frame", tr("settings.schema.desktop.frame-bleed.label"),
+        tr("settings.schema.desktop.frame-bleed.description"), {"shell", "frame", "bleed"},
+        sliderFor(cfg.shell.frame.bleed, noctalia::config::schema::kFrameBleedRange, true),
+        "frame bleed gap compositor gaps overscan"
+    ));
+
+    entries.push_back(makeEntry(
         SettingsSection::Desktop, "hot-corners", tr("settings.schema.desktop.hot-corners-enabled.label"),
         tr("settings.schema.desktop.hot-corners-enabled.description"), {"hot_corners", "enabled"},
         ToggleSetting{cfg.hotCorners.enabled}, "hot corners trigger mouse edge screen"

--- a/tests/config_path_resolution_test.cpp
+++ b/tests/config_path_resolution_test.cpp
@@ -45,6 +45,12 @@ int main() {
   expectKnown({"shell", "panel", "control_center_placement"});
   expectKnown({"shell", "shadow", "alpha"});
   expectKnown({"shell", "screen_corners", "size"});
+  expectKnown({"shell", "frame", "enabled"});
+  expectKnown({"shell", "frame", "thickness"});
+  expectKnown({"shell", "frame", "radius"});
+  expectKnown({"shell", "frame", "opacity"});
+  expectKnown({"shell", "frame", "match_bar"});
+  expectKnown({"shell", "frame", "bleed"});
   expectKnown({"shell", "screenshot", "directory"});
   expectKnown({"system", "monitor", "cpu_poll_seconds"});
   expectKnown({"theme", "mode"});

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -444,6 +444,12 @@ location = "https://example.invalid/bad"
     };
     c.shell.screenCorners.enabled = true;
     c.shell.screenCorners.size = 24;
+    c.shell.frame.enabled = true;
+    c.shell.frame.thickness = 10;
+    c.shell.frame.radius = 18;
+    c.shell.frame.opacity = 0.4f;
+    c.shell.frame.matchBar = false;
+    c.shell.frame.bleed = 6;
     c.shell.mpris.blacklist = {"firefox"};
     c.shell.screenshot.directory = "/shots";
     c.shell.screenshot.pipeToCommand = true;

--- a/tests/frame_geometry_test.cpp
+++ b/tests/frame_geometry_test.cpp
@@ -1,0 +1,273 @@
+// Geometry rules for the screen frame.
+//
+// Every case here corresponds to a defect that actually shipped during development, so the
+// comments name the symptom rather than restating the assertion. The recurring mistake was
+// conflating three separate questions about the bar — which edge it occupies, whether it is
+// on screen, and whether it reserves space — so most of the file is about keeping those apart.
+
+#include "shell/frame/frame_geometry.h"
+
+#include <array>
+#include <print>
+#include <string>
+
+using namespace frame_geometry;
+
+namespace {
+
+  int g_failures = 0;
+
+  void fail(const std::string& message) {
+    std::println(stderr, "frame_geometry: FAIL: {}", message);
+    ++g_failures;
+  }
+
+  void expect(bool condition, const std::string& message) {
+    if (!condition) {
+      fail(message);
+    }
+  }
+
+  void expectRect(const Rect& got, const Rect& want, const std::string& what) {
+    if (!(got == want)) {
+      fail(what + ": got {" + std::to_string(got.x) + "," + std::to_string(got.y) + "," + std::to_string(got.width)
+           + "," + std::to_string(got.height) + "} want {" + std::to_string(want.x) + "," + std::to_string(want.y) + ","
+           + std::to_string(want.width) + "," + std::to_string(want.height) + "}");
+    }
+  }
+
+  constexpr float kW = 3440.0f;
+  constexpr float kH = 1440.0f;
+
+  ShellConfig::FrameConfig frameCfg(int thickness = 8, int radius = 12, int bleed = 0) {
+    ShellConfig::FrameConfig cfg;
+    cfg.enabled = true;
+    cfg.thickness = thickness;
+    cfg.radius = radius;
+    cfg.bleed = bleed;
+    return cfg;
+  }
+
+  BarConfig barCfg(std::string position = "bottom", int thickness = 34) {
+    BarConfig bar;
+    bar.enabled = true;
+    bar.position = std::move(position);
+    bar.thickness = thickness;
+    return bar;
+  }
+
+  void checkEdgeMapping() {
+    expect(edgeForPosition("bottom") == Edge::Bottom, "edge: bottom");
+    expect(edgeForPosition("left") == Edge::Left, "edge: left");
+    expect(edgeForPosition("right") == Edge::Right, "edge: right");
+    expect(edgeForPosition("top") == Edge::Top, "edge: top");
+    // Unknown positions must fall through to "top", matching the bar's own default.
+    expect(edgeForPosition("") == Edge::Top, "edge: empty falls back to top");
+    expect(edgeForPosition("diagonal") == Edge::Top, "edge: unknown falls back to top");
+  }
+
+  void checkHoleInsets() {
+    const auto cfg = frameCfg(8);
+    const auto bar = barCfg("bottom", 34);
+
+    // The bar IS the frame on its edge: that edge takes the bar's thickness, not the bar's
+    // thickness plus the frame's. Getting this wrong double-insets the desktop.
+    const auto shown = holeInsets(cfg, &bar, /*barVisible=*/true, /*barReserves=*/true);
+    expect(shown.bottom == 34.0f, "insets: bar edge takes bar thickness, not bar + frame");
+    expect(shown.left == 8.0f && shown.right == 8.0f && shown.top == 8.0f, "insets: other edges take frame thickness");
+
+    // Hidden but still reserving (auto-hide keeps its exclusive zone): the band is still the
+    // bar's, so the inset stays. Regression: the frame stopped covering an empty band.
+    const auto hiddenReserving = holeInsets(cfg, &bar, false, true);
+    expect(hiddenReserving.bottom == 34.0f, "insets: reserved band keeps the bar's thickness while hidden");
+
+    // Hidden AND released (IPC hide, or a non-reserving bar): windows own the band, so the
+    // frame falls back to its own thickness and still closes the border.
+    const auto released = holeInsets(cfg, &bar, false, false);
+    expect(released.bottom == 8.0f, "insets: released band falls back to frame thickness");
+
+    // No bar at all — every edge is the frame's.
+    const auto noBar = holeInsets(cfg, nullptr, false, false);
+    expect(
+        noBar.bottom == 8.0f && noBar.top == 8.0f && noBar.left == 8.0f && noBar.right == 8.0f,
+        "insets: no bar means uniform frame thickness"
+    );
+
+    // Each bar position must inset its own edge and no other.
+    const auto leftBar = barCfg("left", 30);
+    const auto left = holeInsets(cfg, &leftBar, true, true);
+    expect(left.left == 30.0f && left.right == 8.0f && left.top == 8.0f, "insets: left bar insets only the left edge");
+    const auto topBar = barCfg("top", 30);
+    const auto top = holeInsets(cfg, &topBar, true, true);
+    expect(top.top == 30.0f && top.bottom == 8.0f, "insets: top bar insets only the top edge");
+  }
+
+  void checkFillOpacity() {
+    auto cfg = frameCfg();
+    auto bar = barCfg();
+    bar.backgroundOpacity = 0.67f;
+
+    cfg.matchBar = true;
+    cfg.opacity = 1.0f;
+    expect(fillOpacity(cfg, &bar) == 0.67f, "opacity: match_bar follows the bar and ignores `opacity`");
+
+    // Regression: matching used to be routed through the reserving-bar lookup, so a bar with
+    // reserve_space = false silently made the frame opaque instead of matching it. Matching
+    // must not depend on reservation at all — hence no reservation argument here.
+    cfg.matchBar = false;
+    expect(fillOpacity(cfg, &bar) == 1.0f, "opacity: match_bar off uses the frame's own opacity");
+
+    cfg.matchBar = true;
+    expect(fillOpacity(cfg, nullptr) == 1.0f, "opacity: match_bar with no bar falls back to `opacity`");
+
+    cfg.matchBar = false;
+    cfg.opacity = 2.5f;
+    expect(fillOpacity(cfg, &bar) == 1.0f, "opacity: clamped to 1");
+    cfg.opacity = -1.0f;
+    expect(fillOpacity(cfg, &bar) == 0.0f, "opacity: clamped to 0");
+  }
+
+  void checkCededEdge() {
+    const auto bar = barCfg("bottom");
+    // The frame cedes the edge only while the bar is actually on it. Painting there regardless
+    // put the frame's rail on top of the bar's own pixels, because same-layer stacking follows
+    // creation order and the frame is not reliably below the bar.
+    expect(cededEdge(&bar, true) == Edge::Bottom, "ceded: bar on screen owns its edge");
+    expect(cededEdge(&bar, false) == Edge::None, "ceded: bar off screen cedes nothing");
+    expect(cededEdge(nullptr, true) == Edge::None, "ceded: no bar cedes nothing");
+  }
+
+  void checkPaintedHoleAndRadius() {
+    const Insets reserved{8.0f, 8.0f, 8.0f, 34.0f};
+
+    const auto noBleed = paintedHole(kW, kH, reserved, 0);
+    expectRect(noBleed, Rect{8.0f, 8.0f, kW - 16.0f, kH - 42.0f}, "hole: no bleed");
+
+    // Bleed pulls the hole inward on every edge so the frame covers the compositor's gap.
+    const auto bled = paintedHole(kW, kH, reserved, 4);
+    expectRect(bled, Rect{12.0f, 12.0f, kW - 24.0f, kH - 50.0f}, "hole: bleed pulls inward on all edges");
+
+    // A radius past half the hole would make the corner arcs self-intersect.
+    expect(clampRadius(20, bled) == 20.0f, "radius: kept when it fits");
+    const Rect tiny{0.0f, 0.0f, 30.0f, 10.0f};
+    expect(clampRadius(64, tiny) == 5.0f, "radius: clamped to half the shorter hole side");
+    expect(clampRadius(-5, bled) == 0.0f, "radius: never negative");
+  }
+
+  void checkRailsCedeTheBarBand() {
+    const Insets reserved{8.0f, 8.0f, 8.0f, 34.0f};
+    const auto hole = paintedHole(kW, kH, reserved, 0);
+    const auto barBand = kH - reserved.bottom;
+
+    // With the bar on its edge, no rail may enter the band — a rail crossing it hid the bar's
+    // widgets outright when the frame happened to stack above the bar.
+    const auto ceded = rails(kW, kH, reserved, hole, Edge::Bottom);
+    for (const auto& r : ceded) {
+      expect(r.empty() || r.y + r.height <= barBand, "rails: nothing may enter the bar's band");
+    }
+
+    // With the bar gone, the bottom rail extends through the band so the border still closes.
+    const auto reclaimed = rails(kW, kH, reserved, hole, Edge::None);
+    expect(reclaimed[1].y + reclaimed[1].height == kH, "rails: bottom rail reaches the output edge once ceded");
+  }
+
+  void checkRailsAreDisjoint() {
+    // Rails are painted at fractional opacity; any overlap double-blends into a visible seam.
+    const std::array<Edge, 5> edges{Edge::None, Edge::Top, Edge::Bottom, Edge::Left, Edge::Right};
+    for (const auto edge : edges) {
+      for (const int bleed : {0, 4, 14}) {
+        const Insets reserved{8.0f, 8.0f, 8.0f, 34.0f};
+        const auto hole = paintedHole(kW, kH, reserved, bleed);
+        const auto rs = rails(kW, kH, reserved, hole, edge);
+        const auto caps = endCaps(kW, kH, reserved, edge);
+        std::array<Rect, 6> all{rs[0], rs[1], rs[2], rs[3], caps[0], caps[1]};
+        for (std::size_t i = 0; i < all.size(); ++i) {
+          for (std::size_t j = i + 1; j < all.size(); ++j) {
+            expect(!overlaps(all[i], all[j]), "rails/caps must stay disjoint at every edge and bleed");
+          }
+        }
+      }
+    }
+  }
+
+  void checkEndCapsUseReservedInset() {
+    const Insets reserved{8.0f, 8.0f, 8.0f, 34.0f};
+
+    // Caps are sized by the RESERVED inset. Sizing them by the painted (bled) inset reached
+    // past the bar's edge and clipped its outermost widget.
+    const auto caps = endCaps(kW, kH, reserved, Edge::Bottom);
+    expectRect(caps[0], Rect{0.0f, kH - 34.0f, 8.0f, 34.0f}, "caps: bottom-left sized by reserved inset");
+    expectRect(caps[1], Rect{kW - 8.0f, kH - 34.0f, 8.0f, 34.0f}, "caps: bottom-right sized by reserved inset");
+
+    // A vertical bar is capped above and below instead.
+    const Insets vertical{30.0f, 8.0f, 8.0f, 8.0f};
+    const auto leftCaps = endCaps(kW, kH, vertical, Edge::Left);
+    expectRect(leftCaps[0], Rect{0.0f, 0.0f, 30.0f, 8.0f}, "caps: left bar capped at the top");
+    expectRect(leftCaps[1], Rect{0.0f, kH - 8.0f, 30.0f, 8.0f}, "caps: left bar capped at the bottom");
+
+    // No bar means no caps to draw.
+    const auto none = endCaps(kW, kH, reserved, Edge::None);
+    expect(none[0].empty() && none[1].empty(), "caps: none without a bar edge");
+  }
+
+  void checkDegenerateOutputs() {
+    // Tiny or zero-sized outputs must not produce negative or inverted rectangles.
+    const auto cfg = frameCfg(64, 64, 64);
+    const auto bar = barCfg("bottom", 34);
+    for (const float w : {0.0f, 1.0f, 40.0f}) {
+      for (const float h : {0.0f, 1.0f, 40.0f}) {
+        const auto reserved = holeInsets(cfg, &bar, true, true);
+        const auto hole = paintedHole(w, h, reserved, cfg.bleed);
+        expect(hole.width >= 0.0f && hole.height >= 0.0f, "degenerate: hole never negative");
+        expect(clampRadius(cfg.radius, hole) >= 0.0f, "degenerate: radius never negative");
+        for (const auto& r : rails(w, h, reserved, hole, Edge::Bottom)) {
+          expect(r.width >= 0.0f || r.empty(), "degenerate: rail width never negative");
+        }
+        for (const auto& c : endCaps(w, h, reserved, Edge::Bottom)) {
+          expect(c.width >= 0.0f || c.empty(), "degenerate: cap width never negative");
+        }
+      }
+    }
+  }
+
+  void checkStyleBarIgnoresReservation() {
+    Config config;
+    config.bars.clear();
+    expect(styleBar(config) == nullptr, "styleBar: none when there are no bars");
+
+    BarConfig disabled = barCfg();
+    disabled.enabled = false;
+    config.bars.push_back(disabled);
+    expect(styleBar(config) == nullptr, "styleBar: skips disabled bars");
+
+    // A bar that reserves nothing still sits on screen, so it still supplies the frame's edge
+    // and fill. Requiring reserveSpace here made the frame reserve and paint the bar's own
+    // edge, which stacked a rail under the bar and made it look taller.
+    BarConfig noReserve = barCfg();
+    noReserve.reserveSpace = false;
+    config.bars.push_back(noReserve);
+    const BarConfig* picked = styleBar(config);
+    expect(picked != nullptr && !picked->reserveSpace, "styleBar: a non-reserving bar still counts");
+  }
+
+} // namespace
+
+int main() {
+  checkEdgeMapping();
+  checkHoleInsets();
+  checkFillOpacity();
+  checkCededEdge();
+  checkPaintedHoleAndRadius();
+  checkRailsCedeTheBarBand();
+  checkRailsAreDisjoint();
+  checkEndCapsUseReservedInset();
+  checkDegenerateOutputs();
+  checkStyleBarIgnoresReservation();
+
+  if (g_failures == 0) {
+    std::println("frame_geometry: all checks passed");
+    return 0;
+  }
+  std::println(stderr, "frame_geometry: {} failure(s)", g_failures);
+  return 1;
+}


### PR DESCRIPTION
## Summary

Adds a "screen frame": a solid border drawn around each output with a rounded rectangular hole in the middle that the desktop shows through. The edge that already carries a bar is inset by the bar's own thickness rather than the frame's, and the hole supplies the rounded inner corners for all four sides, so the frame and the bar read as one continuous shape rather than two strips meeting at a corner.

New module `src/shell/frame/`, a new `[shell.frame]` config section, and three settings entries under Desktop. No changes were needed under `render/` — the frame is built from the existing `Box` primitive plus the existing `ScreenCorner` node, whose shader already fills *outside* a superellipse, which is exactly one inner corner of a frame-with-hole.

Also changes `screen_corners` from the `Top` layer to `Overlay`. Those masks model the physical shape of the display, so nothing the shell draws should sit on top of them. On `Top` they competed with the bar, dock and frame purely by creation order, and any partial rebuild silently reordered them.

## Motivation

This existed in v4 as the **"Framed" bar type** (`barType = "framed"`, `frameThickness`, `frameRadius`) and was dropped in the C++ rewrite. It landed in v4 as PR #1548 (`680dfccff`, `dba523592`); none of those commits are ancestors of v5 `main`, so the feature was never deleted — it simply was not ported.

The port is deliberately not a transcription. v4 drew one full-screen `ShapePath` with an even-odd fill hole under Qt's `CurveRenderer`; v5 has no such primitive, so this uses the scene graph instead. It also does not reproduce v4's habit of swallowing clicks on the frame rails, nor its per-screen mask bugs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

None.

## Testing

```
just format                 # clean
meson compile -C build-debug  # clean, no new warnings
meson test -C build-debug   # 43/43 pass
python3 tools/i18n-check.py # OK: 788 tr keys — all present in catalog
/repos/noctalia.sh          # built, hot-swapped, 4 frame surfaces up, no errors in log
```

New unit test `tests/frame_geometry_test.cpp` (10 groups). The frame's geometry is extracted into `src/shell/frame/frame_geometry.h` as pure functions so it is testable without a compositor, renderer or live bar — the same pattern `taskbar_workspace_label.h` uses. `frame.cpp` delegates to it rather than duplicating it, so the tests exercise shipping code. Cases cover: bar-edge insets (bar thickness, not bar + frame), reserved-but-empty vs released bands, `match_bar` opacity being independent of `reserveSpace`, rails never entering the bar's band, end caps sized by the reserved inset, exhaustive disjointness across 5 edges x 3 bleed values, and degenerate output sizes. Every case corresponds to a defect that actually occurred during development; the comments name the symptom.

Extended `tests/config_schema_roundtrip_test.cpp` and `tests/config_path_resolution_test.cpp` for the six new config keys.

Manual verification was done by pixel probe against a flat wallpaper rather than by eye — several defects in this work were initially misdiagnosed from screenshots, so the numbers are the evidence:

- Rail, end cap and bar render identically at `(17, 92, 6)`; the cap read `(23, 38, 8)` before the compositor blur region was added.
- Inner corners continuous across the frame/bar junction, all four verified.
- `bleed` closes the compositor gap: frame runs to the window border with no wallpaper between.
- The opacity slider's `visibleWhen` was confirmed in the running settings window (5 controls with Match Bar on, 6 with it off), not assumed.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Only a bottom bar was exercised live, on a single 3440x1440 output at scale 1. All four bar positions are covered by unit tests, but not on a real compositor. Scaling and multi-monitor were not tested at all — see Additional Notes.

## Screenshots / Videos

<img width="3440" height="1440" alt="screenshot-frame" src="https://github.com/user-attachments/assets/e2e94264-132d-4bda-ae6c-db92215644cc" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

This should be marked **Draft**. The known gaps below are not polish items; two of them are wrong behaviour that a user with more than one bar will hit immediately.

## Additional Notes

### Config

`[shell.frame]` — `enabled` (bool, false), `thickness` (int, 8, 1-64), `radius` (int, 12, 0-64), `match_bar` (bool, true), `opacity` (float, 1.0, 0-1), `bleed` (int, 0, 0-64). Settings UI under **Desktop → Screen Frame**; the opacity slider is hidden while Match Bar is on, since it has no effect then.

### Three invariants worth preserving

Each caused a visible bug when violated, so they are stated as invariants in the code and pinned by tests:

1. **The bar owns its reserved band; the frame owns everything outside it.** A rail crossing that band hides the bar's widgets outright whenever the frame happens to stack above the bar.
2. **End caps are sized by the reserved inset, never the painted one.** Sizing them with `thickness + bleed` reaches past the bar's edge and clips its outermost widget.
3. **The frame requests the same compositor blur as the bar.** The bar calls `setBlurRegion`, so its translucent fill sits on a blurred backdrop and stays flat across a patterned wallpaper. Without the same request the frame's fill tracks the wallpaper and visibly drifts from the bar's colour where the two meet.

### Known gaps

- **Multiple bars are handled incorrectly.** `styleBar()` returns the first enabled bar, so the frame cedes a single edge and both reserves and paints over any other bar. With a left or right bar added alongside a bottom one, that bar renders behind the frame. `holeInsets`, `rails` and `endCaps` are pure functions taking a single edge; the fix is to make them take a set of edges, and the existing single-bar test cases extend to that directly. This is the most important follow-up.
- **Enabling a bar at runtime leaves it behind the frame.** Toggling a bar on sets `changed.bars`, which rebuilds the frame; wlr-layer-shell stacks same-layer surfaces by creation order with no way to restack, so the frame lands on top. A plain config reload does not rebuild the frame and the bar correctly stays above, which is what isolates this to ordering rather than geometry. Registering the frame's reload callback before `Bar::initialize` did not resolve it and the cause is not yet established.
- **Per-monitor bar overrides are ignored,** and multi-monitor is untested — only one output was available. v4 hit the same bug (`b3fe8930c`).
- **`bleed` is a single value for all four edges,** so asymmetric compositor gaps cannot be fully covered. Concretely: niri `gaps 14` with `struts { left -10 right -10 top -10 bottom 0 }` yields a 4px gap on three edges and 14px on the fourth. Per-edge bleed would fix it.
- **Auto-hide is not animated in step with the bar.** The frame switches its bottom edge on a discrete visibility transition while the bar slides over an animation, so it snaps rather than following. Painting that edge unconditionally does sync perfectly, but only if the frame is reliably stacked below the bar, which it is not — that attempt put the frame's rail on top of the bar and was reverted.
- **An IPC `bar-hide` leaves that edge unframed.** Releasing the exclusive zone hands the band to windows, so the frame correctly cedes it, but then draws no rail there because `holeInsets()` still sizes that edge from the bar's thickness. Cosmetic.
- **Outer corners are square.** Rounded display corners remain the separate `[shell.screen_corners]` feature. This matches v4, where the framed outer contour used a 0.01px radius and screen rounding was a distinct module.

### What the frame cannot fix

Compositors apply their own gap *inside* whatever exclusive zone the shell reserves (niri `layout.gaps`, Hyprland `general:gaps_out`), leaving wallpaper between the frame and the nearest window. Window placement belongs to the compositor and a shell cannot prevent it; the frame sits above windows, so `bleed` paints over it. Gaps *between* windows are not reachable at all — the frame has no surface there, and that space is meant to show the desktop.

### Stacking order

wlr-layer-shell stacks same-layer surfaces by creation order. Two places must agree and nothing enforces it: `reconcileOutputSurfaces()` in `application_services.cpp`, and reload-callback registration order in `application_ui.cpp`. Moving `screen_corners` to `Overlay` removes the corners from that race entirely, which is why it is included here. Routing reloads through the same single ordering used by `reconcileOutputSurfaces()` would remove the remaining class of bug, including the runtime bar-enable case above, and is the natural follow-up.