### PR TITLE
fix(bar): truncate vertical keyboard layout label by code points

### DIFF
--- a/src/shell/bar/widgets/keyboard_layout_widget.cpp
+++ b/src/shell/bar/widgets/keyboard_layout_widget.cpp
@@ -476,8 +476,8 @@ void KeyboardLayoutWidget::sync(Renderer& renderer) {
     m_refreshTimer.stop();
   }
   std::string layoutLabel = resolveLayoutLabel(layoutName, m_displayMode, m_customLabels);
-  if (m_isVertical && layoutLabel.size() > 3) {
-    layoutLabel = layoutLabel.substr(0, 3);
+  if (m_isVertical) {
+    layoutLabel = StringUtils::truncateUtf8CodePoints(layoutLabel, 3);
   }
 
   if (layoutName == m_lastLayoutName && layoutLabel == m_lastLabel && m_isVertical == m_lastVertical) {


### PR DESCRIPTION
## Summary
Fix for a keyboard layout widget breaking on emoji icons.
Panel should be set to align to right side.
When you try to set flag emoji as label for keyboard layout widget - it displays 3 question marks.
<img width="377" height="119" alt="fixed" src="https://github.com/user-attachments/assets/5c9c4c5e-b640-49b2-8de0-ba6ef4dc9622" />
Fixed version
<img width="451" height="176" alt="fixed" src="https://github.com/user-attachments/assets/33c413b3-75ac-4f7a-ac60-301bdefd047c" />
So fixed version works for one emoji or for text labels.
Emoji flags were taken from https://emojipedia.org/flags


## Motivation
Motivation was getting widget fixed


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging


## Testing
Run these commands
```
just format
just lint
just test
```

## Manual Coverage
- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes