### PR TITLE
feat(session): add toggle for showing shortcuts in session panel

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2347,6 +2347,10 @@
         "session-grid-columns": {
           "description": "Number of columns for the grid layout",
           "label": "Columns"
+        },
+        "session-show-shortcuts": {
+          "description": "Show or hide the shortcut hints",
+          "label": "Show shortcuts"
         }
       },
       "services": {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -227,6 +227,7 @@ struct ShellSessionConfig {
   // fitting them on a single row.
   bool grid = false;
   std::int32_t gridColumns = 3;
+  bool showShortcuts = true;
   // Optional overrides for built-in session power commands. Empty = auto-detect at runtime.
   struct ShellSessionPowerConfig {
     // Shell strings run with `/bin/sh -lc` (shell=True).

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1362,6 +1362,7 @@ namespace noctalia::config::schema {
           ),
           field(&ShellSessionConfig::grid, "grid"),
           field(&ShellSessionConfig::gridColumns, "grid_columns", kSessionGridColumnsRange),
+          field(&ShellSessionConfig::showShortcuts, "show_shortcuts"),
           subTable(&ShellSessionConfig::power, "power", shellSessionPowerSchema()),
       };
       return s;

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -179,7 +179,9 @@ Button* SessionPanel::createActionButton(const SessionPanelActionConfig& cfg, st
   const std::string labelText =
       cfg.label.has_value() && !cfg.label->empty() ? *cfg.label : i18n::tr(session_action::labelKey(cfg.action));
   button->setText(labelText);
-  if (index < m_entryShortcutBadges.size() && m_entryShortcutBadges[index].has_value() && m_config->config().shell.session.showShortcuts) {
+  if (index < m_entryShortcutBadges.size()
+      && m_entryShortcutBadges[index].has_value()
+      && m_config->config().shell.session.showShortcuts) {
     button->setBadge(*m_entryShortcutBadges[index]);
   }
   button->setGlyph(
@@ -351,7 +353,9 @@ void SessionPanel::restoreEntryBadges() {
     if (button == nullptr) {
       continue;
     }
-    if (i < m_entryShortcutBadges.size() && m_entryShortcutBadges[i].has_value() && m_config->config().shell.session.showShortcuts) {
+    if (i < m_entryShortcutBadges.size()
+        && m_entryShortcutBadges[i].has_value()
+        && m_config->config().shell.session.showShortcuts) {
       button->setBadge(*m_entryShortcutBadges[i]);
     } else {
       button->setBadge("");

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -179,7 +179,7 @@ Button* SessionPanel::createActionButton(const SessionPanelActionConfig& cfg, st
   const std::string labelText =
       cfg.label.has_value() && !cfg.label->empty() ? *cfg.label : i18n::tr(session_action::labelKey(cfg.action));
   button->setText(labelText);
-  if (index < m_entryShortcutBadges.size() && m_entryShortcutBadges[index].has_value()) {
+  if (index < m_entryShortcutBadges.size() && m_entryShortcutBadges[index].has_value() && m_config->config().shell.session.showShortcuts) {
     button->setBadge(*m_entryShortcutBadges[index]);
   }
   button->setGlyph(
@@ -351,7 +351,7 @@ void SessionPanel::restoreEntryBadges() {
     if (button == nullptr) {
       continue;
     }
-    if (i < m_entryShortcutBadges.size() && m_entryShortcutBadges[i].has_value()) {
+    if (i < m_entryShortcutBadges.size() && m_entryShortcutBadges[i].has_value() && m_config->config().shell.session.showShortcuts) {
       button->setBadge(*m_entryShortcutBadges[i]);
     } else {
       button->setBadge("");

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2558,6 +2558,11 @@ namespace settings {
       entries.push_back(std::move(e));
     }
     entries.push_back(makeEntry(
+        SettingsSection::Power, "session-panel", tr("settings.schema.power.session-show-shortcuts.label"),
+        tr("settings.schema.power.session-show-shortcuts.description"), {"shell", "session", "show_shortcuts"},
+        ToggleSetting{.checked = cfg.shell.session.showShortcuts}, "session panel show shortcuts"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Power, "session-panel", tr("settings.schema.power.session-actions.label"),
         tr("settings.schema.power.session-actions.description"), {"shell", "session", "actions"},
         SessionPanelActionsSetting{.items = cfg.shell.session.actions},


### PR DESCRIPTION
## Summary

I've added a toggle right under "Grid layout" to optionally hide shortcut hints on the buttons of the session panel entries. It is enabled by default, and when it is disabled, it skips the calls to `button->setBadge()` in `session_panel.cpp`.

## Motivation

The shortcut hints looked kinda ugly and triggered my OCD

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] ~~Tested with different bar positions and density settings~~
- [ ] ~~Tested at different interface scaling values~~
- [ ] ~~Tested with multiple monitors~~

## Screenshots / Videos

<img width="1397" height="375" alt="2026-07-21 22-04-31" src="https://github.com/user-attachments/assets/9129e1ef-7c67-4e88-8474-90a3e5b4ec0d" />
<img width="1114" height="247" alt="2026-07-21 22-04-48" src="https://github.com/user-attachments/assets/d51d497b-710f-4a23-bb4d-a1ba6c83db47" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
