### PR TITLE
feat(taskbar): add configurable active indicator color

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3191,6 +3191,10 @@
           "description": "Color used for active privacy indicators; fixed hex colors are also supported",
           "label": "Active Color"
         },
+        "active-indicator-color": {
+          "description": "Color used for the active window indicator; fixed hex colors are also supported",
+          "label": "Active Indicator Color"
+        },
         "active-opacity": {
           "description": "Opacity of the icon for the active (focused) window",
           "label": "Active Icon Opacity"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -358,6 +358,11 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .minimal = wc != nullptr ? wc->getBool("minimal", false) : false,
         .groupSingleIconPerApp = wc != nullptr ? wc->getBool("group_single_icon_per_app", false) : false,
         .showActiveIndicator = wc != nullptr ? wc->getBool("show_active_indicator", true) : true,
+        .activeIndicatorColor = wc != nullptr ? wc->getColorSpec(
+                                                    "active_indicator_color", colorSpecFromRole(ColorRole::Primary),
+                                                    "widget." + name + ".active_indicator_color"
+                                                )
+                                              : colorSpecFromRole(ColorRole::Primary),
         .activeOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("active_opacity", 1.0)) : 1.0f,
         .inactiveOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("inactive_opacity", 1.0)) : 1.0f,
         .pinnedOpacity = wc != nullptr ? static_cast<float>(wc->getDouble("pinned_opacity", 0.5)) : 0.5f,

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1107,10 +1107,12 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
               .height = m_vertical ? mainExtent : tileSize,
           }
       );
+      ColorSpec activeDotFill = m_activeIndicatorColor;
+      activeDotFill.alpha = 0.95f;
       for (const TaskModel* task : visibleDots) {
         const bool highlight = task != nullptr && task->active && m_showActiveIndicator;
-        const ColorSpec fill = highlight ? colorSpecFromRole(ColorRole::Primary, 0.95f)
-                                         : colorSpecFromRole(ColorRole::OnSurface, anyActive ? 0.55f : 0.35f);
+        const ColorSpec fill =
+            highlight ? activeDotFill : colorSpecFromRole(ColorRole::OnSurface, anyActive ? 0.55f : 0.35f);
         content->addChild(
             ui::box({
                 .fill = fill,

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -201,12 +201,13 @@ TaskbarWidget::TaskbarWidget(
     : m_platform(platform), m_configService(config), m_output(output), m_configOptions(std::move(options)),
       m_showAllOutputs(m_configOptions.showAllOutputs), m_focusedOutputOnly(m_configOptions.focusedOutputOnly),
       m_minimal(m_configOptions.minimal), m_showActiveIndicator(m_configOptions.showActiveIndicator),
-      m_activeOpacity(m_configOptions.activeOpacity), m_inactiveOpacity(m_configOptions.inactiveOpacity),
-      m_pinnedOpacity(m_configOptions.pinnedOpacity), m_focusedColor(m_configOptions.focusedColor),
-      m_occupiedColor(m_configOptions.occupiedColor), m_emptyColor(m_configOptions.emptyColor),
-      m_urgentColor(m_configOptions.urgentColor), m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth),
-      m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth), m_barPosition(std::move(m_configOptions.barPosition)),
-      m_barName(std::move(m_configOptions.barName)), m_widgetName(std::move(m_configOptions.widgetName)) {
+      m_activeIndicatorColor(m_configOptions.activeIndicatorColor), m_activeOpacity(m_configOptions.activeOpacity),
+      m_inactiveOpacity(m_configOptions.inactiveOpacity), m_pinnedOpacity(m_configOptions.pinnedOpacity),
+      m_focusedColor(m_configOptions.focusedColor), m_occupiedColor(m_configOptions.occupiedColor),
+      m_emptyColor(m_configOptions.emptyColor), m_urgentColor(m_configOptions.urgentColor),
+      m_windowTitleMaxWidth(m_configOptions.windowTitleMaxWidth), m_taskbarMaxWidth(m_configOptions.taskbarMaxWidth),
+      m_barPosition(std::move(m_configOptions.barPosition)), m_barName(std::move(m_configOptions.barName)),
+      m_widgetName(std::move(m_configOptions.widgetName)) {
   syncWorkspaceGroupingCapability();
   buildDesktopIconIndex();
 }
@@ -886,7 +887,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       if (showWindowTitle) {
         const float lineThickness = d * 0.5f;
         auto indicator = ui::box({
-            .fill = colorSpecFromRole(ColorRole::Primary),
+            .fill = m_activeIndicatorColor,
             .radius = lineThickness * 0.5f,
             .width = tileWidthWithTitle - tilePadding * 2,
             .height = lineThickness,
@@ -895,7 +896,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         area->addChild(std::move(indicator));
       } else {
         auto indicator = ui::box({
-            .fill = colorSpecFromRole(ColorRole::Primary),
+            .fill = m_activeIndicatorColor,
             .radius = resolvedBarCapsuleRadius(d, d),
             .width = d,
             .height = d,

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -46,6 +46,7 @@ struct TaskbarWidgetOptions {
   bool minimal = false;
   bool groupSingleIconPerApp = false;
   bool showActiveIndicator = true;
+  ColorSpec activeIndicatorColor = colorSpecFromRole(ColorRole::Primary);
   float activeOpacity = 1.0f;
   float inactiveOpacity = 1.0f;
   float pinnedOpacity = 0.5f;
@@ -166,6 +167,7 @@ private:
   bool m_minimal = false;
   bool m_groupSingleIconPerApp = false;
   bool m_showActiveIndicator = true;
+  ColorSpec m_activeIndicatorColor = colorSpecFromRole(ColorRole::Primary);
   float m_activeOpacity = 1.0f;
   float m_inactiveOpacity = 1.0f;
   float m_pinnedOpacity = 0.5f;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -796,6 +796,12 @@ namespace settings {
         // Windows: what the taskbar lists and how each window tile looks.
         add(withGroup(boolSpec("show_all_outputs", false), "taskbar.windows"));
         add(withGroup(boolSpec("show_active_indicator", true), "taskbar.windows"));
+        {
+          auto activeIndicatorColor = withGroup(colorSpec("active_indicator_color", "primary"), "taskbar.windows");
+          activeIndicatorColor.visibleWhen =
+              WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_active_indicator", {"true"}}};
+          add(std::move(activeIndicatorColor));
+        }
         add(withGroup(doubleSpec("active_opacity", 1.0, 0.1, 1.0, 0.01), "taskbar.windows"));
         add(withGroup(doubleSpec("inactive_opacity", 1.0, 0.1, 1.0, 0.01), "taskbar.windows"));
         {

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -798,8 +798,7 @@ namespace settings {
         add(withGroup(boolSpec("show_active_indicator", true), "taskbar.windows"));
         {
           auto activeIndicatorColor = withGroup(colorSpec("active_indicator_color", "primary"), "taskbar.windows");
-          activeIndicatorColor.visibleWhen =
-              WidgetSettingVisibility{WidgetSettingVisibilityCondition{"show_active_indicator", {"true"}}};
+          activeIndicatorColor.visibleWhen = WidgetSettingVisibility{"show_active_indicator", {"true"}};
           add(std::move(activeIndicatorColor));
         }
         add(withGroup(doubleSpec("active_opacity", 1.0, 0.1, 1.0, 0.01), "taskbar.windows"));


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add a configurable `active_indicator_color` setting to the taskbar widget.

The selected palette role or fixed hex color is applied to both active-indicator layouts:

- the dot below an icon-only task
- the line below a task that displays its window title

This brings the active-window indicator in line with the taskbar's workspace labels, whose focused, occupied, empty, and urgent colors are already configurable.

The setting defaults to `primary` to preserve the existing appearance and is only shown in the settings UI when the active-window indicator is enabled.

## Motivation

The taskbar's active-window indicator was hard-coded to the primary palette color. This prevented users from styling it independently from other primary-colored UI elements.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `just test`
- Manually tested the taskbar with multiple `active_indicator_color` settings, including palette roles and a fixed hex color.
- Verified the configured color is applied when window titles are disabled and the active indicator is rendered as a dot.
- Verified the configured color is applied when window titles are enabled and the active indicator is rendered as a line.
- Verified toggling the active-window indicator and changing its color through the settings UI.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="817" height="130" alt="image" src="https://github.com/user-attachments/assets/e3b991c9-d42e-48c1-bf29-b8fa73266be9" />

before:
<img width="145" height="35" alt="image" src="https://github.com/user-attachments/assets/60794df9-c881-4f3a-90b2-60043205bfb4" />

after:
<img width="144" height="39" alt="image" src="https://github.com/user-attachments/assets/91003ae4-a61a-46cc-9f3a-940d7ca50f1a" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
