### PR TITLE
widgets/workspaces: Fix hover animation crash on teardown

### DIFF
--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -1210,7 +1210,12 @@ float WorkspacesWidget::workspaceMainAxisMinWidth(float baseSize, bool active) c
   return baseSize * (active ? m_activePillSize : m_inactivePillSize);
 }
 
-WorkspacesWidget::~WorkspacesWidget() { cancelAnimation(); }
+WorkspacesWidget::~WorkspacesWidget() {
+  cancelAnimation();
+  if (m_animations != nullptr) {
+    m_animations->cancelForOwner(&m_hoverProgress);
+  }
+}
 
 std::string WorkspacesWidget::activeWindowAppId() const {
   const auto active = m_platform.activeToplevel();


### PR DESCRIPTION
Cancel the separately owned hover animation before destroying the workspace widget, preventing its callback from accessing freed widget and scene-node state during bar config reloads.