### PR TITLE
fix: correctly parse escaped characters in desktop entries

### DIFF
--- a/src/system/desktop_entry_launch.cpp
+++ b/src/system/desktop_entry_launch.cpp
@@ -13,6 +13,29 @@ namespace {
 
   constexpr Logger kLog("desktop_entry_launch");
 
+  std::string decodeDesktopStringValue(std::string_view value) {
+    std::string result;
+    result.reserve(value.size());
+    for (std::size_t i = 0; i < value.size(); ++i) {
+      if (value[i] == '\\' && i + 1 < value.size()) {
+        const char next = value[i + 1];
+        if (next == '\\' || next == 's' || next == 'n' || next == 't' || next == 'r') {
+          // https://specifications.freedesktop.org/desktop-entry/latest/value-types.html
+          // https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+          result += (next == 's') ? ' ' : (next == 'n') ? '\n' : (next == 't') ? '\t' : (next == 'r') ? '\r' : '\\';
+          ++i;
+          continue;
+        }
+        // Any other \X: remove the backslash, keep X
+        result += next;
+        ++i;
+        continue;
+      }
+      result += value[i];
+    }
+    return result;
+  }
+
   std::string stripFieldCodes(std::string_view exec) {
     std::string result;
     result.reserve(exec.size());
@@ -80,7 +103,16 @@ namespace {
     bool inSingle = false;
     bool inDouble = false;
 
-    for (const char c : cmd) {
+    for (std::size_t i = 0; i < cmd.size(); ++i) {
+      const char c = cmd[i];
+      if (c == '\\' && inDouble && i + 1 < cmd.size()) {
+        const char next = cmd[i + 1];
+        if (next == '"' || next == '`' || next == '$' || next == '\\') {
+          current += next;
+          ++i;
+          continue;
+        }
+      }
       if (c == '\'' && !inDouble) {
         inSingle = !inSingle;
         continue;
@@ -135,7 +167,8 @@ namespace {
 namespace desktop_entry_launch {
 
   std::optional<PreparedCommand> prepareCommand(std::string_view exec, bool terminal, const PrepareOptions& options) {
-    std::string cleanExec = stripFieldCodes(exec);
+    const std::string decodedExec = decodeDesktopStringValue(exec);
+    const std::string cleanExec = stripFieldCodes(decodedExec);
     std::vector<std::string> args;
     if (terminal) {
       auto prepared = terminal_launch::prepareCommand(

--- a/tests/desktop_entry_launch_test.cpp
+++ b/tests/desktop_entry_launch_test.cpp
@@ -90,6 +90,13 @@ int main() {
        )
       && ok;
 
+  ok = expectArgs(
+           desktop_entry_launch::prepareCommand(R"(/bin/sh -c "\\$SHELL -i -c scrcpy")", false),
+           {"/bin/sh", "-c", "$SHELL -i -c scrcpy"},
+           "desktop-entry escaping should preserve a shell variable in a quoted argument"
+       )
+      && ok;
+
   desktop_entry_launch::PrepareOptions terminalOptions;
   const std::string fakeTerminal = makeExecutableFixture();
   terminalOptions.terminalCandidates = {"missing-terminal-candidate", fakeTerminal};


### PR DESCRIPTION
Desktop entries apply general string escaping before `Exec` argument quoting, so both layers must be decoded before arguments are passed to applications.

https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html

## Summary

Introduced decoding escaped characters in desktop entry Exec commands before launching applications. Added a test case to prevent regressions.

## Motivation

Couldn't run this desktop entry after upgrading to v5:

```
[Desktop Entry]
Name=scrcpy
GenericName=Android Remote Control
Comment=Display and control your Android device
# For some users, the PATH or ADB environment variables are set from the shell
# startup file, like .bashrc or .zshrc… Run an interactive shell to get
# environment correctly initialized.
Exec=/bin/sh -c "\\$SHELL -i -c scrcpy"
Icon=scrcpy
Terminal=false
Type=Application
Categories=Utility;RemoteAccess;
Keywords=adb;android;screen;mirroring;display;control;phone;device;
StartupNotify=false
```

Turns out it was because of the escaped `$` in the `Exec` line. The launcher code was not decoding the escape sequence before passing the command to `/bin/sh`. The argument received by `/bin/sh` was `\$SHELL` instead of `$SHELL`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

- `just test release`
- Built and installed the patched release, then successfully launched the desktop entry above with the Noctalia launcher

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.