### PR TITLE
fix(launcher): reduce opening and search latency

### DIFF
--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -680,7 +680,7 @@ private:
 };
 
 LauncherPanel::LauncherPanel(ConfigService* config, AsyncTextureCache* asyncTextures)
-    : m_config(config), m_asyncTextures(asyncTextures) {
+    : m_iconResolver(true), m_config(config), m_asyncTextures(asyncTextures) {
   syncUsageTrackingState();
 }
 

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -423,7 +423,9 @@ namespace {
 
 } // namespace
 
-IconResolver::IconResolver() { rebuild(); }
+IconResolver::IconResolver(bool cacheMissing) : m_cacheMissing(cacheMissing) { rebuild(); }
+
+IconResolver::IconResolver() : IconResolver(false) {}
 
 bool IconResolver::checkThemeChanged() {
   auto& state = iconThemeState();
@@ -478,7 +480,7 @@ const std::string& IconResolver::resolve(const std::string& iconName, int target
     return it->second;
   }
   auto icon = findIcon(iconName, targetSize);
-  if (icon.empty()) {
+  if (icon.empty() && !m_cacheMissing) {
     return m_empty;
   }
   auto [ins, _] = m_cache.emplace(key, icon);

--- a/src/system/icon_resolver.h
+++ b/src/system/icon_resolver.h
@@ -16,6 +16,7 @@ struct IconSearchDir {
 class IconResolver {
 public:
   IconResolver();
+  IconResolver(bool cacheMissing);
 
   // targetSize is the intended on-screen pixel size. When > 0, a vector (SVG)
   // icon is preferred and, among bitmaps, the smallest theme size that is still
@@ -38,4 +39,5 @@ private:
   std::vector<std::string> m_pixmapDirs;   // XDG pixmap fallback roots
   std::string m_empty;
   std::uint64_t m_generation = 0;
+  bool m_cacheMissing;
 };


### PR DESCRIPTION
## Summary

Caches missing icons when doing icon lookups for the launcher

## Motivation

Currently, every time the launcher builds the result list, it tries to find missing icons, because `IconResolver` only caches successful lookups. As a result, the launcher panel to take noticeable amount of time to open, which is annoying, and there is significant input lag when typing a query.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

I have measured the opening speed with log statements in the beginning and the end of `LauncherPanel::onOpen`. On my system with 8 missing icons the launch took ~130ms before the changes and ~2ms after. Search latency also noticeably improved

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Not sure if it's safe to cache misses for all modules, so I added a field controlling this behavior to `IconResolver`