### PR TITLE
feat(calendar): add configurable date/time formatting for events

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2367,17 +2367,17 @@
           "button": "Edit",
           "description": "Update this calendar account"
         },
-        "calendar-refresh-interval": {
-          "description": "How often to sync calendar events (minutes)",
-          "label": "Refresh Interval"
+        "calendar-event-date-format": {
+          "description": "The date format shown in the event card for the selected date",
+          "label": "Event Date Format"
         },
         "calendar-event-time-format": {
           "description": "The time format shown for calendar events",
           "label": "Event Time Format"
         },
-        "calendar-event-date-format": {
-          "description": "The date format shown in the event card for the selected date",
-          "label": "Event Date Format"
+        "calendar-refresh-interval": {
+          "description": "How often to sync calendar events (minutes)",
+          "label": "Refresh Interval"
         },
         "custom-schedule": {
           "description": "Use manual sunrise/sunset times instead of computing from coordinates",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2371,6 +2371,14 @@
           "description": "How often to sync calendar events (minutes)",
           "label": "Refresh Interval"
         },
+        "calendar-event-time-format": {
+          "description": "The time format shown for calendar events",
+          "label": "Event Time Format"
+        },
+        "calendar-event-date-format": {
+          "description": "The date format shown in the event card for the selected date",
+          "label": "Event Date Format"
+        },
         "custom-schedule": {
           "description": "Use manual sunrise/sunset times instead of computing from coordinates",
           "label": "Custom Schedule"

--- a/example.toml
+++ b/example.toml
@@ -218,6 +218,12 @@ memory_poll_seconds = 2.0           # RAM usage
 network_poll_seconds = 3.0          # network throughput
 disk_poll_seconds = 10.0            # disk usage and swap usage; graph widgets use the fastest poll above
 
+# ── Calendar ──────────────────────────────────────────────────────────────────
+
+[calendar]
+event_time_format           = "%H:%M"       # time format used for events
+event_date_format           = "%A %e %B"    # date format used for events
+
 # ── Weather ───────────────────────────────────────────────────────────────────
 
 [weather]

--- a/example.toml
+++ b/example.toml
@@ -221,8 +221,10 @@ disk_poll_seconds = 10.0            # disk usage and swap usage; graph widgets u
 # ── Calendar ──────────────────────────────────────────────────────────────────
 
 [calendar]
-event_time_format           = "%H:%M"       # time format used for events
+enabled                     = false
+refresh_minutes             = 15
 event_date_format           = "%A %e %B"    # date format used for events
+event_time_format           = "%H:%M"       # time format used for events
 
 # ── Weather ───────────────────────────────────────────────────────────────────
 

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1045,6 +1045,8 @@ struct CalendarConfig {
 
   bool enabled = false;
   std::int32_t refreshMinutes = 15;
+  std::string eventDateFormat = "%A %e %B";
+  std::string eventTimeFormat = "%H:%M";
   std::vector<Account> accounts;
 
   bool operator==(const CalendarConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1506,6 +1506,8 @@ namespace noctalia::config::schema {
     static const Schema<CalendarConfig> s = {
         field(&CalendarConfig::enabled, "enabled"),
         field(&CalendarConfig::refreshMinutes, "refresh_minutes", kRefreshMinutesRange),
+        field(&CalendarConfig::eventDateFormat, "event_date_format"),
+        field(&CalendarConfig::eventTimeFormat, "event_time_format"),
         namedMap<CalendarConfig, CalendarConfig::Account>(
             &CalendarConfig::accounts, "account", calendarAccountSchema(),
             [](CalendarConfig::Account& a, std::string_view id) { a.id = std::string(id); },

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -841,7 +841,8 @@ void CalendarTab::rebuildEventList(float scale) {
   selectedTm.tm_isdst = -1;
   std::mktime(&selectedTm); // normalize tm_wday
   if (m_eventsTitle != nullptr) {
-    m_eventsTitle->setText(formatStrftime("%A %e %B", selectedTm));
+    const char* format = m_config != nullptr ? m_config->config().calendar.eventDateFormat.c_str() : "%A %e %B";
+    m_eventsTitle->setText(formatStrftime(format, selectedTm));
   }
 
   const int selectedKey = dateKey(m_selectedYear, m_selectedMonth, m_selectedDay);
@@ -882,7 +883,8 @@ void CalendarTab::rebuildEventList(float scale) {
       const std::time_t raw = std::chrono::system_clock::to_time_t(event->start);
       std::tm tm{};
       localtime_r(&raw, &tm);
-      timeText = formatStrftime("%H:%M", tm);
+      const char* format = m_config != nullptr ? m_config->config().calendar.eventTimeFormat.c_str() : "%H:%M";
+      timeText = formatStrftime(format, tm);
     }
 
     auto dot = ui::box({

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -839,10 +839,10 @@ void CalendarTab::rebuildEventList(float scale) {
   selectedTm.tm_mon = m_selectedMonth;
   selectedTm.tm_mday = m_selectedDay;
   selectedTm.tm_isdst = -1;
-  std::mktime(&selectedTm); // normalize tm_wday
+  const std::time_t selectedRaw = std::mktime(&selectedTm); // normalize tm_wday
   if (m_eventsTitle != nullptr) {
     const char* format = m_config != nullptr ? m_config->config().calendar.eventDateFormat.c_str() : "%A %e %B";
-    m_eventsTitle->setText(formatStrftime(format, selectedTm));
+    m_eventsTitle->setText(formatLocalUnixTime(static_cast<std::int64_t>(selectedRaw), format));
   }
 
   const int selectedKey = dateKey(m_selectedYear, m_selectedMonth, m_selectedDay);
@@ -881,10 +881,8 @@ void CalendarTab::rebuildEventList(float scale) {
       timeText = i18n::tr("control-center.calendar.all-day");
     } else {
       const std::time_t raw = std::chrono::system_clock::to_time_t(event->start);
-      std::tm tm{};
-      localtime_r(&raw, &tm);
       const char* format = m_config != nullptr ? m_config->config().calendar.eventTimeFormat.c_str() : "%H:%M";
-      timeText = formatStrftime(format, tm);
+      timeText = formatLocalUnixTime(static_cast<std::int64_t>(raw), format);
     }
 
     auto dot = ui::box({

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2467,20 +2467,20 @@ namespace settings {
     }
     {
       auto e = makeEntry(
-          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-time-format.label"),
-          tr("settings.schema.services.calendar-event-time-format.description"), {"calendar", "event_time_format"},
-          TextSetting{.value = cfg.calendar.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}},
-          "calendar time format strftime chrono"
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-date-format.label"),
+          tr("settings.schema.services.calendar-event-date-format.description"), {"calendar", "event_date_format"},
+          TextSetting{.value = cfg.calendar.eventDateFormat, .placeholder = "%A %e %B", .browseFileExtensions = {}},
+          "calendar date format strftime chrono"
       );
       e.visibleWhen = calendarOn;
       entries.push_back(std::move(e));
     }
     {
       auto e = makeEntry(
-          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-date-format.label"),
-          tr("settings.schema.services.calendar-event-date-format.description"), {"calendar", "event_date_format"},
-          TextSetting{.value = cfg.calendar.eventDateFormat, .placeholder = "%A %e %B", .browseFileExtensions = {}},
-          "calendar date format strftime chrono"
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-time-format.label"),
+          tr("settings.schema.services.calendar-event-time-format.description"), {"calendar", "event_time_format"},
+          TextSetting{.value = cfg.calendar.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}},
+          "calendar time format strftime chrono"
       );
       e.visibleWhen = calendarOn;
       entries.push_back(std::move(e));

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2465,6 +2465,26 @@ namespace settings {
       e.visibleWhen = calendarOn;
       entries.push_back(std::move(e));
     }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-time-format.label"),
+          tr("settings.schema.services.calendar-event-time-format.description"), {"calendar", "event_time_format"},
+          TextSetting{.value = cfg.calendar.eventTimeFormat, .placeholder = "%H:%M", .browseFileExtensions = {}},
+          "calendar time format strftime chrono"
+      );
+      e.visibleWhen = calendarOn;
+      entries.push_back(std::move(e));
+    }
+    {
+      auto e = makeEntry(
+          SettingsSection::Services, "calendar", tr("settings.schema.services.calendar-event-date-format.label"),
+          tr("settings.schema.services.calendar-event-date-format.description"), {"calendar", "event_date_format"},
+          TextSetting{.value = cfg.calendar.eventDateFormat, .placeholder = "%A %e %B", .browseFileExtensions = {}},
+          "calendar date format strftime chrono"
+      );
+      e.visibleWhen = calendarOn;
+      entries.push_back(std::move(e));
+    }
 
     entries.push_back(makeEntry(
         SettingsSection::Services, "audio", tr("settings.schema.services.audio-overdrive.label"),

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -382,6 +382,8 @@ location = "https://example.invalid/bad"
     c.controlCenter.shortcuts = {{"wifi"}, {"bluetooth"}};
     c.calendar.enabled = true;
     c.calendar.refreshMinutes = 30;
+    c.calendar.eventDateFormat = "%Y-%m-%d";
+    c.calendar.eventTimeFormat = "%I:%M %p";
     c.calendar.accounts = {
         {"acc1", "google", "Work", "#ff0000", "", "", "", {}},
         {"acc2", "caldav", "Home", "", "custom", "https://dav.example.com/remote.php/dav/", "user", {"personal"}},


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds two new settings, `calendar.event_time_format` and `calendar.event_date_format` that control the formatting used for the event card in the calendar panel, with the default option being the previous hardcoded value.

## Motivation

I do not use 24-hour time (the default), and would like to be able to configure the event card accordingly. Adding two new fields over reusing the default matches the configuration in other areas of the program. 

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Manually tested on Hyprland.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
	- (Read: different control panel sizes)
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

**Before**
<img width="601" height="522" alt="image" src="https://github.com/user-attachments/assets/eebe5cd9-b612-4964-b6a7-add265ba5c2e" />


**After**
<img width="598" height="506" alt="image" src="https://github.com/user-attachments/assets/56c3436e-865f-4f82-b545-41b8341cbe2e" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
