### PR TITLE
fix(taskbar): preserve compositor ID workspace matches (#3614)

### DIFF
--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1952,6 +1952,9 @@ void TaskbarWidget::updateModels() {
       };
 
       for (auto& task : nextTasks) {
+        if (!task.workspaceKey.empty()) {
+          continue;
+        }
         const auto previous = previousWorkspaceWindowByHandle.find(task.handleKey);
         if (previous == previousWorkspaceWindowByHandle.end()) {
           continue;


### PR DESCRIPTION
Follow up to #3614

Workspace assignment first binds tasks using current or focused compositor window IDs. The previous-frame fallback could then revisit those tasks and overwrite the authoritative match, putting the active task back in the wrong workspace.

Only reuse a previous window ID for tasks that remain unassigned.
