### PR TITLE
fix(taskbar): focus Niri windows by compositor ID

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1143,6 +1143,7 @@ if build_tests
     'monitor_selector',
     'notification_filter',
     'notification_history_utf8',
+    'niri_workspace_backend',
     'path_browse',
     'plugin_bindings',
     'plugin_catalog',

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -62,6 +62,23 @@ namespace {
 
   constexpr Logger kLog("compositor_platform");
 
+  [[nodiscard]] std::unordered_set<std::string>
+  windowIdsFromAssignments(const std::vector<WorkspaceWindowAssignment>& assignments) {
+    std::unordered_set<std::string> windowIds;
+    windowIds.reserve(assignments.size());
+    for (const auto& assignment : assignments) {
+      if (!assignment.windowId.empty()) {
+        windowIds.insert(assignment.windowId);
+      }
+    }
+    return windowIds;
+  }
+
+  void
+  retainToplevelsWithWindowIds(std::vector<ToplevelInfo>& windows, const std::unordered_set<std::string>& windowIds) {
+    std::erase_if(windows, [&](const ToplevelInfo& window) { return !windowIds.contains(window.identifier); });
+  }
+
   [[nodiscard]] const char* valueOrUnset(const char* value) {
     return value != nullptr && value[0] != '\0' ? value : "<unset>";
   }
@@ -875,11 +892,56 @@ std::vector<ToplevelInfo> CompositorPlatform::windowsWithoutAppId(wl_output* out
   return windows;
 }
 
+std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsForApp(
+    const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter,
+    const std::unordered_set<std::string>* allowedNiriWindowIds
+) const {
+  if (compositors::isNiri() && m_wayland.hasExtForeignToplevelList()) {
+    // Niri exposes its numeric IPC window ID as the ext-foreign-toplevel
+    // identifier, providing an exact association even for duplicate titles.
+    auto windows = m_wayland.extWindowsForApp(idLower, wmClassLower);
+    if (!windows.empty()) {
+      if (allowedNiriWindowIds != nullptr) {
+        retainToplevelsWithWindowIds(windows, *allowedNiriWindowIds);
+      } else {
+        retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
+      }
+    }
+    // Do not fall back to title/app-id matching while one side of the exact
+    // Niri-id join is still pending. The ext `done` or IPC update will retry.
+    return windows;
+  }
+  return windowsForApp(idLower, wmClassLower, outputFilter);
+}
+
+std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsWithoutAppId(
+    wl_output* outputFilter, const std::unordered_set<std::string>* allowedNiriWindowIds
+) const {
+  if (compositors::isNiri() && m_wayland.hasExtForeignToplevelList()) {
+    auto windows = m_wayland.extWindowsWithoutAppId();
+    if (!windows.empty()) {
+      if (allowedNiriWindowIds != nullptr) {
+        retainToplevelsWithWindowIds(windows, *allowedNiriWindowIds);
+      } else {
+        retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
+      }
+    }
+    return windows;
+  }
+  return windowsWithoutAppId(outputFilter);
+}
+
 void CompositorPlatform::activateToplevel(zwlr_foreign_toplevel_handle_v1* handle) {
   m_wayland.activateToplevel(handle);
 }
 
 void CompositorPlatform::activateToplevelInfo(const ToplevelInfo& window) {
+  // Niri's ext-foreign-toplevel identifier is its exact IPC window ID, and
+  // foreign-toplevel activation does not reliably scroll to the target.
+  if (compositors::isNiri() && window.extHandle != nullptr && !window.identifier.empty()) {
+    focusCompositorWindow(window.identifier);
+    return;
+  }
   if (window.handle != nullptr) {
     activateToplevel(window.handle);
     return;
@@ -898,6 +960,12 @@ void CompositorPlatform::closeToplevel(zwlr_foreign_toplevel_handle_v1* handle) 
 void CompositorPlatform::closeToplevelInfo(const ToplevelInfo& window) {
   if (window.handle != nullptr) {
     closeToplevel(window.handle);
+    return;
+  }
+  if (compositors::isNiri() && !window.identifier.empty()) {
+    if (m_workspaceMetadataBackend != nullptr) {
+      (void)m_workspaceMetadataBackend->closeWindowById(window.identifier);
+    }
     return;
   }
   if (compositors::isKde() && m_kwinActiveWindow != nullptr && m_kwinActiveWindow->isAvailable()) {

--- a/src/compositors/compositor_platform.cpp
+++ b/src/compositors/compositor_platform.cpp
@@ -893,19 +893,14 @@ std::vector<ToplevelInfo> CompositorPlatform::windowsWithoutAppId(wl_output* out
 }
 
 std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsForApp(
-    const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter,
-    const std::unordered_set<std::string>* allowedNiriWindowIds
+    const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter
 ) const {
   if (compositors::isNiri() && m_wayland.hasExtForeignToplevelList()) {
     // Niri exposes its numeric IPC window ID as the ext-foreign-toplevel
     // identifier, providing an exact association even for duplicate titles.
     auto windows = m_wayland.extWindowsForApp(idLower, wmClassLower);
     if (!windows.empty()) {
-      if (allowedNiriWindowIds != nullptr) {
-        retainToplevelsWithWindowIds(windows, *allowedNiriWindowIds);
-      } else {
-        retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
-      }
+      retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
     }
     // Do not fall back to title/app-id matching while one side of the exact
     // Niri-id join is still pending. The ext `done` or IPC update will retry.
@@ -914,17 +909,11 @@ std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsForApp(
   return windowsForApp(idLower, wmClassLower, outputFilter);
 }
 
-std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsWithoutAppId(
-    wl_output* outputFilter, const std::unordered_set<std::string>* allowedNiriWindowIds
-) const {
+std::vector<ToplevelInfo> CompositorPlatform::taskbarWindowsWithoutAppId(wl_output* outputFilter) const {
   if (compositors::isNiri() && m_wayland.hasExtForeignToplevelList()) {
     auto windows = m_wayland.extWindowsWithoutAppId();
     if (!windows.empty()) {
-      if (allowedNiriWindowIds != nullptr) {
-        retainToplevelsWithWindowIds(windows, *allowedNiriWindowIds);
-      } else {
-        retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
-      }
+      retainToplevelsWithWindowIds(windows, windowIdsFromAssignments(workspaceWindowAssignments(outputFilter)));
     }
     return windows;
   }

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 struct wl_output;
@@ -104,6 +105,13 @@ public:
   [[nodiscard]] std::vector<ToplevelInfo>
   windowsForApp(const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<ToplevelInfo> windowsWithoutAppId(wl_output* outputFilter = nullptr) const;
+  [[nodiscard]] std::vector<ToplevelInfo> taskbarWindowsForApp(
+      const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter = nullptr,
+      const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr
+  ) const;
+  [[nodiscard]] std::vector<ToplevelInfo> taskbarWindowsWithoutAppId(
+      wl_output* outputFilter = nullptr, const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr
+  ) const;
   [[nodiscard]] bool containsWlrToplevelHandle(zwlr_foreign_toplevel_handle_v1* handle) const;
   void activateToplevel(zwlr_foreign_toplevel_handle_v1* handle);
   void activateToplevelInfo(const ToplevelInfo& window);

--- a/src/compositors/compositor_platform.h
+++ b/src/compositors/compositor_platform.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 struct wl_output;
@@ -106,12 +105,9 @@ public:
   windowsForApp(const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<ToplevelInfo> windowsWithoutAppId(wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<ToplevelInfo> taskbarWindowsForApp(
-      const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter = nullptr,
-      const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr
+      const std::string& idLower, const std::string& wmClassLower, wl_output* outputFilter = nullptr
   ) const;
-  [[nodiscard]] std::vector<ToplevelInfo> taskbarWindowsWithoutAppId(
-      wl_output* outputFilter = nullptr, const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr
-  ) const;
+  [[nodiscard]] std::vector<ToplevelInfo> taskbarWindowsWithoutAppId(wl_output* outputFilter = nullptr) const;
   [[nodiscard]] bool containsWlrToplevelHandle(zwlr_foreign_toplevel_handle_v1* handle) const;
   void activateToplevel(zwlr_foreign_toplevel_handle_v1* handle);
   void activateToplevelInfo(const ToplevelInfo& window);

--- a/src/compositors/niri/niri_workspace_backend.cpp
+++ b/src/compositors/niri/niri_workspace_backend.cpp
@@ -318,6 +318,18 @@ std::optional<std::string> NiriWorkspaceBackend::focusedWindowId() const {
   return std::to_string(*m_focusedWindowId);
 }
 
+bool NiriWorkspaceBackend::closeWindowById(const std::string& windowId) {
+  const auto id = parseUnsigned(windowId);
+  if (!id.has_value()) {
+    return false;
+  }
+  return m_runtime.requestAction(
+      nlohmann::json{
+          {"CloseWindow", nlohmann::json{{"id", *id}}},
+      }
+  );
+}
+
 void NiriWorkspaceBackend::cleanup() { m_runtime.cleanup(); }
 
 void NiriWorkspaceBackend::handleStreamReset() {
@@ -481,12 +493,13 @@ bool NiriWorkspaceBackend::handleWindowOpenedOrChanged(const nlohmann::json& pay
 
   const bool membershipChanged = existing == m_windows.end() ? (state.workspaceId.has_value() || !state.appId.empty())
                                                              : !sameWindowMembership(existing->second, state);
+  const bool layoutChanged = existing != m_windows.end() && !sameWindowLayout(existing->second, state);
   m_windows[*id] = state;
   if (membershipChanged) {
     recomputeOccupancy();
   }
 
-  return membershipChanged || focusUpdated;
+  return membershipChanged || layoutChanged || focusUpdated;
 }
 
 bool NiriWorkspaceBackend::handleWindowLayoutsChanged(const nlohmann::json& payload) {
@@ -692,6 +705,10 @@ bool NiriWorkspaceBackend::sameWindowMembership(
     }
   }
   return true;
+}
+
+bool NiriWorkspaceBackend::sameWindowLayout(const WindowState& lhs, const WindowState& rhs) noexcept {
+  return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
 std::optional<std::uint64_t> NiriWorkspaceBackend::parseUnsigned(const std::string& value) {

--- a/src/compositors/niri/niri_workspace_backend.h
+++ b/src/compositors/niri/niri_workspace_backend.h
@@ -41,8 +41,9 @@ public:
   [[nodiscard]] std::unordered_map<std::string, std::vector<std::string>>
   appIdsByWorkspace(const std::string& outputName = {}) const override;
   [[nodiscard]] std::vector<WorkspaceWindow> workspaceWindows(const std::string& outputName = {}) const override;
-  bool focusWindowById(const std::string& windowId) override;
   [[nodiscard]] std::optional<std::string> focusedWindowId() const override;
+  bool focusWindowById(const std::string& windowId) override;
+  bool closeWindowById(const std::string& windowId) override;
   void cleanup() override;
 
 private:
@@ -81,6 +82,7 @@ private:
       const std::unordered_map<std::uint64_t, WindowState>& lhs,
       const std::unordered_map<std::uint64_t, WindowState>& rhs
   ) noexcept;
+  [[nodiscard]] static bool sameWindowLayout(const WindowState& lhs, const WindowState& rhs) noexcept;
   [[nodiscard]] static std::optional<std::uint64_t> parseUnsigned(const std::string& value);
   [[nodiscard]] static std::optional<std::size_t> parseLeadingNumber(const std::string& value);
   [[nodiscard]] static std::string workspaceKey(const WorkspaceState& workspace);

--- a/src/compositors/workspace_backend.h
+++ b/src/compositors/workspace_backend.h
@@ -144,13 +144,13 @@ namespace compositors {
     [[nodiscard]] virtual std::vector<WorkspaceWindow> workspaceWindows(const std::string& /*outputName*/ = {}) const {
       return {};
     }
+    [[nodiscard]] virtual std::optional<std::string> focusedWindowId() const { return std::nullopt; }
     // Focus a window by its compositor-specific id. Returns true if the backend
     // handled the request (so the caller can skip other focus paths). Named
     // distinctly from WorkspaceBackend::focusWindow so backends that implement
     // both interfaces don't hit a conflicting-return-type override.
     virtual bool focusWindowById(const std::string& /*windowId*/) { return false; }
-    // Currently focused compositor window id, when the backend tracks focus.
-    [[nodiscard]] virtual std::optional<std::string> focusedWindowId() const { return std::nullopt; }
+    virtual bool closeWindowById(const std::string& /*windowId*/) { return false; }
     [[nodiscard]] virtual bool canTrackOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool hasOverviewState() const noexcept { return false; }
     [[nodiscard]] virtual bool isOverviewOpen() const noexcept { return true; }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -278,17 +278,23 @@ TaskbarWidget::resolveTask(const std::vector<TaskModel>& tasks, TaskRef ref, std
   return &tasks[ref.index];
 }
 
+std::string_view TaskbarWidget::workspaceBindingWindowId(const TaskModel& task) {
+  return !task.exactCompositorWindowId.empty() ? std::string_view(task.exactCompositorWindowId)
+                                               : std::string_view(task.workspaceWindowId);
+}
+
 void TaskbarWidget::activateTaskModel(const TaskModel& task) {
-  if (task.firstHandle != nullptr) {
-    m_platform.activateToplevel(task.firstHandle);
-    return;
-  }
-  if (compositors::isKde() && (!task.title.empty() || !task.appId.empty())) {
-    m_platform.activateKdeWindow(task.title, task.appId, task.workspaceWindowId);
-    return;
-  }
-  if (!task.workspaceWindowId.empty()) {
-    m_platform.focusCompositorWindow(task.workspaceWindowId);
+  const bool hasCompositorWindow =
+      compositors::isNiri() ? !task.exactCompositorWindowId.empty() : !task.workspaceWindowId.empty();
+  if (task.firstHandle != nullptr
+      || hasCompositorWindow
+      || (compositors::isKde() && (!task.title.empty() || !task.appId.empty()))) {
+    ToplevelInfo window{};
+    window.title = task.title;
+    window.appId = task.appId;
+    window.identifier = compositors::isNiri() ? task.exactCompositorWindowId : task.workspaceWindowId;
+    window.handle = task.exactCompositorWindowId.empty() ? task.firstHandle : nullptr;
+    m_platform.activateToplevelInfo(window);
     return;
   }
   if (!task.workspaceKey.empty()) {
@@ -302,8 +308,13 @@ void TaskbarWidget::activateTaskModel(const TaskModel& task) {
 }
 
 void TaskbarWidget::closeTaskModel(const TaskModel& task) {
-  if (task.firstHandle != nullptr) {
-    m_platform.closeToplevel(task.firstHandle);
+  if (task.firstHandle != nullptr || !task.exactCompositorWindowId.empty()) {
+    m_platform.closeToplevelInfo(
+        ToplevelInfo{
+            .identifier = task.exactCompositorWindowId,
+            .handle = task.exactCompositorWindowId.empty() ? task.firstHandle : nullptr,
+        }
+    );
     return;
   }
   if (compositors::isKde() && (!task.title.empty() || !task.appId.empty() || !task.workspaceWindowId.empty())) {
@@ -407,9 +418,9 @@ void TaskbarWidget::launchDesktopEntry(const TaskModel& task) {
 }
 
 void TaskbarWidget::activateOrLaunchPinned(const TaskModel& task) {
-  auto windows = m_platform.windowsForApp(task.idLower, task.startupWmClassLower, toplevelOutputFilter());
+  auto windows = m_platform.taskbarWindowsForApp(task.idLower, task.startupWmClassLower, toplevelOutputFilter());
   if (windows.empty() && !task.appIdLower.empty() && task.appIdLower != task.idLower) {
-    windows = m_platform.windowsForApp(task.appIdLower, task.startupWmClassLower, toplevelOutputFilter());
+    windows = m_platform.taskbarWindowsForApp(task.appIdLower, task.startupWmClassLower, toplevelOutputFilter());
   }
   if (windows.empty()) {
     launchDesktopEntry(task);
@@ -812,7 +823,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
         }
         if (data.button == BTN_RIGHT
             && areaPtr != nullptr
-            && (current->firstHandle != nullptr || compositors::isKde())) {
+            && (current->firstHandle != nullptr || !current->exactCompositorWindowId.empty() || compositors::isKde())) {
           openTaskContextMenu(*current, *areaPtr);
         }
       });
@@ -1387,6 +1398,7 @@ void TaskbarWidget::updateModels() {
 
   const auto active = m_platform.activeToplevel();
   const auto* activeHandle = active.has_value() ? active->handle : nullptr;
+  const auto focusedCompositorWindowId = m_platform.focusedCompositorWindowId();
 
   wl_output* const topFilter = toplevelOutputFilter();
   const auto assignmentMode = m_platform.taskbarAssignmentMode();
@@ -1492,6 +1504,18 @@ void TaskbarWidget::updateModels() {
     });
   }
 
+  std::unordered_set<std::string> currentNiriWindowIds;
+  const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr;
+  if (compositors::isNiri()) {
+    currentNiriWindowIds.reserve(workspaceAssignments.size());
+    for (const auto& assignment : workspaceAssignments) {
+      if (!assignment.windowId.empty()) {
+        currentNiriWindowIds.insert(assignment.windowId);
+      }
+    }
+    allowedNiriWindowIds = &currentNiriWindowIds;
+  }
+
   std::vector<std::string> running = m_platform.runningAppIds(topFilter);
   if (compositors::isHyprland() || compositors::isKde()) {
     std::unordered_set<std::string> seenApps(running.begin(), running.end());
@@ -1511,7 +1535,7 @@ void TaskbarWidget::updateModels() {
         !run.entry.startupWmClass.empty() ? toLower(run.entry.startupWmClass) : run.runningLower;
     const std::string nameLower = !run.entry.nameLower.empty() ? run.entry.nameLower : run.runningLower;
 
-    const auto windows = m_platform.windowsForApp(idLower, startupLower, topFilter);
+    const auto windows = m_platform.taskbarWindowsForApp(idLower, startupLower, topFilter, allowedNiriWindowIds);
     for (const auto& window : windows) {
       const auto handleKey = taskHandleKey(window);
       if (handleKey == 0 || !processedHandles.insert(handleKey).second) {
@@ -1529,7 +1553,10 @@ void TaskbarWidget::updateModels() {
       task.title = window.title;
       task.active = activeHandle != nullptr && activeHandle == window.handle;
       task.firstHandle = window.handle;
-      if (!window.identifier.empty()) {
+      if (compositors::isNiri() && window.extHandle != nullptr && !window.identifier.empty()) {
+        task.workspaceWindowId = window.identifier;
+        task.exactCompositorWindowId = window.identifier;
+      } else if (!compositors::isNiri() && !window.identifier.empty()) {
         task.workspaceWindowId = window.identifier;
       }
       task.iconPath = resolveIconPath(run.runningAppId, run.entry.icon);
@@ -1539,7 +1566,7 @@ void TaskbarWidget::updateModels() {
   }
 
   // Windows with no app id still get a task keyed by toplevel handle / window id.
-  for (const auto& window : m_platform.windowsWithoutAppId(topFilter)) {
+  for (const auto& window : m_platform.taskbarWindowsWithoutAppId(topFilter, allowedNiriWindowIds)) {
     // Skip anonymous XWayland menu popups (no app id and no title to show).
     if (window.title.empty()) {
       continue;
@@ -1555,6 +1582,10 @@ void TaskbarWidget::updateModels() {
     task.title = window.title;
     task.active = activeHandle != nullptr && activeHandle == window.handle;
     task.firstHandle = window.handle;
+    if (compositors::isNiri() && window.extHandle != nullptr && !window.identifier.empty()) {
+      task.workspaceWindowId = window.identifier;
+      task.exactCompositorWindowId = window.identifier;
+    }
     task.iconPath = resolveIconPath({}, {});
     nextTasks.push_back(std::move(task));
   }
@@ -1607,7 +1638,6 @@ void TaskbarWidget::updateModels() {
   });
 
   if (compositors::isHyprland()) {
-    const auto focusedCompositorWindowId = m_platform.focusedCompositorWindowId();
     for (auto& task : nextTasks) {
       ToplevelInfo toplevelInfo{};
       toplevelInfo.handle = task.firstHandle;
@@ -1868,10 +1898,11 @@ void TaskbarWidget::updateModels() {
       // (Hyprland address mapping). Unrelated identifiers (e.g. ext-toplevel tokens)
       // must not block later title matching or icons disappear from workspace groups.
       for (auto& task : nextTasks) {
-        if (task.workspaceWindowId.empty() || !task.workspaceKey.empty()) {
+        const std::string_view bindingWindowId = workspaceBindingWindowId(task);
+        if (bindingWindowId.empty() || !task.workspaceKey.empty()) {
           continue;
         }
-        const auto index = assignmentIndexForWindowId(task.workspaceWindowId);
+        const auto index = assignmentIndexForWindowId(bindingWindowId);
         if (!index.has_value() || used[*index]) {
           continue;
         }
@@ -1883,8 +1914,9 @@ void TaskbarWidget::updateModels() {
       }
 
       // Bind focused compositor window id to the active toplevel before title match.
-      if (const auto focusedId = m_platform.focusedCompositorWindowId(); focusedId.has_value()) {
-        if (const auto index = assignmentIndexForWindowId(*focusedId); index.has_value() && !used[*index]) {
+      if (focusedCompositorWindowId.has_value()) {
+        if (const auto index = assignmentIndexForWindowId(*focusedCompositorWindowId);
+            index.has_value() && !used[*index]) {
           TaskModel* activeTask = nullptr;
           for (auto& task : nextTasks) {
             if (task.active) {
@@ -1904,6 +1936,9 @@ void TaskbarWidget::updateModels() {
 
       auto assignMatch = [&](TaskModel& task, bool requireTitle,
                              const std::function<bool(const WorkspaceWindowAssignment&)>& extraPredicate) -> bool {
+        if (!task.exactCompositorWindowId.empty()) {
+          return false;
+        }
         if (const auto existing = assignmentIndexForWindowId(task.workspaceWindowId); existing.has_value()) {
           if (!used[*existing] && extraPredicate(workspaceAssignments[*existing])) {
             const auto& assignment = workspaceAssignments[*existing];
@@ -1949,7 +1984,7 @@ void TaskbarWidget::updateModels() {
       };
 
       for (auto& task : nextTasks) {
-        if (!task.workspaceKey.empty()) {
+        if (!task.workspaceKey.empty() || !task.exactCompositorWindowId.empty()) {
           continue;
         }
         const auto previous = previousWorkspaceWindowByHandle.find(task.handleKey);
@@ -1973,7 +2008,7 @@ void TaskbarWidget::updateModels() {
       }
 
       for (auto& task : nextTasks) {
-        if (!task.workspaceKey.empty()) {
+        if (!task.workspaceKey.empty() || !task.exactCompositorWindowId.empty()) {
           continue;
         }
         const auto previous = previousWorkspaceByHandle.find(task.handleKey);
@@ -1986,7 +2021,7 @@ void TaskbarWidget::updateModels() {
       }
 
       for (auto& task : nextTasks) {
-        if (!task.workspaceKey.empty()) {
+        if (!task.workspaceKey.empty() || !task.exactCompositorWindowId.empty()) {
           continue;
         }
         const auto previous = previousWorkspaceByHandle.find(task.handleKey);
@@ -2006,7 +2041,7 @@ void TaskbarWidget::updateModels() {
       }
 
       for (auto& task : nextTasks) {
-        if (!task.workspaceKey.empty()) {
+        if (!task.workspaceKey.empty() || !task.exactCompositorWindowId.empty()) {
           continue;
         }
         // Real compositor window id already present in assignments — leave it alone.
@@ -2045,7 +2080,9 @@ void TaskbarWidget::updateModels() {
       }
 
       for (auto& task : nextTasks) {
-        if (task.workspaceKey.empty() || task.workspaceOrder != std::numeric_limits<std::uint64_t>::max()) {
+        if (!task.exactCompositorWindowId.empty()
+            || task.workspaceKey.empty()
+            || task.workspaceOrder != std::numeric_limits<std::uint64_t>::max()) {
           continue;
         }
 
@@ -2081,10 +2118,13 @@ void TaskbarWidget::updateModels() {
       }
 
       // Active indicator follows the focused compositor window id when bound.
-      if (const auto focusedId = m_platform.focusedCompositorWindowId(); focusedId.has_value()) {
+      if (focusedCompositorWindowId.has_value()) {
         TaskModel* focusedTask = nullptr;
         for (auto& task : nextTasks) {
-          if (!task.workspaceWindowId.empty() && windowIdsMatch(task.workspaceWindowId, *focusedId)) {
+          const std::string_view activationWindowId = compositors::isNiri()
+              ? std::string_view(task.exactCompositorWindowId)
+              : std::string_view(task.workspaceWindowId);
+          if (!activationWindowId.empty() && windowIdsMatch(activationWindowId, *focusedCompositorWindowId)) {
             focusedTask = &task;
             break;
           }
@@ -2112,12 +2152,14 @@ void TaskbarWidget::updateModels() {
       std::unordered_set<std::string> claimedWindowIds;
       for (std::size_t taskIndex = 0; taskIndex < nextTasks.size(); ++taskIndex) {
         auto& task = nextTasks[taskIndex];
-        if (task.workspaceWindowId.empty()) {
+        const std::string_view bindingWindowId = workspaceBindingWindowId(task);
+        if (bindingWindowId.empty()) {
           continue;
         }
         for (std::size_t assignmentIndex = 0; assignmentIndex < workspaceAssignments.size(); ++assignmentIndex) {
           const auto& assignment = workspaceAssignments[assignmentIndex];
-          if (assignment.windowId != task.workspaceWindowId || !matchesApp(task, assignment)) {
+          if (assignment.windowId != bindingWindowId
+              || (task.exactCompositorWindowId.empty() && !matchesApp(task, assignment))) {
             continue;
           }
           task.workspaceKey = assignment.workspaceKey;
@@ -2154,7 +2196,7 @@ void TaskbarWidget::updateModels() {
         auto tryClaim = [&](bool requireWorkspace, bool requireTitle) -> bool {
           for (std::size_t i = 0; i < nextTasks.size(); ++i) {
             auto& task = nextTasks[i];
-            if (orderClaimed[i] || !appMatches(task)) {
+            if (orderClaimed[i] || !task.exactCompositorWindowId.empty() || !appMatches(task)) {
               continue;
             }
             if (!task.workspaceWindowId.empty() && !currentAssignmentWindowIds.contains(task.workspaceWindowId)) {
@@ -2274,6 +2316,10 @@ void TaskbarWidget::updateModels() {
         task.iconPath = resolveIconPath({}, {});
         task.workspaceKey = assignment.workspaceKey;
         task.workspaceWindowId = assignment.windowId;
+        if (compositors::isNiri()) {
+          task.exactCompositorWindowId = assignment.windowId;
+          task.active = focusedCompositorWindowId.has_value() && assignment.windowId == *focusedCompositorWindowId;
+        }
         task.workspaceOrder = i;
         nextTasks.push_back(std::move(task));
         representedWindowIds.insert(assignment.windowId);
@@ -2298,7 +2344,8 @@ void TaskbarWidget::updateModels() {
       for (const auto& appId : *list) {
         const std::string appLower = toLower(appId);
         const std::string startupWmClassLower = toLower(appId);
-        const auto windows = m_platform.windowsForApp(appLower, startupWmClassLower, topFilter);
+        const auto windows =
+            m_platform.taskbarWindowsForApp(appLower, startupWmClassLower, topFilter, allowedNiriWindowIds);
         if (windows.empty()) {
           continue;
         }
@@ -2479,28 +2526,29 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
     return;
   }
 
-  const auto windows = m_platform.windowsForApp(task.idLower, task.startupWmClassLower, toplevelOutputFilter());
+  const auto windows = m_platform.taskbarWindowsForApp(task.idLower, task.startupWmClassLower, toplevelOutputFilter());
   m_contextMenuHandles.clear();
-  m_contextMenuKdeWindows.clear();
+  m_contextMenuInfoWindows.clear();
   m_contextMenuPrimaryHandle = task.firstHandle;
-  m_contextMenuKdePrimary = {};
+  m_contextMenuInfoPrimary = {};
 
   const bool kde = compositors::isKde();
-  if (kde) {
-    m_contextMenuKdeWindows = windows;
-    m_contextMenuKdePrimary = ToplevelInfo{
+  const bool infoClose = kde || (compositors::isNiri() && !task.exactCompositorWindowId.empty());
+  if (infoClose) {
+    m_contextMenuInfoWindows = windows;
+    m_contextMenuInfoPrimary = ToplevelInfo{
         .title = task.title,
         .appId = task.appId,
-        .identifier = task.workspaceWindowId,
-        .handle = task.firstHandle,
+        .identifier = compositors::isNiri() ? task.exactCompositorWindowId : task.workspaceWindowId,
+        .handle = task.exactCompositorWindowId.empty() ? task.firstHandle : nullptr,
     };
-    for (const auto& window : m_contextMenuKdeWindows) {
-      if (!task.workspaceWindowId.empty() && window.identifier == task.workspaceWindowId) {
-        m_contextMenuKdePrimary = window;
+    for (const auto& window : m_contextMenuInfoWindows) {
+      if (!m_contextMenuInfoPrimary.identifier.empty() && window.identifier == m_contextMenuInfoPrimary.identifier) {
+        m_contextMenuInfoPrimary = window;
         break;
       }
       if (task.firstHandle != nullptr && window.handle == task.firstHandle) {
-        m_contextMenuKdePrimary = window;
+        m_contextMenuInfoPrimary = window;
         break;
       }
     }
@@ -2541,15 +2589,16 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
     }
   }
 
-  const auto kdeCanClose = [](const ToplevelInfo& window) {
+  const auto infoCanClose = [](const ToplevelInfo& window) {
     return !window.identifier.empty() || !window.title.empty() || !window.appId.empty();
   };
   const bool showClose = task.running
-      && (kde ? (kdeCanClose(m_contextMenuKdePrimary) || !m_contextMenuKdeWindows.empty())
-              : !m_contextMenuHandles.empty());
-  const bool closePrimaryEnabled = kde ? kdeCanClose(m_contextMenuKdePrimary) : m_contextMenuPrimaryHandle != nullptr;
-  const std::size_t closeAllCount = kde
-      ? (m_contextMenuKdeWindows.empty() ? (closePrimaryEnabled ? 1U : 0U) : m_contextMenuKdeWindows.size())
+      && (infoClose ? (infoCanClose(m_contextMenuInfoPrimary) || !m_contextMenuInfoWindows.empty())
+                    : !m_contextMenuHandles.empty());
+  const bool closePrimaryEnabled =
+      infoClose ? infoCanClose(m_contextMenuInfoPrimary) : m_contextMenuPrimaryHandle != nullptr;
+  const std::size_t closeAllCount = infoClose
+      ? (m_contextMenuInfoWindows.empty() ? (closePrimaryEnabled ? 1U : 0U) : m_contextMenuInfoWindows.size())
       : m_contextMenuHandles.size();
 
   const bool pinAvailable = !m_groupByWorkspace && menuEntry.has_value() && !menuEntry->id.empty();
@@ -2617,7 +2666,7 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
   }
   m_contextMenuPopup->setShadowConfig(m_configService.config().shell.shadow);
   m_contextMenuPopup->setOnActivate([this, entryActions, entryAppName, entryWorkingDir, entryTerminal, menuEntry,
-                                     isPinned](const ContextMenuControlEntry& entry) {
+                                     isPinned, infoClose](const ContextMenuControlEntry& entry) {
     if (entry.id == -4) {
       if (menuEntry.has_value()) {
         setEntryPinned(*menuEntry, !isPinned);
@@ -2652,21 +2701,21 @@ void TaskbarWidget::openTaskContextMenu(const TaskModel& task, InputArea& area) 
       return;
     }
     if (entry.id == -1) {
-      if (compositors::isKde()) {
-        m_platform.closeToplevelInfo(m_contextMenuKdePrimary);
+      if (infoClose) {
+        m_platform.closeToplevelInfo(m_contextMenuInfoPrimary);
       } else if (m_contextMenuPrimaryHandle != nullptr) {
         m_platform.closeToplevel(m_contextMenuPrimaryHandle);
       }
       return;
     }
     if (entry.id == -2) {
-      if (compositors::isKde()) {
-        if (!m_contextMenuKdeWindows.empty()) {
-          for (const auto& window : m_contextMenuKdeWindows) {
+      if (infoClose) {
+        if (!m_contextMenuInfoWindows.empty()) {
+          for (const auto& window : m_contextMenuInfoWindows) {
             m_platform.closeToplevelInfo(window);
           }
         } else {
-          m_platform.closeToplevelInfo(m_contextMenuKdePrimary);
+          m_platform.closeToplevelInfo(m_contextMenuInfoPrimary);
         }
       } else {
         for (auto* handle : m_contextMenuHandles) {
@@ -2810,6 +2859,8 @@ TaskbarWidget::ModelComparison TaskbarWidget::compareModels(
         || nextTasks[i].active != previousTasks[i].active
         || nextTasks[i].firstHandle != previousTasks[i].firstHandle
         || nextTasks[i].workspaceKey != previousTasks[i].workspaceKey
+        || nextTasks[i].workspaceWindowId != previousTasks[i].workspaceWindowId
+        || nextTasks[i].exactCompositorWindowId != previousTasks[i].exactCompositorWindowId
         || nextTasks[i].order != previousTasks[i].order
         || nextTasks[i].workspaceOrder != previousTasks[i].workspaceOrder
         || nextTasks[i].handleKey != previousTasks[i].handleKey

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -1504,18 +1504,6 @@ void TaskbarWidget::updateModels() {
     });
   }
 
-  std::unordered_set<std::string> currentNiriWindowIds;
-  const std::unordered_set<std::string>* allowedNiriWindowIds = nullptr;
-  if (compositors::isNiri()) {
-    currentNiriWindowIds.reserve(workspaceAssignments.size());
-    for (const auto& assignment : workspaceAssignments) {
-      if (!assignment.windowId.empty()) {
-        currentNiriWindowIds.insert(assignment.windowId);
-      }
-    }
-    allowedNiriWindowIds = &currentNiriWindowIds;
-  }
-
   std::vector<std::string> running = m_platform.runningAppIds(topFilter);
   if (compositors::isHyprland() || compositors::isKde()) {
     std::unordered_set<std::string> seenApps(running.begin(), running.end());
@@ -1535,7 +1523,7 @@ void TaskbarWidget::updateModels() {
         !run.entry.startupWmClass.empty() ? toLower(run.entry.startupWmClass) : run.runningLower;
     const std::string nameLower = !run.entry.nameLower.empty() ? run.entry.nameLower : run.runningLower;
 
-    const auto windows = m_platform.taskbarWindowsForApp(idLower, startupLower, topFilter, allowedNiriWindowIds);
+    const auto windows = m_platform.taskbarWindowsForApp(idLower, startupLower, topFilter);
     for (const auto& window : windows) {
       const auto handleKey = taskHandleKey(window);
       if (handleKey == 0 || !processedHandles.insert(handleKey).second) {
@@ -1566,7 +1554,7 @@ void TaskbarWidget::updateModels() {
   }
 
   // Windows with no app id still get a task keyed by toplevel handle / window id.
-  for (const auto& window : m_platform.taskbarWindowsWithoutAppId(topFilter, allowedNiriWindowIds)) {
+  for (const auto& window : m_platform.taskbarWindowsWithoutAppId(topFilter)) {
     // Skip anonymous XWayland menu popups (no app id and no title to show).
     if (window.title.empty()) {
       continue;
@@ -2344,8 +2332,7 @@ void TaskbarWidget::updateModels() {
       for (const auto& appId : *list) {
         const std::string appLower = toLower(appId);
         const std::string startupWmClassLower = toLower(appId);
-        const auto windows =
-            m_platform.taskbarWindowsForApp(appLower, startupWmClassLower, topFilter, allowedNiriWindowIds);
+        const auto windows = m_platform.taskbarWindowsForApp(appLower, startupWmClassLower, topFilter);
         if (windows.empty()) {
           continue;
         }

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -97,6 +97,9 @@ private:
     std::string iconPath;
     std::string workspaceKey;
     std::string workspaceWindowId;
+    // Authoritative compositor identity used for actions. Unlike workspaceWindowId,
+    // this is never rewritten by workspace-placement reconciliation.
+    std::string exactCompositorWindowId;
     // Desktop entry id used for pin persistence / launch (empty for unmatched windows).
     std::string desktopEntryId;
     std::uint64_t workspaceOrder = std::numeric_limits<std::uint64_t>::max();
@@ -165,6 +168,7 @@ private:
   [[nodiscard]] static bool taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws);
   [[nodiscard]] static const TaskModel*
   resolveTask(const std::vector<TaskModel>& tasks, TaskRef ref, std::uint64_t currentGeneration);
+  [[nodiscard]] static std::string_view workspaceBindingWindowId(const TaskModel& task);
   void activateTaskModel(const TaskModel& task);
   void closeTaskModel(const TaskModel& task);
   void applyPinnedMerge(std::vector<TaskModel>& tasks);
@@ -230,9 +234,10 @@ private:
   std::unique_ptr<ContextMenuPopup> m_contextMenuPopup;
   std::vector<zwlr_foreign_toplevel_handle_v1*> m_contextMenuHandles;
   zwlr_foreign_toplevel_handle_v1* m_contextMenuPrimaryHandle = nullptr;
-  // KDE has no wlr foreign-toplevel handles; close targets use title/appId/uuid instead.
-  std::vector<ToplevelInfo> m_contextMenuKdeWindows;
-  ToplevelInfo m_contextMenuKdePrimary;
+  // KDE and Niri ext-foreign-toplevel tasks close through ToplevelInfo rather
+  // than a wlr foreign-toplevel handle.
+  std::vector<ToplevelInfo> m_contextMenuInfoWindows;
+  ToplevelInfo m_contextMenuInfoPrimary;
   std::uint64_t m_desktopEntriesVersion = 0;
   IconResolver m_iconResolver;
   Signal<>::ScopedConnection m_appIconColorizeConn;

--- a/src/wayland/ext_foreign_toplevels.cpp
+++ b/src/wayland/ext_foreign_toplevels.cpp
@@ -92,7 +92,10 @@ std::vector<std::string> WaylandExtForeignToplevels::allAppIds() const {
   std::vector<const ToplevelState*> ordered;
   ordered.reserve(m_handles.size());
   for (const auto& [_, state] : m_handles) {
-    const auto appId = effectiveAppId(state.appId, state.title);
+    if (!state.ready) {
+      continue;
+    }
+    const auto appId = effectiveAppId(state.committed.appId, state.committed.title);
     if (!appId.empty()) {
       ordered.push_back(&state);
     }
@@ -104,7 +107,7 @@ std::vector<std::string> WaylandExtForeignToplevels::allAppIds() const {
   std::vector<std::string> ids;
   ids.reserve(ordered.size());
   for (const auto* state : ordered) {
-    ids.push_back(effectiveAppId(state->appId, state->title));
+    ids.push_back(effectiveAppId(state->committed.appId, state->committed.title));
   }
   return ids;
 }
@@ -118,7 +121,10 @@ WaylandExtForeignToplevels::windowsForApp(const std::string& idLower, const std:
 
   std::vector<MatchedWindow> matched;
   for (const auto& [handle, state] : m_handles) {
-    const auto appId = effectiveAppId(state.appId, state.title);
+    if (!state.ready) {
+      continue;
+    }
+    const auto appId = effectiveAppId(state.committed.appId, state.committed.title);
     if (appId.empty()) {
       continue;
     }
@@ -133,9 +139,9 @@ WaylandExtForeignToplevels::windowsForApp(const std::string& idLower, const std:
         MatchedWindow{
             .order = state.order,
             .info = ToplevelInfo{
-                .title = state.title,
+                .title = state.committed.title,
                 .appId = appId,
-                .identifier = state.identifier,
+                .identifier = state.committed.identifier,
                 .order = state.order,
                 .handle = nullptr,
                 .extHandle = handle,
@@ -161,7 +167,10 @@ std::vector<ToplevelInfo> WaylandExtForeignToplevels::windowsWithoutAppId() cons
 
   std::vector<OrphanWindow> orphans;
   for (const auto& [handle, state] : m_handles) {
-    const auto appId = effectiveAppId(state.appId, state.title);
+    if (!state.ready) {
+      continue;
+    }
+    const auto appId = effectiveAppId(state.committed.appId, state.committed.title);
     if (!appId.empty()) {
       continue;
     }
@@ -169,9 +178,9 @@ std::vector<ToplevelInfo> WaylandExtForeignToplevels::windowsWithoutAppId() cons
         OrphanWindow{
             .order = state.order,
             .info = ToplevelInfo{
-                .title = state.title,
+                .title = state.committed.title,
                 .appId = {},
-                .identifier = state.identifier,
+                .identifier = state.committed.identifier,
                 .order = state.order,
                 .handle = nullptr,
                 .extHandle = handle,
@@ -210,19 +219,26 @@ void WaylandExtForeignToplevels::onListFinished() {
 void WaylandExtForeignToplevels::onHandleClosed(ext_foreign_toplevel_handle_v1* handle) {
   if (handle != nullptr) {
     ext_foreign_toplevel_handle_v1_destroy(handle);
-    m_handles.erase(handle);
-    notifyChanged();
+    removeHandle(handle);
   }
 }
 
-void WaylandExtForeignToplevels::onHandleDone(ext_foreign_toplevel_handle_v1* /*handle*/) { notifyChanged(); }
+void WaylandExtForeignToplevels::onHandleDone(ext_foreign_toplevel_handle_v1* handle) {
+  const auto it = m_handles.find(handle);
+  if (it == m_handles.end()) {
+    return;
+  }
+  it->second.committed = it->second.pending;
+  it->second.ready = true;
+  notifyChanged();
+}
 
 void WaylandExtForeignToplevels::onHandleTitle(ext_foreign_toplevel_handle_v1* handle, const char* title) {
   const auto it = m_handles.find(handle);
   if (it == m_handles.end()) {
     return;
   }
-  it->second.title = StringUtils::windowTitleSingleLine(title != nullptr ? title : "");
+  it->second.pending.title = StringUtils::windowTitleSingleLine(title != nullptr ? title : "");
 }
 
 void WaylandExtForeignToplevels::onHandleAppId(ext_foreign_toplevel_handle_v1* handle, const char* appId) {
@@ -230,7 +246,7 @@ void WaylandExtForeignToplevels::onHandleAppId(ext_foreign_toplevel_handle_v1* h
   if (it == m_handles.end()) {
     return;
   }
-  it->second.appId = appId != nullptr ? appId : "";
+  it->second.pending.appId = appId != nullptr ? appId : "";
 }
 
 void WaylandExtForeignToplevels::onHandleIdentifier(ext_foreign_toplevel_handle_v1* handle, const char* identifier) {
@@ -238,7 +254,13 @@ void WaylandExtForeignToplevels::onHandleIdentifier(ext_foreign_toplevel_handle_
   if (it == m_handles.end()) {
     return;
   }
-  it->second.identifier = identifier != nullptr ? identifier : "";
+  it->second.pending.identifier = identifier != nullptr ? identifier : "";
+}
+
+void WaylandExtForeignToplevels::removeHandle(ext_foreign_toplevel_handle_v1* handle) {
+  if (m_handles.erase(handle) > 0) {
+    notifyChanged();
+  }
 }
 
 void WaylandExtForeignToplevels::notifyChanged() {

--- a/src/wayland/ext_foreign_toplevels.h
+++ b/src/wayland/ext_foreign_toplevels.h
@@ -28,8 +28,8 @@ public:
   [[nodiscard]] std::vector<ToplevelInfo> windowsWithoutAppId() const;
 
   template <typename Fn> void visitExtHandles(Fn&& fn) const {
-    for (const auto& [handle, _] : m_handles) {
-      if (handle != nullptr) {
+    for (const auto& [handle, state] : m_handles) {
+      if (handle != nullptr && state.ready) {
         fn(handle);
       }
     }
@@ -44,14 +44,21 @@ public:
   void onHandleIdentifier(ext_foreign_toplevel_handle_v1* handle, const char* identifier);
 
 private:
-  struct ToplevelState {
+  struct ToplevelProperties {
     std::string title;
     std::string appId;
     std::string identifier;
+  };
+
+  struct ToplevelState {
+    ToplevelProperties pending;
+    ToplevelProperties committed;
     std::uint64_t order = 0;
+    bool ready = false;
   };
 
   void requestInitialSync();
+  void removeHandle(ext_foreign_toplevel_handle_v1* handle);
   void notifyChanged();
 
   ext_foreign_toplevel_list_v1* m_list = nullptr;

--- a/src/wayland/wayland_connection.cpp
+++ b/src/wayland/wayland_connection.cpp
@@ -626,10 +626,15 @@ std::vector<ToplevelInfo> WaylandConnection::windowsWithoutAppId(wl_output* outp
 
 std::vector<ToplevelInfo>
 WaylandConnection::extWindowsForApp(const std::string& idLower, const std::string& wmClassLower) const {
-  if ((!compositors::isHyprland() && !compositors::isKde()) || !m_extForeignToplevels.isBound()) {
+  if ((!compositors::isHyprland() && !compositors::isKde() && !compositors::isNiri())
+      || !m_extForeignToplevels.isBound()) {
     return {};
   }
   return m_extForeignToplevels.windowsForApp(idLower, wmClassLower);
+}
+
+std::vector<ToplevelInfo> WaylandConnection::extWindowsWithoutAppId() const {
+  return m_extForeignToplevels.isBound() ? m_extForeignToplevels.windowsWithoutAppId() : std::vector<ToplevelInfo>{};
 }
 
 bool WaylandConnection::containsWlrToplevelHandle(zwlr_foreign_toplevel_handle_v1* handle) const {

--- a/src/wayland/wayland_connection.cpp
+++ b/src/wayland/wayland_connection.cpp
@@ -24,6 +24,7 @@
 #include "wayland/hyprland/focus_grab_service.h"
 #include "wayland/text_input_service.h"
 #include "wayland/virtual_keyboard_service.h"
+#include "wayland/wayland_protocol_policy.h"
 #include "wlr-data-control-unstable-v1-client-protocol.h"
 #include "wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
 #include "wlr-gamma-control-unstable-v1-client-protocol.h"
@@ -1074,8 +1075,9 @@ void WaylandConnection::bindGlobal(
 
   if (interfaceName == ext_foreign_toplevel_list_v1_interface.name) {
     const auto compositor = compositors::detect();
-    // Niri/Sway also expose this global; binding it duplicates every window on top of wlr foreign-toplevel.
-    if (compositor != compositors::CompositorKind::Hyprland && compositor != compositors::CompositorKind::Kde) {
+    // Niri needs the ext identifier for an exact join with its numeric IPC window id. Keep the
+    // wlr manager bound as well because other shell features still consume its richer state.
+    if (!wayland_protocol_policy::shouldBindExtForeignToplevelList(compositor)) {
       return;
     }
     m_hasExtForeignToplevelListGlobal = true;

--- a/src/wayland/wayland_connection.h
+++ b/src/wayland/wayland_connection.h
@@ -212,6 +212,7 @@ public:
   [[nodiscard]] std::vector<ToplevelInfo> windowsWithoutAppId(wl_output* outputFilter = nullptr) const;
   [[nodiscard]] std::vector<ToplevelInfo>
   extWindowsForApp(const std::string& idLower, const std::string& wmClassLower) const;
+  [[nodiscard]] std::vector<ToplevelInfo> extWindowsWithoutAppId() const;
   [[nodiscard]] bool containsWlrToplevelHandle(zwlr_foreign_toplevel_handle_v1* handle) const;
   template <typename Fn> void visitExtToplevelHandles(Fn&& fn) const {
     m_extForeignToplevels.visitExtHandles(std::forward<Fn>(fn));

--- a/src/wayland/wayland_protocol_policy.h
+++ b/src/wayland/wayland_protocol_policy.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "compositors/compositor_detect.h"
+
+namespace wayland_protocol_policy {
+
+  [[nodiscard]] constexpr bool shouldBindExtForeignToplevelList(compositors::CompositorKind compositor) noexcept {
+    return compositor == compositors::CompositorKind::Niri
+        || compositor == compositors::CompositorKind::Hyprland
+        || compositor == compositors::CompositorKind::Kde;
+  }
+
+} // namespace wayland_protocol_policy

--- a/tests/niri_workspace_backend_test.cpp
+++ b/tests/niri_workspace_backend_test.cpp
@@ -1,0 +1,108 @@
+#include "compositors/niri/niri_runtime.h"
+#include "compositors/niri/niri_workspace_backend.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdlib>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <thread>
+#include <unistd.h>
+
+int main() {
+  const std::string socketPath = "/tmp/noctalia-niri-workspace-test-" + std::to_string(getpid()) + ".sock";
+  const int listener = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  assert(listener >= 0);
+
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  assert(socketPath.size() < sizeof(address.sun_path));
+  std::copy(socketPath.begin(), socketPath.end(), address.sun_path);
+  assert(::bind(listener, reinterpret_cast<const sockaddr*>(&address), sizeof(address)) == 0);
+  assert(::listen(listener, 1) == 0);
+  setenv("NIRI_SOCKET", socketPath.c_str(), 1);
+
+  std::string request;
+  std::jthread server([&]() {
+    const int eventClient = ::accept4(listener, nullptr, nullptr, SOCK_CLOEXEC);
+    assert(eventClient >= 0);
+    char buffer[512];
+    const ssize_t eventSize = ::read(eventClient, buffer, sizeof(buffer));
+    assert(eventSize > 0);
+
+    const int actionClient = ::accept4(listener, nullptr, nullptr, SOCK_CLOEXEC);
+    assert(actionClient >= 0);
+    const ssize_t size = ::read(actionClient, buffer, sizeof(buffer));
+    assert(size > 0);
+    request.assign(buffer, static_cast<std::size_t>(size));
+    constexpr std::string_view response = "{\"Ok\":null}\n";
+    assert(::write(actionClient, response.data(), response.size()) == static_cast<ssize_t>(response.size()));
+    ::close(actionClient);
+    ::close(eventClient);
+  });
+
+  compositors::niri::NiriRuntime runtime;
+  NiriWorkspaceBackend backend(runtime);
+  int changes = 0;
+  backend.setChangeCallback([&]() { ++changes; });
+  backend.handleEvent(
+      "WorkspacesChanged",
+      {{"workspaces",
+        {
+            {{"id", 1}, {"idx", 1}, {"output", "DP-1"}},
+            {{"id", 2}, {"idx", 2}, {"output", "DP-1"}},
+        }}}
+  );
+  changes = 0;
+  backend.handleEvent(
+      "WindowsChanged",
+      {{"windows",
+        {
+            {{"id", 41},
+             {"workspace_id", 1},
+             {"app_id", "com.mitchellh.ghostty"},
+             {"is_focused", true},
+             {"layout", {{"pos_in_scrolling_layout", {1, 1}}}}},
+            {{"id", 42},
+             {"workspace_id", 2},
+             {"app_id", "com.mitchellh.ghostty"},
+             {"is_focused", false},
+             {"layout", {{"pos_in_scrolling_layout", {1, 1}}}}},
+        }}}
+  );
+  assert(backend.focusedWindowId() == std::optional<std::string>("41"));
+
+  backend.handleEvent("WindowFocusChanged", {{"id", 42}});
+  assert(backend.focusedWindowId() == std::optional<std::string>("42"));
+  assert(changes == 2);
+
+  // A new scrolling-layout position must invalidate taskbar ordering even
+  // though workspace/app membership is unchanged.
+  backend.handleEvent(
+      "WindowOpenedOrChanged",
+      {{"window",
+        {{"id", 41},
+         {"workspace_id", 1},
+         {"app_id", "com.mitchellh.ghostty"},
+         {"layout", {{"pos_in_scrolling_layout", {2, 1}}}}}}}
+  );
+  assert(changes == 3);
+  auto windows = backend.workspaceWindows();
+  const auto window41 = std::ranges::find(windows, "41", &WorkspaceWindow::windowId);
+  assert(window41 != windows.end() && window41->x == 2 && window41->y == 1);
+
+  assert(backend.closeWindowById("42"));
+  server.join();
+  const nlohmann::json expectedRequest{{"Action", {{"CloseWindow", {{"id", 42}}}}}};
+  assert(nlohmann::json::parse(request) == expectedRequest);
+  assert(!backend.closeWindowById("not-an-id"));
+
+  ::close(listener);
+  ::unlink(socketPath.c_str());
+  return 0;
+}

--- a/tests/taskbar_widget_test.cpp
+++ b/tests/taskbar_widget_test.cpp
@@ -41,6 +41,39 @@ public:
         .title = std::move(title),
     };
   }
+
+  static std::pair<std::string, std::string>
+  rebindWorkspaceWindow(std::string exactWindowId, std::string assignedWindowId) {
+    TaskbarWidget::TaskModel task{
+        .workspaceWindowId = exactWindowId,
+        .exactCompositorWindowId = std::move(exactWindowId),
+    };
+    task.workspaceWindowId = std::move(assignedWindowId);
+    return {task.workspaceWindowId, task.exactCompositorWindowId};
+  }
+
+  static std::string bindingWindowId(std::string workspaceWindowId, std::string exactWindowId) {
+    return std::string(
+        TaskbarWidget::workspaceBindingWindowId(
+            TaskbarWidget::TaskModel{
+                .workspaceWindowId = std::move(workspaceWindowId),
+                .exactCompositorWindowId = std::move(exactWindowId),
+            }
+        )
+    );
+  }
+
+  static bool exactWindowIdChangeKeepsLayout(std::string previousId, std::string nextId) {
+    const TaskbarWidget::TaskModel previous{
+        .handleKey = 11,
+        .exactCompositorWindowId = std::move(previousId),
+    };
+    const TaskbarWidget::TaskModel next{
+        .handleKey = 11,
+        .exactCompositorWindowId = std::move(nextId),
+    };
+    return TaskbarWidget::compareModels(false, {previous}, {}, {next}, {}).layoutEqual;
+  }
 };
 
 int main() {
@@ -62,6 +95,15 @@ int main() {
   assert(TaskbarWidgetTestAccess::resolvedTitle(tasks, 0, 7, 7) == std::optional<std::string>("retitled"));
   assert(!TaskbarWidgetTestAccess::resolvedTitle(tasks, 2, 7, 7).has_value());
   assert(!TaskbarWidgetTestAccess::resolvedTitle(tasks, 0, 7, 8).has_value());
+
+  // Workspace placement can be rebound while compositor actions retain the
+  // authoritative ext-foreign-toplevel identifier.
+  assert(TaskbarWidgetTestAccess::rebindWorkspaceWindow("41", "42") == std::pair(std::string("42"), std::string("41")));
+  // Exact compositor identity also remains authoritative for later workspace
+  // reconciliation instead of preserving the crossed mutable assignment.
+  assert(TaskbarWidgetTestAccess::bindingWindowId("42", "41") == "41");
+  assert(TaskbarWidgetTestAccess::bindingWindowId("42", "") == "42");
+  assert(!TaskbarWidgetTestAccess::exactWindowIdChangeKeepsLayout("41", "42"));
 
   return 0;
 }

--- a/tests/wayland_toplevels_identity_test.cpp
+++ b/tests/wayland_toplevels_identity_test.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #define private public
+#include "wayland/ext_foreign_toplevels.h"
 #include "wayland/wayland_toplevels.h"
 #undef private
 
@@ -58,5 +59,82 @@ int main() {
   toplevels.onHandleOutputLeave(handle, otherOutput);
   assert(it->second.output == nullptr);
   assert(toplevels.windowsForApp("sample-chat-desktop", "samplechat", someOutput).empty());
+
+  WaylandExtForeignToplevels extToplevels;
+  int changeCount = 0;
+  extToplevels.setChangeCallback([&]() { ++changeCount; });
+
+  auto* extHandle = reinterpret_cast<ext_foreign_toplevel_handle_v1*>(0x30);
+  auto [extIt, extInserted] =
+      extToplevels.m_handles.try_emplace(extHandle, WaylandExtForeignToplevels::ToplevelState{});
+  assert(extInserted);
+  extIt->second.order = extToplevels.m_nextOrder++;
+
+  extToplevels.onHandleTitle(extHandle, "noctalia");
+  extToplevels.onHandleAppId(extHandle, "com.mitchellh.ghostty");
+  extToplevels.onHandleIdentifier(extHandle, "49");
+
+  // Initial properties are an atomic batch and remain hidden until `done`.
+  assert(extToplevels.allAppIds().empty());
+  assert(extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty").empty());
+  std::size_t visited = 0;
+  extToplevels.visitExtHandles([&](ext_foreign_toplevel_handle_v1*) { ++visited; });
+  assert(visited == 0);
+
+  extToplevels.onHandleDone(extHandle);
+  assert(changeCount == 1);
+  assert(extToplevels.allAppIds() == std::vector<std::string>{"com.mitchellh.ghostty"});
+  auto extWindows = extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty");
+  assert(extWindows.size() == 1);
+  assert(extWindows[0].identifier == "49");
+  assert(extWindows[0].title == "noctalia");
+  visited = 0;
+  extToplevels.visitExtHandles([&](ext_foreign_toplevel_handle_v1* current) {
+    assert(current == extHandle);
+    ++visited;
+  });
+  assert(visited == 1);
+
+  // Later property batches also remain hidden until their own `done`.
+  extToplevels.onHandleTitle(extHandle, "renamed");
+  extToplevels.onHandleIdentifier(extHandle, "50");
+  extWindows = extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty");
+  assert(extWindows.size() == 1);
+  assert(extWindows[0].identifier == "49");
+  assert(extWindows[0].title == "noctalia");
+
+  extToplevels.onHandleDone(extHandle);
+  assert(changeCount == 2);
+  extWindows = extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty");
+  assert(extWindows.size() == 1);
+  assert(extWindows[0].identifier == "50");
+  assert(extWindows[0].title == "renamed");
+
+  // Identical presentation metadata never collapses distinct exact identities.
+  auto* duplicateHandle = reinterpret_cast<ext_foreign_toplevel_handle_v1*>(0x31);
+  auto [duplicateIt, duplicateInserted] =
+      extToplevels.m_handles.try_emplace(duplicateHandle, WaylandExtForeignToplevels::ToplevelState{});
+  assert(duplicateInserted);
+  duplicateIt->second.order = extToplevels.m_nextOrder++;
+  extToplevels.onHandleTitle(duplicateHandle, "renamed");
+  extToplevels.onHandleAppId(duplicateHandle, "com.mitchellh.ghostty");
+  extToplevels.onHandleIdentifier(duplicateHandle, "52");
+  extToplevels.onHandleDone(duplicateHandle);
+
+  extWindows = extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty");
+  assert(extWindows.size() == 2);
+  assert(extWindows[0].identifier == "50");
+  assert(extWindows[1].identifier == "52");
+
+  // State removal is safe for both ready and not-yet-ready handles.
+  extToplevels.removeHandle(duplicateHandle);
+  assert(changeCount == 4);
+  assert(extToplevels.windowsForApp("com.mitchellh.ghostty", "ghostty").size() == 1);
+  auto* pendingHandle = reinterpret_cast<ext_foreign_toplevel_handle_v1*>(0x32);
+  extToplevels.m_handles.try_emplace(pendingHandle, WaylandExtForeignToplevels::ToplevelState{});
+  extToplevels.removeHandle(pendingHandle);
+  assert(changeCount == 5);
+  assert(!extToplevels.m_handles.contains(pendingHandle));
+
   return 0;
 }

--- a/tests/wayland_toplevels_identity_test.cpp
+++ b/tests/wayland_toplevels_identity_test.cpp
@@ -1,4 +1,5 @@
 #include "system/internal_app_metadata.h"
+#include "wayland/wayland_protocol_policy.h"
 
 #include <cassert>
 #include <cstdint>
@@ -25,6 +26,15 @@ namespace internal_apps {
 } // namespace internal_apps
 
 int main() {
+  using compositors::CompositorKind;
+  using wayland_protocol_policy::shouldBindExtForeignToplevelList;
+
+  assert(shouldBindExtForeignToplevelList(CompositorKind::Niri));
+  assert(shouldBindExtForeignToplevelList(CompositorKind::Hyprland));
+  assert(shouldBindExtForeignToplevelList(CompositorKind::Kde));
+  assert(!shouldBindExtForeignToplevelList(CompositorKind::Unknown));
+  assert(!shouldBindExtForeignToplevelList(CompositorKind::Sway));
+
   WaylandToplevels toplevels;
   auto* handle = reinterpret_cast<zwlr_foreign_toplevel_handle_v1*>(0x1);
   auto [it, inserted] = toplevels.m_handles.try_emplace(handle, WaylandToplevels::ToplevelState{});


### PR DESCRIPTION
## Summary

Use Niri’s compositor window IDs to give each taskbar entry a stable identity for ordering, focus state, and window actions.

On `main`, the taskbar builds its window list from the generic foreign-toplevel interface and reconciles those entries with compositor workspace data separately. This works when a foreign-toplevel handle is sufficient, but Niri’s workspace layout and focus operations are addressed by numeric window ID. Multiple windows from the same application can therefore be assigned by less-specific metadata such as app ID and title.

This change adds a Niri-specific taskbar path that:

- Reads exact window IDs, workspace placement, focus state, and layout coordinates from Niri IPC.
- Uses the matching `ext-foreign-toplevel` identifier as the immutable identity stored by each task.
- Filters taskbar windows to the IDs reported for the bar’s output.
- Orders tasks from Niri’s current workspace and layout positions.
- Activates and closes Niri windows by compositor ID.
- Selects the focused-window indicator using Niri’s focused window ID.
- Recomputes the model when Niri reports window layout changes.
- Keeps foreign-toplevel property updates pending until the protocol’s `done` event, so the taskbar only consumes complete records.
- Binds `ext-foreign-toplevel-list-v1` on Niri alongside the existing WLR foreign-toplevel manager, making the stable identifier available while preserving richer WLR state used elsewhere.

On Niri, Noctalia intentionally binds both foreign-toplevel protocols. The WLR manager continues providing richer state used by other shell features, while the ext-foreign-toplevel identifier provides the exact join to Niri’s numeric IPC window ID. When either side of that join is temporarily unavailable, the taskbar waits for the next protocol or IPC update instead of falling back to ambiguous app/title matching. Existing behavior remains unchanged on other compositors.

## Motivation

On Niri, clicking a taskbar entry does not always focus the window represented by that entry. The problem is most noticeable with several windows from the same application and with windows on secondary monitors or other workspaces.

For example, two Ghostty windows can appear in one left-to-right order while clicking their taskbar entries focuses them in the opposite order. The focused-window indicator can consequently appear under the wrong entry as well.

Niri exposes the information needed to avoid this ambiguity:

- A stable numeric ID for every window.
- The focused window’s ID.
- Each window’s workspace and position in the scrolling layout.
- An equivalent identifier through `ext-foreign-toplevel`.

Using that ID throughout the taskbar model ensures that displayed position, focused state, and click target all refer to the same compositor window.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- `just format`
- `just lint debug` — passed with warnings treated as errors
- `just build debug`
- `just test debug --print-errorlogs` — 69/69 tests passed
- Added regression coverage for:
  - Niri window identity and workspace assignment
  - Layout-position updates
  - Exact compositor-ID preservation during reconciliation
  - Focus changes based on compositor window ID
  - Multiple windows with identical app IDs and titles
  - Atomic foreign-toplevel property publication on `done`
  - Pending and committed foreign-toplevel removal
  - Compositor-specific ext-foreign-toplevel binding policy

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

N/A — this changes taskbar window association and interaction behavior without changing its visual design.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] Formatting was validated with clang-format v22.
- [x] I ran the relevant build and test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not require end-user documentation changes.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

gpt-5.6-sol was used extensively in debugging and implementation. I reviewed + iterated on the implementation to try to not overcomplicate this patch, but I did some digging around how other bars with Niri-specific behavior manage this, and they seem to just rely on Niri's specific IPC interface vs. using Wayland's generic interface. This avoids all ambiguity and issues with joining the Wayland vs. Niri representations together. I don't have enough context on the direction Noctalia is trying to take to know if that's a refactor worth exploring, but it does seem to be cleaner as far as the data model is concerned when using Niri.