### PR TITLE
feat(notification): auto-clear notification history

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1141,6 +1141,7 @@
         "general": "General",
         "greeter": "Greeter",
         "grouping": "Grouping",
+        "history": "History",
         "home": "Home",
         "hot-corners": "Hot Corners",
         "idle": "Idle",
@@ -2180,6 +2181,10 @@
         "toast-opacity": {
           "description": "Background opacity of notification toasts",
           "label": "Background Opacity"
+        },
+        "history-retention-hours": {
+          "description": "Automatically remove notification history entries older than this many hours (0 to keep forever)",
+          "label": "Keep history for"
         }
       },
       "panels": {

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -700,6 +700,11 @@ void Application::initNotificationAndOsd() {
   auto applyNotificationFilterConfig = [this]() {
     m_notificationManager.setFilters(m_configService.config().notification.filters);
   };
+  auto applyHistoryRetention = [this]() {
+    m_notificationManager.setHistoryRetentionHours(m_configService.config().notification.historyRetentionHours);
+  };
+  applyHistoryRetention();
+  m_configService.addReloadCallback(applyHistoryRetention);
   applyNotificationFilterConfig();
   m_configService.addReloadCallback(applyNotificationFilterConfig);
   m_configService.setNotificationManager(&m_notificationManager);

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -695,6 +695,8 @@ struct NotificationConfig {
   int offsetY = 8;                 // absolute vertical margin from the screen edge
   std::vector<std::string> monitors;
   bool collapseOnDismiss = true;
+  int historyRetentionHours = 0;
+
   std::vector<NotificationFilterConfig> filters;
 
   bool operator==(const NotificationConfig&) const = default;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -252,6 +252,7 @@ namespace noctalia::config::schema {
         field(&NotificationConfig::offsetY, "offset_y"),
         field(&NotificationConfig::monitors, "monitors"),
         field(&NotificationConfig::collapseOnDismiss, "collapse_on_dismiss"),
+        field(&NotificationConfig::historyRetentionHours, "history_retention_hours", Range<std::int64_t>{0, 8760}),
         custom<NotificationConfig>(
             "blacklist",
             [](const toml::table& tbl, NotificationConfig& out, std::string_view, Diagnostics&) {

--- a/src/dbus/notification/notification_service.cpp
+++ b/src/dbus/notification/notification_service.cpp
@@ -179,12 +179,7 @@ NotificationService::~NotificationService() {
   }
 }
 
-void NotificationService::processExpired() {
-  const std::vector<uint32_t> ids = m_manager.expiredIds();
-  for (const uint32_t id : ids) {
-    (void)m_manager.close(id, CloseReason::Expired);
-  }
-}
+void NotificationService::processExpired() { m_manager.processExpired(); }
 
 bool NotificationService::isHealthy() const {
   if (!m_nameAcquired) {

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -14,7 +14,6 @@
 #include <string_view>
 
 namespace {
-
   constexpr Logger kLog("notification");
   constexpr auto kImplicitDuplicateWindow = std::chrono::seconds(1);
   constexpr std::string_view urgencyStr(Urgency u) noexcept {
@@ -655,9 +654,9 @@ void NotificationManager::pauseExpiry(uint32_t id) {
 void NotificationManager::setHistoryRetentionHours(int hours) {
   m_historyRetentionHours = hours;
   if (hours > 0) {
-    m_autoClearTimer.startRepeating(std::chrono::seconds(60), [this]() { cleanupOldHistoryEntries(); });
+    m_historyRetentionTimer.startRepeating(std::chrono::seconds(60), [this]() { cleanupOldHistoryEntries(); });
   } else {
-    m_autoClearTimer.stop();
+    m_historyRetentionTimer.stop();
   }
   cleanupOldHistoryEntries();
 }
@@ -760,7 +759,14 @@ void NotificationManager::markNotificationHistorySeen() {
 }
 
 void NotificationManager::schedulePersistHistory() {
-  DeferredCall::callLater([this]() { persistHistoryToDisk(); });
+  if (m_persistScheduled) {
+    return;
+  }
+  m_persistScheduled = true;
+  DeferredCall::callLater([this]() {
+    m_persistScheduled = false;
+    persistHistoryToDisk();
+  });
 }
 
 void NotificationManager::persistHistoryToDisk() {

--- a/src/notification/notification_manager.cpp
+++ b/src/notification/notification_manager.cpp
@@ -17,7 +17,6 @@ namespace {
 
   constexpr Logger kLog("notification");
   constexpr auto kImplicitDuplicateWindow = std::chrono::seconds(1);
-
   constexpr std::string_view urgencyStr(Urgency u) noexcept {
     switch (u) {
     case Urgency::Low:
@@ -123,6 +122,38 @@ void NotificationManager::rebuildHistoryIndex() {
   for (size_t i = 0; i < m_history.size(); ++i) {
     m_historyIndex[m_history[i].notification.id] = i;
   }
+}
+
+void NotificationManager::cleanupOldHistoryEntries() {
+  if (m_historyRetentionHours <= 0 || m_history.empty()) {
+    return;
+  }
+
+  const auto retention = std::chrono::hours(m_historyRetentionHours);
+  const auto cutoff = WallClock::now() - retention;
+  const bool hadUnreadBefore = computeHasUnreadNotificationHistory();
+
+  std::deque<NotificationHistoryEntry> kept;
+  for (auto& entry : m_history) {
+    const bool eligible = !entry.active
+        && entry.notification.receivedWallClock.has_value()
+        && *entry.notification.receivedWallClock <= cutoff;
+    if (eligible) {
+      emitPendingDBusClose(entry.notification.id, CloseReason::Expired);
+    } else {
+      kept.push_back(std::move(entry));
+    }
+  }
+
+  if (kept.size() == m_history.size()) {
+    return;
+  }
+
+  m_history = std::move(kept);
+  ++m_changeSerial;
+  rebuildHistoryIndex();
+  schedulePersistHistory();
+  notifyUnreadStateChangedIfNeeded(hadUnreadBefore);
 }
 
 void NotificationManager::upsertHistory(
@@ -621,6 +652,16 @@ void NotificationManager::pauseExpiry(uint32_t id) {
   m_notifications[it->second].expiryWallClock.reset();
 }
 
+void NotificationManager::setHistoryRetentionHours(int hours) {
+  m_historyRetentionHours = hours;
+  if (hours > 0) {
+    m_autoClearTimer.startRepeating(std::chrono::seconds(60), [this]() { cleanupOldHistoryEntries(); });
+  } else {
+    m_autoClearTimer.stop();
+  }
+  cleanupOldHistoryEntries();
+}
+
 void NotificationManager::resumeExpiry(uint32_t id, int32_t remainingMs) {
   const auto it = m_idToIndex.find(id);
   if (it == m_idToIndex.end()) {
@@ -719,14 +760,7 @@ void NotificationManager::markNotificationHistorySeen() {
 }
 
 void NotificationManager::schedulePersistHistory() {
-  if (m_persistScheduled) {
-    return;
-  }
-  m_persistScheduled = true;
-  DeferredCall::callLater([this]() {
-    m_persistScheduled = false;
-    persistHistoryToDisk();
-  });
+  DeferredCall::callLater([this]() { persistHistoryToDisk(); });
 }
 
 void NotificationManager::persistHistoryToDisk() {

--- a/src/notification/notification_manager.h
+++ b/src/notification/notification_manager.h
@@ -165,7 +165,8 @@ private:
   uint32_t suppressExternal(std::string_view appName, Urgency urgency);
 
   int m_historyRetentionHours = 0;
-  Timer m_autoClearTimer;
+  bool m_persistScheduled = false;
+  Timer m_historyRetentionTimer;
 
   std::deque<Notification> m_notifications;
   std::unordered_map<uint32_t, size_t> m_idToIndex;

--- a/src/notification/notification_manager.h
+++ b/src/notification/notification_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/config_types.h"
+#include "core/timer_manager.h"
 #include "notification.h"
 
 #include <cstddef>
@@ -123,6 +124,7 @@ public:
   void clearHistory();
   void setFilters(std::vector<NotificationFilterConfig> filters);
   [[nodiscard]] const std::vector<NotificationFilterConfig>& filters() const noexcept;
+  void setHistoryRetentionHours(int hours);
   void setDoNotDisturb(bool enabled);
   [[nodiscard]] bool doNotDisturb() const noexcept;
   [[nodiscard]] bool toggleDoNotDisturb();
@@ -140,6 +142,7 @@ public:
   void flushPersistedHistory();
 
 private:
+  void cleanupOldHistoryEntries();
   void upsertHistory(const Notification& notification, bool active, std::optional<CloseReason> closeReason);
   void rebuildHistoryIndex();
   void schedulePersistHistory();
@@ -161,7 +164,8 @@ private:
   ) const;
   uint32_t suppressExternal(std::string_view appName, Urgency urgency);
 
-  bool m_persistScheduled = false;
+  int m_historyRetentionHours = 0;
+  Timer m_autoClearTimer;
 
   std::deque<Notification> m_notifications;
   std::unordered_map<uint32_t, size_t> m_idToIndex;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2845,6 +2845,19 @@ namespace settings {
         "monitor output display screen"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Notifications, "history", tr("settings.schema.notifications.history-retention-hours.label"),
+        tr("settings.schema.notifications.history-retention-hours.description"),
+        {"notification", "history_retention_hours"},
+        StepperSetting{
+            .value = cfg.notification.historyRetentionHours,
+            .minValue = 0,
+            .maxValue = 8760,
+            .step = 1,
+            .valueSuffix = "h",
+        },
+        "history retention hours clear"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Notifications, "filtering", tr("settings.schema.notifications.filters.label"),
         tr("settings.schema.notifications.filters.description"), {"notification", "filter"},
         NotificationFiltersSetting{.items = cfg.notification.filters},

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -347,6 +347,7 @@ location = "https://example.invalid/bad"
         .offsetY = 6,
         .monitors = {"DP-2"},
         .collapseOnDismiss = false,
+        .historyRetentionHours = 48,
         .filters = {NotificationFilterConfig{
             .name = "discord",
             .enabled = true,


### PR DESCRIPTION
## Summary

- Auto-clear notification history entries older than a configurable number of hours.
- Adds a "Keep history for" stepper in Settings -> Notifications -> History.
- Value 0 disables auto-clear (keep forever).

## Motivation

Notification getting piled up doesn't look good, this allows users to auto clears them with their own choice of time.This allows automatic cleanup of stale entries without manually clearing history.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3514 

## Testing

- Ran `meson compile -C build-debug` && `meson test -C build-debug`  # 56/56 pass
- Then `./build-bebug/noctalia` to start debug build
- Manual:- Enabled (1h), sent test notifications via `notify-send`, notification stays for the time until the feature kicks in and clears it.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="750" height="135" alt="image" src="https://github.com/user-attachments/assets/c2e9b229-0f48-4be3-9a47-78d2420f5f0f" />

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

