### PR TITLE
fix(polkit): open panel during fingerprint auth

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -303,9 +303,13 @@ void Application::syncPolkitAgent() {
       return;
     }
     m_polkitIdleCloseTimer.stop();
-    // Open once the session asks for a response so preferredHeight includes the
-    // password field. BeginAuthentication alone still has responseRequired=false.
-    if (!m_polkitAgent->isResponseRequired() && !m_panelManager.isOpenPanel("polkit")) {
+    // Open once the session has content to display so preferredHeight accounts for
+    // the real text. BeginAuthentication alone has neither responseRequired nor
+    // supplementaryMessage — skip it. show-info (fingerprint) sets supplementaryMessage
+    // without flipping responseRequired; request sets responseRequired without
+    // supplementaryMessage. Either is sufficient content to show.
+    const bool hasContent = m_polkitAgent->isResponseRequired() || !m_polkitAgent->supplementaryMessage().empty();
+    if (!hasContent && !m_panelManager.isOpenPanel("polkit")) {
       return;
     }
     if (!m_panelManager.isOpenPanel("polkit")) {


### PR DESCRIPTION
## Summary

Fixed the polkit state callback gate to open the panel when the session has content to display, not only when a password response is required. `pam_fprintd` emits show-info (stored as supplementaryMessage, responseRequired=false) but never request, so the old gate kept the panel invisible during the entire ~30s fingerprint timeout.

## Motivation

Fixes a regression introduced in 1f32612 where the polkit panel stays hidden during fingerprint verification (pam_fprintd before pam_unix). The user sees nothing for ~30s while the reader is armed, then the password panel appears after fprintd times out. The existing presentation code for the fingerprint panel (promoting supplementaryMessage to the prompt slot while hiding the input field) was correct but unreachable because the gate prevented the panel from opening.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3656 

## Testing

- Ran `just format` on the branch then build with `meson compile -C build-release`, installed system with `sudo meson install -C build-release` for manual testing, restarted laptop.
- Tested on mounting the partitions and it shows the panel and partiton mounts correctly (see image below).
- Ran `pkexec ls` ls with fingerprint-first PAM, panel appears immediately with "Place your finger on the fingerprint reader" text.
- Normal password-only polkit actions still work (regression test for #2896)

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="487" height="264" alt="image" src="https://github.com/user-attachments/assets/5779894b-bc24-40a2-a901-dd59237f07c7" />

> Panel when I mount my partitions

<img width="1851" height="732" alt="image" src="https://github.com/user-attachments/assets/8293ab96-fd72-46e1-a193-17df188b832c" />


## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

