### PR TITLE
Battery widget: show state glyph always outside the graphical battery

### DIFF
--- a/src/shell/bar/widgets/battery_widget.cpp
+++ b/src/shell/bar/widgets/battery_widget.cpp
@@ -111,7 +111,7 @@ void BatteryWidget::createGraphicMode() {
   container->addChild(
       ui::box({
           .out = &m_bodyBg,
-          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.25f),
+          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3f),
       })
   );
 
@@ -124,7 +124,7 @@ void BatteryWidget::createGraphicMode() {
   container->addChild(
       ui::box({
           .out = &m_terminalNub,
-          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.25f),
+          .fill = withOpacity(widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface)), 0.3f),
       })
   );
 
@@ -214,12 +214,12 @@ void BatteryWidget::layoutGraphicMode(Renderer& renderer) {
   const float termW = std::round(kGraphicTerminalWidth * scale);
   const float termH = std::round(kGraphicTerminalHeight * scale);
   const float cornerR = std::round(kGraphicCornerRadius * scale);
-  const float labelGap = Style::spaceXs * m_contentScale;
+  const float labelGap = std::round(Style::spaceXs * m_contentScale);
   const float stateGap = std::round(Style::spaceXs * 0.5f * m_contentScale);
   const bool showLabel = m_overlayLabel != nullptr && m_showLabel;
   const bool showStateGlyph = m_overlayGlyph != nullptr && m_overlayGlyph->visible();
-  const bool showStateGlyphOutside = showStateGlyph && showLabel;
-  const bool showStateGlyphInside = showStateGlyph && !showLabel;
+  const bool hasOverlay = showLabel || showStateGlyph;
+
   if (showLabel) {
     m_overlayLabel->setFontSize((m_isVertical ? Style::fontSizeCaption : Style::fontSizeBody) * m_contentScale);
     m_overlayLabel->measure(renderer);
@@ -233,10 +233,10 @@ void BatteryWidget::layoutGraphicMode(Renderer& renderer) {
     const float graphicW = bodyH;
     const float graphicH = bodyW + termW;
     const float labelW = showLabel ? m_overlayLabel->width() : 0.0f;
-    const float labelH = showLabel ? m_overlayLabel->height() : 0.0f;
-    const float stateW = showStateGlyphOutside ? m_overlayGlyph->width() : 0.0f;
-    const float stateH = showStateGlyphOutside ? m_overlayGlyph->height() : 0.0f;
-    const float labelGroupH = labelH + (showStateGlyphOutside ? stateGap + stateH : 0.0f);
+    const float labelH = showLabel ? labelGap + m_overlayLabel->height() : 0.0f;
+    const float stateW = showStateGlyph ? m_overlayGlyph->width() : 0.0f;
+    const float stateH = showStateGlyph ? stateGap + m_overlayGlyph->height() : 0.0f;
+    const float overlayGroupH = stateH + labelH;
     const float rootW = std::max({graphicW, labelW, stateW});
     const float bodyX = std::round((rootW - graphicW) * 0.5f);
     const float bodyY = termW;
@@ -252,30 +252,25 @@ void BatteryWidget::layoutGraphicMode(Renderer& renderer) {
     m_fillRect->setRadius(cornerR);
     updateFillGeometry();
 
+    if (showStateGlyph) {
+      m_overlayGlyph->setPosition(std::round((rootW - stateW) * 0.5f), graphicH + stateGap);
+    }
     if (showLabel) {
-      m_overlayLabel->setPosition(std::round((rootW - labelW) * 0.5f), graphicH + labelGap);
+      const float labelY = graphicH + labelGap + (showStateGlyph ? stateH : 0.0f);
+      m_overlayLabel->setPosition(std::round((rootW - labelW) * 0.5f), labelY);
     }
 
-    if (showStateGlyphOutside) {
-      m_overlayGlyph->setPosition(std::round((rootW - stateW) * 0.5f), graphicH + labelGap + labelH + stateGap);
-    } else if (showStateGlyphInside) {
-      m_overlayGlyph->setPosition(
-          bodyX + std::round((bodyH - m_overlayGlyph->width()) * 0.5f),
-          bodyY + std::round((bodyW - m_overlayGlyph->height()) * 0.5f)
-      );
-    }
-
-    rootNode->setSize(rootW, graphicH + (showLabel ? labelGap + labelGroupH : 0.0f));
+    rootNode->setSize(rootW, graphicH + (hasOverlay ? overlayGroupH : 0.0f));
   } else {
     const float graphicW = bodyW + termW;
     const float graphicH = bodyH;
-    const float labelW = showLabel ? m_overlayLabel->width() : 0.0f;
+    const float labelW = showLabel ? labelGap + m_overlayLabel->width() : 0.0f;
     const float labelH = showLabel ? m_overlayLabel->height() : 0.0f;
-    const float stateW = showStateGlyphOutside ? m_overlayGlyph->width() : 0.0f;
-    const float stateH = showStateGlyphOutside ? m_overlayGlyph->height() : 0.0f;
-    const float labelGroupW = labelW + (showStateGlyphOutside ? stateGap + stateW : 0.0f);
-    const float labelGroupH = std::max(labelH, stateH);
-    const float rootH = std::max(graphicH, labelGroupH);
+    const float stateW = showStateGlyph ? stateGap + m_overlayGlyph->width() : 0.0f;
+    const float stateH = showStateGlyph ? m_overlayGlyph->height() : 0.0f;
+    const float overlayGroupW = stateW + labelW;
+    const float overlayGroupH = std::max(labelH, stateH);
+    const float rootH = std::max(graphicH, overlayGroupH);
     const float bodyY = std::round((rootH - bodyH) * 0.5f);
 
     m_bodyBg->setRadius(cornerR);
@@ -289,20 +284,15 @@ void BatteryWidget::layoutGraphicMode(Renderer& renderer) {
     m_fillRect->setRadius(cornerR);
     updateFillGeometry();
 
+    if (showStateGlyph) {
+      m_overlayGlyph->setPosition(graphicW + stateGap, std::round((rootH - stateH) * 0.5f));
+    }
     if (showLabel) {
-      m_overlayLabel->setPosition(graphicW + labelGap, std::round((rootH - labelH) * 0.5f));
+      const float labelX = graphicW + labelGap + (showStateGlyph ? stateW : 0.0f);
+      m_overlayLabel->setPosition(labelX, std::round((rootH - labelH) * 0.5f));
     }
 
-    if (showStateGlyphOutside) {
-      m_overlayGlyph->setPosition(graphicW + labelGap + labelW + stateGap, std::round((rootH - stateH) * 0.5f));
-    } else if (showStateGlyphInside) {
-      m_overlayGlyph->setPosition(
-          std::round((bodyW - m_overlayGlyph->width()) * 0.5f),
-          bodyY + std::round((bodyH - m_overlayGlyph->height()) * 0.5f)
-      );
-    }
-
-    rootNode->setSize(graphicW + (showLabel ? labelGap + labelGroupW : 0.0f), rootH);
+    rootNode->setSize(graphicW + (hasOverlay ? overlayGroupW : 0.0f), rootH);
   }
 }
 
@@ -433,11 +423,11 @@ void BatteryWidget::syncState(Renderer& renderer) {
       m_fillRect->setFill(fgColor);
     }
     if (m_bodyBg != nullptr) {
-      m_bodyBg->setFill(withOpacity(fgColor, 0.25f));
+      m_bodyBg->setFill(withOpacity(fgColor, 0.3f));
     }
 
     if (m_terminalNub != nullptr) {
-      m_terminalNub->setFill(isWarning ? m_warningColor : withOpacity(normalFgColor, 0.25f));
+      m_terminalNub->setFill(withOpacity(fgColor, 0.3f));
     }
 
     // Animate fill percentage


### PR DESCRIPTION
As described in #3283, there is a visibility issue with the state glyph icon inside the graphical battery widget. To fix this, I moved the glyph outside of the graphical battery for every case, not just when Show Label is enabled (giving the glyph inside the battery another color still can lead to bad visibility as I've found). I also switched the position of the glyph and the label text around.

Before:
<img width="110" height="43" alt="Screenshot_2026-07-26 20-38-39" src="https://github.com/user-attachments/assets/e7d3a9db-b9a0-4f7a-b106-0855e5a8a6ea" />

After:
<img width="110" height="43" alt="Screenshot_2026-07-26 20-38-23" src="https://github.com/user-attachments/assets/fc7980df-77b6-431c-9890-9da9912a6f7f" />

The glyph is also shown if Show Label is disabled:
<img width="63" height="38" alt="Screenshot_2026-07-26 20-39-07" src="https://github.com/user-attachments/assets/bc45decd-31c2-4cc1-8511-3f144e4ed33e" />

Additionally, I removed the coloring of the battery nub if the battery is in warning state:
<img width="56" height="32" alt="Screenshot_2026-07-26 20-23-19" src="https://github.com/user-attachments/assets/2f56a775-5104-4af4-b03a-8babb0b671b0" />
