### PR TITLE
fix(wayland): keep toplevels without output_enter in output-scoped lists

### DIFF
--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -142,6 +142,42 @@ namespace {
     return false;
   }
 
+  std::unordered_set<std::string> outputScopedWindowIds(const WaylandWorkspaces* workspaces, wl_output* output) {
+    std::unordered_set<std::string> ids;
+    if (output == nullptr || workspaces == nullptr) {
+      return ids;
+    }
+    for (const auto& row : workspaces->workspaceWindows(output)) {
+      const auto normalized = compositors::hyprland::normalizeWindowId(row.windowId);
+      if (!normalized.empty()) {
+        ids.insert(normalized);
+      }
+    }
+    return ids;
+  }
+
+  // Toplevels whose output the compositor never announced stay in every output-scoped wlr list, so
+  // the IPC window list is what actually places them: drop the ones owned by another output.
+  void dropWindowsOnOtherOutputs(
+      std::vector<ToplevelInfo>& windows, const compositors::hyprland::HyprlandToplevelMapping& mapping,
+      const std::unordered_set<std::string>& outputWindowIds
+  ) {
+    if (outputWindowIds.empty()) {
+      return;
+    }
+    std::erase_if(windows, [&](const ToplevelInfo& window) {
+      if (window.outputAnnounced || window.handle == nullptr) {
+        return false;
+      }
+      const auto windowId = mapping.windowIdForWlrHandle(window.handle);
+      if (!windowId.has_value()) {
+        return false;
+      }
+      const auto normalized = compositors::hyprland::normalizeWindowId(*windowId);
+      return !normalized.empty() && !outputWindowIds.contains(normalized);
+    });
+  }
+
   void appendHyprlandExtOnlyWindows(
       std::vector<ToplevelInfo>& windows, const std::vector<ToplevelInfo>& extWindows,
       const compositors::hyprland::HyprlandToplevelMapping& mapping,
@@ -170,8 +206,7 @@ namespace {
       const auto windowId = mapping.windowIdForExtHandle(extWindow.extHandle);
       if (windowId.has_value()) {
         const auto normalized = compositors::hyprland::normalizeWindowId(*windowId);
-        // Hyprland announces pre-shell windows over wlr but omits output_enter for them, so an
-        // output-scoped wlr list can miss them; dedupe only against live wlr results.
+        // The wlr results above already cover this output, so skip the ext copy of anything in them.
         if (!normalized.empty() && wlrRepresentedIds.contains(normalized)) {
           continue;
         }
@@ -812,23 +847,16 @@ std::vector<ToplevelInfo> CompositorPlatform::windowsForApp(
   }
 
   auto windows = m_wayland.windowsForApp(idLower, wmClassLower, outputFilter);
-  if (!compositors::isHyprland()
-      || m_hyprlandToplevelMapping == nullptr
-      || !m_hyprlandToplevelMapping->available()
-      || !m_wayland.hasExtForeignToplevelList()) {
+  if (!compositors::isHyprland() || m_hyprlandToplevelMapping == nullptr || !m_hyprlandToplevelMapping->available()) {
     return windows;
   }
 
-  std::unordered_set<std::string> outputWindowIds;
-  if (outputFilter != nullptr && m_workspaces != nullptr) {
-    for (const auto& row : m_workspaces->workspaceWindows(outputFilter)) {
-      const auto normalized = compositors::hyprland::normalizeWindowId(row.windowId);
-      if (!normalized.empty()) {
-        outputWindowIds.insert(normalized);
-      }
-    }
-  }
+  const auto outputWindowIds = outputScopedWindowIds(m_workspaces.get(), outputFilter);
+  dropWindowsOnOtherOutputs(windows, *m_hyprlandToplevelMapping, outputWindowIds);
 
+  if (!m_wayland.hasExtForeignToplevelList()) {
+    return windows;
+  }
   appendHyprlandExtOnlyWindows(
       windows, m_wayland.extWindowsForApp(idLower, wmClassLower), *m_hyprlandToplevelMapping,
       outputFilter != nullptr ? &outputWindowIds : nullptr
@@ -837,7 +865,14 @@ std::vector<ToplevelInfo> CompositorPlatform::windowsForApp(
 }
 
 std::vector<ToplevelInfo> CompositorPlatform::windowsWithoutAppId(wl_output* outputFilter) const {
-  return m_wayland.windowsWithoutAppId(outputFilter);
+  auto windows = m_wayland.windowsWithoutAppId(outputFilter);
+  if (!compositors::isHyprland() || m_hyprlandToplevelMapping == nullptr || !m_hyprlandToplevelMapping->available()) {
+    return windows;
+  }
+  dropWindowsOnOtherOutputs(
+      windows, *m_hyprlandToplevelMapping, outputScopedWindowIds(m_workspaces.get(), outputFilter)
+  );
+  return windows;
 }
 
 void CompositorPlatform::activateToplevel(zwlr_foreign_toplevel_handle_v1* handle) {

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -170,8 +170,8 @@ namespace {
       const auto windowId = mapping.windowIdForExtHandle(extWindow.extHandle);
       if (windowId.has_value()) {
         const auto normalized = compositors::hyprland::normalizeWindowId(*windowId);
-        // Pre-shell windows are often ext-only: mapping may know a wlr handle Hyprland never
-        // exports via zwlr_foreign_toplevel_management, so dedupe only against live wlr results.
+        // Hyprland announces pre-shell windows over wlr but omits output_enter for them, so an
+        // output-scoped wlr list can miss them; dedupe only against live wlr results.
         if (!normalized.empty() && wlrRepresentedIds.contains(normalized)) {
           continue;
         }

--- a/src/wayland/wayland_toplevels.cpp
+++ b/src/wayland/wayland_toplevels.cpp
@@ -76,6 +76,13 @@ namespace {
     return {};
   }
 
+  // Some compositors omit output_enter for toplevels that already existed when the client bound
+  // (observed on Hyprland), leaving state.output null. Treat those as present on every output;
+  // toplevels that announced an output and later left it stay filtered out.
+  [[nodiscard]] bool matchesOutputFilter(wl_output* toplevelOutput, bool sawOutputEnter, wl_output* outputFilter) {
+    return outputFilter == nullptr || toplevelOutput == outputFilter || !sawOutputEnter;
+  }
+
 } // namespace
 
 void WaylandToplevels::bind(zwlr_foreign_toplevel_manager_v1* manager) {
@@ -276,7 +283,7 @@ std::vector<std::string> WaylandToplevels::allAppIds(wl_output* outputFilter) co
   ordered.reserve(m_handles.size());
   for (const auto& [handle, state] : m_handles) {
     (void)handle;
-    if (outputFilter != nullptr && state.output != outputFilter) {
+    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
       continue;
     }
     ordered.push_back(&state);
@@ -307,7 +314,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsForApp(
   std::vector<MatchedWindow> matched;
   std::vector<ToplevelInfo> out;
   for (const auto& [handle, state] : m_handles) {
-    if (outputFilter != nullptr && state.output != outputFilter) {
+    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
       continue;
     }
     const auto appId = effectiveAppId(state.appId, state.title);
@@ -350,7 +357,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsWithoutAppId(wl_output* outpu
 
   std::vector<OrphanWindow> orphans;
   for (const auto& [handle, state] : m_handles) {
-    if (outputFilter != nullptr && state.output != outputFilter) {
+    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
       continue;
     }
     if (!effectiveAppId(state.appId, state.title).empty()) {
@@ -398,6 +405,7 @@ void WaylandToplevels::closeHandle(zwlr_foreign_toplevel_handle_v1* handle) {
 void WaylandToplevels::onHandleOutputEnter(zwlr_foreign_toplevel_handle_v1* handle, wl_output* output) {
   auto it = m_handles.find(handle);
   if (it != m_handles.end()) {
+    it->second.sawOutputEnter = true;
     if (!std::ranges::contains(it->second.activeOutputs, output)) {
       it->second.activeOutputs.push_back(output);
     }

--- a/src/wayland/wayland_toplevels.cpp
+++ b/src/wayland/wayland_toplevels.cpp
@@ -76,13 +76,6 @@ namespace {
     return {};
   }
 
-  // Some compositors omit output_enter for toplevels that already existed when the client bound
-  // (observed on Hyprland), leaving state.output null. Treat those as present on every output;
-  // toplevels that announced an output and later left it stay filtered out.
-  [[nodiscard]] bool matchesOutputFilter(wl_output* toplevelOutput, bool sawOutputEnter, wl_output* outputFilter) {
-    return outputFilter == nullptr || toplevelOutput == outputFilter || !sawOutputEnter;
-  }
-
 } // namespace
 
 void WaylandToplevels::bind(zwlr_foreign_toplevel_manager_v1* manager) {
@@ -278,12 +271,21 @@ wl_output* WaylandToplevels::currentOutput() const {
   return it->second.output;
 }
 
+bool WaylandToplevels::matchesOutputFilter(const ToplevelState& state, wl_output* outputFilter) {
+  if (outputFilter == nullptr || state.output == outputFilter) {
+    return true;
+  }
+  // Some compositors omit output_enter for toplevels that predate the bind (observed on Hyprland),
+  // leaving the output unknown.
+  return !state.sawOutputEnter;
+}
+
 std::vector<std::string> WaylandToplevels::allAppIds(wl_output* outputFilter) const {
   std::vector<const ToplevelState*> ordered;
   ordered.reserve(m_handles.size());
   for (const auto& [handle, state] : m_handles) {
     (void)handle;
-    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
+    if (!matchesOutputFilter(state, outputFilter)) {
       continue;
     }
     ordered.push_back(&state);
@@ -314,7 +316,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsForApp(
   std::vector<MatchedWindow> matched;
   std::vector<ToplevelInfo> out;
   for (const auto& [handle, state] : m_handles) {
-    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
+    if (!matchesOutputFilter(state, outputFilter)) {
       continue;
     }
     const auto appId = effectiveAppId(state.appId, state.title);
@@ -336,6 +338,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsForApp(
                   .identifier = appId + ":" + state.title,
                   .order = state.order,
                   .handle = handle,
+                  .outputAnnounced = state.sawOutputEnter,
               },
           }
       );
@@ -357,7 +360,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsWithoutAppId(wl_output* outpu
 
   std::vector<OrphanWindow> orphans;
   for (const auto& [handle, state] : m_handles) {
-    if (!matchesOutputFilter(state.output, state.sawOutputEnter, outputFilter)) {
+    if (!matchesOutputFilter(state, outputFilter)) {
       continue;
     }
     if (!effectiveAppId(state.appId, state.title).empty()) {
@@ -372,6 +375,7 @@ std::vector<ToplevelInfo> WaylandToplevels::windowsWithoutAppId(wl_output* outpu
                 .identifier = state.title,
                 .order = state.order,
                 .handle = handle,
+                .outputAnnounced = state.sawOutputEnter,
             },
         }
     );

--- a/src/wayland/wayland_toplevels.h
+++ b/src/wayland/wayland_toplevels.h
@@ -107,6 +107,9 @@ private:
     bool activated = false;
     bool minimized = false;
     bool dirty = false;
+    // Set on the first output_enter, never cleared: distinguishes "never announced an output"
+    // from "left every output".
+    bool sawOutputEnter = false;
     std::uint64_t generation = 0;
     std::uint64_t order = 0;
   };

--- a/src/wayland/wayland_toplevels.h
+++ b/src/wayland/wayland_toplevels.h
@@ -29,6 +29,8 @@ struct ToplevelInfo {
   std::uint64_t order = 0;
   zwlr_foreign_toplevel_handle_v1* handle = nullptr;
   ext_foreign_toplevel_handle_v1* extHandle = nullptr;
+  // True when the compositor announced the output(s) this toplevel sits on.
+  bool outputAnnounced = false;
 };
 
 struct WlrToplevelSnapshot {
@@ -113,6 +115,10 @@ private:
     std::uint64_t generation = 0;
     std::uint64_t order = 0;
   };
+
+  // A toplevel whose output the compositor never announced matches every filter; one that announced
+  // an output and later left all of them does not.
+  [[nodiscard]] static bool matchesOutputFilter(const ToplevelState& state, wl_output* outputFilter);
 
   [[nodiscard]] bool notifyIfChanged(const std::optional<ActiveToplevel>& before);
   [[nodiscard]] zwlr_foreign_toplevel_handle_v1* latestActivatedHandle() const;

--- a/tests/wayland_toplevels_identity_test.cpp
+++ b/tests/wayland_toplevels_identity_test.cpp
@@ -39,17 +39,24 @@ int main() {
   assert(windows[0].appId == "Sample.ChatDesktop");
   assert(toplevels.containsWlrHandle(handle));
   assert(!toplevels.containsWlrHandle(reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2)));
-  // Never announced an output (compositor omitted output_enter): matches any filter.
+  // Never announced an output (compositor omitted output_enter): matches any filter, and reports the
+  // output as unannounced so the platform layer can scope it.
   auto* someOutput = reinterpret_cast<wl_output*>(0x10);
-  assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).size() == 1);
+  auto* otherOutput = reinterpret_cast<wl_output*>(0x20);
+  const auto unscoped = toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput);
+  assert(unscoped.size() == 1);
+  assert(!unscoped[0].outputAnnounced);
 
-  // Announced a different output: excluded.
-  it->second.sawOutputEnter = true;
-  it->second.output = reinterpret_cast<wl_output*>(0x20);
+  // Announced a different output: excluded there, present on its own output.
+  toplevels.onHandleOutputEnter(handle, otherOutput);
   assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).empty());
+  const auto scoped = toplevels.windowsForApp("sample-chat-desktop", "samplechat", otherOutput);
+  assert(scoped.size() == 1);
+  assert(scoped[0].outputAnnounced);
 
   // Announced an output, then left all of them: still excluded.
-  it->second.output = nullptr;
+  toplevels.onHandleOutputLeave(handle, otherOutput);
+  assert(it->second.output == nullptr);
   assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).empty());
   return 0;
 }

--- a/tests/wayland_toplevels_identity_test.cpp
+++ b/tests/wayland_toplevels_identity_test.cpp
@@ -39,6 +39,17 @@ int main() {
   assert(windows[0].appId == "Sample.ChatDesktop");
   assert(toplevels.containsWlrHandle(handle));
   assert(!toplevels.containsWlrHandle(reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x2)));
+  // Never announced an output (compositor omitted output_enter): matches any filter.
+  auto* someOutput = reinterpret_cast<wl_output*>(0x10);
+  assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).size() == 1);
 
+  // Announced a different output: excluded.
+  it->second.sawOutputEnter = true;
+  it->second.output = reinterpret_cast<wl_output*>(0x20);
+  assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).empty());
+
+  // Announced an output, then left all of them: still excluded.
+  it->second.output = nullptr;
+  assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).empty());
   return 0;
 }


### PR DESCRIPTION
## Summary

On Hyprland, toplevels that already exist when a client binds `zwlr_foreign_toplevel_manager_v1` are announced normally but never receive an `output_enter` event, so `WaylandToplevels::ToplevelState::output` stays null for them.

`allAppIds()`, `windowsForApp()`, and `windowsWithoutAppId()` all filtered with `outputFilter != nullptr && state.output != outputFilter`, which excluded those toplevels from every output-scoped query. They then reached the taskbar only via the ext-foreign-toplevel list, with `handle == nullptr` and the taskbar's non-KDE context-menu and activation paths require a wlr handle, so they silently did nothing.

This adds a `sawOutputEnter` flag on `ToplevelState` (set on the first `output_enter`, never cleared) so "never announced an output" can be distinguished from "left every output", plus a `matchesOutputFilter()` helper encoding the rule:

- no filter given → matches
- output matches the filter → matches
- never announced an output → matches
- announced an output and later left all of them → **still excluded**, as before

All three output-scoped queries use the helper.

It also corrects a comment in `compositor_platform.cpp` which claimed Hyprland never exports these windows over `zwlr_foreign_toplevel_management`. It does export them; just omits `output_enter` instead.

## Motivation

After restarting noctalia mid-session on Hyprland, taskbar tiles for windows that were already open stop responding: right-click shows no context menu, and left-click doesn't activate the window or switch workspace. Windows opened *after* the restart behave normally.

Reproduces on v5.0.0-beta.6 (AUR) and on `main`. It mainly affects anyone who restarts the shell. So, mostly developers but it's a real gap in the wlr path.

Root cause evidence, using `lswt` (an unrelated client that binds both protocols) while several windows were already open:

```
$ WAYLAND_DEBUG=1 lswt 2>&1 | grep -cE 'zwlr_foreign_toplevel_manager_v1#[0-9]+\.toplevel'
6
$ WAYLAND_DEBUG=1 lswt 2>&1 | grep -cE 'zwlr_foreign_toplevel_handle_v1#[0-9]+\.output_enter'
0
```

Six toplevels announced over wlr, zero `output_enter` events.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None filed. Happy to open one if you'd prefer it tracked separately though.

## Testing

```
just format
just build
just test
```

`wayland_toplevels_identity` passes with three new assertions covering:

1. never announced an output → matches an output filter
2. announced a different output → excluded
3. announced an output, then left all of them → excluded

Note: `i18n_supported_languages` currently fails on `main` independently of this PR (`ko.json` exists in `assets/translations/` but is missing from `kSupportedLanguages`).

Verification on Hyprland: opened several apps, restarted noctalia, then confirmed right-click context menus and left-click activate/workspace-switch work again on those pre-existing windows.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

**Multi-monitor is untested.** I only have one monitor. With this change, a pre-existing window will appear on *every* output's taskbar until it announces an output, instead of appearing on none. I think present-on-all beats absent-and-inert, and it self-corrects as soon as the window is touched. But if you'd prefer a different fallback for multi-output setups, let me know.

`sawOutputEnter` is deliberately sticky. Without it, `output == nullptr` would also cover windows that left every output (see `onHandleOutputLeave`), and those would have started showing up on all outputs for every user on every compositor. The flag keeps this change inert for compositors that send `output_enter` properly.

**Disclosure:** I used Claude Code as a pair-programming assistant on this one. It suggested where to instrument and proposed comparing the two toplevel protocols with `WAYLAND_DEBUG`, which is what surfaced the missing `output_enter`. The reproduction, all testing and verification on my machine, and the final code are mine, but the diagnostic path was a collaboration, and it seemed worth disclosing this.