### PR TITLE
fix(launcher): invalidate cached icon misses on changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1243,6 +1243,19 @@ desktop_entry_launch_test = executable('desktop_entry_launch_test',
 
 test('desktop_entry_launch', desktop_entry_launch_test)
 
+icon_resolver_test = executable('icon_resolver_test',
+  sources: files(
+    'tests/icon_resolver_test.cpp',
+    'src/system/icon_resolver.cpp',
+  ),
+  dependencies: [
+    gio_dep,
+  ],
+  include_directories: _noctalia_inc,
+)
+
+test('icon_resolver', icon_resolver_test)
+
 string_utils_test = executable('string_utils_test',
   sources: files(
     'tests/string_utils_test.cpp',

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1218,6 +1218,12 @@ bool LauncherPanel::handleGlobalKey(std::uint32_t sym, std::uint32_t modifiers, 
 }
 
 void LauncherPanel::onInputChanged(const std::string& text) {
+  const auto desktopVersion = desktopEntriesVersion();
+  if (desktopVersion != m_desktopEntriesVersion) {
+    m_iconResolver.invalidateMissingCache();
+    m_desktopEntriesVersion = desktopVersion;
+  }
+
   m_query = text;
   m_allResults.clear();
 

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -134,6 +134,7 @@ private:
   bool m_launcherAppGrid = false;
   bool m_usingAppGrid = false;
   float m_launcherRowHeight = 0.0f;
+  std::uint64_t m_desktopEntriesVersion = 0;
   ConfigService* m_config = nullptr;
   AsyncTextureCache* m_asyncTextures = nullptr;
   std::unique_ptr<ContextMenuPopup> m_actionsMenu;

--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -142,20 +142,23 @@ namespace {
   std::string signatureFor(const IconThemePlan& plan) {
     std::string signature = plan.activeTheme;
     signature += '\n';
-    for (const auto& root : plan.baseDirs) {
-      signature += "root:";
-      signature += root;
+    auto appendPath = [&](std::string_view kind, const std::string& path) {
+      signature += kind;
+      signature += path;
+      signature += ':';
+      std::error_code ec;
+      const auto modified = fs::last_write_time(path, ec);
+      signature += ec ? "missing" : std::to_string(modified.time_since_epoch().count());
       signature += '\n';
+    };
+    for (const auto& root : plan.baseDirs) {
+      appendPath("root:", root);
     }
     for (const auto& dir : plan.searchDirs) {
-      signature += "theme:";
-      signature += dir.path;
-      signature += '\n';
+      appendPath("theme:", dir.path);
     }
     for (const auto& dir : plan.pixmapDirs) {
-      signature += "pixmap:";
-      signature += dir;
-      signature += '\n';
+      appendPath("pixmap:", dir);
     }
     return signature;
   }
@@ -460,6 +463,7 @@ void IconResolver::rebuild() {
   m_searchDirs = state.plan.searchDirs;
   m_pixmapDirs = state.plan.pixmapDirs;
   m_cache.clear();
+  m_missingCache.clear();
   m_generation = state.generation;
 }
 
@@ -479,13 +483,22 @@ const std::string& IconResolver::resolve(const std::string& iconName, int target
   if (it != m_cache.end()) {
     return it->second;
   }
+  const bool canCacheMissing = m_cacheMissing && iconName.front() != '/';
+  if (canCacheMissing && m_missingCache.contains(key)) {
+    return m_empty;
+  }
   auto icon = findIcon(iconName, targetSize);
-  if (icon.empty() && !m_cacheMissing) {
+  if (icon.empty()) {
+    if (canCacheMissing) {
+      m_missingCache.emplace(key);
+    }
     return m_empty;
   }
   auto [ins, _] = m_cache.emplace(key, icon);
   return ins->second;
 }
+
+void IconResolver::invalidateMissingCache() { m_missingCache.clear(); }
 
 std::string IconResolver::findIcon(const std::string& name, int targetSize) const {
   // Absolute path — use directly

--- a/src/system/icon_resolver.h
+++ b/src/system/icon_resolver.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // One concrete icon-theme directory to search, with the metadata needed for
@@ -16,7 +17,7 @@ struct IconSearchDir {
 class IconResolver {
 public:
   IconResolver();
-  IconResolver(bool cacheMissing);
+  explicit IconResolver(bool cacheMissing);
 
   // targetSize is the intended on-screen pixel size. When > 0, a vector (SVG)
   // icon is preferred and, among bitmaps, the smallest theme size that is still
@@ -24,6 +25,7 @@ public:
   // gently instead of crushing a 1024px PNG. targetSize == 0 keeps the legacy
   // "prefer scalable, then largest" behavior for callers that have no size.
   const std::string& resolve(const std::string& iconName, int targetSize = 0);
+  void invalidateMissingCache();
 
   static bool checkThemeChanged();
   static std::uint64_t themeGeneration();
@@ -34,10 +36,11 @@ private:
   std::string findIcon(const std::string& name, int targetSize) const;
 
   std::unordered_map<std::string, std::string> m_cache;
+  std::unordered_set<std::string> m_missingCache;
   std::vector<std::string> m_baseDirs;     // XDG icon theme roots
   std::vector<IconSearchDir> m_searchDirs; // Ordered list of concrete theme dirs to search
   std::vector<std::string> m_pixmapDirs;   // XDG pixmap fallback roots
   std::string m_empty;
   std::uint64_t m_generation = 0;
-  bool m_cacheMissing;
+  bool m_cacheMissing = false;
 };

--- a/tests/icon_resolver_test.cpp
+++ b/tests/icon_resolver_test.cpp
@@ -1,0 +1,74 @@
+#include "system/icon_resolver.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <print>
+#include <string>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "icon_resolver_test: {}", message);
+    }
+    return condition;
+  }
+
+} // namespace
+
+int main() {
+  char tempDir[] = "/tmp/noctalia-icon-resolver-test-XXXXXX";
+  if (mkdtemp(tempDir) == nullptr) {
+    std::perror("mkdtemp");
+    return 1;
+  }
+
+  const fs::path root(tempDir);
+  const fs::path iconDir = root / "icons/hicolor/scalable/apps";
+  fs::create_directories(iconDir);
+  setenv("HOME", tempDir, 1);
+  setenv("XDG_DATA_HOME", tempDir, 1);
+  setenv("XDG_DATA_DIRS", tempDir, 1);
+
+  bool ok = true;
+  IconResolver resolver(true);
+
+  const fs::path invalidatedIcon = iconDir / "invalidated-icon.svg";
+  ok = expect(resolver.resolve("invalidated-icon", 32).empty(), "initial missing icon should not resolve") && ok;
+  std::ofstream(invalidatedIcon) << "<svg/>";
+  ok = expect(resolver.resolve("invalidated-icon", 32).empty(), "named icon miss should be cached") && ok;
+  resolver.invalidateMissingCache();
+  ok = expect(
+           resolver.resolve("invalidated-icon", 32) == invalidatedIcon.string(),
+           "invalidating misses should discover a newly created icon"
+       )
+      && ok;
+
+  const fs::path polledIcon = iconDir / "polled-icon.svg";
+  ok = expect(resolver.resolve("polled-icon", 32).empty(), "second initial icon miss should be cached") && ok;
+  std::ofstream(polledIcon) << "<svg/>";
+  ok = expect(IconResolver::checkThemeChanged(), "theme poll should detect icon directory changes") && ok;
+  ok = expect(
+           resolver.resolve("polled-icon", 32) == polledIcon.string(),
+           "theme generation change should invalidate cached misses"
+       )
+      && ok;
+
+  const fs::path absoluteIcon = root / "absolute-icon.svg";
+  ok = expect(resolver.resolve(absoluteIcon.string(), 32).empty(), "missing absolute icon should not resolve") && ok;
+  std::ofstream(absoluteIcon) << "<svg/>";
+  ok = expect(
+           resolver.resolve(absoluteIcon.string(), 32) == absoluteIcon.string(),
+           "absolute icon misses should not be cached"
+       )
+      && ok;
+
+  std::error_code ec;
+  fs::remove_all(root, ec);
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Follow-up to #3621. Preserves negative icon caching while invalidating misses when desktop entries or icon directories change.