### PR TITLE
fix(screen-corners): keep corner overlays above the bar after a bar config change

### DIFF
--- a/src/shell/screen_corners/screen_corners.cpp
+++ b/src/shell/screen_corners/screen_corners.cpp
@@ -61,7 +61,19 @@ void ScreenCorners::onConfigReload() {
     return;
   }
 
-  if (cfg.enabled != m_lastEnabled || cfg.size != m_lastSize || m_instances.size() != eligibleOutputCount(*m_wayland)) {
+  // The bar and dock share the Top layer with the corners, and wlr-layer-shell stacks
+  // same-layer surfaces by creation order with no way to restack afterwards. A config
+  // change that makes either recreate its surfaces (a bar corner radius resizes the
+  // surface, for instance) puts them above the corners, which then get clipped away
+  // wherever the bar sits. Recreate ours too so they climb back on top; this callback is
+  // registered after the bar's, so the rebuild lands last.
+  const auto& changed = m_config->lastChange();
+  const bool stackingMayHaveChanged = changed.bars || changed.widgets || changed.dock;
+
+  if (cfg.enabled != m_lastEnabled
+      || cfg.size != m_lastSize
+      || m_instances.size() != eligibleOutputCount(*m_wayland)
+      || stackingMayHaveChanged) {
     destroySurfaces();
     m_lastEnabled = cfg.enabled;
     m_lastSize = cfg.size;

--- a/src/shell/screen_corners/screen_corners.cpp
+++ b/src/shell/screen_corners/screen_corners.cpp
@@ -64,11 +64,12 @@ void ScreenCorners::onConfigReload() {
   // The bar and dock share the Top layer with the corners, and wlr-layer-shell stacks
   // same-layer surfaces by creation order with no way to restack afterwards. A config
   // change that makes either recreate its surfaces (a bar corner radius resizes the
-  // surface, for instance) puts them above the corners, which then get clipped away
-  // wherever the bar sits. Recreate ours too so they climb back on top; this callback is
-  // registered after the bar's, so the rebuild lands last.
+  // surface, or a shadow change alters bar/dock surface metrics, for instance) puts
+  // them above the corners, which then get clipped away wherever the bar sits.
+  // Recreate ours too so they climb back on top; this callback is registered after
+  // the bar's, so the rebuild lands last.
   const auto& changed = m_config->lastChange();
-  const bool stackingMayHaveChanged = changed.bars || changed.widgets || changed.dock;
+  const bool stackingMayHaveChanged = changed.bars || changed.widgets || changed.dock || changed.shell;
 
   if (cfg.enabled != m_lastEnabled
       || cfg.size != m_lastSize


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Rounded screen corners silently disappeared behind the bar as soon as any bar setting changed. For a bottom bar this meant the two bottom corners went square while the top two stayed rounded, and they stayed that way until screen corners were toggled off and on again.

The corner overlays and the bar both live on the wlr-layer-shell **`Top`** layer. Same-layer surfaces stack by **creation order**, and the protocol gives no way to restack after the fact — so whichever surface is created last ends up on top.

`ScreenCorners::onConfigReload()` only rebuilt its surfaces when `enabled`, `size`, or the eligible output count changed. A bar-only change left the corner surfaces untouched while the bar recreated its own, putting the bar above the corners and clipping the overlay away wherever the bar sits.

This PR also rebuilds the corner surfaces when the bar, widgets, or dock config changed, so the corners are created last and land back on top (`src/shell/screen_corners/screen_corners.cpp`):

```cpp
const auto& changed = m_config->lastChange();
const bool stackingMayHaveChanged = changed.bars || changed.widgets || changed.dock;

if (cfg.enabled != m_lastEnabled || cfg.size != m_lastSize
    || m_instances.size() != eligibleOutputCount(*m_wayland) || stackingMayHaveChanged) {
  destroySurfaces();
  ...
  ensureSurfaces();
}
```

This is ordering-dependent and only correct because the corner rebuild runs after the bar's: `Bar::initialize()` registers its reload callback at `src/app/application_ui.cpp:775`, screen corners register theirs at `:841`, and `ConfigService` dispatches callbacks in registration order (`src/config/config_service.cpp:634-636`). Moving either registration earlier or later than the other reintroduces the bug.

`widgets` and `dock` are included alongside `bars` because a widget change also routes through `Bar::reload()` (`src/shell/bar/bar.cpp:1236-1248`) and the dock is another configurable `Top`-layer surface with the same recreate behaviour.

## Motivation

With screen corners enabled and a bar flush against the screen edge, changing *any* bar setting permanently broke the corner masking on the edge the bar sits on. The only recovery was toggling `screen_corners.enabled` off and on, because that was the one path that recreated the corner surfaces.

The bar recreates its surfaces for more than just radii — see `barConfigSurfaceFieldsEqual` in `src/shell/bar/bar.cpp:688-713`, which returns true only when two configs would produce an identical layer-shell surface. Any of `thickness`, `layer`, all four corner radii, `concave_edge_corners`, `margin_ends`, `margin_edge`, `shadow`, or the monitor overrides differing makes it false, and the bar is recreated. Corner radii are in that list because they feed the concave-corner bulge, which changes the surface size:

```cpp
// Corner radii feed the concave-corner bulge, which changes the surface size.
&& a.radiusTopLeft == b.radiusTopLeft
&& a.radiusTopRight == b.radiusTopRight
```

So in practice a large share of bar settings trigger the bug.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

**Reproducing (before the fix).** Requires a bar that actually overlaps a screen corner — i.e. `margin_edge = 0` and `margin_ends = 0`, so it runs flush into the corners. With `margin_ends > 0` the bar stops short of the corners and the bug is invisible even though the stacking is still wrong.

**1. Enable screen corners** in `~/.local/state/noctalia/settings.toml`:

```toml
[shell.screen_corners]
enabled = true
size = 32
```

**2. Make the bar reach the corners** (Settings → Bar → Layout):

```toml
[bar.default]
position = "bottom"
margin_edge = 0        # flush against the bottom edge
margin_ends = 0        # full width, so it covers both bottom corners
```

**3. Reload and confirm the corners are rounded** — all four should be masked:

```
noctalia msg config-reload
grim -g "0,1404 36x36" bl.png     # bottom-left; corner pixel should be black
```

**4. Change any bar setting that forces a surface recreate.** The cheapest is a corner radius:

```toml
radius_top_left = 20
radius_top_right = 20
```

**5. Reload again** — the two bottom corners are now square. The top two are unaffected, because no surface covers them. Every subsequent bar change keeps them hidden; only toggling `screen_corners.enabled` off and on brings them back.

Probing the bottom-left corner pixel across those steps, before the fix:

```
screen_corners just toggled   px=(0,0,0)     -> MASK VISIBLE
after bar radius change       px=(52,30,17)  -> mask hidden (bar on top)
after another bar change      px=(52,30,17)  -> mask hidden
```

**Verification (after the fix).** Built and hot-swapped, then re-ran the reproduction: the mask survives repeated bar changes, and all four corners read black at the extreme pixel.

```
baseline              px=(0, 0, 0)  -> MASK VISIBLE
bar radius -> 21      px=(0, 0, 0)  -> MASK VISIBLE
bar radius -> 20      px=(0, 0, 0)  -> MASK VISIBLE
bar radius -> 24      px=(0, 0, 0)  -> MASK VISIBLE
```

`clang-format` v22.1.6 reports no diff on the changed file.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Tested on niri, single output, scale 1, bottom bar with `margin_edge = 0` and `margin_ends = 0` (the configuration required to expose the bug at all).

## Screenshots / Videos

No screenshots attached — the change is a one-pixel-visibility fix. The `grim` corner-pixel probes above are the objective before/after evidence: `(52,30,17)` (bar showing through) vs `(0,0,0)` (corner mask on top).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Known gaps, all of them the same root cause with a different trigger:

- **Not fixed: on-demand `Overlay` panels.** The launcher, control center, session and wallpaper panels are created on `LayerShellLayer::Overlay` when opened, so they are created after the corners and cover them while open.
- **Rejected alternative: moving the corners to `Overlay`.** It would put them above the bar unconditionally, but it is not a guarantee either — the panels above are already on `Overlay` and would still be created later. It also trades a narrow bug for a broad layering change. The fix here is narrower and addresses the reported case.
- A full guarantee would need the corner surfaces recreated after *any* other surface, which layer-shell cannot express; a compositor-side or protocol-level restack would be the real answer.

Reviewer note: the registration-order dependency described in the Summary is the fragile part of this fix. It is documented in a comment above the changed condition, but a future reordering of the reload callbacks in `application_ui.cpp` would silently reintroduce the bug.