### PR TITLE
[Control Center] Span shortcut blocks horizontally

### DIFF
--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -519,6 +519,7 @@ std::unique_ptr<Flex> HomeTab::create() {
   grid->setStretchItems(true);
   grid->setSquareCells(false);
   grid->setMinCellHeight(0.0f);
+  grid->setSpanLastItem(true);
   grid->setFlexGrow(kHomeShortcutsFlexGrow);
   m_shortcutsGrid = grid.get();
 

--- a/src/ui/controls/grid_view.cpp
+++ b/src/ui/controls/grid_view.cpp
@@ -227,44 +227,67 @@ void GridView::doLayout(Renderer& renderer) {
       layoutWithAssignedSize(child, itemWidth, uniformHeight);
     }
   } else {
-    if (hasFixedWidth && m_stretchItems) {
-      std::ranges::fill(columnWidths, stretchedWidth);
+    const std::size_t lastIndex = visibleChildren.size() - 1;
+    const std::size_t lastCol = lastIndex % columns;
+    const bool lastItemSpans = m_spanLastItem && lastCol + 1 < columns;
+    const std::size_t lastColSpan = lastItemSpans ? columns - lastCol : 1;
+    const bool stretchToFixedWidth = hasFixedWidth && m_stretchItems;
+    float lastItemNaturalWidth = 0.0f;
+
+    // Measure first so every column width is final before a spanning child is arranged.
+    for (std::size_t index = 0; index < visibleChildren.size(); ++index) {
+      Node* child = visibleChildren[index];
+      const std::size_t col = index % columns;
+      const std::size_t row = index / columns;
+      child->layout(renderer);
+
+      if (!stretchToFixedWidth) {
+        if (lastItemSpans && index == lastIndex) {
+          lastItemNaturalWidth = child->width();
+        } else {
+          columnWidths[col] = std::max(columnWidths[col], child->width());
+        }
+      }
+      rowHeights[row] = std::max(rowHeights[row], child->height());
+    }
+
+    if (stretchToFixedWidth) {
+      std::ranges::fill(columnWidths, std::max(stretchedWidth, m_minCellWidth));
+    } else {
+      for (auto& columnWidth : columnWidths) {
+        columnWidth = std::max(columnWidth, m_minCellWidth);
+      }
+
+      if (lastItemSpans) {
+        const auto spanBegin = columnWidths.begin() + static_cast<std::ptrdiff_t>(lastCol);
+        const float currentSpanWidth =
+            std::accumulate(spanBegin, columnWidths.end(), 0.0f) + static_cast<float>(lastColSpan - 1) * m_columnGap;
+        if (lastItemNaturalWidth > currentSpanWidth) {
+          const float extraPerColumn = (lastItemNaturalWidth - currentSpanWidth) / static_cast<float>(lastColSpan);
+          for (std::size_t col = lastCol; col < columns; ++col) {
+            columnWidths[col] += extraPerColumn;
+          }
+        }
+      }
+    }
+
+    for (auto& rowHeight : rowHeights) {
+      rowHeight = std::max(rowHeight, m_minCellHeight);
     }
 
     for (std::size_t index = 0; index < visibleChildren.size(); ++index) {
       Node* child = visibleChildren[index];
       const std::size_t col = index % columns;
-      const std::size_t row = index / columns;
-
-      float itemWidth = columnWidths[col];
-      if (m_spanLastItem && index == visibleChildren.size() - 1 && columns > 0) {
-        const std::size_t colSpan = columns - col;
-        if (colSpan > 1) {
-          itemWidth = 0.0f;
-          for (std::size_t c = col; c < columns; ++c) {
-            itemWidth += columnWidths[c];
-          }
-          itemWidth += static_cast<float>(colSpan - 1) * m_columnGap;
-        }
+      const bool spans = lastItemSpans && index == lastIndex;
+      if (!stretchToFixedWidth && !spans) {
+        continue;
       }
 
-      if (hasFixedWidth && m_stretchItems && stretchedWidth > 0.0f) {
-        layoutWithAssignedSize(child, itemWidth, child->height());
-      } else {
-        child->layout(renderer);
-      }
-
-      if (!hasFixedWidth || !m_stretchItems) {
-        columnWidths[col] = std::max(columnWidths[col], child->width());
-      }
-      rowHeights[row] = std::max(rowHeights[row], child->height());
-    }
-
-    for (auto& columnWidth : columnWidths) {
-      columnWidth = std::max(columnWidth, m_minCellWidth);
-    }
-    for (auto& rowHeight : rowHeights) {
-      rowHeight = std::max(rowHeight, m_minCellHeight);
+      const std::size_t colSpan = spans ? lastColSpan : 1;
+      const auto spanBegin = columnWidths.begin() + static_cast<std::ptrdiff_t>(col);
+      const auto spanEnd = spanBegin + static_cast<std::ptrdiff_t>(colSpan);
+      const float itemWidth = std::accumulate(spanBegin, spanEnd, 0.0f) + static_cast<float>(colSpan - 1) * m_columnGap;
+      layoutWithAssignedSize(child, itemWidth, child->height());
     }
   }
 

--- a/src/ui/controls/grid_view.cpp
+++ b/src/ui/controls/grid_view.cpp
@@ -89,6 +89,14 @@ void GridView::setMinCellHeight(float height) {
   markLayoutDirty();
 }
 
+void GridView::setSpanLastItem(bool span) {
+  if (m_spanLastItem == span) {
+    return;
+  }
+  m_spanLastItem = span;
+  markLayoutDirty();
+}
+
 LayoutSize GridView::doMeasure(Renderer& renderer, const LayoutConstraints& constraints) {
   float useW = width();
   if (constraints.hasExactWidth()) {
@@ -206,8 +214,17 @@ void GridView::doLayout(Renderer& renderer) {
     std::ranges::fill(columnWidths, uniformWidth);
     std::ranges::fill(rowHeights, uniformHeight);
 
-    for (Node* child : visibleChildren) {
-      layoutWithAssignedSize(child, uniformWidth, uniformHeight);
+    for (std::size_t index = 0; index < visibleChildren.size(); ++index) {
+      Node* child = visibleChildren[index];
+      float itemWidth = uniformWidth;
+      if (m_spanLastItem && index == visibleChildren.size() - 1 && columns > 0) {
+        const std::size_t col = index % columns;
+        const std::size_t colSpan = columns - col;
+        if (colSpan > 1) {
+          itemWidth = static_cast<float>(colSpan) * uniformWidth + static_cast<float>(colSpan - 1) * m_columnGap;
+        }
+      }
+      layoutWithAssignedSize(child, itemWidth, uniformHeight);
     }
   } else {
     if (hasFixedWidth && m_stretchItems) {
@@ -219,8 +236,20 @@ void GridView::doLayout(Renderer& renderer) {
       const std::size_t col = index % columns;
       const std::size_t row = index / columns;
 
+      float itemWidth = columnWidths[col];
+      if (m_spanLastItem && index == visibleChildren.size() - 1 && columns > 0) {
+        const std::size_t colSpan = columns - col;
+        if (colSpan > 1) {
+          itemWidth = 0.0f;
+          for (std::size_t c = col; c < columns; ++c) {
+            itemWidth += columnWidths[c];
+          }
+          itemWidth += static_cast<float>(colSpan - 1) * m_columnGap;
+        }
+      }
+
       if (hasFixedWidth && m_stretchItems && stretchedWidth > 0.0f) {
-        layoutWithAssignedSize(child, columnWidths[col], child->height());
+        layoutWithAssignedSize(child, itemWidth, child->height());
       } else {
         child->layout(renderer);
       }

--- a/src/ui/controls/grid_view.h
+++ b/src/ui/controls/grid_view.h
@@ -21,6 +21,8 @@ public:
   void setSquareGridShrinkWrap(bool shrinkWrap);
   void setMinCellWidth(float width);
   void setMinCellHeight(float height);
+  // When true, the last child in an incomplete row stretches across remaining columns.
+  void setSpanLastItem(bool span);
 
   [[nodiscard]] std::size_t columns() const noexcept { return m_columns; }
   [[nodiscard]] float columnGap() const noexcept { return m_columnGap; }
@@ -33,6 +35,7 @@ public:
   [[nodiscard]] bool uniformCellSize() const noexcept { return m_uniformCellSize; }
   [[nodiscard]] bool squareCells() const noexcept { return m_squareCells; }
   [[nodiscard]] bool squareGridShrinkWrap() const noexcept { return m_squareGridShrinkWrap; }
+  [[nodiscard]] bool spanLastItem() const noexcept { return m_spanLastItem; }
   [[nodiscard]] float minCellWidth() const noexcept { return m_minCellWidth; }
   [[nodiscard]] float minCellHeight() const noexcept { return m_minCellHeight; }
 
@@ -50,6 +53,7 @@ private:
   bool m_uniformCellSize = true;
   bool m_squareCells = false;
   bool m_squareGridShrinkWrap = true;
+  bool m_spanLastItem = false;
   float m_minCellWidth = 0.0f;
   float m_minCellHeight = 0.0f;
 };


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Implements spanning of shortcut blocks across columns for odd number of shortcuts

## Motivation

<!-- What problem does this solve? -->
Solves the issue where when there are odd number of shortcuts, it leaves a blank space to the right side

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just test`, `just build` to ensure zero compilation errors and that the code follows clang-format

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland
- [x] Tested at different interface scaling values

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
|**Before**|**After**|
|----------|---------|
|<img width="605" height="524" alt="image" src="https://github.com/user-attachments/assets/94a26f7c-f132-44d1-a996-794044c7a333" />|<img width="606" height="523" alt="image" src="https://github.com/user-attachments/assets/861a2c53-b7f1-42ad-b703-e3ad1b7b0b49" />|
## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
