### PR TITLE
Fix spacing and margins in a few areas (cards/blocks/elements)

### DIFF
--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -113,7 +113,7 @@ void ControlCenterPanel::create() {
         .out = &m_sidebar,
         .align = FlexAlign::Start,
         .gap = 0.0f,
-        .padding = Style::spaceSm * scale,
+        .padding = Style::spaceMd * scale,
         .fillWidth = false,
         .fillHeight = true,
         .configure = [this, scale](Flex& column) {

--- a/src/shell/control_center/tab.cpp
+++ b/src/shell/control_center/tab.cpp
@@ -11,7 +11,7 @@ namespace control_center {
     card.setDirection(FlexDirection::Vertical);
     card.setAlign(FlexAlign::Stretch);
     card.setGap(Style::spaceSm * scale);
-    card.setPadding((Style::spaceSm + Style::spaceXs) * scale, Style::spaceMd * scale);
+    card.setPadding(Style::spaceMd * scale);
   }
 
   Label* addTitle(Flex& parent, const std::string& text, float scale) {

--- a/src/shell/control_center/tabs/audio_tab.cpp
+++ b/src/shell/control_center/tabs/audio_tab.cpp
@@ -1712,7 +1712,7 @@ std::unique_ptr<Flex> AudioTab::create() {
       ui::row(
           {
               .align = FlexAlign::Stretch,
-              .gap = Style::spaceSm * scale,
+              .gap = Style::spaceMd * scale,
               // Keep volume cards at natural content height.
               .flexGrow = 0.0f,
           },

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -373,7 +373,7 @@ std::unique_ptr<Flex> HomeTab::create() {
   auto leftColumn = ui::column({
       .align = FlexAlign::Stretch,
       .justify = FlexJustify::Start,
-      .gap = Style::spaceSm * scale,
+      .gap = Style::spaceMd * scale,
       .fillWidth = true,
       .flexGrow = kHomeMainColumnFlexGrow,
   });
@@ -512,8 +512,8 @@ std::unique_ptr<Flex> HomeTab::create() {
 
   auto grid = std::make_unique<GridView>();
   grid->setColumns(kHomeShortcutGridColumns);
-  grid->setColumnGap(Style::spaceSm * scale);
-  grid->setRowGap(Style::spaceSm * scale);
+  grid->setColumnGap(Style::spaceMd * scale);
+  grid->setRowGap(Style::spaceMd * scale);
   grid->setPadding(0.0f);
   grid->setUniformCellSize(true);
   grid->setStretchItems(true);
@@ -841,28 +841,28 @@ void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight)
       }
     }
 
-    const float measuredRowH = m_bottomRow != nullptr ? m_bottomRow->height() : m_shortcutsGrid->height();
-    const float formulaH = static_cast<float>(rows) * cellSide
+    const float gridH = std::round(
+        static_cast<float>(rows) * cellSide
         + static_cast<float>(rows > 0 ? rows - 1 : 0) * m_shortcutsGrid->rowGap()
         + m_shortcutsGrid->paddingTop()
-        + m_shortcutsGrid->paddingBottom();
-    const float gridH = std::round(std::max(measuredRowH, formulaH));
+        + m_shortcutsGrid->paddingBottom()
+    );
     if (m_bottomRow != nullptr) {
       m_bottomRow->setMinHeight(gridH);
     }
 
     // Integer card heights track the snapped row height so top/bottom borders land on pixels.
     if (m_mediaCard != nullptr && m_dateTimeCard != nullptr) {
-      const float colGap = Style::spaceSm * contentScale();
+      const float colGap = Style::spaceMd * contentScale();
       const float avail = std::max(0.0f, gridH - colGap);
       const float cardGrowTotal = kHomeMediaCardFlexGrow + kHomeDateTimeCardFlexGrow;
       const float mediaH = std::round(avail * (kHomeMediaCardFlexGrow / cardGrowTotal));
       const float dateH = std::max(0.0f, avail - mediaH);
 
       m_mediaCard->setMinHeight(mediaH);
-      m_mediaCard->setMaxHeight(mediaH);
+      m_mediaCard->setMaxHeight(0.0f);
       m_dateTimeCard->setMinHeight(dateH);
-      m_dateTimeCard->setMaxHeight(dateH);
+      m_dateTimeCard->setMaxHeight(0.0f);
     }
   }
 

--- a/src/shell/control_center/tabs/media_tab.cpp
+++ b/src/shell/control_center/tabs/media_tab.cpp
@@ -174,7 +174,7 @@ std::unique_ptr<Flex> MediaTab::create() {
   auto tab = ui::row({
       .out = &m_rootLayout,
       .align = FlexAlign::Stretch,
-      .gap = Style::spaceSm * scale,
+      .gap = Style::spaceMd * scale,
   });
 
   auto mediaColumn = ui::column({
@@ -442,7 +442,7 @@ std::unique_ptr<Flex> MediaTab::create() {
   auto visualizerColumn = ui::column({
       .out = &m_visualizerColumn,
       .align = FlexAlign::Stretch,
-      .gap = Style::spaceSm * scale,
+      .gap = Style::spaceMd * scale,
       .clipChildren = true,
       .flexGrow = 2.0f,
       .configure = [scale, opacity = panelCardOpacity()](Flex& column) {

--- a/src/shell/control_center/tabs/monitor_tab.cpp
+++ b/src/shell/control_center/tabs/monitor_tab.cpp
@@ -244,6 +244,7 @@ void MonitorTab::rebuildCards(Renderer& /*renderer*/) {
   for (const auto& display : displays) {
     // Card container
     auto card = ui::column({
+        .gap = Style::spaceMd * scale,
         .configure = [scale, opacity = panelCardOpacity()](Flex& section) {
           applySectionCardStyle(section, scale, opacity);
         },

--- a/src/shell/control_center/tabs/monitor_tab.cpp
+++ b/src/shell/control_center/tabs/monitor_tab.cpp
@@ -244,9 +244,9 @@ void MonitorTab::rebuildCards(Renderer& /*renderer*/) {
   for (const auto& display : displays) {
     // Card container
     auto card = ui::column({
-        .gap = Style::spaceMd * scale,
         .configure = [scale, opacity = panelCardOpacity()](Flex& section) {
           applySectionCardStyle(section, scale, opacity);
+          section.setGap(Style::spaceMd * scale);
         },
     });
 

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -453,9 +453,11 @@ std::unique_ptr<Flex> NetworkTab::create() {
 
   auto passwordCard = ui::column({
       .out = &m_passwordCard,
-      .gap = Style::spaceMd * scale,
       .visible = false,
-      .configure = [scale, opacity = panelCardOpacity()](Flex& card) { applySectionCardStyle(card, scale, opacity); },
+      .configure = [scale, opacity = panelCardOpacity()](Flex& card) {
+        applySectionCardStyle(card, scale, opacity);
+        card.setGap(Style::spaceMd * scale);
+      },
   });
 
   passwordCard->addChild(

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -453,6 +453,7 @@ std::unique_ptr<Flex> NetworkTab::create() {
 
   auto passwordCard = ui::column({
       .out = &m_passwordCard,
+      .gap = Style::spaceMd * scale,
       .visible = false,
       .configure = [scale, opacity = panelCardOpacity()](Flex& card) { applySectionCardStyle(card, scale, opacity); },
   });

--- a/src/shell/control_center/tabs/notifications_tab.cpp
+++ b/src/shell/control_center/tabs/notifications_tab.cpp
@@ -648,7 +648,7 @@ std::unique_ptr<Flex> NotificationsTab::create() {
   auto tab = ui::column({
       .out = &m_root,
       .align = FlexAlign::Stretch,
-      .gap = Style::spaceSm * scale,
+      .gap = Style::spaceMd * scale,
   });
 
   tab->addChild(

--- a/src/shell/control_center/tabs/system_tab.cpp
+++ b/src/shell/control_center/tabs/system_tab.cpp
@@ -214,7 +214,7 @@ std::unique_ptr<Flex> SystemTab::create() {
   auto tab = ui::column({
       .out = &m_root,
       .align = FlexAlign::Stretch,
-      .gap = Style::spaceSm * sc,
+      .gap = Style::spaceMd * sc,
   });
 
   // --- Graph grid ---
@@ -222,7 +222,7 @@ std::unique_ptr<Flex> SystemTab::create() {
   {
     auto row = ui::row({
         .align = FlexAlign::Stretch,
-        .gap = Style::spaceSm * sc,
+        .gap = Style::spaceMd * sc,
         .flexGrow = 1.0f,
     });
 
@@ -271,7 +271,7 @@ std::unique_ptr<Flex> SystemTab::create() {
   {
     auto row = ui::row({
         .align = FlexAlign::Stretch,
-        .gap = Style::spaceSm * sc,
+        .gap = Style::spaceMd * sc,
         .flexGrow = 1.0f,
     });
 
@@ -328,7 +328,7 @@ std::unique_ptr<Flex> SystemTab::create() {
   {
     auto row = ui::row({
         .align = FlexAlign::Stretch,
-        .gap = Style::spaceSm * sc,
+        .gap = Style::spaceMd * sc,
     });
     static constexpr const char* kSystemGlyphs[] = {"cpu-usage",        "video",      "device-desktop",
                                                     "layers-intersect", "app-window", "clock"};

--- a/src/shell/control_center/tabs/weather_tab.cpp
+++ b/src/shell/control_center/tabs/weather_tab.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<Flex> WeatherTab::create() {
   auto leftColumn = ui::column({
       .out = &m_leftColumn,
       .align = FlexAlign::Stretch,
-      .gap = Style::spaceSm * scale,
+      .gap = Style::spaceMd * scale,
       .flexGrow = 3.0f,
   });
 

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -87,7 +87,7 @@ float SessionPanel::preferredWidth() const {
   const float w = kButtonMinWidth * static_cast<float>(n)
       + gap * static_cast<float>(n > 1 ? n - 1 : 0)
       + Style::panelPadding * 2.0f;
-  return scaled(gridEnabled() ? w : std::max(kPanelMinWidth, w));
+  return scaled(w);
 }
 
 float SessionPanel::preferredHeight() const {

--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -83,18 +83,16 @@ PanelPlacement SessionPanel::panelPlacement() const noexcept {
 
 float SessionPanel::preferredWidth() const {
   const std::size_t n = visibleColumnCount();
-  const float gap = Style::spaceSm;
+  const float gap = Style::spaceMd;
   const float w = kButtonMinWidth * static_cast<float>(n)
       + gap * static_cast<float>(n > 1 ? n - 1 : 0)
       + Style::panelPadding * 2.0f;
-  // The min-width floor keeps the default single-row panel comfortably wide; an explicit
-  // grid sizes to its own columns instead of being stretched back out to it.
   return scaled(gridEnabled() ? w : std::max(kPanelMinWidth, w));
 }
 
 float SessionPanel::preferredHeight() const {
   const std::size_t rows = visibleRowCount();
-  const float gap = Style::spaceSm;
+  const float gap = Style::spaceMd;
   const float h = kActionButtonMinHeight * static_cast<float>(rows)
       + gap * static_cast<float>(rows > 1 ? rows - 1 : 0)
       + Style::panelPadding * 2.0f;
@@ -135,8 +133,8 @@ void SessionPanel::create() {
 
   auto rootLayout = std::make_unique<GridView>();
   rootLayout->setColumns(columns);
-  rootLayout->setColumnGap(Style::spaceSm * scale);
-  rootLayout->setRowGap(Style::spaceSm * scale);
+  rootLayout->setColumnGap(Style::spaceMd * scale);
+  rootLayout->setRowGap(Style::spaceMd * scale);
   rootLayout->setStretchItems(true);
   rootLayout->setUniformCellSize(true);
   rootLayout->setMinCellWidth(kButtonMinWidth * scale);
@@ -197,7 +195,7 @@ Button* SessionPanel::createActionButton(const SessionPanelActionConfig& cfg, st
       .minWidth = kButtonMinWidth * scale,
       .minHeight = kActionButtonMinHeight * scale,
       .paddingV = Style::spaceMd * scale,
-      .paddingH = Style::spaceLg * scale,
+      .paddingH = Style::spaceMd * scale,
       .gap = Style::spaceSm * scale,
       .radius = Style::scaledRadiusLg(scale),
       .flexGrow = 1.0f,

--- a/src/shell/session/session_panel.h
+++ b/src/shell/session/session_panel.h
@@ -52,7 +52,6 @@ private:
 
   static constexpr float kActionButtonMinHeight = 112.0f;
   static constexpr float kButtonMinWidth = 152.0f;
-  static constexpr float kPanelMinWidth = 152.0f;
   static constexpr std::size_t kMaxColumns = 5;
 
   void doLayout(Renderer& renderer, float width, float height) override;

--- a/src/shell/session/session_panel.h
+++ b/src/shell/session/session_panel.h
@@ -52,7 +52,7 @@ private:
 
   static constexpr float kActionButtonMinHeight = 112.0f;
   static constexpr float kButtonMinWidth = 152.0f;
-  static constexpr float kPanelMinWidth = 680.0f;
+  static constexpr float kPanelMinWidth = 152.0f;
   static constexpr std::size_t kMaxColumns = 5;
 
   void doLayout(Renderer& renderer, float width, float height) override;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Harmonizes element spacing, card padding, and outer margins across Control Center tabs and the Session panel for a clean, consistent visual 
- **Control Center**: Standardized inter-card row/column gaps, sidebar padding, grid spacing, and inner container paddings to uniform `12px` (`Style::spaceMd * scale`) across all tabs (`Home`, `Audio`, `Media`, `Monitor`, `Network`, `Notifications`, `Weather`, and `System`
- **Session Panel**: Removed artificial `kPanelMinWidth` floor stretching on vertical layouts, aligning outer margins to `16px` (`Style::panelPadding`) and inter-button gaps to `12px` (`Style::spaceMd * scale`)


## Motivation

<!-- What problem does this solve? -->
Previously, inter-card gaps and outer container margins varied between 4px, 8px, 12px, and 16px across different Control Center tabs and shell causing visual misalignment and uneven borders.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just test` and `just build` to ensure zero compilation errors and that the code follows clang-format

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland
- [x] Tested at different interface scaling values

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
| **Before** | **After** |
| :--- | :--- |
| <img width="616" height="540" alt="image" src="https://github.com/user-attachments/assets/4e838bf9-abbb-461f-ba39-6c20309e189b" /> | <img width="611" height="531" alt="image" src="https://github.com/user-attachments/assets/578b2058-3cb9-4a5e-9bdb-ae39db0db768" /> |
| <img width="627" height="543" alt="image" src="https://github.com/user-attachments/assets/b75f483c-01e3-453b-9797-113e7ee59e2e" /> | <img width="631" height="531" alt="image" src="https://github.com/user-attachments/assets/d04067e1-b64f-4be4-988d-9517407b0ec9" /> |
| <img width="190" height="632" alt="image" src="https://github.com/user-attachments/assets/69964816-edd7-4c65-a01e-b10a82c7a3d2" /> | <img width="189" height="643" alt="image" src="https://github.com/user-attachments/assets/49e59527-4f05-4546-af8d-16e23fb5be3a" /> |

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR adds no new user-facing strings.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Chose not to touch other areas like login box, where they still look fine without the spacing fixes