### PR TITLE
fix(clipboard): move selection to top when an entry is copied

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1654,10 +1654,6 @@ void ClipboardPanel::activateSelected() {
   const bool promoted = wasPinned ? false : m_clipboard->promoteEntry(historyIndex);
   const bool copied = m_clipboard->copyEntry(entry);
   if (copied || promoted) {
-    if (m_activateCallback) {
-      m_activateCallback(entry);
-      return;
-    }
     if (!wasPinned) {
       m_selectedIndex = 0;
       applyFilter();
@@ -1671,6 +1667,9 @@ void ClipboardPanel::activateSelected() {
       schedulePreviewPayloadRefresh(false);
     }
     PanelManager::instance().refresh();
+    if (m_activateCallback) {
+      m_activateCallback(entry);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

The code that moves the selection to the top seemingly didn't run before. This fixes it

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Tested manually with auto-paste disabled and enabled

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

