### PR TITLE
hyprland: fix out-of-sync workspace state

### DIFF
--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -397,8 +397,12 @@ bool HyprlandWorkspaceBackend::refreshWorkspaces() {
     return before != after;
   }();
 
+  if (!changed) {
+    return false;
+  }
+
   m_workspaces = std::move(next);
-  return changed;
+  return true;
 }
 
 void HyprlandWorkspaceBackend::refreshMonitors() {


### PR DESCRIPTION
Avoid replacing workspace state when the structural snapshot is unchanged. This prevents active, occupied, and urgent flags from being cleared before the reconciliation path exits early.

