### PR TITLE
feat(widgets/sysmon): blend gauge colors in HSV space

### DIFF
--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -136,6 +136,16 @@ Color lerpColorInHsv(const Color& a, const Color& b, float t) {
   rgbToHsv(a, h0, s0, v0);
   float h1, s1, v1;
   rgbToHsv(b, h1, s1, v1);
+
+  // Hue is undefined when saturation is ~0; use the other endpoint's hue to avoid spurious tints.
+  constexpr float kHueEps = 1e-6f;
+  if (s0 <= kHueEps) {
+    h0 = h1;
+  }
+  if (s1 <= kHueEps) {
+    h1 = h0;
+  }
+
   float hDelta = h1 - h0;
   if (hDelta > 0.5f) {
     hDelta -= 1.0f;

--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -131,6 +131,20 @@ void rgbToHsv(const Color& rgb, float& h, float& s, float& v) {
   h = h - std::floor(h);
 }
 
+Color lerpColorInHsv(const Color& a, const Color& b, float t) {
+  float h0, s0, v0;
+  rgbToHsv(a, h0, s0, v0);
+  float h1, s1, v1;
+  rgbToHsv(b, h1, s1, v1);
+  float hDelta = h1 - h0;
+  if (hDelta > 0.5f) {
+    hDelta -= 1.0f;
+  } else if (hDelta < -0.5f) {
+    hDelta += 1.0f;
+  }
+  return hsv(h0 + hDelta * t, s0 + (s1 - s0) * t, v0 + (v1 - v0) * t, a.a + (b.a - a.a) * t);
+}
+
 float relativeLuminance(const Color& color) {
   return 0.2126f * linearizedColorChannel(color.r)
       + 0.7152f * linearizedColorChannel(color.g)

--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -131,18 +131,18 @@ void rgbToHsv(const Color& rgb, float& h, float& s, float& v) {
   h = h - std::floor(h);
 }
 
-Color lerpColorInHsv(const Color& a, const Color& b, float t) {
+Color lerpHsv(const Color& a, const Color& b, float t) {
   float h0, s0, v0;
   rgbToHsv(a, h0, s0, v0);
   float h1, s1, v1;
   rgbToHsv(b, h1, s1, v1);
 
-  // Hue is undefined when saturation is ~0; use the other endpoint's hue to avoid spurious tints.
-  constexpr float kHueEps = 1e-6f;
-  if (s0 <= kHueEps) {
+  // Hue is undefined at negligible chroma; borrow the other endpoint's hue to avoid spurious tints.
+  constexpr float kChromaEpsilon = 1e-6f;
+  if (s0 * v0 <= kChromaEpsilon) {
     h0 = h1;
   }
-  if (s1 <= kHueEps) {
+  if (s1 * v1 <= kChromaEpsilon) {
     h1 = h0;
   }
 

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -135,9 +135,8 @@ constexpr Color lerpColor(const Color& a, const Color& b, float t) {
 [[nodiscard]] Color hsl(float h, float s, float l, float a = 1.0f);
 // Decomposes rgb into hue (turns, [0,1)), saturation, and value (each [0,1]).
 void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
-// Linear blend from a to b in HSV space; t in [0,1].
-// Prevents issues like saturation drop when blending two highly saturated colors in RGB space.
-[[nodiscard]] Color lerpColorInHsv(const Color& a, const Color& b, float t);
+// Blends from a to b through HSV space on the shortest hue path; t in [0,1].
+[[nodiscard]] Color lerpHsv(const Color& a, const Color& b, float t);
 // WCAG relative luminance of color, in [0,1].
 [[nodiscard]] float relativeLuminance(const Color& color);
 // Returns opaque black or white, whichever reads better on background.

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -135,6 +135,9 @@ constexpr Color lerpColor(const Color& a, const Color& b, float t) {
 [[nodiscard]] Color hsl(float h, float s, float l, float a = 1.0f);
 // Decomposes rgb into hue (turns, [0,1)), saturation, and value (each [0,1]).
 void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
+// Linear blend from a to b in HSV space; t in [0,1].
+// Prevents issues like saturation drop when blending two highly saturated colors in RGB space.
+[[nodiscard]] Color lerpColorInHsv(const Color& a, const Color& b, float t);
 // WCAG relative luminance of color, in [0,1].
 [[nodiscard]] float relativeLuminance(const Color& color);
 // Returns opaque black or white, whichever reads better on background.

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -341,7 +341,7 @@ Color SysmonWidget::currentValueColor(ColorSpec baseColor) {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpColorInHsv(base, highlight, factor);
+  return lerpHsv(base, highlight, factor);
 }
 
 void SysmonWidget::syncIcon(Renderer& renderer) {

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -341,7 +341,7 @@ Color SysmonWidget::currentValueColor(ColorSpec baseColor) {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpColor(base, highlight, factor);
+  return lerpColorInHsv(base, highlight, factor);
 }
 
 void SysmonWidget::syncIcon(Renderer& renderer) {

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -562,7 +562,7 @@ Color DesktopSysmonWidget::currentValueColor(ColorSpec baseColor) const {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpColor(base, highlight, factor);
+  return lerpColorInHsv(base, highlight, factor);
 }
 
 std::pair<double, double> DesktopSysmonWidget::currentThresholds() const {

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -562,7 +562,7 @@ Color DesktopSysmonWidget::currentValueColor(ColorSpec baseColor) const {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpColorInHsv(base, highlight, factor);
+  return lerpHsv(base, highlight, factor);
 }
 
 std::pair<double, double> DesktopSysmonWidget::currentThresholds() const {


### PR DESCRIPTION
## Summary

Blend gauge colors in HSV space

## Motivation

This prevents satuation drop when blending to highly satuated colors. E.g., when the base color is bright green, and highlight is bright red. The current algorithm blends them into a dark brown, while this change a bright yellow.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.