### PR TITLE
Change Eldritch primary color in light palette

### DIFF
--- a/src/theme/builtin_palettes.cpp
+++ b/src/theme/builtin_palettes.cpp
@@ -398,7 +398,7 @@ namespace noctalia::theme {
                         FixedPaletteMode{
                             .palette =
                                 Palette{
-                                    .primary = hex("#38ff9f"),
+                                    .primary = hex("#fb5bb6"),
                                     .onPrimary = hex("#1e2029"),
                                     .secondary = hex("#0ad6ff"),
                                     .onSecondary = hex("#1e2029"),


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Changes the primary color of the Eldritch light palette from green to pink.

## Motivation

I'm the maintainer responsible for managing the Eldritch variants, and I asked neon to make the PR to update the light theme in Noctalia.

He seemingly did it without giving it a second look, so this is a follow-up to that >:v

The primary color, in this case green, is used for many text roles. The usage of green for text roles is discouraged since it lacks contrast, instead pink is recommended.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

Portage patch.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
