### PR TITLE
feat(launcher): pin/unpin apps to taskbar widgets, not just dock

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -627,7 +627,9 @@
     "context-menu": {
       "open": "Open",
       "pin-to-dock": "Pin to dock",
-      "unpin-from-dock": "Unpin from dock"
+      "unpin-from-dock": "Unpin from dock",
+      "pin-to-taskbar": "Pin to taskbar",
+      "unpin-from-taskbar": "Unpin from taskbar"
     },
     "empty": {
       "no-results": "No results found",

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1611,10 +1611,36 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
       m_config != nullptr && shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, *match);
   const bool canPinToDock = m_config != nullptr && !dockPinned;
   const bool canUnpinFromDock = m_config != nullptr && dockPinned;
-
+  // Taskbar widgets keep their own `pinned` list under `[widget.<name>]` (see
+  // TaskbarWidget::pinnedConfigIds), separate from `[dock].pinned`. Mirror pin state across every
+  // configured taskbar widget so "Pin" here matches what right-clicking an icon in the taskbar does.
+  std::vector<std::string> taskbarWidgetNames;
+  if (m_config != nullptr) {
+    for (const auto& [name, widgetConfig] : m_config->config().widgets) {
+      if (widgetConfig.type == "taskbar") {
+        taskbarWidgetNames.push_back(name);
+      }
+    }
+  }
+  const bool hasTaskbarWidget = !taskbarWidgetNames.empty();
+  bool taskbarPinned = false;
+  if (hasTaskbarWidget) {
+    const auto& widgets = m_config->config().widgets;
+    for (const auto& name : taskbarWidgetNames) {
+      const auto it = widgets.find(name);
+      if (it != widgets.end() && shell::dock::pinned_apps::containsEntry(it->second.getStringList("pinned"), *match)) {
+        taskbarPinned = true;
+        break;
+      }
+    }
+  }
+  const bool canPinToTaskbar = hasTaskbarWidget && !taskbarPinned;
+  const bool canUnpinFromTaskbar = hasTaskbarWidget && taskbarPinned;
   constexpr std::int32_t kActionOpen = -1;
   constexpr std::int32_t kActionPinToDock = -2;
   constexpr std::int32_t kActionUnpinFromDock = -3;
+  constexpr std::int32_t kActionPinToTaskbar = -4;
+  constexpr std::int32_t kActionUnpinFromTaskbar = -5;
 
   std::vector<ContextMenuControlEntry> entries;
   entries.reserve(actionsCopy.size() + 2);
@@ -1648,6 +1674,27 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
         }
     );
   }
+  if (canPinToTaskbar) {
+    entries.push_back(
+        ContextMenuControlEntry{
+            .id = kActionPinToTaskbar,
+            .label = i18n::tr("launcher.context-menu.pin-to-taskbar"),
+            .enabled = true,
+            .separator = false,
+            .hasSubmenu = false,
+        }
+    );
+  } else if (canUnpinFromTaskbar) {
+    entries.push_back(
+        ContextMenuControlEntry{
+            .id = kActionUnpinFromTaskbar,
+            .label = i18n::tr("launcher.context-menu.unpin-from-taskbar"),
+            .enabled = true,
+            .separator = false,
+            .hasSubmenu = false,
+        }
+    );
+  }
   for (std::int32_t i = 0; i < static_cast<std::int32_t>(actionsCopy.size()); ++i) {
     entries.push_back(
         ContextMenuControlEntry{
@@ -1675,8 +1722,9 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     PanelManager::instance().endAttachedPopup(parentSurface);
   });
 
-  m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
-                                entryForPin = *match](const ContextMenuControlEntry& entry) {
+  m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy), entryForPin = *match,
+                                taskbarWidgetNames =
+                                    std::move(taskbarWidgetNames)](const ContextMenuControlEntry& entry) {
     LauncherResult result = base;
     result.desktopActionId.clear();
     if (entry.id == kActionPinToDock) {
@@ -1697,6 +1745,39 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
       std::vector<std::string> pinned = m_config->config().dock.pinned;
       shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
       (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
+      return;
+    }
+    if (entry.id == kActionPinToTaskbar) {
+      if (m_config == nullptr || entryForPin.id.empty()) {
+        return;
+      }
+      const auto& widgets = m_config->config().widgets;
+      for (const auto& name : taskbarWidgetNames) {
+        const auto it = widgets.find(name);
+        std::vector<std::string> pinned =
+            it != widgets.end() ? it->second.getStringList("pinned") : std::vector<std::string>{};
+        if (shell::dock::pinned_apps::containsEntry(pinned, entryForPin)) {
+          continue;
+        }
+        pinned.push_back(entryForPin.id);
+        (void)m_config->setOverride({"widget", name, "pinned"}, std::move(pinned));
+      }
+      return;
+    }
+    if (entry.id == kActionUnpinFromTaskbar) {
+      if (m_config == nullptr) {
+        return;
+      }
+      const auto& widgets = m_config->config().widgets;
+      for (const auto& name : taskbarWidgetNames) {
+        const auto it = widgets.find(name);
+        if (it == widgets.end()) {
+          continue;
+        }
+        std::vector<std::string> pinned = it->second.getStringList("pinned");
+        shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
+        (void)m_config->setOverride({"widget", name, "pinned"}, std::move(pinned));
+      }
       return;
     }
     if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {


### PR DESCRIPTION
Disclosure

This investigation and the attached patch was put together with Claude Code's help. I'm not
an experienced programmer. I have read through the relevant source and tested the patch myself (built it locally, swapped it into my live session, confirmed pin/unpin round-trips correctly), but the code should
be reviewed since it was written by AI's help. Sharing it as a starting point/confirmation of fix, not finished in any means.

## Summary

The Application Launcher's right-click "Pin"/"Unpin" only ever wrote to `dock.pinned`, even when no
dock is configured. Just a `taskbar` bar widget. Apps pinned from the launcher went to a list
nothing displays. This adds independent **"Pin to taskbar" / "Unpin from taskbar"** entries to the
launcher's context menu (alongside the existing dock ones, not replacing them) that write through
the same `{"widget", <name>, "pinned"}` override path `TaskbarWidget::setEntryPinned` already uses
for its own right-click pin, so pin state stays in sync between the launcher and the taskbar strip.

## Motivation

Half of the taskbar-pinning story (issue #3584) was already fixed by #3130; right-clicking an icon
directly in the taskbar strip works fine. But the Application Launcher's own pin action was never
updated to look at taskbar widgets at all; it's hardcoded to `ConfigService::config().dock.pinned`.
From a user's perspective (no dock enabled, just a taskbar), pinning from the launcher silently does
nothing.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Related to #3584 (this covers the pin/unpin half of that issue; drag-to-reorder is not addressed
here).

## Testing

- `python3 tools/i18n-check.py`: passes (830 tr keys, 7 trp base keys, all present in catalog).
- `just format`: clean, no additional diff after running.
- `meson setup build-release --buildtype=release -Db_lto=true -Dcpp_std=c++23 --prefix=/usr/local &&
  meson compile -C build-release`: builds with zero warnings.
- `meson test -C build-release` (with `-Dtests=enabled`): all 55 existing unit tests pass, including
  `dock_pinned_apps` (the helper this patch reuses).
- No automated test covers `LauncherPanel::openAppActionsMenu` directly, so this was also verified
  manually end-to-end (see Manual Coverage).

## Manual Coverage

- [x] Tested on Hyprland
- [ ] Tested on another compositor:
- [ ] Tested on Niri
- [ ] Tested on Sway
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Manual round-trip tested: pin from the Application Launcher → app appears in the taskbar strip
immediately → `widget.taskbar.pinned` updates in `settings.toml` → right-clicking the now-pinned
icon in the taskbar correctly shows "Unpin" → unpinning from either surface removes it cleanly and
stays in sync.

Only tested single-monitor / single bar with one `taskbar` widget. Multi-bar setups with more than
one taskbar widget should work per the code (it loops over every configured `taskbar`-type widget),
but I haven't verified that myself.

## Screenshots / Videos

---

<img width="653" height="585" alt="image" src="https://github.com/user-attachments/assets/66bf8ec0-6a2b-43fc-a582-b93ef46973ea" />

---

<img width="210" height="32" alt="Image" src="https://github.com/user-attachments/assets/5f8fb5ae-735d-48b5-946d-ad667f55f83f" />

---

<img width="543" height="94" alt="Image" src="https://github.com/user-attachments/assets/cab69f25-63d4-4f38-a7df-31c2a78b5d21" />

---

<img width="183" height="36" alt="Image" src="https://github.com/user-attachments/assets/d84a3c31-1901-4b72-a126-2b0fade783fc" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing
      configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation
      tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This doesn't touch drag-to-reorder, which #3584 also asks for. The dock already has that
(`dock_instance.h` `DragState`, `dock.cpp` `beginDrag`/`updateDrag`/`endDrag`) but the taskbar strip
doesn't yet. Happy to look into porting that too if it'd help, but wanted to keep this PR scoped to
the part I could verify working end-to-end.

No end-user documentation exists for the launcher's pin context menu today (checked `README.md`,
`CONTRIBUTING.md`, and elsewhere in this repo), and this doesn't add a new config key. Just a new
UI entry point onto the existing `[widget.<name>].pinned` field the taskbar already reads/writes. So there was nothing in-repo to update.