### PR TITLE
feat(wallpaper-panel): add sort by random

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3822,7 +3822,7 @@
       "sort-date-desc": "Sort by date (newest first)",
       "sort-name-asc": "Sort by name (A-Z)",
       "sort-name-desc": "Sort by name (Z-A)",
-      "sort-random": "Sort by random",
+      "sort-random": "Sort by random (shuffle)",
       "title": "Wallpaper"
     }
   },

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3822,6 +3822,7 @@
       "sort-date-desc": "Sort by date (newest first)",
       "sort-name-asc": "Sort by name (A-Z)",
       "sort-name-desc": "Sort by name (Z-A)",
+      "sort-random": "Sort by random",
       "title": "Wallpaper"
     }
   },

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <filesystem>
 #include <memory>
+#include <random>
 #include <string_view>
 #include <system_error>
 #include <unordered_set>
@@ -206,6 +207,18 @@ namespace {
       return std::nullopt;
     }
     return mtime;
+  }
+
+  // Ordering key for SortMode::Random. Hashing the path against a seed keeps the
+  // shuffled order fixed until the seed changes, so filtering or starring a tile
+  // rebuilds the visible entries without reordering the grid.
+  [[nodiscard]] std::uint64_t randomOrderKey(const WallpaperEntry& entry, std::uint64_t seed) {
+    std::uint64_t hash = std::filesystem::hash_value(entry.absPath) ^ seed;
+    hash ^= hash >> 30U;
+    hash *= 0xBF58476D1CE4E5B9ULL;
+    hash ^= hash >> 27U;
+    hash *= 0x94D049BB133111EBULL;
+    return hash ^ (hash >> 31U);
   }
 
   [[nodiscard]] bool favoriteVisibleInBrowseContext(
@@ -858,6 +871,7 @@ void WallpaperPanel::onOpen(std::string_view /*context*/) {
   m_navStack.clear();
   populateMonitorChoices();
   syncSortButtonGlyph();
+  reseedRandomSort();
   refreshVisibleEntries();
   resetSelection();
   rebindGrid();
@@ -1676,6 +1690,9 @@ void WallpaperPanel::setSortMode(SortMode mode) {
     return;
   }
   m_sortMode = mode;
+  if (mode == SortMode::Random) {
+    reseedRandomSort();
+  }
   if (m_config != nullptr) {
     (void)m_config->setStateString("wallpaper_panel", "sort", std::string(sortModeStateValue(mode)));
   }
@@ -1684,6 +1701,10 @@ void WallpaperPanel::setSortMode(SortMode mode) {
   rebindGrid();
   m_dirty = true;
   PanelManager::instance().refresh();
+}
+
+void WallpaperPanel::reseedRandomSort() {
+  m_randomSeed = std::uniform_int_distribution<std::uint64_t>{}(Random::rng());
 }
 
 void WallpaperPanel::sortVisibleEntries() {
@@ -1721,6 +1742,14 @@ void WallpaperPanel::sortVisibleEntries() {
       }
       return caseInsensitiveNameOrder(a.name, b.name) < 0;
     }
+    case SortMode::Random: {
+      const std::uint64_t aKey = randomOrderKey(a, m_randomSeed);
+      const std::uint64_t bKey = randomOrderKey(b, m_randomSeed);
+      if (aKey != bKey) {
+        return aKey < bKey;
+      }
+      return caseInsensitiveNameOrder(a.name, b.name) < 0;
+    }
     case SortMode::NameAsc:
     default: {
       const int order = caseInsensitiveNameOrder(a.name, b.name);
@@ -1736,19 +1765,12 @@ void WallpaperPanel::sortVisibleEntries() {
     const std::size_t end = std::min(endIndex, m_visibleEntries.size());
     const auto begin = m_visibleEntries.begin() + static_cast<std::ptrdiff_t>(beginIndex);
     const auto endIt = m_visibleEntries.begin() + static_cast<std::ptrdiff_t>(end);
-    const auto sortSubrange = [&](const auto subBegin, const auto subEnd) {
-      if (m_sortMode == SortMode::Random) {
-        std::shuffle(subBegin, subEnd, Random::rng());
-      } else {
-        std::sort(subBegin, subEnd, compareEntries);
-      }
-    };
     if (foldersFirst) {
       const auto folderEnd = std::partition(begin, endIt, [](const WallpaperEntry& entry) { return entry.isDir; });
-      sortSubrange(begin, folderEnd);
-      sortSubrange(folderEnd, endIt);
+      std::sort(begin, folderEnd, compareEntries);
+      std::sort(folderEnd, endIt, compareEntries);
     } else {
-      sortSubrange(begin, endIt);
+      std::sort(begin, endIt, compareEntries);
     }
   };
 

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -3,6 +3,7 @@
 #include "config/config_service.h"
 #include "core/input/keybind_matcher.h"
 #include "core/log.h"
+#include "core/random.h"
 #include "core/ui_phase.h"
 #include "i18n/i18n.h"
 #include "render/core/renderer.h"
@@ -1573,6 +1574,9 @@ WallpaperPanel::SortMode WallpaperPanel::sortModeFromState(std::string_view valu
   if (value == "date_desc") {
     return SortMode::DateDesc;
   }
+  if (value == "random") {
+    return SortMode::Random;
+  }
   return SortMode::NameAsc;
 }
 
@@ -1584,6 +1588,8 @@ std::string_view WallpaperPanel::sortModeStateValue(SortMode mode) {
     return "date_asc";
   case SortMode::DateDesc:
     return "date_desc";
+  case SortMode::Random:
+    return "random";
   case SortMode::NameAsc:
   default:
     return "name_asc";
@@ -1598,6 +1604,8 @@ std::string_view WallpaperPanel::sortModeGlyph(SortMode mode) {
     return "sort-ascending-2";
   case SortMode::DateDesc:
     return "sort-descending-2";
+  case SortMode::Random:
+    return "arrows-random";
   case SortMode::NameAsc:
   default:
     return "sort-a-z";
@@ -1612,6 +1620,8 @@ const char* WallpaperPanel::sortModeTooltipKey(SortMode mode) {
     return "wallpaper.panel.sort-date-asc";
   case SortMode::DateDesc:
     return "wallpaper.panel.sort-date-desc";
+  case SortMode::Random:
+    return "wallpaper.panel.sort-random";
   case SortMode::NameAsc:
   default:
     return "wallpaper.panel.sort-name-asc";
@@ -1652,6 +1662,9 @@ void WallpaperPanel::cycleSortMode() {
     next = SortMode::DateDesc;
     break;
   case SortMode::DateDesc:
+    next = SortMode::Random;
+    break;
+  case SortMode::Random:
     next = SortMode::NameAsc;
     break;
   }
@@ -1723,12 +1736,19 @@ void WallpaperPanel::sortVisibleEntries() {
     const std::size_t end = std::min(endIndex, m_visibleEntries.size());
     const auto begin = m_visibleEntries.begin() + static_cast<std::ptrdiff_t>(beginIndex);
     const auto endIt = m_visibleEntries.begin() + static_cast<std::ptrdiff_t>(end);
+    const auto sortSubrange = [&](const auto subBegin, const auto subEnd) {
+      if (m_sortMode == SortMode::Random) {
+        std::shuffle(subBegin, subEnd, Random::rng());
+      } else {
+        std::sort(subBegin, subEnd, compareEntries);
+      }
+    };
     if (foldersFirst) {
       const auto folderEnd = std::partition(begin, endIt, [](const WallpaperEntry& entry) { return entry.isDir; });
-      std::sort(begin, folderEnd, compareEntries);
-      std::sort(folderEnd, endIt, compareEntries);
+      sortSubrange(begin, folderEnd);
+      sortSubrange(folderEnd, endIt);
     } else {
-      std::sort(begin, endIt, compareEntries);
+      sortSubrange(begin, endIt);
     }
   };
 

--- a/src/shell/wallpaper/panel/wallpaper_panel.h
+++ b/src/shell/wallpaper/panel/wallpaper_panel.h
@@ -7,6 +7,7 @@
 #include "shell/wallpaper/panel/wallpaper_scanner.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <limits>
 #include <memory>
@@ -97,6 +98,7 @@ private:
       const std::filesystem::path& activeDir, const std::filesystem::path& rootDir
   ) const;
   void sortVisibleEntries();
+  void reseedRandomSort();
   void syncSortButtonGlyph();
   void cycleSortMode();
   void setSortMode(SortMode mode);
@@ -164,6 +166,7 @@ private:
   bool m_flatten = false;
   bool m_scanPending = false;
   SortMode m_sortMode = SortMode::NameAsc;
+  std::uint64_t m_randomSeed = 0;
   std::size_t m_pinnedFavoriteCount = 0;
   bool m_syncingFavoriteControls = false;
   bool m_syncingGridSelectionVisual = false;

--- a/src/shell/wallpaper/panel/wallpaper_panel.h
+++ b/src/shell/wallpaper/panel/wallpaper_panel.h
@@ -39,6 +39,7 @@ public:
     NameDesc,
     DateAsc,
     DateDesc,
+    Random,
   };
 
   WallpaperPanel(


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added a Sort by: Random (shuffle) option to the wallpaper-panel.

## Motivation

I have a lot of wallpapers, and I want a "surprise me" when I open the panel, instead of always seeing the same few wallpapers.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

`noctalia msg panel-open wallpaper` and just cycle through the sorting modes.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="974" height="719" alt="image" src="https://github.com/user-attachments/assets/fb23b187-8f85-4865-a1e0-b7e39c898f92" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
