### PR TITLE
fix(calendar): retain CalDAV password during discovery

### DIFF
--- a/src/calendar/calendar_service.cpp
+++ b/src/calendar/calendar_service.cpp
@@ -419,8 +419,8 @@ void CalendarService::fetchCalDav(const CalendarConfig::Account& account) {
 
         calendar::discoverCalDavCollections(
             m_httpClient, serverUrl, username, password, allowRedirectAuth,
-            [this, accountId, username, password = std::move(password), accountColor, selectedCalendars,
-             allowRedirectAuth, now](bool discovered, std::vector<calendar::CalDavCollection> collections) {
+            [this, accountId, username, password, accountColor, selectedCalendars, allowRedirectAuth,
+             now](bool discovered, std::vector<calendar::CalDavCollection> collections) {
               if (!discovered) {
                 accountDone(accountId, false, {});
                 return;


### PR DESCRIPTION
## Summary

Preserve the CalDAV password while starting collection discovery.

The password is now copied into the completion callback instead of move-captured in the same function call that passes it to `discoverCalDavCollections()`.

## Motivation

C++ argument evaluation order allowed the callback capture to move the password before it was passed to discovery. Discovery then received an empty credential and logged:

`missing server_url/username/password`

This occurred even when the CalDAV password was present in the keyring.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `just format`
- `just build`
- `just lint`
- `just test debug calendar_credential_store calendar_discovery_state --print-errorlogs`
  - 2/2 passed
- `just test debug --print-errorlogs`
  - 52/53 passed
  - The unrelated `process` test fails with `completion-only async command stdout was wrong`
  - All calendar tests passed

## Manual Coverage

Not manually tested.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable. No UI changes.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

No configuration, credential-storage, or keyring migration changes.
