### PR TITLE
feat(plugins): add service enable and exit reasons

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1137,6 +1137,7 @@ if build_tests
     'plugin_catalog',
     'plugin_git_export',
     'plugin_i18n',
+    'plugin_lifecycle',
     'plugin_manifest',
     'plugin_source_locks',
     'plugin_source_paths',

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -228,6 +228,7 @@ void Application::run(std::function<void()> startupReadyCallback) {
     m_pluginManager.setOnSourceUpdated([this](const std::string& sourceName) {
       m_settingsWindow.invalidatePluginSourceCache(sourceName);
     });
+    m_pluginManager.setOnEnabled([this](std::string_view pluginId) { m_pluginServiceHost.enablePlugin(pluginId); });
   });
   runStartupPhase("initIpc", [this]() { initIpc(); });
   runStartupPhase("buildPollSources", [this]() { (void)buildPollSources(); });

--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -16,7 +16,8 @@ namespace scripting {
   inline constexpr std::uint32_t kWidgetGestureActionsPluginApiVersion = 14;
   inline constexpr std::uint32_t kOpenSettingsPluginApiVersion = 15;
   inline constexpr std::uint32_t kExtendedSystemStatsPluginApiVersion = 16;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kExtendedSystemStatsPluginApiVersion;
+  inline constexpr std::uint32_t kServiceLifecyclePluginApiVersion = 17;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kServiceLifecyclePluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/scripting/plugin_manager.cpp
+++ b/src/scripting/plugin_manager.cpp
@@ -13,6 +13,7 @@
 #include "scripting/plugin_registry.h"
 #include "scripting/plugin_source_locks.h"
 #include "scripting/plugin_source_paths.h"
+#include "scripting/script_runtime.h"
 #include "util/file_utils.h"
 #include "util/string_utils.h"
 
@@ -542,7 +543,11 @@ namespace scripting {
         m_enabling.erase(id);
         if (ok) {
           kLog.info("enabling plugin '{}' (resolved + exported in {:.0f}ms)", id, elapsedMs);
+          const bool wasEnabled = std::ranges::contains(m_config.config().plugins.enabled, id);
           m_config.setPluginEnabled(id, true);
+          if (!wasEnabled && std::ranges::contains(m_config.config().plugins.enabled, id) && m_onEnabled) {
+            m_onEnabled(id);
+          }
           refresh();
         } else if (incompatible) {
           kLog.warn(
@@ -582,6 +587,12 @@ namespace scripting {
 
   void PluginManager::disable(std::string_view pluginId) {
     kLog.info("disabling plugin '{}'", pluginId);
+    const bool wasEnabled = std::ranges::contains(m_config.config().plugins.enabled, pluginId);
+    const auto* manifest = wasEnabled ? PluginRegistry::instance().findManifest(pluginId) : nullptr;
+    std::optional<PluginExitReasonScope> exitScope;
+    if (manifest != nullptr && manifest->pluginApiVersion >= kServiceLifecyclePluginApiVersion) {
+      exitScope.emplace(pluginId, ScriptExitReason::Disable);
+    }
     m_config.setPluginEnabled(pluginId, false);
     refresh();
   }
@@ -592,7 +603,15 @@ namespace scripting {
       return;
     }
     kLog.info("removing plugin '{}'", pluginId);
-    m_config.setPluginEnabled(pluginId, false);
+    const bool wasEnabled = std::ranges::contains(m_config.config().plugins.enabled, pluginId);
+    const auto* manifest = wasEnabled ? PluginRegistry::instance().findManifest(pluginId) : nullptr;
+    std::optional<PluginExitReasonScope> exitScope;
+    if (manifest != nullptr && manifest->pluginApiVersion >= kServiceLifecyclePluginApiVersion) {
+      exitScope.emplace(pluginId, ScriptExitReason::Uninstall);
+    }
+    if (wasEnabled) {
+      m_config.setPluginEnabled(pluginId, false);
+    }
 
     const auto& plugins = m_config.config().plugins;
     for (const auto& source : plugins.sources) {

--- a/src/scripting/plugin_manager.h
+++ b/src/scripting/plugin_manager.h
@@ -84,6 +84,9 @@ namespace scripting {
       m_onSourceUpdated = std::move(cb);
     }
 
+    // Called after a disabled plugin has been enabled successfully.
+    void setOnEnabled(std::function<void(std::string_view pluginId)> cb) { m_onEnabled = std::move(cb); }
+
     // Resolve source roots + enabled filter from config and (re)scan the registry.
     // No-op when the plugins config is unchanged since the last applied refresh.
     void refresh();
@@ -165,6 +168,7 @@ namespace scripting {
     std::function<void()> m_onChanged;
     std::function<void()> m_onEnablingChanged;
     std::function<void(const std::string& sourceName)> m_onSourceUpdated;
+    std::function<void(std::string_view pluginId)> m_onEnabled;
     // Git-source plugins whose runtime export is running on a worker thread. Touched
     // only on the main thread (enable() inserts, the DeferredCall completion erases).
     std::unordered_set<std::string> m_enabling;

--- a/src/scripting/plugin_service_host.cpp
+++ b/src/scripting/plugin_service_host.cpp
@@ -3,6 +3,7 @@
 #include "core/log.h"
 #include "i18n/i18n.h"
 #include "notification/notifications.h"
+#include "scripting/plugin_api.h"
 #include "scripting/plugin_ipc.h"
 #include "scripting/plugin_manifest.h"
 #include "scripting/plugin_registry.h"
@@ -109,7 +110,7 @@ namespace scripting {
     return service;
   }
 
-  void PluginServiceHost::stopService(Service& service) {
+  void PluginServiceHost::stopService(Service& service, ScriptExitReason exitReason) {
     PluginIpcRouter::instance().unregisterEndpoint(&service);
     teardownScriptWatch(service);
     service.updateTimer.stop();
@@ -121,7 +122,7 @@ namespace scripting {
         service.runtime->unsubscribe(service.subscription);
         service.subscription = 0;
       }
-      service.runtime->stop();
+      service.runtime->stop(exitReason);
     }
   }
 
@@ -212,6 +213,23 @@ namespace scripting {
         setupScriptWatch(service);
       }
       kLog.info("restarted service '{}' after {} change", id, sourceChanged ? "source" : "settings");
+    }
+  }
+
+  void PluginServiceHost::enablePlugin(std::string_view pluginId) {
+    const std::string entryPrefix = std::string(pluginId) + ":";
+    for (const auto& service : m_services) {
+      if (!service->entryId.starts_with(entryPrefix) || service->runtime == nullptr) {
+        continue;
+      }
+      const auto entry = PluginRegistry::instance().resolve(service->entryId);
+      if (!entry.has_value()
+          || entry->manifest == nullptr
+          || entry->manifest->pluginApiVersion < kServiceLifecyclePluginApiVersion) {
+        continue;
+      }
+      kLog.info("enabling service '{}'", service->entryId);
+      (void)service->runtime->enqueueCall("onEnable", {});
     }
   }
 

--- a/src/scripting/plugin_service_host.h
+++ b/src/scripting/plugin_service_host.h
@@ -45,6 +45,10 @@ namespace scripting {
     // whose effective settings changed. Called on config reload.
     void refresh(const PluginSettingsMap& pluginSettings);
 
+    // Invoke the optional onEnable() callback for every service belonging to
+    // a plugin after an explicit successful enable.
+    void enablePlugin(std::string_view pluginId);
+
     // Notify every service that the set/geometry of connected outputs changed, so a
     // service can reconcile (e.g. relaunch a per-output child). The current output
     // list is read via noctalia.outputs() inside the callback.
@@ -84,7 +88,7 @@ namespace scripting {
     makeService(const std::string& entryId, const std::filesystem::path& source, ScriptSettings seeded);
     // Full teardown for removal/shutdown: unregister IPC, stop timer + runtime, and
     // mark the alive token dead so any in-flight callback is a no-op.
-    void stopService(Service& service);
+    void stopService(Service& service, ScriptExitReason exitReason = ScriptExitReason::Reload);
     // Build the effective seeded settings for an entry (manifest defaults + plugin
     // overrides). Returns nullopt if the entry no longer resolves.
     [[nodiscard]] std::optional<ScriptSettings>

--- a/src/scripting/script_runtime.cpp
+++ b/src/scripting/script_runtime.cpp
@@ -17,6 +17,8 @@
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <optional>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -44,6 +46,18 @@ namespace scripting {
     constexpr std::size_t kMaxTimeoutsPerWindow = 5;
     constexpr auto kCrashWindow = std::chrono::seconds(60);
     constexpr std::size_t kMaxHardErrorsPerWindow = 5;
+    std::mutex g_pluginExitReasonsMutex;
+    std::unordered_map<std::string, ScriptExitReason> g_pluginExitReasons;
+
+    std::optional<ScriptExitReason> pluginExitReasonFor(std::string_view runtimeName) {
+      const auto separator = runtimeName.find(':');
+      if (separator == std::string_view::npos) {
+        return std::nullopt;
+      }
+      std::scoped_lock lock(g_pluginExitReasonsMutex);
+      const auto it = g_pluginExitReasons.find(std::string(runtimeName.substr(0, separator)));
+      return it != g_pluginExitReasons.end() ? std::optional(it->second) : std::nullopt;
+    }
 
     void mergePatch(ScriptPatch& dest, const ScriptPatch& src) {
       if (src.text.has_value()) {
@@ -259,7 +273,7 @@ namespace scripting {
       subscribers.erase(id);
     }
 
-    void stop(int exitSignal) {
+    void stop(int exitSignal, ScriptExitReason exitReason) {
       bool shouldSchedule = false;
       {
         std::scoped_lock lock(mutex);
@@ -276,6 +290,7 @@ namespace scripting {
           event.kind = ScriptEventKind::Stop;
           event.generation = generation;
           event.exitSignal = exitSignal;
+          event.exitReason = exitReason;
           queue.push_back(std::move(event));
           if (!scheduled) {
             scheduled = true;
@@ -485,7 +500,7 @@ namespace scripting {
         }
 
         if (event.kind == ScriptEventKind::Stop) {
-          teardownHost(event.exitSignal, event.snapshot);
+          teardownHost(event.exitSignal, event.snapshot, event.exitReason);
           {
             std::scoped_lock lock(mutex);
             queue.clear();
@@ -636,7 +651,7 @@ namespace scripting {
     }
 
     ScriptResult processLoad(const ScriptEvent& event) {
-      teardownHost(0, event.snapshot);
+      teardownHost(0, event.snapshot, ScriptExitReason::Reload);
 
       host = std::make_unique<LuauHost>(scriptApi);
       bindingContext.settings = &settings;
@@ -741,12 +756,27 @@ namespace scripting {
       return result;
     }
 
-    void teardownHost(int signal, const ScriptSnapshot& snapshot) {
+    void
+    teardownHost(int signal, const ScriptSnapshot& snapshot, ScriptExitReason exitReason = ScriptExitReason::Reload) {
       // Prevent old or newly registered watchers from outliving this VM.
       PluginStateStore::instance().removeWatchers(stateToken);
       if (host != nullptr && host->hasGlobal("onExit")) {
         bindingContext.beginCall(snapshot);
-        const ScriptArgs args{static_cast<double>(signal)};
+        const char* reason = "reload";
+        switch (exitReason) {
+        case ScriptExitReason::Reload:
+          break;
+        case ScriptExitReason::Disable:
+          reason = "disable";
+          break;
+        case ScriptExitReason::Uninstall:
+          reason = "uninstall";
+          break;
+        case ScriptExitReason::Shutdown:
+          reason = "shutdown";
+          break;
+        }
+        const ScriptArgs args{static_cast<double>(signal), std::string(reason)};
         (void)host->callGlobalWithArgsAndBudget("onExit", args, kCallbackBudget);
       }
       PluginStateStore::instance().removeWatchers(stateToken);
@@ -882,6 +912,24 @@ namespace scripting {
     }
   };
 
+  PluginExitReasonScope::PluginExitReasonScope(std::string_view pluginId, ScriptExitReason reason)
+      : m_pluginId(pluginId) {
+    std::scoped_lock lock(g_pluginExitReasonsMutex);
+    if (const auto it = g_pluginExitReasons.find(m_pluginId); it != g_pluginExitReasons.end()) {
+      m_previous = it->second;
+    }
+    g_pluginExitReasons[m_pluginId] = reason;
+  }
+
+  PluginExitReasonScope::~PluginExitReasonScope() {
+    std::scoped_lock lock(g_pluginExitReasonsMutex);
+    if (m_previous.has_value()) {
+      g_pluginExitReasons[m_pluginId] = *m_previous;
+    } else {
+      g_pluginExitReasons.erase(m_pluginId);
+    }
+  }
+
   ScriptRuntime::ScriptRuntime(
       std::string runtimeName, ScriptSettings settings, ScriptApiContext& api, std::filesystem::path pluginDir,
       HttpClient* httpClient, ClipboardService* clipboard, TogglePanelCallback togglePanelCallback
@@ -905,9 +953,15 @@ namespace scripting {
     }
   }
 
-  void ScriptRuntime::stop() {
+  void ScriptRuntime::stop(ScriptExitReason exitReason) {
     if (m_state != nullptr) {
-      m_state->stop(g_shutdownSignal.load(std::memory_order_relaxed));
+      const int signal = g_shutdownSignal.load(std::memory_order_relaxed);
+      if (signal != 0) {
+        exitReason = ScriptExitReason::Shutdown;
+      } else if (exitReason == ScriptExitReason::Reload) {
+        exitReason = pluginExitReasonFor(m_state->runtimeName).value_or(ScriptExitReason::Reload);
+      }
+      m_state->stop(signal, exitReason);
     }
   }
 

--- a/src/scripting/script_runtime.h
+++ b/src/scripting/script_runtime.h
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -16,6 +17,23 @@ class HttpClient;
 namespace scripting {
 
   class ScriptApiContext;
+
+  // While a plugin-manager disable/uninstall mutation synchronously rebuilds entry hosts,
+  // make their ordinary stop() calls report the explicit plugin lifecycle reason. Scopes
+  // are nest-safe per plugin and affect only runtimes whose name starts with
+  // "<plugin-id>:".
+  class PluginExitReasonScope {
+  public:
+    PluginExitReasonScope(std::string_view pluginId, ScriptExitReason reason);
+    ~PluginExitReasonScope();
+
+    PluginExitReasonScope(const PluginExitReasonScope&) = delete;
+    PluginExitReasonScope& operator=(const PluginExitReasonScope&) = delete;
+
+  private:
+    std::string m_pluginId;
+    std::optional<ScriptExitReason> m_previous;
+  };
 
   class ScriptRuntime {
   public:
@@ -34,7 +52,8 @@ namespace scripting {
 
     [[nodiscard]] SubscriberId subscribe(ScriptResultCallback callback);
     void unsubscribe(SubscriberId id);
-    void stop();
+    // Stop the runtime and pass its reason to onExit(signal, reason).
+    void stop(ScriptExitReason exitReason = ScriptExitReason::Reload);
 
     // Records the process signal delivered during graceful shell shutdown so
     // entry onExit callbacks can distinguish SIGINT/SIGTERM from ordinary teardown.

--- a/src/scripting/script_runtime_types.h
+++ b/src/scripting/script_runtime_types.h
@@ -179,6 +179,13 @@ namespace scripting {
     Stop,
   };
 
+  enum class ScriptExitReason : std::uint8_t {
+    Reload,
+    Disable,
+    Uninstall,
+    Shutdown,
+  };
+
   // Queue policy for a callback invocation.
   struct ScriptCallOptions {
     // A newer queued call to the same callback replaces this one.
@@ -220,6 +227,8 @@ namespace scripting {
     std::string stateJson;
     // Stop payload: SIGINT/SIGTERM for signal-driven process shutdown, otherwise 0.
     int exitSignal = 0;
+    // Stop payload: identifies why the runtime is being destroyed.
+    ScriptExitReason exitReason = ScriptExitReason::Reload;
     // SettingsChanged payload: the new seeded settings snapshot to swap in.
     ScriptSettings newSettings;
     ScriptSnapshot snapshot;

--- a/tests/plugin_lifecycle_test.cpp
+++ b/tests/plugin_lifecycle_test.cpp
@@ -1,0 +1,442 @@
+#include "config/config_service.h"
+#include "core/deferred_call.h"
+#include "scripting/plugin_manager.h"
+#include "scripting/plugin_registry.h"
+#include "scripting/plugin_service_host.h"
+#include "scripting/plugin_state_store.h"
+#include "scripting/script_api_context.h"
+#include "scripting/script_runtime.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <print>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "plugin_lifecycle_test: {}", message);
+    }
+    return condition;
+  }
+
+  bool waitForState(std::string_view pluginId, std::string_view key) {
+    constexpr auto timeout = std::chrono::seconds(2);
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (scripting::PluginStateStore::instance().get(std::string(pluginId), std::string(key)).has_value()) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  }
+
+  bool drainUntil(const std::function<bool()>& predicate) {
+    constexpr auto timeout = std::chrono::seconds(2);
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+      for (auto& callback : DeferredCall::takePending()) {
+        callback();
+      }
+      if (predicate()) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  }
+
+  bool writeText(const std::filesystem::path& path, std::string_view contents) {
+    std::filesystem::create_directories(path.parent_path());
+    auto* file = std::fopen(path.c_str(), "wb");
+    if (file == nullptr) {
+      return false;
+    }
+    const bool written = std::fwrite(contents.data(), 1, contents.size(), file) == contents.size();
+    return std::fclose(file) == 0 && written;
+  }
+
+} // namespace
+
+int main() {
+  scripting::ScriptApiContext api;
+  bool ok = true;
+
+  {
+    scripting::ScriptRuntime runtime("test/enable:service", {}, api, {});
+    runtime.start(
+        "=enable",
+        "noctalia.state.set('loaded', true)\n"
+        "function onEnable()\n"
+        "  noctalia.state.set('enabled', true)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/enable", "loaded"), "enable service did not load") && ok;
+    ok = expect(
+             !scripting::PluginStateStore::instance().get("test/enable", "enabled").has_value(),
+             "service load invoked onEnable without an explicit enable"
+         )
+        && ok;
+    ok = expect(runtime.enqueueCall("onEnable", {}), "could not enqueue onEnable") && ok;
+    ok = expect(waitForState("test/enable", "enabled"), "onEnable was not delivered") && ok;
+  }
+
+  {
+    scripting::ScriptRuntime runtime("test/deactivate:service", {}, api, {});
+    runtime.start(
+        "=deactivate",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(signal, reason)\n"
+        "  noctalia.state.set('exit_signal', signal)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/deactivate", "loaded"), "service did not load") && ok;
+    runtime.stop(scripting::ScriptExitReason::Disable);
+  }
+
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/deactivate", "exit_signal") == "0",
+           "disable changed the existing numeric exit signal"
+       )
+      && ok;
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/deactivate", "exit_reason") == R"("disable")",
+           "onExit did not receive the disable reason"
+       )
+      && ok;
+
+  {
+    scripting::ScriptRuntime runtime("test/remove:service", {}, api, {});
+    runtime.start(
+        "=remove",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(signal, reason)\n"
+        "  noctalia.state.set('exit_signal', signal)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/remove", "loaded"), "removal service did not load") && ok;
+    runtime.stop(scripting::ScriptExitReason::Uninstall);
+  }
+
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/remove", "exit_signal") == "0",
+           "remove changed the existing numeric exit signal"
+       )
+      && ok;
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/remove", "exit_reason") == R"("uninstall")",
+           "onExit did not receive the uninstall reason"
+       )
+      && ok;
+
+  {
+    scripting::ScriptRuntime runtime("test/ordinary-stop:service", {}, api, {});
+    runtime.start(
+        "=ordinary-stop",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(signal, reason)\n"
+        "  noctalia.state.set('exit_signal', signal)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/ordinary-stop", "loaded"), "ordinary service did not load") && ok;
+    runtime.stop();
+  }
+
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/ordinary-stop", "exit_signal") == "0"
+               && scripting::PluginStateStore::instance().get("test/ordinary-stop", "exit_reason") == R"("reload")",
+           "ordinary runtime teardown reported the wrong exit context"
+       )
+      && ok;
+
+  {
+    scripting::PluginExitReasonScope scope("test/non-service", scripting::ScriptExitReason::Disable);
+    scripting::ScriptRuntime runtime("test/non-service:widget", {}, api, {});
+    runtime.start(
+        "=non-service-disable",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(_signal, reason)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/non-service", "loaded"), "non-service runtime did not load") && ok;
+    runtime.stop();
+  }
+
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/non-service", "exit_reason") == R"("disable")",
+           "scoped plugin reason did not reach a non-service runtime"
+       )
+      && ok;
+
+  {
+    scripting::ScriptRuntime runtime("test/reload:service", {}, api, {});
+    runtime.start(
+        "=before-reload",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(signal, reason)\n"
+        "  noctalia.state.set('exit_signal', signal)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/reload", "loaded"), "reload service did not load") && ok;
+    runtime.reload("=after-reload", "noctalia.state.set('reloaded', true)\n", {});
+    ok = expect(waitForState("test/reload", "reloaded"), "service did not reload") && ok;
+    ok = expect(
+             scripting::PluginStateStore::instance().get("test/reload", "exit_signal") == "0"
+                 && scripting::PluginStateStore::instance().get("test/reload", "exit_reason") == R"("reload")",
+             "runtime reload reported the wrong exit context"
+         )
+        && ok;
+  }
+
+  {
+    scripting::ScriptRuntime runtime("test/shutdown:service", {}, api, {});
+    runtime.start(
+        "=shutdown",
+        "noctalia.state.set('loaded', true)\n"
+        "function onExit(signal, reason)\n"
+        "  noctalia.state.set('exit_signal', signal)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/shutdown", "loaded"), "shutdown service did not load") && ok;
+    scripting::ScriptRuntime::setShutdownSignal(15);
+    runtime.stop();
+    scripting::ScriptRuntime::setShutdownSignal(0);
+  }
+
+  ok = expect(
+           scripting::PluginStateStore::instance().get("test/shutdown", "exit_signal") == "15"
+               && scripting::PluginStateStore::instance().get("test/shutdown", "exit_reason") == R"("shutdown")",
+           "graceful shutdown reported the wrong exit context"
+       )
+      && ok;
+
+  const auto root =
+      std::filesystem::temp_directory_path() / ("noctalia-plugin-lifecycle-test-" + std::to_string(::getpid()));
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(root / "config");
+  std::filesystem::create_directories(root / "state");
+  std::filesystem::create_directories(root / "data");
+  ::setenv("NOCTALIA_CONFIG_HOME", (root / "config").c_str(), 1);
+  ::setenv("NOCTALIA_STATE_HOME", (root / "state").c_str(), 1);
+  ::setenv("NOCTALIA_DATA_HOME", (root / "data").c_str(), 1);
+  ok = expect(
+           writeText(
+               root / "path-plugins/plugin/plugin.toml",
+               "id = \"test/plugin\"\n"
+               "name = \"Lifecycle test\"\n"
+               "version = \"1\"\n"
+               "plugin_api = 17\n"
+           ),
+           "failed to create local plugin fixture"
+       )
+      && ok;
+  ok = expect(
+           writeText(
+               root / "path-plugins/api16/plugin.toml",
+               "id = \"test/api16\"\n"
+               "name = \"API 16 service\"\n"
+               "version = \"1\"\n"
+               "plugin_api = 16\n"
+               "[[service]]\n"
+               "id = \"service\"\n"
+               "entry = \"service.luau\"\n"
+           )
+               && writeText(
+                   root / "path-plugins/api16/service.luau",
+                   "noctalia.state.set('loaded', true)\n"
+                   "function onEnable()\n"
+                   "  noctalia.state.set('enabled', true)\n"
+                   "end\n"
+               )
+               && writeText(
+                   root / "path-plugins/api17/plugin.toml",
+                   "id = \"test/api17\"\n"
+                   "name = \"API 17 service\"\n"
+                   "version = \"1\"\n"
+                   "plugin_api = 17\n"
+                   "[[service]]\n"
+                   "id = \"service\"\n"
+                   "entry = \"service.luau\"\n"
+               )
+               && writeText(
+                   root / "path-plugins/api17/service.luau",
+                   "noctalia.state.set('loaded', true)\n"
+                   "function onEnable()\n"
+                   "  noctalia.state.set('enabled', true)\n"
+                   "end\n"
+               ),
+           "failed to create service API fixtures"
+       )
+      && ok;
+
+  {
+    ConfigService config;
+    config.addPluginSource(
+        {.kind = PluginSourceKind::Path,
+         .name = "lifecycle-test",
+         .location = (root / "path-plugins").string(),
+         .enabled = true}
+    );
+    scripting::PluginManager manager(config);
+    manager.refresh();
+    config.addReloadCallback([&]() { manager.refresh(); });
+    scripting::PluginServiceHost host(api, nullptr, nullptr, nullptr);
+    host.start(config.config().plugins.pluginSettings);
+    config.addReloadCallback([&]() {
+      if (config.lastChange().plugins) {
+        host.refresh(config.config().plugins.pluginSettings);
+      }
+    });
+    std::vector<std::string> enables;
+    std::unique_ptr<scripting::ScriptRuntime> lifecycleRuntime;
+    std::string lifecyclePluginId;
+    config.addReloadCallback([&]() {
+      if (lifecycleRuntime != nullptr
+          && !std::ranges::contains(config.config().plugins.enabled, std::string_view(lifecyclePluginId))) {
+        lifecycleRuntime.reset();
+      }
+    });
+    manager.setOnEnabled([&](std::string_view pluginId) {
+      enables.emplace_back(pluginId);
+      host.enablePlugin(pluginId);
+      ok = expect(
+               std::ranges::contains(config.config().plugins.enabled, pluginId),
+               "activation callback ran before the plugin was enabled"
+           )
+          && ok;
+    });
+
+    const auto firstEnable = manager.enable("test/plugin");
+    ok = expect(firstEnable.ok, "first enable request failed") && ok;
+    ok = expect(drainUntil([&] { return enables.size() == 1; }), "first enable did not publish an enable event") && ok;
+    ok = expect(
+             enables == std::vector<std::string>{"test/plugin"}, "first enable did not publish exactly one enable event"
+         )
+        && ok;
+
+    lifecyclePluginId = "test/plugin";
+    lifecycleRuntime =
+        std::make_unique<scripting::ScriptRuntime>("test/plugin:widget", scripting::ScriptSettings{}, api, root);
+    lifecycleRuntime->start(
+        "=manager-disable",
+        "noctalia.state.set('disable_loaded', true)\n"
+        "function onExit(_signal, reason)\n"
+        "  noctalia.state.set('disable_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/plugin", "disable_loaded"), "manager disable runtime did not load") && ok;
+    manager.disable("test/plugin");
+    ok = expect(
+             lifecycleRuntime == nullptr
+                 && scripting::PluginStateStore::instance().get("test/plugin", "disable_reason") == R"("disable")",
+             "manager disable did not propagate its reason through config teardown"
+         )
+        && ok;
+
+    const auto secondEnable = manager.enable("test/plugin");
+    ok = expect(secondEnable.ok, "second enable request failed") && ok;
+    ok = expect(drainUntil([&] { return enables.size() == 2; }), "second enable did not publish an enable event") && ok;
+    ok = expect(
+             enables == std::vector<std::string>{"test/plugin", "test/plugin"},
+             "re-enable did not publish exactly one enable event"
+         )
+        && ok;
+
+    lifecyclePluginId = "test/plugin";
+    lifecycleRuntime =
+        std::make_unique<scripting::ScriptRuntime>("test/plugin:panel", scripting::ScriptSettings{}, api, root);
+    lifecycleRuntime->start(
+        "=manager-uninstall",
+        "noctalia.state.set('uninstall_loaded', true)\n"
+        "function onExit(_signal, reason)\n"
+        "  noctalia.state.set('uninstall_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/plugin", "uninstall_loaded"), "manager uninstall runtime did not load") && ok;
+    manager.remove("test/plugin");
+    ok = expect(
+             lifecycleRuntime == nullptr
+                 && scripting::PluginStateStore::instance().get("test/plugin", "uninstall_reason") == R"("uninstall")",
+             "manager uninstall did not propagate its reason through config teardown"
+         )
+        && ok;
+
+    const auto legacyEnable = manager.enable("test/api16");
+    ok = expect(legacyEnable.ok, "API 16 enable request failed") && ok;
+    ok = expect(
+             drainUntil([&] { return std::ranges::contains(config.config().plugins.enabled, "test/api16"); }),
+             "API 16 plugin was not enabled"
+         )
+        && ok;
+    ok = expect(waitForState("test/api16", "loaded"), "API 16 service did not load through manager refresh") && ok;
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    ok = expect(
+             !scripting::PluginStateStore::instance().get("test/api16", "enabled").has_value(),
+             "service below API 17 received onEnable"
+         )
+        && ok;
+    lifecyclePluginId = "test/api16";
+    lifecycleRuntime =
+        std::make_unique<scripting::ScriptRuntime>("test/api16:widget", scripting::ScriptSettings{}, api, root);
+    lifecycleRuntime->start(
+        "=legacy-disable",
+        "noctalia.state.set('legacy_loaded', true)\n"
+        "function onExit(_signal, reason)\n"
+        "  noctalia.state.set('exit_reason', reason)\n"
+        "end\n",
+        {}
+    );
+    ok = expect(waitForState("test/api16", "legacy_loaded"), "API 16 lifecycle runtime did not load") && ok;
+    manager.disable("test/api16");
+    ok = expect(
+             lifecycleRuntime == nullptr
+                 && scripting::PluginStateStore::instance().get("test/api16", "exit_reason") == R"("reload")",
+             "plugin below API 17 received an explicit lifecycle reason"
+         )
+        && ok;
+
+    const auto lifecycleEnable = manager.enable("test/api17");
+    ok = expect(lifecycleEnable.ok, "API 17 enable request failed") && ok;
+    ok = expect(
+             drainUntil([&] {
+               return std::ranges::contains(config.config().plugins.enabled, "test/api17")
+                   && scripting::PluginStateStore::instance().get("test/api17", "enabled").has_value();
+             }),
+             "manager enable did not deliver onEnable to the API 17 service after refresh"
+         )
+        && ok;
+  }
+
+  ::unsetenv("NOCTALIA_CONFIG_HOME");
+  ::unsetenv("NOCTALIA_STATE_HOME");
+  ::unsetenv("NOCTALIA_DATA_HOME");
+  std::filesystem::remove_all(root);
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add service `onEnable()` after an explicit successful plugin enable
- pass `shutdown`, `disable`, `uninstall`, and `reload` to every entry `onExit(signal, reason)`
- keep one-argument handlers and plugins below API 17 compatible
- bump the plugin API from 16 to 17

## Why

Plugins need to distinguish explicit lifecycle actions from reloads and shell shutdown.

## Testing

- `meson compile -C build-debug`
- `meson test -C build-debug --print-errorlogs` (62 passed)