### PR TITLE
[Bug]Fix launcher/clipboard panels covering fcitx5 preedit on Hyprland

### DIFF
--- a/src/shell/clipboard/clipboard_panel.h
+++ b/src/shell/clipboard/clipboard_panel.h
@@ -38,7 +38,7 @@ public:
 
   [[nodiscard]] float preferredWidth() const override { return scaled(720.0f); }
   [[nodiscard]] float preferredHeight() const override { return scaled(560.0f); }
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::Exclusive; }
   [[nodiscard]] bool handleGlobalKey(std::uint32_t sym, std::uint32_t modifiers, bool pressed, bool preedit) override;
   [[nodiscard]] InputArea* initialFocusArea() const override;

--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -87,7 +87,7 @@ public:
   [[nodiscard]] bool handleGlobalKey(std::uint32_t sym, std::uint32_t modifiers, bool pressed, bool preedit) override;
   [[nodiscard]] bool deferExternalRefresh() const override;
   [[nodiscard]] bool deferPointerRelayout() const override;
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] float preferredWidth() const override;
   [[nodiscard]] float preferredHeight() const override { return scaled(520.0f); }
   [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -56,7 +56,7 @@ public:
 
   [[nodiscard]] float preferredWidth() const override { return scaled(560.0f); }
   [[nodiscard]] float preferredHeight() const override { return scaled(500.0f); }
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::Exclusive; }
   [[nodiscard]] InputArea* initialFocusArea() const override;
   [[nodiscard]] bool handleGlobalKey(std::uint32_t sym, std::uint32_t modifiers, bool pressed, bool preedit) override;

--- a/src/shell/session/session_panel.h
+++ b/src/shell/session/session_panel.h
@@ -33,7 +33,7 @@ public:
   [[nodiscard]] float preferredWidth() const override;
   [[nodiscard]] float preferredHeight() const override;
   [[nodiscard]] bool hasDecoration() const override { return true; }
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::Exclusive; }
   [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;
 

--- a/src/shell/setup_wizard/setup_wizard_panel.h
+++ b/src/shell/setup_wizard/setup_wizard_panel.h
@@ -24,7 +24,7 @@ public:
   [[nodiscard]] float preferredWidth() const override { return scaled(620.0f); }
   [[nodiscard]] float preferredHeight() const override { return scaled(580.0f); }
   [[nodiscard]] bool hasDecoration() const override { return true; }
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::OnDemand; }
 
   static bool isFirstRun(const ConfigService& config);

--- a/src/shell/wallpaper/panel/wallpaper_panel.h
+++ b/src/shell/wallpaper/panel/wallpaper_panel.h
@@ -57,7 +57,7 @@ public:
   [[nodiscard]] float preferredWidth() const override { return scaled(980.0f); }
   [[nodiscard]] float preferredHeight() const override { return scaled(700.0f); }
   [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;
-  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Overlay; }
+  [[nodiscard]] LayerShellLayer layer() const override { return LayerShellLayer::Top; }
   [[nodiscard]] LayerShellKeyboard keyboardMode() const override { return LayerShellKeyboard::Exclusive; }
   [[nodiscard]] InputArea* initialFocusArea() const override;
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

On Hyprland, noctalia's panels and fcitx5's preedit window both use the Overlay layer-shell layer, causing noctalia's panels to render above and completely obscure the IME preedit box — users cannot see what they are typing.
This PR moves user-interactive panels from Overlay to Top layer — the semantically correct layer for taskbars, launchers, and popup panels. System overlays that do not accept text input (polkit, OSD, window switcher) remain on Overlay.

## Motivation

https://github.com/noctalia-dev/noctalia/issues/3438
https://github.com/noctalia-dev/noctalia/issues/2786

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

before:
<img width="536" height="318" alt="图片" src="https://github.com/user-attachments/assets/10aa93dd-1b86-4e63-be80-48c3ba76fc5f" />

after:
<img width="981" height="244" alt="图片" src="https://github.com/user-attachments/assets/396fdc70-b526-43df-a951-b82c87613c35" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
