### PR TITLE
feat(volume-widget): add option for middle click command

### DIFF
--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -666,12 +666,13 @@ std::unique_ptr<Widget> WidgetFactory::create(
         : colorSpecFromRole(ColorRole::Error);
     std::string glyphOverride = wc != nullptr ? wc->getString("glyph", "") : std::string{};
     std::string muteGlyphOverride = wc != nullptr ? wc->getString("mute_glyph", "") : std::string{};
+    std::string middleCommand = wc != nullptr ? wc->getString("middle_command", "") : std::string{};
     auto effectsProfileGlyphs =
         wc != nullptr ? wc->getStringMap("effects_profile_glyphs") : std::unordered_map<std::string, std::string>{};
     auto widget = std::make_unique<VolumeWidget>(
         m_audio, m_easyEffects, &m_config, output, showLabel, volumeTarget, scrollStep, muteColor,
-        std::move(glyphOverride), std::move(muteGlyphOverride), std::move(effectsProfileGlyphs), customImageFor(wc),
-        enableScroll
+        std::move(glyphOverride), std::move(muteGlyphOverride), std::move(effectsProfileGlyphs),
+        std::move(middleCommand), customImageFor(wc), enableScroll
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/volume_widget.cpp
+++ b/src/shell/bar/widgets/volume_widget.cpp
@@ -1,6 +1,8 @@
 #include "shell/bar/widgets/volume_widget.h"
 
 #include "config/config_types.h"
+#include "core/log.h"
+#include "core/process/process.h"
 #include "i18n/i18n.h"
 #include "pipewire/pipewire_service.h"
 #include "render/scene/input_area.h"
@@ -16,24 +18,40 @@
 #include <string_view>
 #include <utility>
 
+namespace {
+  constexpr Logger kLog("volume-widget");
+}
+
 VolumeWidget::VolumeWidget(
     PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* /*output*/,
     bool showLabel, VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
     std::string muteGlyphOverride, std::unordered_map<std::string, std::string> effectsProfileGlyphs,
-    WidgetCustomImage customImage, bool enableScroll
+    std::string middleCommand, WidgetCustomImage customImage, bool enableScroll
 )
     : m_audio(audio), m_easyEffects(easyEffects), m_config(config), m_showLabel(showLabel),
       m_enableScroll(enableScroll), m_scrollStep(static_cast<float>(scrollStepPercent) / 100.0f), m_target(target),
       m_muteColor(muteColor), m_glyphOverride(std::move(glyphOverride)),
       m_muteGlyphOverride(std::move(muteGlyphOverride)), m_effectsProfileGlyphs(std::move(effectsProfileGlyphs)),
-      m_customImage(std::move(customImage)) {}
+      m_middleCommand(std::move(middleCommand)), m_customImage(std::move(customImage)) {}
 
 void VolumeWidget::create() {
   auto area = std::make_unique<InputArea>();
-  area->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT}));
+
+  std::uint32_t acceptedButtons = InputArea::buttonMask({BTN_LEFT, BTN_RIGHT});
+  if (!m_middleCommand.empty()) {
+    acceptedButtons |= InputArea::buttonMask(BTN_MIDDLE);
+  }
+  area->setAcceptedButtons(acceptedButtons);
+
   area->setOnClick([this](const InputArea::PointerData& data) {
     if (data.button == BTN_LEFT) {
       requestPanelToggle("control-center", "audio");
+      return;
+    }
+    if (data.button == BTN_MIDDLE && !m_middleCommand.empty()) {
+      if (!process::runAsync(m_middleCommand)) {
+        kLog.warn("failed to launch command for '{}'", configName());
+      }
       return;
     }
     if (data.button != BTN_RIGHT || m_audio == nullptr) {
@@ -94,6 +112,10 @@ void VolumeWidget::create() {
   );
 
   setRoot(std::move(area));
+}
+
+bool VolumeWidget::reservesMiddleClick(float /*sceneX*/, float /*sceneY*/) const noexcept {
+  return !m_middleCommand.empty();
 }
 
 void VolumeWidget::doLayout(Renderer& renderer, float containerWidth, float containerHeight) {

--- a/src/shell/bar/widgets/volume_widget.h
+++ b/src/shell/bar/widgets/volume_widget.h
@@ -26,10 +26,11 @@ public:
       PipeWireService* audio, EasyEffectsService* easyEffects, const Config* config, wl_output* output, bool showLabel,
       VolumeWidgetTarget target, int scrollStepPercent, ColorSpec muteColor, std::string glyphOverride,
       std::string muteGlyphOverride, std::unordered_map<std::string, std::string> effectsProfileGlyphs,
-      WidgetCustomImage customImage = {}, bool enableScroll = true
+      std::string middleCommand, WidgetCustomImage customImage = {}, bool enableScroll = true
   );
 
   void create() override;
+  [[nodiscard]] bool reservesMiddleClick(float sceneX, float sceneY) const noexcept override;
 
 private:
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
@@ -48,6 +49,7 @@ private:
   std::string m_glyphOverride;
   std::string m_muteGlyphOverride;
   std::unordered_map<std::string, std::string> m_effectsProfileGlyphs;
+  std::string m_middleCommand;
   WidgetCustomImage m_customImage;
   Glyph* m_glyph = nullptr;
   Image* m_image = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -1152,6 +1152,7 @@ namespace settings {
       add(stringMapSpec("effects_profile_glyphs"));
       add(stringSpec("custom_image", ""));
       add(boolSpec("custom_image_colorize", false));
+      add(stringSpec("middle_command"));
       add(boolSpec("enable_scroll", true));
       {
         auto scrollStep = stepperIntSpec("scroll_step", 5, 1.0, 25.0, 1.0, "%");


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds the option to be able to run a shell command on middle click for the volume widget. 

## Motivation

I have a script that toggles between speakers and headphones, and I missed the ability to switch between them by middle clicking, like in v4.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Opened the settings for volume widget, set a middle click command and then clicked again to see it running. Also checked that the relevant settings are persisted to `settings.toml`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="812" height="1179" alt="image" src="https://github.com/user-attachments/assets/8674ad16-7370-4977-93ba-1eb581a1832b" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
