### PR TITLE
feat(control-center/network): separate saved and available Wi-Fi networks

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -255,6 +255,7 @@
       "start-playback": "Start playback in an MPRIS app"
     },
     "network": {
+      "available": "Available",
       "connect": "Connect",
       "current-connection": "Current Connection",
       "external-ip": "WAN {ip}",
@@ -263,6 +264,7 @@
       "password": "Password",
       "password-prompt": "Enter password",
       "password-prompt-for": "Enter password for {ssid}",
+      "saved": "Saved",
       "unavailable-detail": "Install and enable NetworkManager, wpa_supplicant, or iwd to manage networks from here.",
       "unavailable-title": "Network service unavailable",
       "vpns": "VPNs",

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -60,6 +60,40 @@ namespace {
 
   std::string percentText(std::uint8_t percent) { return std::to_string(static_cast<int>(percent)) + "%"; }
 
+  std::unique_ptr<Flex> makeWifiBucketHeaderRow(const std::string& title, float scale) {
+    auto row = ui::row({
+        .align = FlexAlign::Center,
+        .gap = Style::spaceSm * scale,
+    });
+
+    auto pill = ui::row({
+        .align = FlexAlign::Center,
+        .paddingV = Style::spaceXs * 0.5f * scale,
+        .paddingH = Style::spaceSm * scale,
+        .fill = colorSpecFromRole(ColorRole::SurfaceVariant, 0.8f),
+        .radius = Style::scaledRadiusSm(scale),
+    });
+    pill->addChild(
+        ui::label({
+            .text = title,
+            .fontSize = Style::fontSizeMini * scale,
+            .fontWeight = FontWeight::Bold,
+            .color = colorSpecFromRole(ColorRole::OnSurfaceVariant),
+        })
+    );
+    row->addChild(std::move(pill));
+    row->addChild(
+        ui::separator({
+            .color = colorSpecFromRole(ColorRole::Outline, 0.55f),
+            .thickness = std::max(1.0f, scale),
+            .spacing = 0.0f,
+            .gradientEdges = false,
+            .flexGrow = 1.0f,
+        })
+    );
+    return row;
+  }
+
   // Active first, then by signal band, then by name. Ordering on the raw strength —
   // as the services do — reshuffles rows on every scan update, moving the row you are
   // aiming at out from under the pointer.
@@ -787,7 +821,7 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
   auto buildApRows = [&]() {
     auto container = ui::column({
         .align = FlexAlign::Stretch,
-        .gap = Style::spaceXs * scale,
+        .gap = Style::spaceSm * scale,
     });
     if (aps.empty()) {
       container->addChild(
@@ -798,32 +832,73 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
           })
       );
     } else {
+      std::vector<AccessPointInfo> activeAps;
+      std::vector<AccessPointInfo> savedAps;
+      std::vector<AccessPointInfo> availableAps;
+      activeAps.reserve(aps.size());
+      savedAps.reserve(aps.size());
+      availableAps.reserve(aps.size());
+
       for (const auto& ap : aps) {
         const bool saved = m_network != nullptr && m_network->hasSavedConnection(ap.ssid);
-        auto row = std::make_unique<AccessPointRow>(
-            scale, ap, saved,
-            [this](const AccessPointInfo& clicked) {
-              if (clicked.active || m_network == nullptr) {
-                return;
-              }
-              if (clicked.secured && !m_network->hasSavedConnection(clicked.ssid)) {
-                showPasswordPrompt(clicked);
-                PanelManager::instance().refresh();
-                return;
-              }
-              m_network->activateAccessPoint(clicked);
-            },
-            [this](const AccessPointInfo& clicked) {
-              if (m_network != nullptr) {
-                m_network->forgetSsid(clicked.ssid);
-              }
-              PanelManager::instance().refresh();
-            }
-        );
-        auto* rowPtr = row.get();
-        container->addChild(std::move(row));
-        m_apRows.emplace(rowPtr->ssid(), rowPtr);
+        if (ap.active) {
+          activeAps.push_back(ap);
+        } else if (saved) {
+          savedAps.push_back(ap);
+        } else {
+          availableAps.push_back(ap);
+        }
       }
+
+      auto addRows = [&](Flex& parent, const std::vector<AccessPointInfo>& bucket) {
+        if (bucket.empty()) {
+          return;
+        }
+        for (const auto& ap : bucket) {
+          const bool saved = m_network != nullptr && m_network->hasSavedConnection(ap.ssid);
+          auto row = std::make_unique<AccessPointRow>(
+              scale, ap, saved,
+              [this](const AccessPointInfo& clicked) {
+                if (clicked.active || m_network == nullptr) {
+                  return;
+                }
+                if (clicked.secured && !m_network->hasSavedConnection(clicked.ssid)) {
+                  showPasswordPrompt(clicked);
+                  PanelManager::instance().refresh();
+                  return;
+                }
+                m_network->activateAccessPoint(clicked);
+              },
+              [this](const AccessPointInfo& clicked) {
+                if (m_network != nullptr) {
+                  m_network->forgetSsid(clicked.ssid);
+                }
+                PanelManager::instance().refresh();
+              }
+          );
+          auto* rowPtr = row.get();
+          parent.addChild(std::move(row));
+          m_apRows.emplace(rowPtr->ssid(), rowPtr);
+        }
+      };
+
+      addRows(*container, activeAps);
+
+      auto addBucket = [&](const std::string& title, const std::vector<AccessPointInfo>& bucket) {
+        if (bucket.empty()) {
+          return;
+        }
+        auto group = ui::column({
+            .align = FlexAlign::Stretch,
+            .gap = Style::spaceXs * scale,
+        });
+        group->addChild(makeWifiBucketHeaderRow(title, scale));
+        addRows(*group, bucket);
+        container->addChild(std::move(group));
+      };
+
+      addBucket(i18n::tr("control-center.network.saved"), savedAps);
+      addBucket(i18n::tr("control-center.network.available"), availableAps);
     }
     return container;
   };

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -63,7 +63,6 @@ namespace {
   std::unique_ptr<Flex> makeWifiBucketHeaderRow(const std::string& title, float scale) {
     auto row = ui::row({
         .align = FlexAlign::Center,
-        .gap = Style::spaceSm * scale,
     });
 
     auto pill = ui::row({
@@ -82,15 +81,6 @@ namespace {
         })
     );
     row->addChild(std::move(pill));
-    row->addChild(
-        ui::separator({
-            .color = colorSpecFromRole(ColorRole::Outline, 0.55f),
-            .thickness = std::max(1.0f, scale),
-            .spacing = 0.0f,
-            .gradientEdges = false,
-            .flexGrow = 1.0f,
-        })
-    );
     return row;
   }
 


### PR DESCRIPTION
## Summary

- Separate saved Wi-Fi networks from other available networks in the control center.
- Add compact Saved / Available section headers inside the Wi-Fi card.

## Motivation

- Saved networks are usually what I want to reconnect to first, so separating them makes the list easier to scan.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="520" alt="image" src="https://github.com/user-attachments/assets/c3da8f5d-2031-41f9-a5e0-c98093bccc9b" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.