### PR TITLE
feat(custom_workspace_ids)

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3307,6 +3307,11 @@
           "label": "Labels Only When Occupied",
           "workspaces-description": "Show workspace ID or name labels on workspaces with open windows and on the active workspace even when it is empty; other empty tags stay unlabeled"
         },
+        "use-custom-workspace-ids":{
+          "description": "Use Custom workspace IDs",
+          "label": "Custom Workspace IDs",
+          "workspaces-description": "Set a custom ID for each numerical workspace to be displayed on the widget"
+        },
         "length": {
           "description": "Spacer length in pixels",
           "label": "Length"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -13,6 +13,8 @@
 #include "shell/bar/widgets/clock_widget.h"
 #include "shell/bar/widgets/control_center_widget.h"
 #include "shell/bar/widgets/custom_button_widget.h"
+
+#include <iostream>
 #ifndef NDEBUG
 #include "shell/bar/widgets/debug_indicator_widget.h"
 #endif
@@ -690,7 +692,21 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const ColorSpec urgentColor = wc != nullptr
         ? wc->getColorSpec("urgent_color", colorSpecFromRole(ColorRole::Error), "widget." + name + ".urgent_color")
         : colorSpecFromRole(ColorRole::Error);
+    const bool useCustomWorkspaceIDs = wc != nullptr ? wc->getBool("use_custom_workspace_ids") : false;
     WorkspacesWidget::DisplayMode displayMode = WorkspacesWidget::DisplayMode::Id;
+
+    std::unordered_map<int, std::string> workspaceLabelMap{};
+    for (int i = 1; i <= 10; i++) {
+      auto id = std::format("workspace_{}_id", i);
+      if (wc == nullptr)
+        break;
+      if (wc->hasSetting(id)) {
+        workspaceLabelMap[i] = wc->getString(id);
+      }
+    }
+    auto workspace2id = wc != nullptr ? wc->getString("workspace_2_id") : "2";
+    std::cout << workspace2id << std::endl;
+
     if (display == "id") {
       displayMode = WorkspacesWidget::DisplayMode::Id;
     } else if (display == "name") {
@@ -719,6 +735,8 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .focusedPill = workspaceStyle == "focus_hint",
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
         .enableScroll = wc != nullptr ? wc->getBool("enable_scroll", true) : true,
+        .useCustomWorkspaceIds = useCustomWorkspaceIDs,
+        .workspaceIdMap= std::move(workspaceLabelMap)
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, m_configService, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -693,7 +693,6 @@ std::unique_ptr<Widget> WidgetFactory::create(
         : colorSpecFromRole(ColorRole::Error);
     const bool useCustomWorkspaceIDs = wc != nullptr ? wc->getBool("use_custom_workspace_ids") : false;
     WorkspacesWidget::DisplayMode displayMode = WorkspacesWidget::DisplayMode::Id;
-
     std::unordered_map<int, std::string> workspaceLabelMap{};
     for (int i = 1; i <= 10; i++) {
       auto id = std::format("workspace_{}_id", i);
@@ -703,7 +702,6 @@ std::unique_ptr<Widget> WidgetFactory::create(
         workspaceLabelMap[i] = wc->getString(id);
       }
     }
-
     if (display == "id") {
       displayMode = WorkspacesWidget::DisplayMode::Id;
     } else if (display == "name") {

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -14,7 +14,6 @@
 #include "shell/bar/widgets/control_center_widget.h"
 #include "shell/bar/widgets/custom_button_widget.h"
 
-#include <iostream>
 #ifndef NDEBUG
 #include "shell/bar/widgets/debug_indicator_widget.h"
 #endif
@@ -704,8 +703,6 @@ std::unique_ptr<Widget> WidgetFactory::create(
         workspaceLabelMap[i] = wc->getString(id);
       }
     }
-    auto workspace2id = wc != nullptr ? wc->getString("workspace_2_id") : "2";
-    std::cout << workspace2id << std::endl;
 
     if (display == "id") {
       displayMode = WorkspacesWidget::DisplayMode::Id;
@@ -736,7 +733,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .focusedOutputOnly = wc != nullptr ? wc->getBool("focused_output_only", false) : false,
         .enableScroll = wc != nullptr ? wc->getBool("enable_scroll", true) : true,
         .useCustomWorkspaceIds = useCustomWorkspaceIDs,
-        .workspaceIdMap= std::move(workspaceLabelMap)
+        .workspaceIdMap = std::move(workspaceLabelMap)
     };
     auto widget = std::make_unique<WorkspacesWidget>(m_platform, m_configService, output, options);
     widget->setContentScale(contentScale);

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -21,7 +21,6 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
-
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <utility>
@@ -80,7 +79,8 @@ WorkspacesWidget::WorkspacesWidget(
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
       m_focusedPill(options.focusedPill), m_focusedOutputOnly(options.focusedOutputOnly),
       m_enableScroll(options.enableScroll), m_useCustomWorkspaceIds(options.useCustomWorkspaceIds),
-      m_workspaceIdMap(options.workspaceIdMap), m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor) , m_emptyColor(options.emptyColor) , m_urgentColor(options.urgentColor) {
+      m_workspaceIdMap(std::move(options.workspaceIdMap)), m_focusedColor(options.focusedColor),
+      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor), m_urgentColor(options.urgentColor) {
   buildDesktopIconIndex();
 }
 
@@ -1419,10 +1419,10 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
   const DisplayMode displayMode = effectiveDisplayMode();
   std::string label;
   if (displayMode == DisplayMode::Id) {
-    if(m_useCustomWorkspaceIds && m_workspaceIdMap.contains(static_cast<int>(workspace.index))){
+    if (m_useCustomWorkspaceIds && m_workspaceIdMap.contains(static_cast<int>(workspace.index))) {
       return m_workspaceIdMap.at(static_cast<int>(workspace.index));
     }
-    
+
     if (workspace.index > 0) {
       label = std::to_string(workspace.index);
     } else if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -21,6 +21,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <iostream>
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <utility>
@@ -1426,7 +1427,11 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
     if (workspace.index > 0) {
       label = std::to_string(workspace.index);
     } else if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {
-      label = std::to_string(*numericId);
+      if (m_useCustomWorkspaceIds && m_workspaceIdMap.contains(static_cast<int>(*numericId))) {
+        label = m_workspaceIdMap.at(static_cast<int>(*numericId));
+      } else {
+        label = std::to_string(*numericId);
+      }
     } else {
       label = std::to_string(displayIndex + 1);
     }

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -21,6 +21,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+
 #include <linux/input-event-codes.h>
 #include <optional>
 #include <utility>
@@ -78,8 +79,8 @@ WorkspacesWidget::WorkspacesWidget(
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
       m_focusedPill(options.focusedPill), m_focusedOutputOnly(options.focusedOutputOnly),
-      m_enableScroll(options.enableScroll), m_focusedColor(options.focusedColor),
-      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor), m_urgentColor(options.urgentColor) {
+      m_enableScroll(options.enableScroll), m_useCustomWorkspaceIds(options.useCustomWorkspaceIds),
+      m_workspaceIdMap(options.workspaceIdMap), m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor) , m_emptyColor(options.emptyColor) , m_urgentColor(options.urgentColor) {
   buildDesktopIconIndex();
 }
 
@@ -1418,6 +1419,10 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
   const DisplayMode displayMode = effectiveDisplayMode();
   std::string label;
   if (displayMode == DisplayMode::Id) {
+    if(m_useCustomWorkspaceIds && m_workspaceIdMap.contains(static_cast<int>(workspace.index))){
+      return m_workspaceIdMap.at(static_cast<int>(workspace.index));
+    }
+    
     if (workspace.index > 0) {
       label = std::to_string(workspace.index);
     } else if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -44,6 +44,8 @@ public:
     bool focusedPill = false;
     bool focusedOutputOnly = false;
     bool enableScroll = true;
+    bool useCustomWorkspaceIds = false;
+    std::unordered_map<int, std::string> workspaceIdMap;
   };
 
   WorkspacesWidget(CompositorPlatform& platform, ConfigService& config, wl_output* output, Options options);
@@ -157,6 +159,8 @@ private:
   bool m_enableScroll = true;
   bool m_wasFocusedOutput = true;
   bool m_activeUsesFocusedColor = true;
+  bool m_useCustomWorkspaceIds = false;
+  std::unordered_map<int, std::string> m_workspaceIdMap;
   std::string m_cachedActiveWindowAppId;
   IconResolver m_iconResolver;
   std::unordered_map<std::string, std::string> m_appIcons;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <format>
 #include <iterator>
 #include <string>
 #include <unordered_set>
@@ -1092,6 +1093,27 @@ namespace settings {
         labelsOnlyWhenOccupied.descriptionKey =
             "settings.widgets.settings.labels-only-when-occupied.workspaces-description";
         add(std::move(labelsOnlyWhenOccupied));
+      }
+      {
+        auto useCustomWorkspaceIds = withGroup(boolSpec("use_custom_workspace_ids", false), "workspaces.list");
+        useCustomWorkspaceIds.descriptionKey =
+            "settings.widgets.settings.use-custom-workspace-ids.workspaces-description";
+        add(std::move(useCustomWorkspaceIds));
+      }
+      {
+        WidgetSettingVisibility workspaceIdVisibility;
+        workspaceIdVisibility.all = {
+            WidgetSettingVisibilityCondition{"use_custom_workspace_ids", {"true"}},
+        };
+
+        for (int i = 1; i <= 10; i++) {
+          auto spec = stringSpec(std::format("workspace_{}_id", i), std::to_string(i));
+          spec.literalLabel = std::format("Workspace {} ID", i);
+          auto workspace_id = withGroup(std::move(spec), "workspaces.list");
+          workspace_id.literalDescription = std::format("Display ID for workspace {}", i);
+          workspace_id.visibleWhen = workspaceIdVisibility;
+          add(std::move(workspace_id));
+        }
       }
       {
         auto maxLabelChars = withGroup(intSpec("max_label_chars", 1, 1.0, 20.0, 1.0), "workspaces.list");


### PR DESCRIPTION


## Summary
This PR allows users to change the display of workspace IDs directly in Noctalia without setting up compositor specific named workspaces which may exhibit inconsistent behaviour and are rigid.

## Motivation
Is a neat feature to have.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing
Tested on Niri, Hyprland and Sway. All tests pass with ```just test```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## 
<img width="1214" height="237" alt="Screenshot from 2026-07-22 11-51-51" src="https://github.com/user-attachments/assets/709690ec-26bd-491c-95e3-bcdea56ac964" />
<img width="985" height="299" alt="Screenshot from 2026-07-22 11-52-33" src="https://github.com/user-attachments/assets/546bd7cd-61a5-46c1-afe6-83ab445241ce" />
<img width="1144" height="268" alt="Screenshot from 2026-07-22 11-54-45" src="https://github.com/user-attachments/assets/6b353414-a376-4938-9c6f-cc3baec50c51" />
<img width="1151" height="582" alt="Screenshot from 2026-07-22 11-55-05" src="https://github.com/user-attachments/assets/21f4606e-6da1-4693-af59-e5f33c00a3f9" />
Screenshots / Videos

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
Current Problems:
- Only works for workspaces 1 - 10, anything higher will fallback to integer index
- There's some user facing string in the settings menu for each workspace id, it has some string interpolation so i wasn't sure of the best way to translate it
