### PR TITLE
fix(control-center/calendar): use nominative case for month's name

### DIFF
--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -54,7 +54,7 @@ namespace {
     std::tm tm{};
     tm.tm_mon = month;
     tm.tm_mday = 1;
-    return formatStrftime("%B", tm);
+    return formatStrftime("%OB", tm);
   }
 
   int daysInMonth(int yearValue, int monthValue) {

--- a/src/shell/control_center/tabs/calendar_tab.cpp
+++ b/src/shell/control_center/tabs/calendar_tab.cpp
@@ -54,7 +54,11 @@ namespace {
     std::tm tm{};
     tm.tm_mon = month;
     tm.tm_mday = 1;
+#ifdef __GLIBC__
     return formatStrftime("%OB", tm);
+#else
+    return formatStrftime("%B", tm);
+#endif
   }
 
   int daysInMonth(int yearValue, int monthValue) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary
Use nominative instead of genitive case for month name displayed in the calendar tab of the control center.

## Motivation
Month name that isn't used as part of further date formatting with a day should be written in nominative, and `%B` uses genitive.
With English locale this is not a problem, but it's as if it was written "of July 2026" instead of just "July 2026".

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing
`just test` passes. Manually verified.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

[`std::strftime` doesn't have an `OB` specifier](https://en.cppreference.com/cpp/chrono/c/strftime) even though [C23's `strftime`](https://en.cppreference.com/c/chrono/strftime) has. Since the standard doesn't mention it, it technically may not be available, however I assume that any implementation of C++'s `std::strftime` just calls C's `strftime` and since noctalia depends on GLIBC anyway, I further assume that GLIBC is going to be used for that and [`%OB` has been in GLIBC since 2.27 (released in 2018)](https://lists.gnu.org/archive/html/info-gnu/2018-02/msg00000.html).

Maybe an additional check for a GLIBC version should be done in the build system?