### PR TITLE
fix(calendar_tab): introduce customColorPalette for todays day dayBut…

### DIFF
--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -14,6 +14,7 @@
 #include "shell/panel/panel_manager.h"
 #include "time/time_format.h"
 #include "ui/builders.h"
+#include "ui/controls/button.h"
 #include "ui/controls/flex.h"
 #include "ui/controls/grid_tile.h"
 #include "ui/controls/grid_view.h"
@@ -723,7 +724,7 @@ void CalendarTab::rebuild() {
     int cellMonthShift = 0;
     bool inMonth = false;
 
-    const auto mutedDayPalette = [] {
+    const Button::ButtonPalette mutedDayPalette = [] {
       Button::ButtonPalette ghostPalette = Button::defaultPalette(ButtonVariant::Ghost);
       ghostPalette.normal.label = colorSpecFromRole(ColorRole::OnSurfaceVariant, 0.75f);
       return ghostPalette;
@@ -747,14 +748,18 @@ void CalendarTab::rebuild() {
     } else {
       cellDay = day;
       inMonth = true;
-      const bool selected = m_selectedYear == year && m_selectedMonth == month && m_selectedDay == day;
-      const bool isToday = state.isCurrentMonth && day == state.today;
       dayButton->setText(std::to_string(day));
+      const bool selected = m_selectedYear == year && m_selectedMonth == month && m_selectedDay == day;
       if (selected) {
         dayButton->setVariant(ButtonVariant::Primary);
       } else {
+        const bool isToday = state.isCurrentMonth && day == state.today;
+        if (isToday) {
+          Button::ButtonPalette currentDayButtonPalette = Button::defaultPalette(ButtonVariant::Ghost);
+          currentDayButtonPalette.normal.label = colorSpecFromRole(ColorRole::Primary);
+          dayButton->setCustomPalette(currentDayButtonPalette);
+        }
         dayButton->label()->setFontWeight(FontWeight::Bold);
-        dayButton->label()->setColor(colorSpecFromRole(isToday ? ColorRole::Primary : ColorRole::OnSurface));
       }
       ++day;
     }


### PR DESCRIPTION
…ton to no longer loose the primary color configruation for the palette.normal.label

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Give the current days dayButton a `customPalette` which retains the Primary color config for its label in its normal state after a hover is no longer active.

## Motivation
Viewing the calendar and having a day other than the current one active. When hovering over the current day and leaving, the primary color of its label is lost because the button use the `OnSurface` color as it still is a Ghost variant. Making it look like any other day and the user is left not knowing what the current day is.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
- None 
## Testing
- `just test`
- visual confirmation when using the calendar

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

I currently have not screenrecording tool setup. If needed i will provide videos to demonstrate the issue/fix.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge (i do not think this needs to be updated since it behaved in an undefined way?)
- [x] I PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
