### PR TITLE
feat(plugins): support panel context in togglePanel

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -480,8 +480,14 @@ void Application::initStyleThemeAndWayland() {
     }
   });
 
-  // Let a plugin toggle one of its own panels.
-  m_scriptApi.setTogglePanelHook([this](const std::string& panelId) { m_panelManager.togglePanel(panelId); });
+  // Let plugins toggle host panels.
+  m_scriptApi.setTogglePanelHook([this](const std::string& panelId, const std::string& context) {
+    if (context.empty()) {
+      m_panelManager.togglePanel(panelId);
+    } else {
+      m_panelManager.togglePanel(panelId, PanelOpenRequest{.context = context});
+    }
+  });
 
   m_themeService.setResolvedCallback([this, lastResolvedThemeMode = std::optional<std::string>{},
                                       syncScriptApiWallpaperDirectory](

--- a/src/scripting/luau_host.cpp
+++ b/src/scripting/luau_host.cpp
@@ -407,12 +407,14 @@ namespace {
     return 0;
   }
 
-  // togglePanel("author/plugin:panel") — toggle a host panel by id.
+  // togglePanel(panelId, context?) — toggle a host panel by id.
   int luau_togglePanel(lua_State* L) {
-    size_t len = 0;
-    const char* panelId = luaL_checklstring(L, 1, &len);
+    size_t panelIdLen = 0;
+    const char* panelId = luaL_checklstring(L, 1, &panelIdLen);
+    size_t contextLen = 0;
+    const char* context = luaL_optlstring(L, 2, "", &contextLen);
     if (auto* host = hostForState(L)) {
-      host->scriptTogglePanel(std::string(panelId, len));
+      host->scriptTogglePanel(std::string(panelId, panelIdLen), std::string(context, contextLen));
     }
     return 0;
   }
@@ -2057,11 +2059,13 @@ void LuauHost::scriptSetWallpaper(std::string connector, std::string path) {
   }
 }
 
-void LuauHost::scriptTogglePanel(std::string panelId) {
+void LuauHost::scriptTogglePanel(std::string panelId, std::string context) {
   if (m_scriptContext != nullptr) {
-    m_scriptContext->sideEffects.push_back(
-        {.kind = scripting::ScriptSideEffectKind::TogglePanel, .title = std::move(panelId), .body = {}}
-    );
+    m_scriptContext->sideEffects.push_back({
+        .kind = scripting::ScriptSideEffectKind::TogglePanel,
+        .title = std::move(panelId),
+        .body = std::move(context),
+    });
   }
 }
 

--- a/src/scripting/luau_host.h
+++ b/src/scripting/luau_host.h
@@ -168,8 +168,8 @@ public:
   // Apply and persist a wallpaper image. Empty connector targets all outputs.
   // Queued as a side effect and applied on the main thread.
   void scriptSetWallpaper(std::string connector, std::string path);
-  // Toggle a host panel by id ("author/plugin:panel"). Queued, applied on the main thread.
-  void scriptTogglePanel(std::string panelId);
+  // Toggle a host panel by id, optionally with an open context. Queued, applied on the main thread.
+  void scriptTogglePanel(std::string panelId, std::string context);
   [[nodiscard]] bool scriptCopyToClipboard(std::string text, std::string mimeType);
   [[nodiscard]] std::optional<std::string> scriptFocusedOutputName() const;
 

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -8,7 +8,8 @@ namespace scripting {
   inline constexpr std::uint32_t kStringMapSettingPluginApiVersion = 6;
   inline constexpr std::uint32_t kAllowInsecureTlsPluginApiVersion = 7;
   inline constexpr std::uint32_t kPanelDismissOnOutsideClickPluginApiVersion = 8;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kPanelDismissOnOutsideClickPluginApiVersion;
+  inline constexpr std::uint32_t kPanelToggleContextPluginApiVersion = 9;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kPanelToggleContextPluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/scripting/script_api_context.h
+++ b/src/scripting/script_api_context.h
@@ -84,12 +84,15 @@ namespace scripting {
       }
     }
 
-    // Toggles a host panel by id. Wired to PanelManager in Application; main thread only.
-    void setTogglePanelHook(std::function<void(const std::string&)> hook) { m_togglePanelHook = std::move(hook); }
+    // Toggles a host panel by id, optionally with an open context. Wired to PanelManager in Application;
+    // main thread only.
+    void setTogglePanelHook(std::function<void(const std::string&, const std::string&)> hook) {
+      m_togglePanelHook = std::move(hook);
+    }
 
-    void invokeTogglePanel(const std::string& panelId) const {
+    void invokeTogglePanel(const std::string& panelId, const std::string& context) const {
       if (m_togglePanelHook) {
-        m_togglePanelHook(panelId);
+        m_togglePanelHook(panelId, context);
       }
     }
 
@@ -101,7 +104,7 @@ namespace scripting {
     std::optional<std::string> m_clipboardText;
     std::function<void(const std::string&, bool)> m_wallpaperEnabledHook;
     std::function<void(const std::string&, const std::string&)> m_wallpaperHook;
-    std::function<void(const std::string&)> m_togglePanelHook;
+    std::function<void(const std::string&, const std::string&)> m_togglePanelHook;
   };
 
 } // namespace scripting

--- a/src/scripting/script_runtime.cpp
+++ b/src/scripting/script_runtime.cpp
@@ -148,9 +148,9 @@ namespace scripting {
           break;
         case ScriptSideEffectKind::TogglePanel:
           if (togglePanelCallback) {
-            togglePanelCallback(effect.title);
+            togglePanelCallback(effect.title, effect.body);
           } else {
-            api.invokeTogglePanel(effect.title);
+            api.invokeTogglePanel(effect.title, effect.body);
           }
           break;
         }

--- a/src/scripting/script_runtime.h
+++ b/src/scripting/script_runtime.h
@@ -20,7 +20,7 @@ namespace scripting {
   class ScriptRuntime {
   public:
     using SubscriberId = std::uint64_t;
-    using TogglePanelCallback = std::function<void(std::string_view)>;
+    using TogglePanelCallback = std::function<void(std::string_view, std::string_view)>;
 
     explicit ScriptRuntime(
         std::string runtimeName, ScriptSettings settings, ScriptApiContext& api, std::filesystem::path pluginDir,

--- a/src/scripting/script_runtime_types.h
+++ b/src/scripting/script_runtime_types.h
@@ -148,7 +148,7 @@ namespace scripting {
     std::string body;
     // SetWallpaperEnabled: title holds the output connector, flag the enabled state.
     // SetWallpaper: title holds the output connector (empty = all outputs), body the image path.
-    // TogglePanel: title holds the panel id ("author/plugin:panel").
+    // TogglePanel: title holds the panel id ("author/plugin:panel"), body the optional open context.
     bool flag = false;
   };
 

--- a/src/shell/bar/widgets/plugin_widget.cpp
+++ b/src/shell/bar/widgets/plugin_widget.cpp
@@ -263,12 +263,12 @@ void PluginWidget::create() {
   auto alive = std::weak_ptr<bool>(m_alive);
   m_runtime = std::make_shared<scripting::ScriptRuntime>(
       m_entryId, m_settings, m_scriptApi, m_pluginDir, m_httpClient, m_clipboard,
-      [this, alive](std::string_view panelId) {
+      [this, alive](std::string_view panelId, std::string_view context) {
         auto token = alive.lock();
         if (token == nullptr || !*token) {
           return;
         }
-        requestPanelToggle(panelId);
+        requestPanelToggle(panelId, context);
       }
   );
 


### PR DESCRIPTION
## Summary

- allow plugins to pass an optional context with `noctalia.togglePanel(panelId, context)`
- carry the context through script side effects and both runtime dispatch paths
- keep bar widget toggles on the existing `Widget::requestPanelToggle` path so open-near-click panels retain the clicked widget anchor
- bump the current plugin API version to 9

## Motivation

Plugin bar widgets can currently toggle host panels, but they cannot select a panel context through the anchored widget path. Calling the `panel-toggle` IPC command instead can select a context, but it loses the originating widget anchor, so panels configured to open near the click do not follow the plugin widget.

For example, a network plugin can now use:

```luau
noctalia.togglePanel("control-center", "network")
```

and open the network context near the clicked plugin widget.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `clang-format 22.1.8 --dry-run -Werror` on all changed C++ files
- `meson compile -C build-patched noctalia`
- `meson test -C build-patched plugin_manifest --print-errorlogs`

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A — this changes plugin API plumbing and does not alter visuals by itself.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The existing one-argument form remains unchanged. Script services without a widget anchor also receive the optional context through the application-level fallback.
