### PR TITLE
[Control Center] Add a toggle option to show shortcut labels

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2216,6 +2216,10 @@
           "description": "Choose up to six shortcut buttons for the home tab",
           "label": "Home Shortcuts"
         },
+        "home-shortcuts-show-labels": {
+          "description": "Display text labels under shortcut icons in the home tab",
+          "label": "Show Shortcut Labels"
+        },
         "launcher-app-grid": {
           "description": "Show a grid of application icons with labels underneath when results are apps only",
           "label": "App Grid View"

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1456,6 +1456,7 @@ struct ControlCenterConfig {
   ControlCenterSidebarMode sidebarMode = ControlCenterSidebarMode::Compact;
   ControlCenterSidebarMode sidebarSectionMode = ControlCenterSidebarMode::Compact;
   std::int32_t width = kDefaultWidth; // full-sidebar logical width; compact/none modes scale down from this
+  bool showShortcutLabels = true;
   CalendarTabConfig calendarTab;
   bool operator==(const ControlCenterConfig&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -491,6 +491,7 @@ namespace noctalia::config::schema {
         enumField(&ControlCenterConfig::sidebarMode, "sidebar", kControlCenterSidebarModes),
         enumField(&ControlCenterConfig::sidebarSectionMode, "sidebar_section", kControlCenterSidebarModes),
         field(&ControlCenterConfig::width, "width", kControlCenterWidthRange),
+        field(&ControlCenterConfig::showShortcutLabels, "show_shortcut_labels"),
         field(&ControlCenterConfig::hiddenTabs, "hidden_tabs"),
         subTable(&ControlCenterConfig::calendarTab, "calendar", calendarTabSchema()),
         arrayOf<ControlCenterConfig, ShortcutConfig>(

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -560,17 +560,15 @@ std::unique_ptr<Flex> HomeTab::create() {
         .configure =
             [enabled, isActive, showLabels, fillOpacity = panelCardOpacity(), scale](Button& button) {
               button.setDirection(FlexDirection::Vertical);
+              button.setJustify(FlexJustify::Center);
+              button.setAlign(FlexAlign::Center);
               if (showLabels) {
-                button.setAlign(FlexAlign::Stretch);
-                button.setJustify(FlexJustify::Start);
                 if (button.label() != nullptr) {
                   button.label()->setFontSize(Style::fontSizeMini * scale);
                   button.label()->setMaxLines(1);
                   button.label()->setTextAlign(TextAlign::Center);
                 }
               } else {
-                button.setAlign(FlexAlign::Center);
-                button.setJustify(FlexJustify::Center);
                 if (button.label() != nullptr) {
                   button.label()->setVisible(false);
                   button.label()->setParticipatesInLayout(false);

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -530,15 +530,17 @@ std::unique_ptr<Flex> HomeTab::create() {
       continue;
     }
 
+    const bool showLabels = m_config != nullptr ? m_config->config().controlCenter.showShortcutLabels : true;
     const std::string label = shortcut->displayLabel();
     const bool enabled = shortcut->enabled();
     const bool isActive = shortcut->isToggle() && shortcut->active();
 
     const std::size_t padIdx = m_shortcutPads.size();
     auto btn = ui::button({
-        .text = label,
+        .text = showLabels ? std::optional<std::string>{label} : std::nullopt,
         .glyph = shortcut->displayIcon(),
         .glyphSize = Style::fontSizeTitle * 1.35f * scale,
+        .contentAlign = showLabels ? ButtonContentAlign::Start : ButtonContentAlign::Center,
         .minHeight = 0.0f,
         .padding = Style::spaceSm * scale,
         .gap = Style::spaceXs * scale,
@@ -556,16 +558,24 @@ std::unique_ptr<Flex> HomeTab::create() {
               }
             },
         .configure =
-            [enabled, isActive, fillOpacity = panelCardOpacity(), scale](Button& button) {
-              // Match media card column: Stretch so label width follows the cell; Center uses intrinsic text width and
-              // fights setMaxWidth.
-              button.setAlign(FlexAlign::Stretch);
-              // Label font only: Button::setFontSize also resizes the glyph. Mini + uiScale keeps tiles closer to
-              // other CC rows that use raw fontSizeCaption, while still scaling with shell.uiScale for consistency.
-              button.label()->setFontSize(Style::fontSizeMini * scale);
-              button.label()->setMaxLines(1);
-              button.label()->setTextAlign(TextAlign::Center);
+            [enabled, isActive, showLabels, fillOpacity = panelCardOpacity(), scale](Button& button) {
               button.setDirection(FlexDirection::Vertical);
+              if (showLabels) {
+                button.setAlign(FlexAlign::Stretch);
+                button.setJustify(FlexJustify::Start);
+                if (button.label() != nullptr) {
+                  button.label()->setFontSize(Style::fontSizeMini * scale);
+                  button.label()->setMaxLines(1);
+                  button.label()->setTextAlign(TextAlign::Center);
+                }
+              } else {
+                button.setAlign(FlexAlign::Center);
+                button.setJustify(FlexJustify::Center);
+                if (button.label() != nullptr) {
+                  button.label()->setVisible(false);
+                  button.label()->setParticipatesInLayout(false);
+                }
+              }
               applyShortcutButtonStyle(button, enabled, isActive, fillOpacity);
             },
     });
@@ -784,6 +794,7 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
   // Lock the shortcuts grid height to its square-cell natural size so it does not vary
   // when the media or clock cards change. The leftColumn stretches to match this height.
   if (m_shortcutsGrid != nullptr && !m_shortcutPads.empty()) {
+    const float scale = contentScale();
     const float gridW = m_shortcutsGrid->width();
     const float innerGridW = std::max(1.0f, gridW - m_shortcutsGrid->paddingLeft() - m_shortcutsGrid->paddingRight());
     const std::size_t cols = std::max<std::size_t>(1, std::min(m_shortcutsGrid->columns(), m_shortcutPads.size()));
@@ -794,6 +805,19 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
     // Cells aim for square but trimmed slightly so the grid stays compact and the bottom row
     // doesn't tower over the user card area. The width was capped earlier so this stays bounded.
     const float cellSide = cellWidth * kHomeShortcutSquareTrim;
+    const bool showLabels = m_config != nullptr ? m_config->config().controlCenter.showShortcutLabels : true;
+    for (auto& pad : m_shortcutPads) {
+      if (pad.glyph == nullptr) {
+        continue;
+      }
+      if (showLabels) {
+        pad.glyph->setGlyphSize(Style::fontSizeTitle * 1.35f * scale);
+      } else {
+        const float dynamicGlyphSize = std::clamp(cellSide * 0.42f, 26.0f * scale, 56.0f * scale);
+        pad.glyph->setGlyphSize(dynamicGlyphSize);
+      }
+    }
+
     const float measuredRowH = m_bottomRow != nullptr ? m_bottomRow->height() : m_shortcutsGrid->height();
     const float formulaH = static_cast<float>(rows) * cellSide
         + static_cast<float>(rows > 0 ? rows - 1 : 0) * m_shortcutsGrid->rowGap()

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1404,6 +1404,11 @@ namespace settings {
         },
         "quick settings shortcuts toggles wifi bluetooth caffeine night light dnd power media weather clipboard"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-shortcuts-show-labels.label"),
+        tr("settings.schema.panels.home-shortcuts-show-labels.description"), {"control_center", "show_shortcut_labels"},
+        ToggleSetting{cfg.controlCenter.showShortcutLabels}, "shortcuts labels text hide show titles"
+    ));
     {
       MultiSelectSetting tabs;
       const auto catalog = ControlCenterPanel::hideableTabCatalog();


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Added a new toggle option to show/hide labels for the shortcuts in the home section of Control Center panel

## Motivation

<!-- What problem does this solve? -->
With lower control center width values, the trailing labels really make the shortcuts look odd. With the new toggle option, the user can make the shortcut blocks look clean by hiding it. The glyphs scale with increasing width and display scaling

## Type of Change

<!-- Mark all that apply. -->
- [x] New feature

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just test` and `just build` commands to ensure zero compilation issues and follows the clang-format

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland
- [x] Tested at different interface scaling values

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
|**Before**|**After**|
|----------|---------|
|<img width="527" height="520" alt="image" src="https://github.com/user-attachments/assets/1fe2061e-69cc-41fa-9da1-e048152e4255" />|<img width="525" height="518" alt="image" src="https://github.com/user-attachments/assets/12ff9d41-b006-40c7-b42c-bd5dcab2f0ce" />|

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I asked Lysec for this and he said its good to go and so the PR :)