### PR TITLE
Add "None" display type to sysmon bar widget

### DIFF
--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -518,6 +518,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
       displayMode = SysmonDisplayMode::Text;
     else if (display == "graph")
       displayMode = SysmonDisplayMode::Graph;
+    else if (display == "none")
+      displayMode = SysmonDisplayMode::None;
     if (verticalBar && displayMode == SysmonDisplayMode::Graph) {
       displayMode = SysmonDisplayMode::Gauge;
     }

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -162,7 +162,8 @@ namespace {
 
 SysmonWidget::SysmonWidget(SystemMonitorService* monitor, ConfigService& configService, SysmonWidgetOptions options)
     : m_monitor(monitor), m_stat(options.stat), m_displayMode(options.displayMode),
-      m_highlightColor(options.highlightColor), m_configService(configService), m_showLabel(options.showLabel),
+      m_highlightColor(options.highlightColor), m_configService(configService),
+      m_showLabel(options.showLabel && options.displayMode != SysmonDisplayMode::None),
       m_labelMinWidth(options.labelMinWidth), m_diskPath(std::move(options.diskPath)),
       m_networkInterface(std::move(options.networkInterface)), m_networkSpeedUnit(options.networkSpeedUnit),
       m_networkSpeedLabelStyle(options.networkSpeedLabelStyle), m_glyphOverride(std::move(options.glyph)),

--- a/src/shell/bar/widgets/sysmon_widget.h
+++ b/src/shell/bar/widgets/sysmon_widget.h
@@ -39,7 +39,7 @@ enum class SysmonStat {
   NetRx,
   NetTx
 };
-enum class SysmonDisplayMode { Text, Graph, Gauge };
+enum class SysmonDisplayMode { Text, Graph, Gauge, None };
 
 struct SysmonWidgetOptions {
   SysmonStat stat = SysmonStat::CpuUsage;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -666,6 +666,7 @@ namespace settings {
         {"gauge", "settings.widgets.options.gauge"},
         {"graph", "settings.widgets.options.graph"},
         {"text", "settings.widgets.options.text"},
+        {"none", "settings.widgets.options.none"},
     };
     const std::vector<WidgetSettingSelectOption> networkSpeedUnits = {
         {"auto", "settings.widgets.options.auto"},

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -918,11 +918,20 @@ namespace settings {
       }
       add(segmentedSpec("display", "gauge", sysmonDisplay));
       add(colorSpec("highlight_color", "error"));
-      add(boolSpec("show_label", true));
       {
-        auto minW = intSpec("label_min_width", 0, 0.0, 200.0, 1.0);
-        minW.visibleWhen = WidgetSettingVisibility{"show_label", {"true"}};
-        add(std::move(minW));
+        auto showLabel = boolSpec("show_label", true);
+        showLabel.visibleWhen = WidgetSettingVisibility{"display", {"gauge", "graph", "text"}};
+        add(std::move(showLabel));
+      }
+      {
+        auto minWidth = intSpec("label_min_width", 0, 0.0, 200.0, 1.0);
+        WidgetSettingVisibility minWidthSettings;
+        minWidthSettings.all = {
+            WidgetSettingVisibilityCondition{"display", {"gauge", "graph", "text"}},
+            WidgetSettingVisibilityCondition{"show_label", {"true"}},
+        };
+        minWidth.visibleWhen = minWidthSettings;
+        add(std::move(minWidth));
       }
     } else if (type == "power_profile") {
       add(boolSpec("enable_scroll", true));


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add new display type for "sysmon" bar widget - "None".

## Motivation

This allows turning the sysmon bar widget into a simple icon, without any additional indicators.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

Installed manually, configured the widget with new display type.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/e37cd04d-def5-4e0c-abe7-3f7e0a612b46

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

I'll update the documentation once this commit is merged (https://github.com/noctalia-dev/noctalia-docs/pull/202).
