### PR TITLE
docs(packaging): add a mainenance policy

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -45,6 +45,13 @@ check, but it only covers repositories it indexes (and may still list v4 as
 | Desktop entry | `dev.noctalia.Noctalia.desktop` |
 | Icon | `noctalia` (`share/icons/hicolor/scalable/apps/noctalia.svg`) |
 
+## Maintenance Policy
+
+Releases strive to follow [semantic versioning](https://semver.org).
+The latest version is the only actively maintained version.
+No attempts are made to achieve overlapping lifecycles of major or minor versions.
+Bug reports are required to be reproducible on the latest version.
+
 ## Architectures / libc
 
 First-class targets:


### PR DESCRIPTION
## Summary

Add a mainenance policy.

## Motivation

From the packager perspective, it's useful to have a maintenance policy to communicate intentions around versions and lifecycle.  Based on conversations in discord, I believe this is an accurate representation of the policy in practice.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.