### PR TITLE
fix(clipboard): move selection to top when an entry is copied

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1433,6 +1433,31 @@ void ClipboardPanel::deleteSelectedEntry() {
   performDeleteSelectedEntry();
 }
 
+void ClipboardPanel::selectByStorageId(std::string storageId) {
+  applyFilter();
+
+  std::size_t newSelected = 0;
+  const auto& updated = m_clipboard->history();
+  for (std::size_t pos = 0; pos < m_filteredIndices.size(); ++pos) {
+    const std::size_t idx = m_filteredIndices[pos];
+    if (idx < updated.size() && updated[idx].storageId == storageId) {
+      newSelected = pos;
+      break;
+    }
+  }
+  m_selectedIndex = m_filteredIndices.empty() ? 0 : newSelected;
+
+  updateListState();
+  if (m_listGrid != nullptr) {
+    m_listGrid->notifyDataChanged();
+    m_listGrid->setSelectedIndex(
+        m_filteredIndices.empty() ? std::nullopt : std::optional<std::size_t>(m_selectedIndex)
+    );
+  }
+
+  schedulePreviewPayloadRefresh(false);
+}
+
 void ClipboardPanel::togglePinSelected() {
   if (m_clipboard == nullptr) {
     return;
@@ -1452,28 +1477,10 @@ void ClipboardPanel::togglePinSelected() {
     return;
   }
 
-  applyFilter();
-
   // The toggled entry moved within the deque; keep it selected by locating it
   // again via its stable storage id.
-  std::size_t newSelected = 0;
-  const auto& updated = m_clipboard->history();
-  for (std::size_t pos = 0; pos < m_filteredIndices.size(); ++pos) {
-    const std::size_t idx = m_filteredIndices[pos];
-    if (idx < updated.size() && updated[idx].storageId == storageId) {
-      newSelected = pos;
-      break;
-    }
-  }
-  m_selectedIndex = m_filteredIndices.empty() ? 0 : newSelected;
+  selectByStorageId(storageId);
 
-  updateListState();
-  if (m_listGrid != nullptr) {
-    m_listGrid->notifyDataChanged();
-    m_listGrid->setSelectedIndex(
-        m_filteredIndices.empty() ? std::nullopt : std::optional<std::size_t>(m_selectedIndex)
-    );
-  }
   schedulePreviewPayloadRefresh(false);
   m_pendingScrollToSelected = true;
   PanelManager::instance().refresh();
@@ -1655,16 +1662,7 @@ void ClipboardPanel::activateSelected() {
   const bool copied = m_clipboard->copyEntry(entry);
   if (copied || promoted) {
     if (!wasPinned) {
-      m_selectedIndex = 0;
-      applyFilter();
-      updateListState();
-      if (m_listGrid != nullptr) {
-        m_listGrid->notifyDataChanged();
-        m_listGrid->setSelectedIndex(
-            m_filteredIndices.empty() ? std::nullopt : std::optional<std::size_t>(m_selectedIndex)
-        );
-      }
-      schedulePreviewPayloadRefresh(false);
+      selectByStorageId(entry.storageId);
     }
     PanelManager::instance().refresh();
     if (m_activateCallback) {

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1437,10 +1437,10 @@ void ClipboardPanel::selectByStorageId(std::string storageId) {
   applyFilter();
 
   std::size_t newSelected = 0;
-  const auto& updated = m_clipboard->history();
+  const auto& history = m_clipboard->history();
   for (std::size_t pos = 0; pos < m_filteredIndices.size(); ++pos) {
     const std::size_t idx = m_filteredIndices[pos];
-    if (idx < updated.size() && updated[idx].storageId == storageId) {
+    if (idx < history.size() && history[idx].storageId == storageId) {
       newSelected = pos;
       break;
     }

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1654,10 +1654,6 @@ void ClipboardPanel::activateSelected() {
   const bool promoted = wasPinned ? false : m_clipboard->promoteEntry(historyIndex);
   const bool copied = m_clipboard->copyEntry(entry);
   if (copied || promoted) {
-    if (m_activateCallback) {
-      m_activateCallback(entry);
-      return;
-    }
     if (!wasPinned) {
       m_selectedIndex = 0;
       applyFilter();
@@ -1671,6 +1667,9 @@ void ClipboardPanel::activateSelected() {
       schedulePreviewPayloadRefresh(false);
     }
     PanelManager::instance().refresh();
+    if (m_activateCallback) {
+      m_activateCallback(entry);
+    }
   }
 }
 

--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1481,7 +1481,6 @@ void ClipboardPanel::togglePinSelected() {
   // again via its stable storage id.
   selectByStorageId(storageId);
 
-  schedulePreviewPayloadRefresh(false);
   m_pendingScrollToSelected = true;
   PanelManager::instance().refresh();
 }

--- a/src/shell/clipboard/clipboard_panel.h
+++ b/src/shell/clipboard/clipboard_panel.h
@@ -53,6 +53,7 @@ private:
   void updatePreviewActions();
   void rebuildPreview(Renderer& renderer, float width, float height);
   void selectIndex(std::size_t index);
+  void selectByStorageId(std::string storageId);
   void activateSelected();
   void togglePinSelected();
   void runImageAction();


### PR DESCRIPTION
## Summary

The code that moves the selection to the top seemingly didn't run before. This fixes it

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Tested manually with auto-paste disabled and enabled

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.