### PR TITLE
feat(media-player) add reverse scrolling direction

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3475,6 +3475,10 @@
           "description": "Action performed when left-clicking the bar button",
           "label": "Primary click"
         },
+        "reverse-scroll-direction": {
+          "description": "Mouse scroll up/down binds are swapped for this widget",
+          "label": "Reverse Scrolling Direction"
+        },
         "right-command": {
           "description": "Shell command run when right-clicking this button",
           "label": "Right Click Command"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -331,9 +331,10 @@ std::unique_ptr<Widget> WidgetFactory::create(
     const bool hideArtist = wc != nullptr ? wc->getBool("hide_artist", false) : false;
     const bool artistFirst = wc != nullptr ? wc->getBool("artist_first", false) : false;
     const bool enableScroll = wc != nullptr ? wc->getBool("enable_scroll", true) : true;
+    const bool reverseScrollDirection = wc != nullptr ? wc->getBool("reverse_scroll_direction", false) : false;
     auto widget = std::make_unique<MediaWidget>(
         m_mpris, m_httpClient, output, maxWidth, minWidth, artSize, parseMediaTitleScrollMode(titleScroll),
-        hideWhenNoMedia, albumArtOnly, hideAlbumArt, hideArtist, artistFirst, enableScroll
+        hideWhenNoMedia, albumArtOnly, hideAlbumArt, hideArtist, artistFirst, enableScroll, reverseScrollDirection
     );
     widget->setContentScale(contentScale);
     return widget;

--- a/src/shell/bar/widgets/media_widget.cpp
+++ b/src/shell/bar/widgets/media_widget.cpp
@@ -27,11 +27,11 @@ namespace {
 MediaWidget::MediaWidget(
     MprisService* mpris, HttpClient* httpClient, wl_output* /*output*/, float maxWidth, float minWidth, float artSize,
     MediaTitleScrollMode titleScrollMode, bool hideWhenNoMedia, bool albumArtOnly, bool hideAlbumArt, bool hideArtist,
-    bool artistFirst, bool enableScroll
+    bool artistFirst, bool enableScroll, bool reverseScrollDirection
 )
     : m_mpris(mpris), m_httpClient(httpClient), m_maxWidth(maxWidth), m_minWidth(minWidth), m_artSize(artSize),
       m_titleScrollMode(titleScrollMode), m_hideWhenNoMedia(hideWhenNoMedia), m_albumArtOnly(albumArtOnly),
-      m_hideAlbumArt(hideAlbumArt), m_hideArtist(hideArtist), m_artistFirst(artistFirst), m_enableScroll(enableScroll) {
+      m_hideAlbumArt(hideAlbumArt), m_hideArtist(hideArtist), m_artistFirst(artistFirst), m_enableScroll(enableScroll), m_reverseScrollDirection(reverseScrollDirection) {
 }
 
 void MediaWidget::create() {
@@ -78,8 +78,9 @@ void MediaWidget::create() {
     if (steps == 0.0f) {
       return;
     }
-    // Scroll up → next; Wayland reports up as a negative delta.
-    if (steps < 0.0f) {
+    // Wayland reports up as a negative delta. Scroll up → next by default, but flip it if reverse scrolling direction is enabled.
+    const bool scrollNext = (steps < 0.0f) != m_reverseScrollDirection;
+    if (scrollNext) {
       m_mpris->nextActive();
     } else {
       m_mpris->previousActive();

--- a/src/shell/bar/widgets/media_widget.h
+++ b/src/shell/bar/widgets/media_widget.h
@@ -27,7 +27,7 @@ public:
   MediaWidget(
       MprisService* mpris, HttpClient* httpClient, wl_output* output, float maxWidth, float minWidth, float artSize,
       MediaTitleScrollMode titleScrollMode, bool hideWhenNoMedia = false, bool albumArtOnly = false,
-      bool hideAlbumArt = false, bool hideArtist = false, bool artistFirst = false, bool enableScroll = true
+      bool hideAlbumArt = false, bool hideArtist = false, bool artistFirst = false, bool enableScroll = true, bool reverseScrollDirection = false
   );
 
   void create() override;
@@ -52,6 +52,7 @@ private:
   bool m_hideArtist = false;
   bool m_artistFirst = false;
   bool m_enableScroll = true;
+  bool m_reverseScrollDirection = false;
   InputArea* m_area = nullptr;
   Image* m_art = nullptr;
   Glyph* m_emptyGlyph = nullptr;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -887,6 +887,11 @@ namespace settings {
       }
       add(boolSpec("hide_when_no_media", false));
       add(boolSpec("enable_scroll", true));
+      {
+        auto reverseScrollDirection = boolSpec("reverse_scroll_direction", false);
+        reverseScrollDirection.visibleWhen = WidgetSettingVisibility{"enable_scroll", {"true"}};;
+        add(std::move(reverseScrollDirection));
+      }      
     } else if (type == "network") {
       add(selectSpec("vpn_status", "replace", vpnStatusMode));
       add(boolSpec("show_label", true));


### PR DESCRIPTION
… widget

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This adds a toggle to reverse the mouse wheel binds on a given widget, and implements that for the media player.
It's only configurable when scrolling is enabled.

## Motivation

I've had scroll down for next song for years, the bars I used either allowed this or that was the default behavior (like KDE, waybar or dms).
In my mind when you scroll down on a playlist you're scrolling towards the next songs, but I realise not everyone will want it like this, so I added it as an optional toggle.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
