### PR TITLE
fix(taskbar): preserve input areas on title refresh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1146,6 +1146,7 @@ if build_tests
     'state_store',
     'string_utils',
     'system_monitor_service',
+    'taskbar_widget',
     'time_format',
     'triad_workspace_backend',
     'ui_tree_reconciler',

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -27,6 +27,7 @@
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <cmath>
 #include <functional>
@@ -596,6 +597,7 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
   }
   m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   m_taskTileAreas.clear();
+  m_taskTileAreas.reserve(m_tasks.size());
   clearChildren(m_taskStrip);
   buildTaskButtons(renderer);
 }
@@ -712,7 +714,10 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     });
   };
 
+  // Only elements of m_tasks have a meaningful position; any other TaskModel would yield a
+  // garbage index that the generation check cannot catch.
   const auto taskRefFor = [this](const TaskModel& task) {
+    assert(&task >= m_tasks.data() && &task < m_tasks.data() + m_tasks.size());
     return TaskRef{
         .index = static_cast<std::size_t>(&task - m_tasks.data()),
         .generation = m_taskGeneration,
@@ -721,7 +726,10 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
 
   auto createTaskTile = [&](TaskRef taskRef, std::vector<TaskRef> cycleCandidates = {}, std::string cycleKey = {},
                             std::size_t badgeCount = 1) {
+    // Unreachable at build time: every ref is built from a live m_tasks element at the current
+    // generation. Kept as a release-safe guard so a stale ref cannot deref null.
     const TaskModel* taskModel = resolveTask(m_tasks, taskRef, m_taskGeneration);
+    assert(taskModel != nullptr);
     if (taskModel == nullptr) {
       return ui::inputArea({});
     }
@@ -916,6 +924,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         area->addChild(std::move(indicator));
       }
     }
+    // Installed even for a currently empty title: a title arriving later must surface without a
+    // rebuild. Empty content measures to nothing, so the popup never shows.
     area->setTooltipProvider([this, taskRef]() -> TooltipContent {
       const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
       return current != nullptr && !current->title.empty() ? TooltipContent{current->title}

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -267,25 +267,11 @@ bool TaskbarWidget::taskInWorkspaceGroup(const TaskModel& task, const WorkspaceM
 }
 
 const TaskbarWidget::TaskModel*
-TaskbarWidget::currentTask(const std::vector<TaskModel>& tasks, const TaskModel& identity) {
-  const auto sameTask = [&identity](const TaskModel& current) {
-    if (identity.handleKey != 0 && identity.handleKey == current.handleKey) {
-      return true;
-    }
-    if (!identity.workspaceWindowId.empty() && identity.workspaceWindowId == current.workspaceWindowId) {
-      return true;
-    }
-    return identity.pinned
-        && current.pinned
-        && identity.handleKey == 0
-        && current.handleKey == 0
-        && identity.workspaceWindowId.empty()
-        && current.workspaceWindowId.empty()
-        && !identity.desktopEntryId.empty()
-        && identity.desktopEntryId == current.desktopEntryId;
-  };
-  const auto current = std::ranges::find_if(tasks, sameTask);
-  return current != tasks.end() ? &*current : nullptr;
+TaskbarWidget::resolveTask(const std::vector<TaskModel>& tasks, TaskRef ref, std::uint64_t currentGeneration) {
+  if (ref.generation != currentGeneration || ref.index >= tasks.size()) {
+    return nullptr;
+  }
+  return &tasks[ref.index];
 }
 
 void TaskbarWidget::activateTaskModel(const TaskModel& task) {
@@ -726,8 +712,20 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     });
   };
 
-  auto createTaskTile = [&](const TaskModel& task, std::vector<TaskModel> cycleCandidates = {},
-                            std::string cycleKey = {}, std::size_t badgeCount = 1) {
+  const auto taskRefFor = [this](const TaskModel& task) {
+    return TaskRef{
+        .index = static_cast<std::size_t>(&task - m_tasks.data()),
+        .generation = m_taskGeneration,
+    };
+  };
+
+  auto createTaskTile = [&](TaskRef taskRef, std::vector<TaskRef> cycleCandidates = {}, std::string cycleKey = {},
+                            std::size_t badgeCount = 1) {
+    const TaskModel* taskModel = resolveTask(m_tasks, taskRef, m_taskGeneration);
+    if (taskModel == nullptr) {
+      return ui::inputArea({});
+    }
+    const TaskModel& task = *taskModel;
     auto area = ui::inputArea({});
     area->setFrameSize(tileWidthWithTitle, tileSize);
     float tileOpacity = task.active ? m_activeOpacity : m_inactiveOpacity;
@@ -754,9 +752,9 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         || !cycleCandidates.empty()
         || task.pinned) {
       auto* areaPtr = area.get();
-      area->setOnClick([this, task, areaPtr, cycleCandidates = std::move(cycleCandidates),
+      area->setOnClick([this, taskRef, areaPtr, cycleCandidates = std::move(cycleCandidates),
                         cycleKey = std::move(cycleKey)](const InputArea::PointerData& data) {
-        const TaskModel* current = currentTask(m_tasks, task);
+        const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
         if (current == nullptr) {
           return;
         }
@@ -779,8 +777,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         }
         if (data.button == BTN_MIDDLE) {
           if (!cycleCandidates.empty()) {
-            for (const auto& candidate : cycleCandidates) {
-              const TaskModel* currentCandidate = currentTask(m_tasks, candidate);
+            for (const TaskRef candidate : cycleCandidates) {
+              const TaskModel* currentCandidate = resolveTask(m_tasks, candidate, m_taskGeneration);
               if (currentCandidate != nullptr && currentCandidate->active) {
                 closeTaskModel(*currentCandidate);
                 return;
@@ -796,7 +794,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
             if (cursor >= cycleCandidates.size()) {
               cursor = 0;
             }
-            const TaskModel* target = currentTask(m_tasks, cycleCandidates[cursor]);
+            const TaskModel* target = resolveTask(m_tasks, cycleCandidates[cursor], m_taskGeneration);
             cursor = (cursor + 1) % cycleCandidates.size();
             if (target != nullptr) {
               activateTaskModel(*target);
@@ -918,8 +916,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         area->addChild(std::move(indicator));
       }
     }
-    area->setTooltipProvider([this, task]() -> TooltipContent {
-      const TaskModel* current = currentTask(m_tasks, task);
+    area->setTooltipProvider([this, taskRef]() -> TooltipContent {
+      const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
       return current != nullptr && !current->title.empty() ? TooltipContent{current->title}
                                                            : TooltipContent{std::monostate{}};
     });
@@ -1171,14 +1169,14 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       });
 
       std::vector<const TaskModel*> renderedTasks = tasks;
-      std::unordered_map<std::uintptr_t, std::vector<TaskModel>> cycleCandidatesByHandle;
+      std::unordered_map<std::uintptr_t, std::vector<TaskRef>> cycleCandidatesByHandle;
       std::unordered_map<std::uintptr_t, std::string> cycleKeyByHandle;
       std::unordered_map<std::uintptr_t, std::size_t> badgeCountByHandle;
       if (m_workspaceGroupContent == WorkspaceGroupContent::Icons && m_groupSingleIconPerApp && !tasks.empty()) {
         struct GroupedTaskItem {
           const TaskModel* representative = nullptr;
           std::string cycleKey;
-          std::vector<TaskModel> candidates;
+          std::vector<TaskRef> candidates;
         };
         std::vector<GroupedTaskItem> groupedItems;
         std::unordered_map<std::string, std::size_t> groupedIndexByKey;
@@ -1199,12 +1197,12 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
                 GroupedTaskItem{
                     .representative = task,
                     .cycleKey = groupedKey,
-                    .candidates = {*task},
+                    .candidates = {taskRefFor(*task)},
                 }
             );
           } else {
             auto& grouped = groupedItems[it->second];
-            grouped.candidates.push_back(*task);
+            grouped.candidates.push_back(taskRefFor(*task));
             if (!grouped.representative->active && task->active) {
               grouped.representative = task;
             }
@@ -1322,7 +1320,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           const std::size_t badgeCount =
               badgeCountByHandle.contains(task->handleKey) ? badgeCountByHandle[task->handleKey] : 1;
           group->addChild(createTaskTile(
-              *task, cycleIt != cycleCandidatesByHandle.end() ? cycleIt->second : std::vector<TaskModel>{},
+              taskRefFor(*task), cycleIt != cycleCandidatesByHandle.end() ? cycleIt->second : std::vector<TaskRef>{},
               cycleKeyIt != cycleKeyByHandle.end() ? cycleKeyIt->second : std::string{}, badgeCount
           ));
         }
@@ -1355,12 +1353,13 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   m_taskStrip->setPadding(0.0f, 0.0f, 0.0f, 0.0f);
   m_taskStrip->setGap(tileGap);
   std::unordered_set<std::string> pinnedCycleKeysThisFrame;
-  for (const auto& task : m_tasks) {
+  for (std::size_t i = 0; i < m_tasks.size(); ++i) {
+    const auto& task = m_tasks[i];
     if (task.pinned && task.running && task.instanceCount > 1) {
       pinnedCycleKeysThisFrame.insert(!task.desktopEntryId.empty() ? task.desktopEntryId : task.idLower);
     }
     const std::size_t badgeCount = task.pinned ? std::max<std::size_t>(1, task.instanceCount) : 1;
-    m_taskStrip->addChild(createTaskTile(task, {}, {}, badgeCount));
+    m_taskStrip->addChild(createTaskTile(TaskRef{.index = i, .generation = m_taskGeneration}, {}, {}, badgeCount));
   }
   std::erase_if(m_groupedAppCycleCursor, [&](const auto& item) {
     return !pinnedCycleKeysThisFrame.contains(item.first);
@@ -2437,6 +2436,7 @@ void TaskbarWidget::updateModels() {
     }
     return;
   }
+  ++m_taskGeneration;
   m_tasks = std::move(nextTasks);
   m_workspaces = std::move(nextWorkspaces);
   m_rebuildPending = true;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -266,6 +266,28 @@ bool TaskbarWidget::taskInWorkspaceGroup(const TaskModel& task, const WorkspaceM
   return !ws.workspace.name.empty() && task.workspaceKey == ws.workspace.name;
 }
 
+const TaskbarWidget::TaskModel*
+TaskbarWidget::currentTask(const std::vector<TaskModel>& tasks, const TaskModel& identity) {
+  const auto sameTask = [&identity](const TaskModel& current) {
+    if (identity.handleKey != 0 && identity.handleKey == current.handleKey) {
+      return true;
+    }
+    if (!identity.workspaceWindowId.empty() && identity.workspaceWindowId == current.workspaceWindowId) {
+      return true;
+    }
+    return identity.pinned
+        && current.pinned
+        && identity.handleKey == 0
+        && current.handleKey == 0
+        && identity.workspaceWindowId.empty()
+        && current.workspaceWindowId.empty()
+        && !identity.desktopEntryId.empty()
+        && identity.desktopEntryId == current.desktopEntryId;
+  };
+  const auto current = std::ranges::find_if(tasks, sameTask);
+  return current != tasks.end() ? &*current : nullptr;
+}
+
 void TaskbarWidget::activateTaskModel(const TaskModel& task) {
   if (task.firstHandle != nullptr) {
     m_platform.activateToplevel(task.firstHandle);
@@ -587,6 +609,7 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
     return;
   }
   m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
+  m_taskTileAreas.clear();
   clearChildren(m_taskStrip);
   buildTaskButtons(renderer);
 }
@@ -724,46 +747,47 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         }
       }
     }
-    const std::optional<Workspace> clickWorkspace =
-        taskWorkspace != nullptr ? std::optional<Workspace>(taskWorkspace->workspace) : std::nullopt;
-    wl_output* const taskWsHost = taskWorkspace != nullptr ? workspaceHostOutput(*taskWorkspace) : m_output;
-
     if (task.firstHandle != nullptr
         || !task.workspaceWindowId.empty()
         || (compositors::isKde() && (!task.title.empty() || !task.appId.empty()))
-        || clickWorkspace.has_value()
+        || taskWorkspace != nullptr
         || !cycleCandidates.empty()
         || task.pinned) {
       auto* areaPtr = area.get();
-      area->setOnClick([this, task, areaPtr, handle = task.firstHandle, windowId = task.workspaceWindowId,
-                        clickWorkspace, taskWsHost, cycleCandidates = std::move(cycleCandidates),
+      area->setOnClick([this, task, areaPtr, cycleCandidates = std::move(cycleCandidates),
                         cycleKey = std::move(cycleKey)](const InputArea::PointerData& data) {
-        if (task.pinned) {
+        const TaskModel* current = currentTask(m_tasks, task);
+        if (current == nullptr) {
+          return;
+        }
+
+        if (current->pinned) {
           if (data.button == BTN_MIDDLE) {
-            if (task.running) {
-              closeTaskModel(task);
+            if (current->running) {
+              closeTaskModel(*current);
             }
             return;
           }
           if (data.button == BTN_LEFT) {
-            activateOrLaunchPinned(task);
+            activateOrLaunchPinned(*current);
             return;
           }
           if (data.button == BTN_RIGHT && areaPtr != nullptr) {
-            openTaskContextMenu(task, *areaPtr);
+            openTaskContextMenu(*current, *areaPtr);
           }
           return;
         }
         if (data.button == BTN_MIDDLE) {
           if (!cycleCandidates.empty()) {
             for (const auto& candidate : cycleCandidates) {
-              if (candidate.active) {
-                closeTaskModel(candidate);
+              const TaskModel* currentCandidate = currentTask(m_tasks, candidate);
+              if (currentCandidate != nullptr && currentCandidate->active) {
+                closeTaskModel(*currentCandidate);
                 return;
               }
             }
           }
-          closeTaskModel(task);
+          closeTaskModel(*current);
           return;
         }
         if (data.button == BTN_LEFT) {
@@ -772,30 +796,20 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
             if (cursor >= cycleCandidates.size()) {
               cursor = 0;
             }
-            const TaskModel& target = cycleCandidates[cursor];
+            const TaskModel* target = currentTask(m_tasks, cycleCandidates[cursor]);
             cursor = (cursor + 1) % cycleCandidates.size();
-            activateTaskModel(target);
+            if (target != nullptr) {
+              activateTaskModel(*target);
+            }
             return;
           }
-          if (handle != nullptr) {
-            m_platform.activateToplevel(handle);
-            return;
-          }
-          if (!windowId.empty()) {
-            m_platform.focusCompositorWindow(windowId);
-            return;
-          }
-          if (compositors::isKde() && (!task.title.empty() || !task.appId.empty())) {
-            m_platform.activateKdeWindow(task.title, task.appId);
-            return;
-          }
-          if (clickWorkspace.has_value()) {
-            m_platform.activateWorkspace(taskWsHost, *clickWorkspace);
-          }
+          activateTaskModel(*current);
           return;
         }
-        if (data.button == BTN_RIGHT && areaPtr != nullptr && (handle != nullptr || compositors::isKde())) {
-          openTaskContextMenu(task, *areaPtr);
+        if (data.button == BTN_RIGHT
+            && areaPtr != nullptr
+            && (current->firstHandle != nullptr || compositors::isKde())) {
+          openTaskContextMenu(*current, *areaPtr);
         }
       });
     } else {
@@ -904,11 +918,12 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         area->addChild(std::move(indicator));
       }
     }
-    if (!task.title.empty()) {
-      area->setTooltip(task.title);
-    } else {
-      area->clearTooltip();
-    }
+    area->setTooltipProvider([this, task]() -> TooltipContent {
+      const TaskModel* current = currentTask(m_tasks, task);
+      return current != nullptr && !current->title.empty() ? TooltipContent{current->title}
+                                                           : TooltipContent{std::monostate{}};
+    });
+    m_taskTileAreas.push_back(area.get());
     attachHover(*area, tileWidthWithTitle, tileSize);
     return area;
   };
@@ -2409,9 +2424,17 @@ void TaskbarWidget::updateModels() {
     applyPinnedMerge(nextTasks);
   }
 
-  if (modelsEqual(nextTasks, nextWorkspaces)) {
+  const ModelComparison comparison = compareModels(m_showWindowTitle, m_tasks, m_workspaces, nextTasks, nextWorkspaces);
+  if (comparison.layoutEqual) {
     m_tasks = std::move(nextTasks);
     m_workspaces = std::move(nextWorkspaces);
+    if (comparison.titlesChanged) {
+      for (InputArea* area : m_taskTileAreas) {
+        if (area != nullptr) {
+          area->requestTooltipRefresh();
+        }
+      }
+    }
     return;
   }
   m_tasks = std::move(nextTasks);
@@ -2757,43 +2780,49 @@ std::string TaskbarWidget::workspaceLabel(const Workspace& workspace, std::size_
   return std::to_string(index + 1);
 }
 
-bool TaskbarWidget::modelsEqual(
-    const std::vector<TaskModel>& tasks, const std::vector<WorkspaceModel>& workspaces
-) const {
-  if (tasks.size() != m_tasks.size() || workspaces.size() != m_workspaces.size()) {
-    return false;
+TaskbarWidget::ModelComparison TaskbarWidget::compareModels(
+    bool showWindowTitle, const std::vector<TaskModel>& previousTasks,
+    const std::vector<WorkspaceModel>& previousWorkspaces, const std::vector<TaskModel>& nextTasks,
+    const std::vector<WorkspaceModel>& nextWorkspaces
+) {
+  if (nextTasks.size() != previousTasks.size() || nextWorkspaces.size() != previousWorkspaces.size()) {
+    return {};
   }
-  for (std::size_t i = 0; i < tasks.size(); ++i) {
-    if (tasks[i].appId != m_tasks[i].appId
-        || tasks[i].iconPath != m_tasks[i].iconPath
-        || tasks[i].active != m_tasks[i].active
-        || tasks[i].firstHandle != m_tasks[i].firstHandle
-        || tasks[i].workspaceKey != m_tasks[i].workspaceKey
-        || tasks[i].order != m_tasks[i].order
-        || tasks[i].workspaceOrder != m_tasks[i].workspaceOrder
-        || tasks[i].title != m_tasks[i].title
-        || tasks[i].pinned != m_tasks[i].pinned
-        || tasks[i].running != m_tasks[i].running
-        || tasks[i].instanceCount != m_tasks[i].instanceCount
-        || tasks[i].desktopEntryId != m_tasks[i].desktopEntryId) {
-      return false;
+  bool titlesChanged = false;
+  for (std::size_t i = 0; i < nextTasks.size(); ++i) {
+    const bool titleChanged = nextTasks[i].title != previousTasks[i].title;
+    titlesChanged = titlesChanged || titleChanged;
+    if (nextTasks[i].appId != previousTasks[i].appId
+        || nextTasks[i].iconPath != previousTasks[i].iconPath
+        || nextTasks[i].active != previousTasks[i].active
+        || nextTasks[i].firstHandle != previousTasks[i].firstHandle
+        || nextTasks[i].workspaceKey != previousTasks[i].workspaceKey
+        || nextTasks[i].order != previousTasks[i].order
+        || nextTasks[i].workspaceOrder != previousTasks[i].workspaceOrder
+        || nextTasks[i].handleKey != previousTasks[i].handleKey
+        || (showWindowTitle && titleChanged)
+        || nextTasks[i].pinned != previousTasks[i].pinned
+        || nextTasks[i].running != previousTasks[i].running
+        || nextTasks[i].instanceCount != previousTasks[i].instanceCount
+        || nextTasks[i].desktopEntryId != previousTasks[i].desktopEntryId) {
+      return {};
     }
   }
-  for (std::size_t i = 0; i < workspaces.size(); ++i) {
-    const auto& a = workspaces[i].workspace;
-    const auto& b = m_workspaces[i].workspace;
+  for (std::size_t i = 0; i < nextWorkspaces.size(); ++i) {
+    const auto& a = nextWorkspaces[i].workspace;
+    const auto& b = previousWorkspaces[i].workspace;
     if (a.id != b.id
         || a.name != b.name
         || a.active != b.active
         || a.urgent != b.urgent
         || a.occupied != b.occupied
-        || workspaces[i].key != m_workspaces[i].key
-        || workspaces[i].label != m_workspaces[i].label
-        || workspaces[i].hostOutput != m_workspaces[i].hostOutput) {
-      return false;
+        || nextWorkspaces[i].key != previousWorkspaces[i].key
+        || nextWorkspaces[i].label != previousWorkspaces[i].label
+        || nextWorkspaces[i].hostOutput != previousWorkspaces[i].hostOutput) {
+      return {};
     }
   }
-  return true;
+  return {.layoutEqual = true, .titlesChanged = titlesChanged};
 }
 
 void TaskbarWidget::buildDesktopIconIndex() {

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -118,6 +118,11 @@ private:
     bool titlesChanged = false;
   };
 
+  struct TaskRef {
+    std::size_t index = 0;
+    std::uint64_t generation = 0;
+  };
+
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
 
@@ -150,7 +155,8 @@ private:
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
-  [[nodiscard]] static const TaskModel* currentTask(const std::vector<TaskModel>& tasks, const TaskModel& identity);
+  [[nodiscard]] static const TaskModel*
+  resolveTask(const std::vector<TaskModel>& tasks, TaskRef ref, std::uint64_t currentGeneration);
   void activateTaskModel(const TaskModel& task);
   void closeTaskModel(const TaskModel& task);
   void applyPinnedMerge(std::vector<TaskModel>& tasks);
@@ -202,6 +208,8 @@ private:
   Flex* m_taskStrip = nullptr;
 
   std::vector<TaskModel> m_tasks;
+  // Retained controls resolve task indices only while this model generation matches.
+  std::uint64_t m_taskGeneration = 0;
   // Non-owning; cleared before task-strip children are destroyed.
   std::vector<InputArea*> m_taskTileAreas;
   std::vector<WorkspaceModel> m_workspaces;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -18,6 +18,7 @@ class ContextMenuPopup;
 class ConfigService;
 class Flex;
 class InputArea;
+class TaskbarWidgetTestAccess;
 struct wl_output;
 struct zwlr_foreign_toplevel_handle_v1;
 
@@ -74,6 +75,8 @@ public:
   void cycleAdjacent(int direction);
 
 private:
+  friend class TaskbarWidgetTestAccess;
+
   struct TaskModel {
     std::uintptr_t handleKey = 0;
     std::uint64_t order = 0;
@@ -109,6 +112,12 @@ private:
     std::uint8_t votes = 0;
   };
 
+  struct ModelComparison {
+    bool layoutEqual = false;
+    // Meaningful only when layoutEqual is true and the existing task tiles will be retained.
+    bool titlesChanged = false;
+  };
+
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
 
@@ -119,8 +128,11 @@ private:
   void syncWorkspaceGroupingCapability();
   [[nodiscard]] static std::string toLower(std::string value);
   [[nodiscard]] static std::string workspaceLabel(const Workspace& workspace, std::size_t index);
-  [[nodiscard]] bool
-  modelsEqual(const std::vector<TaskModel>& tasks, const std::vector<WorkspaceModel>& workspaces) const;
+  [[nodiscard]] static ModelComparison compareModels(
+      bool showWindowTitle, const std::vector<TaskModel>& previousTasks,
+      const std::vector<WorkspaceModel>& previousWorkspaces, const std::vector<TaskModel>& nextTasks,
+      const std::vector<WorkspaceModel>& nextWorkspaces
+  );
   void buildDesktopIconIndex();
   [[nodiscard]] std::string resolveIconPath(const std::string& appId, const std::string& iconNameOrPath);
   void openTaskContextMenu(const TaskModel& task, InputArea& area);
@@ -138,6 +150,7 @@ private:
   [[nodiscard]] static ColorSpec readableColorForFill(const ColorSpec& fill);
   [[nodiscard]] static ColorRole onRoleForFill(ColorRole fill);
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
+  [[nodiscard]] static const TaskModel* currentTask(const std::vector<TaskModel>& tasks, const TaskModel& identity);
   void activateTaskModel(const TaskModel& task);
   void closeTaskModel(const TaskModel& task);
   void applyPinnedMerge(std::vector<TaskModel>& tasks);
@@ -189,6 +202,8 @@ private:
   Flex* m_taskStrip = nullptr;
 
   std::vector<TaskModel> m_tasks;
+  // Non-owning; cleared before task-strip children are destroyed.
+  std::vector<InputArea*> m_taskTileAreas;
   std::vector<WorkspaceModel> m_workspaces;
   // Full workspace list before "hide empty" filtering; used for scroll navigation.
   std::vector<WorkspaceModel> m_allWorkspaces;

--- a/tests/input_area_test.cpp
+++ b/tests/input_area_test.cpp
@@ -6,6 +6,7 @@
 #include <linux/input-event-codes.h>
 #include <memory>
 #include <print>
+#include <string>
 #include <thread>
 #include <wayland-client-protocol.h>
 
@@ -283,6 +284,30 @@ int main() {
 
     wheelFrame(area, 1.0f, 8);
     ok = expect(gestureStarts == 2, "axis stop serial starts the next gesture immediately") && ok;
+  }
+
+  {
+    InputArea area;
+    std::string title = "old";
+    int refreshes = 0;
+    area.setTooltipProvider([&title]() -> TooltipContent { return title; });
+    area.setTooltipChangedCallback([&refreshes](InputArea*) { ++refreshes; });
+
+    title = "new";
+    area.requestTooltipRefresh();
+    ok = expect(refreshes == 0, "tooltip refresh stays dormant while not hovered") && ok;
+
+    area.dispatchEnter(0.0f, 0.0f);
+    area.requestTooltipRefresh();
+    ok = expect(refreshes == 1, "tooltip refresh notifies while hovered") && ok;
+    ok = expect(
+             std::get<std::string>(area.tooltipContent()) == "new", "event refresh reads the provider's latest content"
+         )
+        && ok;
+
+    area.dispatchLeave();
+    area.requestTooltipRefresh();
+    ok = expect(refreshes == 1, "tooltip refresh stops notifying after hover leaves") && ok;
   }
 
   return ok ? 0 : 1;

--- a/tests/taskbar_widget_test.cpp
+++ b/tests/taskbar_widget_test.cpp
@@ -1,0 +1,82 @@
+#include "shell/bar/widgets/taskbar_widget.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+class TaskbarWidgetTestAccess {
+public:
+  static std::pair<bool, bool> compare(
+      bool showWindowTitle, std::uintptr_t previousHandle, std::uintptr_t nextHandle, std::string previousTitle,
+      std::string nextTitle
+  ) {
+    const TaskbarWidget::TaskModel previous{
+        .handleKey = previousHandle,
+        .title = std::move(previousTitle),
+    };
+    const TaskbarWidget::TaskModel next{
+        .handleKey = nextHandle,
+        .title = std::move(nextTitle),
+    };
+    const auto comparison = TaskbarWidget::compareModels(showWindowTitle, {previous}, {}, {next}, {});
+    return {comparison.layoutEqual, comparison.titlesChanged};
+  }
+
+  static std::optional<std::string>
+  currentTitle(std::vector<TaskbarWidget::TaskModel> tasks, const TaskbarWidget::TaskModel& identity) {
+    const auto* current = TaskbarWidget::currentTask(tasks, identity);
+    return current != nullptr && !current->title.empty() ? std::optional<std::string>(current->title) : std::nullopt;
+  }
+
+  static std::optional<std::string>
+  currentAppId(std::vector<TaskbarWidget::TaskModel> tasks, const TaskbarWidget::TaskModel& identity) {
+    const auto* current = TaskbarWidget::currentTask(tasks, identity);
+    return current != nullptr ? std::optional<std::string>(current->appId) : std::nullopt;
+  }
+
+  static TaskbarWidget::TaskModel task(
+      std::uintptr_t handleKey, std::string title, std::string windowId = {}, std::string desktopEntryId = {},
+      bool pinned = false, std::string appId = {}
+  ) {
+    return {
+        .handleKey = handleKey,
+        .appId = std::move(appId),
+        .title = std::move(title),
+        .workspaceWindowId = std::move(windowId),
+        .desktopEntryId = std::move(desktopEntryId),
+        .pinned = pinned,
+    };
+  }
+};
+
+int main() {
+  assert(TaskbarWidgetTestAccess::compare(false, 11, 11, "old", "new") == std::pair(true, true));
+  assert(!TaskbarWidgetTestAccess::compare(true, 11, 11, "old", "new").first);
+  assert(TaskbarWidgetTestAccess::compare(true, 11, 11, "same", "same") == std::pair(true, false));
+  assert(!TaskbarWidgetTestAccess::compare(false, 11, 12, "old", "new").first);
+
+  const auto original = TaskbarWidgetTestAccess::task(11, "old", "window-11");
+  auto tasks = std::vector{
+      TaskbarWidgetTestAccess::task(11, "updated", "window-11"),
+      TaskbarWidgetTestAccess::task(12, "second", "window-12"),
+  };
+  assert(TaskbarWidgetTestAccess::currentTitle(tasks, original) == std::optional<std::string>("updated"));
+
+  tasks[0].appId = "updated.app";
+  assert(TaskbarWidgetTestAccess::currentAppId(tasks, original) == std::optional<std::string>("updated.app"));
+
+  tasks[0].title.clear();
+  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, original).has_value());
+
+  tasks[0] = TaskbarWidgetTestAccess::task(21, "renumbered", "window-11");
+  assert(TaskbarWidgetTestAccess::currentTitle(tasks, original) == std::optional<std::string>("renumbered"));
+
+  const auto pinned = TaskbarWidgetTestAccess::task(0, "old", {}, "dev.noctalia.Example", true);
+  tasks = {TaskbarWidgetTestAccess::task(0, "updated", {}, "dev.noctalia.Example", true)};
+  assert(TaskbarWidgetTestAccess::currentTitle(tasks, pinned) == std::optional<std::string>("updated"));
+
+  return 0;
+}

--- a/tests/taskbar_widget_test.cpp
+++ b/tests/taskbar_widget_test.cpp
@@ -25,59 +25,43 @@ public:
     return {comparison.layoutEqual, comparison.titlesChanged};
   }
 
-  static std::optional<std::string> currentTitle(
+  // Resolves a retained tile's task reference the way the live tile callbacks do.
+  static std::optional<std::string> resolvedTitle(
       const std::vector<TaskbarWidget::TaskModel>& tasks, std::size_t index, std::uint64_t referenceGeneration,
       std::uint64_t currentGeneration
   ) {
     const auto* current =
         TaskbarWidget::resolveTask(tasks, {.index = index, .generation = referenceGeneration}, currentGeneration);
-    return current != nullptr && !current->title.empty() ? std::optional<std::string>(current->title) : std::nullopt;
+    return current != nullptr ? std::optional<std::string>(current->title) : std::nullopt;
   }
 
-  static std::optional<std::string> currentAppId(
-      const std::vector<TaskbarWidget::TaskModel>& tasks, std::size_t index, std::uint64_t referenceGeneration,
-      std::uint64_t currentGeneration
-  ) {
-    const auto* current =
-        TaskbarWidget::resolveTask(tasks, {.index = index, .generation = referenceGeneration}, currentGeneration);
-    return current != nullptr ? std::optional<std::string>(current->appId) : std::nullopt;
-  }
-
-  static TaskbarWidget::TaskModel task(
-      std::uintptr_t handleKey, std::string title, std::string windowId = {}, std::string desktopEntryId = {},
-      bool pinned = false, std::string appId = {}
-  ) {
+  static TaskbarWidget::TaskModel task(std::uintptr_t handleKey, std::string title) {
     return {
         .handleKey = handleKey,
-        .appId = std::move(appId),
         .title = std::move(title),
-        .workspaceWindowId = std::move(windowId),
-        .desktopEntryId = std::move(desktopEntryId),
-        .pinned = pinned,
     };
   }
 };
 
 int main() {
+  // A hidden title change keeps the layout and reports the title change for tooltip refreshes.
   assert(TaskbarWidgetTestAccess::compare(false, 11, 11, "old", "new") == std::pair(true, true));
+  // A displayed title is layout, so it still forces a rebuild.
   assert(!TaskbarWidgetTestAccess::compare(true, 11, 11, "old", "new").first);
   assert(TaskbarWidgetTestAccess::compare(true, 11, 11, "same", "same") == std::pair(true, false));
+  // Task identity changes rebuild regardless of the title.
   assert(!TaskbarWidgetTestAccess::compare(false, 11, 12, "old", "new").first);
 
   auto tasks = std::vector{
-      TaskbarWidgetTestAccess::task(11, "updated", "window-11"),
-      TaskbarWidgetTestAccess::task(12, "second", "window-12"),
+      TaskbarWidgetTestAccess::task(11, "first"),
+      TaskbarWidgetTestAccess::task(12, "second"),
   };
-  assert(TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 7) == std::optional<std::string>("updated"));
-
-  tasks[0].appId = "updated.app";
-  assert(TaskbarWidgetTestAccess::currentAppId(tasks, 0, 7, 7) == std::optional<std::string>("updated.app"));
-
-  tasks[0].title.clear();
-  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 7).has_value());
-
-  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 2, 7, 7).has_value());
-  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 8).has_value());
+  assert(TaskbarWidgetTestAccess::resolvedTitle(tasks, 0, 7, 7) == std::optional<std::string>("first"));
+  // Retained references read the current model, not the model they were built from.
+  tasks[0].title = "retitled";
+  assert(TaskbarWidgetTestAccess::resolvedTitle(tasks, 0, 7, 7) == std::optional<std::string>("retitled"));
+  assert(!TaskbarWidgetTestAccess::resolvedTitle(tasks, 2, 7, 7).has_value());
+  assert(!TaskbarWidgetTestAccess::resolvedTitle(tasks, 0, 7, 8).has_value());
 
   return 0;
 }

--- a/tests/taskbar_widget_test.cpp
+++ b/tests/taskbar_widget_test.cpp
@@ -25,15 +25,21 @@ public:
     return {comparison.layoutEqual, comparison.titlesChanged};
   }
 
-  static std::optional<std::string>
-  currentTitle(std::vector<TaskbarWidget::TaskModel> tasks, const TaskbarWidget::TaskModel& identity) {
-    const auto* current = TaskbarWidget::currentTask(tasks, identity);
+  static std::optional<std::string> currentTitle(
+      const std::vector<TaskbarWidget::TaskModel>& tasks, std::size_t index, std::uint64_t referenceGeneration,
+      std::uint64_t currentGeneration
+  ) {
+    const auto* current =
+        TaskbarWidget::resolveTask(tasks, {.index = index, .generation = referenceGeneration}, currentGeneration);
     return current != nullptr && !current->title.empty() ? std::optional<std::string>(current->title) : std::nullopt;
   }
 
-  static std::optional<std::string>
-  currentAppId(std::vector<TaskbarWidget::TaskModel> tasks, const TaskbarWidget::TaskModel& identity) {
-    const auto* current = TaskbarWidget::currentTask(tasks, identity);
+  static std::optional<std::string> currentAppId(
+      const std::vector<TaskbarWidget::TaskModel>& tasks, std::size_t index, std::uint64_t referenceGeneration,
+      std::uint64_t currentGeneration
+  ) {
+    const auto* current =
+        TaskbarWidget::resolveTask(tasks, {.index = index, .generation = referenceGeneration}, currentGeneration);
     return current != nullptr ? std::optional<std::string>(current->appId) : std::nullopt;
   }
 
@@ -58,25 +64,20 @@ int main() {
   assert(TaskbarWidgetTestAccess::compare(true, 11, 11, "same", "same") == std::pair(true, false));
   assert(!TaskbarWidgetTestAccess::compare(false, 11, 12, "old", "new").first);
 
-  const auto original = TaskbarWidgetTestAccess::task(11, "old", "window-11");
   auto tasks = std::vector{
       TaskbarWidgetTestAccess::task(11, "updated", "window-11"),
       TaskbarWidgetTestAccess::task(12, "second", "window-12"),
   };
-  assert(TaskbarWidgetTestAccess::currentTitle(tasks, original) == std::optional<std::string>("updated"));
+  assert(TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 7) == std::optional<std::string>("updated"));
 
   tasks[0].appId = "updated.app";
-  assert(TaskbarWidgetTestAccess::currentAppId(tasks, original) == std::optional<std::string>("updated.app"));
+  assert(TaskbarWidgetTestAccess::currentAppId(tasks, 0, 7, 7) == std::optional<std::string>("updated.app"));
 
   tasks[0].title.clear();
-  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, original).has_value());
+  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 7).has_value());
 
-  tasks[0] = TaskbarWidgetTestAccess::task(21, "renumbered", "window-11");
-  assert(TaskbarWidgetTestAccess::currentTitle(tasks, original) == std::optional<std::string>("renumbered"));
-
-  const auto pinned = TaskbarWidgetTestAccess::task(0, "old", {}, "dev.noctalia.Example", true);
-  tasks = {TaskbarWidgetTestAccess::task(0, "updated", {}, "dev.noctalia.Example", true)};
-  assert(TaskbarWidgetTestAccess::currentTitle(tasks, pinned) == std::optional<std::string>("updated"));
+  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 2, 7, 7).has_value());
+  assert(!TaskbarWidgetTestAccess::currentTitle(tasks, 0, 7, 8).has_value());
 
   return 0;
 }


### PR DESCRIPTION
## Summary

- Preserve existing taskbar tiles when only a hidden window title changes.
- Refresh tooltip content from the latest task model through the existing event-driven tooltip mechanism.
- Resolve retained tile actions and tooltips against the current task model by position, guarded by the model generation.
- Detect structural and title changes in a single model-comparison pass.
- Add focused coverage for tooltip refreshes, model comparison, and retained task references.

## Motivation

This is a follow-up to #3335.

The original fix made every window-title change trigger a structural taskbar rebuild so tooltips would receive the latest title. Applications such as browsers and file managers can change their titles frequently. Rebuilding the task strip destroys and recreates its `InputArea` objects, which can interrupt hover, press, and click state while the user is interacting with a tile.

This change keeps the dynamic tooltip behavior from #3335 without treating tooltip-only title changes as structural changes. When window titles are displayed in the taskbar, title changes still trigger a rebuild because they affect layout. Structural changes and task identity changes also continue to rebuild normally.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Follow-up to #3335.

## Testing

- clang-format checks passed.
- clang-tidy checks passed.
- Debug build completed successfully.
- `meson test -C build-debug --print-errorlogs`
  - 62/62 tests passed.
- Added coverage verifying that:
  - Tooltip refresh notifications are emitted only while the input area is hovered.
  - Tooltip providers return the latest window title.
  - Hidden title changes preserve the existing taskbar layout.
  - Visible title changes still require a rebuild.
  - Task identity changes still require a rebuild.
  - Retained task references resolve current task data only while their model generation remains valid.

## Manual Coverage

Manually tested on Niri with multiple monitors.

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

Not applicable. This fixes interaction stability without an intended visual change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

gpt-5.6-sol was used extensively in this PR. I reviewed the design and resulting changes; I only have Niri locally, so I have not tested this on other WMs/DEs, but this should be WM agnostic as far as I can tell.

I tried my best to implement this in a way that remains aligned with the existing patterns for evented taskbar updates and tried to avoid adding additional processing passes.