### PR TITLE
Add two new border options and fix the border toggles for media and weather cards

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1513,6 +1513,14 @@
           "description": "Draw outlines around buttons throughout the shell",
           "label": "Button Borders"
         },
+        "hover-borders": {
+          "description": "Draw accent outlines when hovering over interactive elements",
+          "label": "Hover Borders"
+        },
+        "profile-borders": {
+          "description": "Draw outlines around the user profile picture in the control center",
+          "label": "Profile Borders"
+        },
         "community-palette": {
           "description": "Choose a palette from the community catalog",
           "label": "Community Palette",

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -401,6 +401,8 @@ void Application::initStyleThemeAndWayland() {
     Style::setButtonBordersEnabled(m_configService.config().shell.buttonBorders);
     Style::setInputBordersEnabled(m_configService.config().shell.inputBorders);
     Style::setPopupBordersEnabled(m_configService.config().shell.popupBorders);
+    Style::setProfileBordersEnabled(m_configService.config().shell.profileBorders);
+    Style::setHoverBordersEnabled(m_configService.config().shell.hoverBorders);
     Style::setPopupShadowsEnabled(m_configService.config().shell.popupShadows);
     lastCornerRadiusScale = corner;
     if (cornerChanged) {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -983,6 +983,8 @@ struct ShellConfig {
   bool buttonBorders = true;
   bool inputBorders = true;
   bool popupBorders = true;
+  bool profileBorders = true;
+  bool hoverBorders = true;
   bool popupShadows = true;
   std::string fontFamily = "sans-serif";
   std::string lang; // empty = auto-detect from $LC_ALL/$LC_MESSAGES/$LANG

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1432,6 +1432,8 @@ namespace noctalia::config::schema {
         field(&ShellConfig::buttonBorders, "button_borders"),
         field(&ShellConfig::inputBorders, "input_borders"),
         field(&ShellConfig::popupBorders, "popup_borders"),
+        field(&ShellConfig::profileBorders, "profile_borders"),
+        field(&ShellConfig::hoverBorders, "hover_borders"),
         field(&ShellConfig::popupShadows, "popup_shadows"),
         // font_family is trimmed; empty falls back to sans-serif.
         custom<ShellConfig>(

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -131,25 +131,16 @@ namespace {
     button.setEnabled(enabled);
   }
 
-  // The whole home cards are clickable; on hover swap the card outline to the hover colour. No fill
-  // change — the user card's fill sits behind the wallpaper, so a thin hover border is the one hover
-  // signal that reads consistently across all three cards.
-  void applyHomeCardHover(Flex& card, bool hovered, bool baseBorders) {
-    if (hovered) {
-      card.setBorder(colorSpecFromRole(ColorRole::Hover), Style::borderWidth);
-    } else if (baseBorders) {
-      card.setBorder(colorSpecFromRole(ColorRole::Outline), Style::borderWidth);
-    } else {
-      card.clearBorder();
-    }
-  }
-
   void applyAvatarChrome(Image* avatar, bool highlighted) {
     if (avatar == nullptr) {
       return;
     }
+    if (!Style::profileBordersEnabled()) {
+      avatar->setBorder(clearColorSpec(), 0.0f);
+      return;
+    }
     const float borderWidth = Style::borderWidth * 3.0f;
-    if (highlighted) {
+    if (highlighted && Style::hoverBordersEnabled()) {
       avatar->setBorder(colorSpecFromRole(ColorRole::Hover), borderWidth);
       return;
     }
@@ -163,6 +154,9 @@ HomeTab::HomeTab(const ControlCenterServices& services)
       m_config(services.config), m_accounts(services.accounts), m_wallpaper(services.wallpaper),
       m_thumbnails(services.thumbnails), m_asyncTextures(services.asyncTextures),
       m_services(services.shortcutServices()) {
+  m_buttonBordersConn = Style::buttonBordersChanged().connect([this] { syncBorders(); });
+  m_profileBordersConn = Style::profileBordersChanged().connect([this] { syncBorders(); });
+  m_hoverBordersConn = Style::hoverBordersChanged().connect([this] { syncBorders(); });
   if (m_thumbnails != nullptr) {
     m_thumbnailPendingSub = m_thumbnails->subscribePendingUpload([this]() {
       if (m_wallpaperBg == nullptr) {
@@ -209,13 +203,13 @@ std::unique_ptr<Flex> HomeTab::create() {
       .justify = FlexJustify::Center,
       .fillHeight = true,
       .flexGrow = 1.0f,
-      .configure = [scale, opacity = panelCardOpacity(), borders = panelBordersEnabled()](Flex& card) {
-        applyHomeCardStyle(card, scale, opacity, borders);
+      .configure = [scale, opacity = panelCardOpacity()](Flex& card) {
+        applyHomeCardStyle(card, scale, opacity, Style::buttonBordersEnabled());
       },
   });
 
   {
-    const float wallpaperRadius = std::max(0.0f, Style::scaledRadiusXl(scale) - Style::borderWidth);
+    const float wallpaperRadius = Style::scaledRadiusXl(scale);
     userCard->addChild(
         ui::image({
             .out = &m_wallpaperPlaceholder,
@@ -244,6 +238,19 @@ std::unique_ptr<Flex> HomeTab::create() {
             .out = &m_wallpaperGradient,
             .participatesInLayout = false,
             .configure = [](Box& box) { box.setZIndex(-1); },
+        })
+    );
+
+    userCard->addChild(
+        ui::box({
+            .out = &m_userCardBorder,
+            .participatesInLayout = false,
+            .configure = [](Box& box) {
+              box.setZIndex(10);
+              box.setHitTestVisible(false);
+              box.setFill(clearColorSpec());
+              box.clearBorder();
+            },
         })
     );
   }
@@ -301,7 +308,7 @@ std::unique_ptr<Flex> HomeTab::create() {
           .width = avatarSize,
           .height = avatarSize,
           .configure = [](Image& image) {
-            image.setBorder(colorSpecFromRole(ColorRole::Primary), Style::borderWidth * 3.0f);
+            applyAvatarChrome(&image, false);
             image.setHitTestVisible(false);
             image.setAsyncReadyCallback([]() { PanelManager::instance().refresh(); });
           },
@@ -395,8 +402,8 @@ std::unique_ptr<Flex> HomeTab::create() {
       .fillWidth = true,
       .fillHeight = true,
       .flexGrow = kHomeMediaCardFlexGrow,
-      .configure = [scale, opacity = panelCardOpacity(), borders = panelBordersEnabled()](Flex& card) {
-        applyHomeCardStyle(card, scale, opacity, borders);
+      .configure = [scale, opacity = panelCardOpacity()](Flex& card) {
+        applyHomeCardStyle(card, scale, opacity, Style::buttonBordersEnabled());
       },
   });
 
@@ -469,8 +476,8 @@ std::unique_ptr<Flex> HomeTab::create() {
        .fillHeight = true,
        .flexGrow = kHomeDateTimeCardFlexGrow,
        .configure =
-           [scale, opacity = panelCardOpacity(), borders = panelBordersEnabled()](Flex& card) {
-             applyHomeCardStyle(card, scale, opacity, borders);
+           [scale, opacity = panelCardOpacity()](Flex& card) {
+             applyHomeCardStyle(card, scale, opacity, Style::buttonBordersEnabled());
              card.setDirection(FlexDirection::Horizontal);
              card.setAlign(FlexAlign::Center);
              card.setJustify(FlexJustify::Center);
@@ -617,6 +624,7 @@ std::unique_ptr<Flex> HomeTab::create() {
   }
   tab->addChild(std::move(bottomRow));
 
+  syncBorders();
   return tab;
 }
 
@@ -869,12 +877,11 @@ InputArea* HomeTab::addCardOverlay(Flex& card, std::function<void()> onActivate,
   }
 
   Flex* cardPtr = &card;
-  const bool borders = panelBordersEnabled();
   InputArea* areaPtr = area.get();
   std::function<void()> activate = std::move(onActivate);
 
-  const auto setHovered = [cardPtr, borders](bool hovered) {
-    applyHomeCardHover(*cardPtr, hovered, borders);
+  const auto setHovered = [cardPtr, this](bool hovered) {
+    applyHomeCardHover(*cardPtr, hovered, Style::buttonBordersEnabled());
     PanelManager::instance().requestRedraw();
   };
 
@@ -962,19 +969,22 @@ void HomeTab::layoutWallpaperBackground(Renderer& renderer) {
     return;
   }
 
-  const float bw = Style::borderWidth;
-  const float cw = std::max(0.0f, m_userCard->width() - bw * 2.0f);
-  const float ch = std::max(0.0f, m_userCard->height() - bw * 2.0f);
-  m_wallpaperBg->setPosition(bw, bw);
+  const float cw = std::max(0.0f, m_userCard->width());
+  const float ch = std::max(0.0f, m_userCard->height());
+  const float radius = Style::scaledRadiusXl(contentScale());
+
+  m_wallpaperBg->setPosition(0.0f, 0.0f);
   m_wallpaperBg->setSize(cw, ch);
+  m_wallpaperBg->setRadius(radius);
+
   if (m_wallpaperPlaceholder != nullptr) {
-    m_wallpaperPlaceholder->setPosition(bw, bw);
+    m_wallpaperPlaceholder->setPosition(0.0f, 0.0f);
     m_wallpaperPlaceholder->setSize(cw, ch);
+    m_wallpaperPlaceholder->setRadius(radius);
   }
 
   if (m_wallpaperGradient != nullptr) {
-    const float radius = std::max(0.0f, Style::scaledRadiusXl(contentScale()) - bw);
-    m_wallpaperGradient->setPosition(bw, bw);
+    m_wallpaperGradient->setPosition(0.0f, 0.0f);
     m_wallpaperGradient->setFrameSize(cw, ch);
     const Color surface = colorForRole(ColorRole::Surface);
     const Color translucentSurface = rgba(surface.r, surface.g, surface.b, surface.a * 0.9f);
@@ -990,6 +1000,12 @@ void HomeTab::layoutWallpaperBackground(Renderer& renderer) {
             .radius = radius,
         }
     );
+  }
+
+  if (m_userCardBorder != nullptr) {
+    m_userCardBorder->setPosition(0.0f, 0.0f);
+    m_userCardBorder->setFrameSize(cw, ch);
+    m_userCardBorder->setRadius(radius);
   }
 
   syncWallpaperBackground(renderer);
@@ -1514,6 +1530,55 @@ void HomeTab::syncShortcuts() {
       if (pad.label->text() != label) {
         pad.button->setText(label);
       }
+    }
+  }
+}
+
+void HomeTab::syncBorders() {
+  const bool buttonBorders = Style::buttonBordersEnabled();
+
+  if (m_userCard != nullptr) {
+    const bool isUserCardHovered = (m_userCardArea != nullptr && m_userCardArea->hovered())
+        || (m_userCardKeyboardArea != nullptr && m_userCardKeyboardArea->hovered());
+    applyHomeCardHover(*m_userCard, isUserCardHovered, buttonBorders);
+  }
+  if (m_mediaCard != nullptr) {
+    const bool isMediaHovered = m_mediaCardArea != nullptr && m_mediaCardArea->hovered();
+    applyHomeCardHover(*m_mediaCard, isMediaHovered, buttonBorders);
+  }
+  if (m_dateTimeCard != nullptr) {
+    const bool isDateTimeHovered = m_dateTimeCardArea != nullptr && m_dateTimeCardArea->hovered();
+    applyHomeCardHover(*m_dateTimeCard, isDateTimeHovered, buttonBorders);
+  }
+  if (m_userAvatar != nullptr) {
+    const bool highlighted =
+        m_userAvatarArea != nullptr && (m_userAvatarArea->focused() || m_userAvatarArea->hovered());
+    applyAvatarChrome(m_userAvatar, highlighted);
+  }
+  PanelManager::instance().requestRedraw();
+}
+
+void HomeTab::applyHomeCardHover(Flex& card, bool hovered, bool baseBorders) {
+  const ColorSpec hoverColor = colorSpecFromRole(ColorRole::Hover);
+  const ColorSpec outlineColor = colorSpecFromRole(ColorRole::Outline);
+  const float bw = Style::borderWidth;
+
+  if (&card == m_userCard && m_userCardBorder != nullptr) {
+    card.clearBorder();
+    if (hovered && Style::hoverBordersEnabled()) {
+      m_userCardBorder->setBorder(hoverColor, bw);
+    } else if (baseBorders) {
+      m_userCardBorder->setBorder(outlineColor, bw);
+    } else {
+      m_userCardBorder->clearBorder();
+    }
+  } else {
+    if (hovered && Style::hoverBordersEnabled()) {
+      card.setBorder(hoverColor, bw);
+    } else if (baseBorders) {
+      card.setBorder(outlineColor, bw);
+    } else {
+      card.clearBorder();
     }
   }
 }

--- a/src/shell/control_center/tabs/home_tab.h
+++ b/src/shell/control_center/tabs/home_tab.h
@@ -73,6 +73,8 @@ private:
   void warnOnOversizedAvatarSource(const std::string& path);
   void syncScaledFonts();
   void syncShortcuts();
+  void syncBorders();
+  void applyHomeCardHover(Flex& card, bool hovered, bool baseBorders);
   bool resizeMediaArtToCard();
   void onPanelCardOpacityChanged(float opacity) override;
 
@@ -119,6 +121,7 @@ private:
   Image* m_wallpaperPlaceholder = nullptr;
   Image* m_wallpaperBg = nullptr;
   Box* m_wallpaperGradient = nullptr;
+  Box* m_userCardBorder = nullptr;
   std::string m_loadedWallpaperPath;
   int m_loadedWallpaperSize = 0;
   std::string m_crispWorkingPath;
@@ -128,6 +131,9 @@ private:
   std::uint32_t m_wallpaperCrispAnimId = 0;
   ThumbnailService::Subscription m_thumbnailPendingSub;
   Signal<>::ScopedConnection m_wallpaperChangedConn;
+  Signal<>::ScopedConnection m_buttonBordersConn;
+  Signal<>::ScopedConnection m_profileBordersConn;
+  Signal<>::ScopedConnection m_hoverBordersConn;
 
   Label* m_mediaTrack = nullptr;
   Label* m_mediaArtist = nullptr;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -574,6 +574,16 @@ namespace settings {
         ToggleSetting{cfg.shell.popupBorders}, "popup menu dropdown outline border flat minimal"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Appearance, "borders", tr("settings.schema.appearance.profile-borders.label"),
+        tr("settings.schema.appearance.profile-borders.description"), {"shell", "profile_borders"},
+        ToggleSetting{cfg.shell.profileBorders}, "profile user avatar outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::Appearance, "borders", tr("settings.schema.appearance.hover-borders.label"),
+        tr("settings.schema.appearance.hover-borders.description"), {"shell", "hover_borders"},
+        ToggleSetting{cfg.shell.hoverBorders}, "hover focus highlight outline border flat minimal"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Appearance, "effects", tr("settings.schema.shared.shadow-direction.label"),
         tr("settings.schema.appearance.global-shadow-direction.description"), {"shell", "shadow", "direction"},
         enumSelect(kShadowDirections, cfg.shell.shadow.direction), "shadow direction"

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -251,6 +251,7 @@ Button::Button() {
   });
   m_buttonBordersConn =
       Style::buttonBordersChanged().connect([this] { setBorder(m_targetBorder, effectiveBorderWidth()); });
+  m_hoverBordersConn = Style::hoverBordersChanged().connect([this] { applyVisualState(); });
 }
 
 Button::~Button() {
@@ -617,7 +618,9 @@ void Button::resolveVisualStateColors(Color& targetBg, Color& targetBorder, Colo
     targetLabel = resolveColorSpec(colorSpecFromRole(ColorRole::OnSecondary));
   } else if (isHovered || isSelected) {
     targetBg = resolveColorSpec(m_palette.hover.bg);
-    targetBorder = resolveColorSpec(m_palette.hover.border);
+    targetBorder = resolveColorSpec(
+        (isHovered && !Style::hoverBordersEnabled()) ? m_palette.normal.border : m_palette.hover.border
+    );
     targetLabel = resolveColorSpec(m_palette.hover.label);
   } else {
     targetBg = resolveColorSpec(m_palette.normal.bg);

--- a/src/ui/controls/button.h
+++ b/src/ui/controls/button.h
@@ -148,6 +148,7 @@ private:
   bool m_visualStateInitialized = false;
   Signal<>::ScopedConnection m_paletteConn;
   Signal<>::ScopedConnection m_buttonBordersConn;
+  Signal<>::ScopedConnection m_hoverBordersConn;
 };
 
 class Renderer;

--- a/src/ui/style.cpp
+++ b/src/ui/style.cpp
@@ -8,6 +8,8 @@ namespace {
   bool g_buttonBordersEnabled = true;
   bool g_inputBordersEnabled = true;
   bool g_popupBordersEnabled = true;
+  bool g_profileBordersEnabled = true;
+  bool g_hoverBordersEnabled = true;
   bool g_popupShadowsEnabled = true;
 
 } // namespace
@@ -50,6 +52,36 @@ namespace Style {
 
   bool popupBordersEnabled() noexcept { return g_popupBordersEnabled; }
   void setPopupBordersEnabled(bool enabled) { g_popupBordersEnabled = enabled; }
+
+  bool profileBordersEnabled() noexcept { return g_profileBordersEnabled; }
+
+  void setProfileBordersEnabled(bool enabled) {
+    if (g_profileBordersEnabled == enabled) {
+      return;
+    }
+    g_profileBordersEnabled = enabled;
+    profileBordersChanged().emit();
+  }
+
+  Signal<>& profileBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
+
+  bool hoverBordersEnabled() noexcept { return g_hoverBordersEnabled; }
+
+  void setHoverBordersEnabled(bool enabled) {
+    if (g_hoverBordersEnabled == enabled) {
+      return;
+    }
+    g_hoverBordersEnabled = enabled;
+    hoverBordersChanged().emit();
+  }
+
+  Signal<>& hoverBordersChanged() {
+    static Signal<> signal;
+    return signal;
+  }
 
   bool popupShadowsEnabled() noexcept { return g_popupShadowsEnabled; }
   void setPopupShadowsEnabled(bool enabled) { g_popupShadowsEnabled = enabled; }

--- a/src/ui/style.h
+++ b/src/ui/style.h
@@ -83,6 +83,14 @@ namespace Style {
   [[nodiscard]] bool popupBordersEnabled() noexcept;
   void setPopupBordersEnabled(bool enabled);
 
+  [[nodiscard]] bool profileBordersEnabled() noexcept;
+  void setProfileBordersEnabled(bool enabled);
+  Signal<>& profileBordersChanged();
+
+  [[nodiscard]] bool hoverBordersEnabled() noexcept;
+  void setHoverBordersEnabled(bool enabled);
+  Signal<>& hoverBordersChanged();
+
   [[nodiscard]] bool popupShadowsEnabled() noexcept;
   void setPopupShadowsEnabled(bool enabled);
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
In response to the support thread in discord titled "Border Setting is inconsistent", added two new border toggles: `Profile` and `Hover` borders. Also fix a minor border toggle flow issue for weather, media and profile cards in Control Center panel where it used to follow the panel border toggle setting

## Motivation

<!-- What problem does this solve? -->
According to the thread, there were a few parts which went unnoticed like hover borders and borders in the profile area. There was also a thin border in the profile card even after disabling all border options. Also as cited earlier, the media, weather and profile cards were following the panels border toggle. So I unified them under the `Button Borders` toggle and added two new border options: `Profile Borders` and `Hover Borders`. Now when disabling `Button Borders` it completely removes the border from the three cards which weren't affected earlier in the Control Center

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix (minor)
- [x] New feature

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just build` and `just test` to ensure zero compilation errors and that all tests are passed

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

### Before

https://github.com/user-attachments/assets/9a9125d0-9280-43bf-b01d-d5be7514123a

### After

https://github.com/user-attachments/assets/f278a680-375c-4ad0-b843-5f47e760e03b

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I'm not sure if this is the intended way, so I'm open to suggestions and improve the PR.
I would also like to suggest to improve the spacing inside the control center panel to have equal spacing between the cards and elements alike. they simply feel off