### PR TITLE
fix(sysmon): skip disabled GPU probes

### DIFF
--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -995,6 +995,7 @@ void SystemMonitorService::applyConfig(const SystemConfig::MonitorConfig& config
     m_pollConfig = sanitized;
     m_historyInterval = pollDuration(effectiveHistoryPollSeconds(sanitized));
   }
+  m_configGeneration.fetch_add(1);
   m_wakeCv.notify_all();
   setEnabled(sanitized.enabled);
 }
@@ -1105,11 +1106,11 @@ void SystemMonitorService::stop() {
   if (m_thread.joinable()) {
     m_thread.join();
   }
+  releaseGpuReaders();
 }
 
 void SystemMonitorService::logDetectedSources() {
   const SystemConfig::MonitorConfig pollCfg = pollConfig();
-  const NvidiaDisplayDeviceState nvidiaDisplayState = detectNvidiaPciDisplayDeviceState();
   const auto cpu = readCpuTotals();
   const auto mem = readMemoryKb();
   const auto net = readNetBytes();
@@ -1130,6 +1131,13 @@ void SystemMonitorService::logDetectedSources() {
   } else {
     kLog.info("detected CPU temperature source: unavailable");
   }
+
+  if (pollCfg.gpuPollSeconds <= 0.0f) {
+    kLog.info("GPU monitoring disabled; source detection skipped");
+    return;
+  }
+
+  const NvidiaDisplayDeviceState nvidiaDisplayState = detectNvidiaPciDisplayDeviceState();
 
   const auto gpuTemp = readGpuTempData(nvidiaDisplayState);
   if (gpuTemp.tempC.has_value()) {
@@ -1171,6 +1179,7 @@ void SystemMonitorService::samplingLoop() {
   auto nextHistory = Clock::now();
 
   while (m_running.load()) {
+    const std::uint64_t configGeneration = m_configGeneration.load();
     const SystemConfig::MonitorConfig pollCfg = pollConfig();
     const float historyPollSeconds = effectiveHistoryPollSeconds(pollCfg);
 
@@ -1181,6 +1190,10 @@ void SystemMonitorService::samplingLoop() {
     const bool networkEnabled = pollCfg.networkPollSeconds > 0.0f;
     const bool diskEnabled = pollCfg.diskPollSeconds > 0.0f;
     const bool historyEnabled = historyPollSeconds > 0.0f;
+
+    if (!gpuEnabled) {
+      releaseGpuReaders();
+    }
 
     const auto cpuInterval = pollDuration(pollCfg.cpuPollSeconds);
     const auto gpuInterval = pollDuration(pollCfg.gpuPollSeconds);
@@ -1374,8 +1387,16 @@ void SystemMonitorService::samplingLoop() {
     considerWake(historyEnabled, nextHistory);
 
     std::unique_lock wakeLock{m_wakeMutex};
-    m_wakeCv.wait_until(wakeLock, nextWake, [this]() { return !m_running.load(); });
+    m_wakeCv.wait_until(wakeLock, nextWake, [this, configGeneration]() {
+      return !m_running.load() || m_configGeneration.load() != configGeneration;
+    });
   }
+}
+
+void SystemMonitorService::releaseGpuReaders() {
+  m_nvidiaNvmlReader.reset();
+  m_amdRsmiReader.reset();
+  m_intelGpuReader.reset();
 }
 
 std::optional<SystemMonitorService::CpuTotals> SystemMonitorService::readCpuTotals() {

--- a/src/system/system_monitor_service.cpp
+++ b/src/system/system_monitor_service.cpp
@@ -995,7 +995,12 @@ void SystemMonitorService::applyConfig(const SystemConfig::MonitorConfig& config
     m_pollConfig = sanitized;
     m_historyInterval = pollDuration(effectiveHistoryPollSeconds(sanitized));
   }
-  m_configGeneration.fetch_add(1);
+  {
+    // The generation must be published under the wake mutex, or the increment can land after the
+    // sampling thread evaluated its predicate but before it blocks, losing the wakeup.
+    std::scoped_lock wakeLock{m_wakeMutex};
+    m_configGeneration.fetch_add(1, std::memory_order_relaxed);
+  }
   m_wakeCv.notify_all();
   setEnabled(sanitized.enabled);
 }
@@ -1101,7 +1106,10 @@ void SystemMonitorService::start() {
 }
 
 void SystemMonitorService::stop() {
-  m_running = false;
+  {
+    std::scoped_lock wakeLock{m_wakeMutex};
+    m_running = false;
+  }
   m_wakeCv.notify_all();
   if (m_thread.joinable()) {
     m_thread.join();

--- a/src/system/system_monitor_service.h
+++ b/src/system/system_monitor_service.h
@@ -156,10 +156,11 @@ private:
   std::thread m_thread;
   std::mutex m_wakeMutex;
   std::condition_variable m_wakeCv;
+  // Bumped under m_wakeMutex so a config change interrupts the sampling loop's wait.
+  std::atomic<std::uint64_t> m_configGeneration{0};
 
   mutable std::mutex m_configMutex;
   SystemConfig::MonitorConfig m_pollConfig;
-  std::atomic<std::uint64_t> m_configGeneration{0};
   std::chrono::steady_clock::duration m_historyInterval{std::chrono::seconds(1)};
 
   mutable std::mutex m_statsMutex;

--- a/src/system/system_monitor_service.h
+++ b/src/system/system_monitor_service.h
@@ -114,6 +114,7 @@ private:
   void stop();
   void samplingLoop();
   void logDetectedSources();
+  void releaseGpuReaders();
 
   [[nodiscard]] static std::optional<CpuTotals> readCpuTotals();
   struct MemData {
@@ -158,6 +159,7 @@ private:
 
   mutable std::mutex m_configMutex;
   SystemConfig::MonitorConfig m_pollConfig;
+  std::atomic<std::uint64_t> m_configGeneration{0};
   std::chrono::steady_clock::duration m_historyInterval{std::chrono::seconds(1)};
 
   mutable std::mutex m_statsMutex;


### PR DESCRIPTION
## Summary

- Skip GPU source detection when GPU polling is disabled.
- Release NVML, RSMI, and Intel GPU readers when polling is disabled or the monitor stops.
- Wake the sampling loop when poll configuration changes so runtime enable/disable changes take effect immediately.

## Motivation

Setting `gpuPollSeconds` to `0` already means GPU monitoring is disabled, but startup detection could still initialize a vendor telemetry backend and retain access to the GPU. That can interfere with legitimate device removal workflows such as eGPU detach, driver unload, power management, and VFIO handoff.

The change is scoped to the existing disabled state. Systems using the default positive GPU polling interval retain the current detection and sampling behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None.

## Testing

- `just format` with clang-format 22.1.8
- `just build`
- `just test debug --print-errorlogs` (42/42 tests passed)
- Targeted clang-tidy with warnings as errors for `src/system/system_monitor_service.cpp`
- `git diff --check`
- `just lint` was also run. It reaches the modified file without findings, but the full command currently fails on unchanged `src/theme/firefox_theme/css.cpp` and `src/theme/firefox_theme/native_messaging.cpp`. The same findings are present in current `main` CI.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable; there are no UI or layout changes.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No documentation update should be necessary: this fixes the implementation of the existing `gpuPollSeconds <= 0` disabled state and adds no configuration keys or user-facing strings.

The current base-branch CI failure is unrelated to this PR; its clang-tidy findings are confined to the Firefox-theme sources listed above.
