### PR TITLE
feat(workspaces): add toggle to disable hover color changes

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3299,6 +3299,10 @@
           "description": "Center visualizer bars instead of aligning them to the edge",
           "label": "Centered"
         },
+        "change-color-on-hover": {
+          "description": "Change a workspace's fill and label colors while the pointer hovers over it",
+          "label": "Change Color on Hover"
+        },
         "color": {
           "description": "Color role for this widget's icon and label; fixed hex colors are also supported",
           "label": "Color"

--- a/src/shell/bar/widget_factory.cpp
+++ b/src/shell/bar/widget_factory.cpp
@@ -489,6 +489,7 @@ std::unique_ptr<Widget> WidgetFactory::create(
         .occupiedColor = occupiedColor,
         .emptyColor = emptyColor,
         .urgentColor = urgentColor,
+        .changeColorOnHover = wc != nullptr ? wc->getBool("change_color_on_hover", true) : true,
         .maxLabelChars = maxLabelChars,
         .labelsOnlyWhenOccupied = wc != nullptr ? wc->getBool("labels_only_when_occupied", false) : false,
         .hideWhenEmpty = wc != nullptr ? wc->getBool("hide_when_empty", false) : false,

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -82,8 +82,8 @@ WorkspacesWidget::WorkspacesWidget(
       m_activePillSize(std::clamp(options.activePillSize, 0.25f, 8.0f)),
       m_inactivePillSize(std::clamp(options.inactivePillSize, 0.25f, 8.0f)), m_minimal(options.minimal),
       m_focusedPill(options.focusedPill), m_focusedOutputOnly(options.focusedOutputOnly),
-      m_focusedColor(options.focusedColor), m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor),
-      m_urgentColor(options.urgentColor) {
+      m_changeColorOnHover(options.changeColorOnHover), m_focusedColor(options.focusedColor),
+      m_occupiedColor(options.occupiedColor), m_emptyColor(options.emptyColor), m_urgentColor(options.urgentColor) {
   buildDesktopIconIndex();
 }
 
@@ -583,6 +583,10 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
       setWorkspaceClickHandler(*area, ws);
 
       area->setOnEnter([this, areaPtr](const InputArea::PointerData&) {
+        if (!m_changeColorOnHover) {
+          return;
+        }
+
         const auto itemIt = std::ranges::find(m_items, areaPtr, &Item::area);
         if (itemIt == m_items.end() || itemIt->exiting) {
           return;
@@ -691,7 +695,7 @@ void WorkspacesWidget::rebuild(Renderer& renderer) {
   }
 
   // Only minimal style draws the translucent per-item hover overlay.
-  if (m_minimal && barCapsuleSpec().hoverHighlight) {
+  if (m_changeColorOnHover && m_minimal && barCapsuleSpec().hoverHighlight) {
     ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
     hoverFill.alpha = 0.0f;
     m_hoverOverlay = static_cast<Box*>(m_container->addChild(

--- a/src/shell/bar/widgets/workspaces_widget.h
+++ b/src/shell/bar/widgets/workspaces_widget.h
@@ -34,6 +34,7 @@ public:
     ColorSpec occupiedColor = colorSpecFromRole(ColorRole::Secondary);
     ColorSpec emptyColor = colorSpecFromRole(ColorRole::Secondary);
     ColorSpec urgentColor = colorSpecFromRole(ColorRole::Error);
+    bool changeColorOnHover = true;
     std::size_t maxLabelChars = 1;
     bool labelsOnlyWhenOccupied = false;
     bool hideWhenEmpty = false;
@@ -151,6 +152,7 @@ private:
   bool m_minimal = false;
   bool m_focusedPill = false;
   bool m_focusedOutputOnly = false;
+  bool m_changeColorOnHover = true;
   bool m_wasFocusedOutput = true;
   bool m_activeUsesFocusedColor = true;
   std::string m_cachedActiveWindowAppId;

--- a/src/shell/settings/widget_settings_registry.cpp
+++ b/src/shell/settings/widget_settings_registry.cpp
@@ -1014,6 +1014,7 @@ namespace settings {
           focusedOutputOnly.descriptionKey = "settings.widgets.settings.focused-output-only.workspaces-description";
           add(std::move(focusedOutputOnly));
         }
+        add(withGroup(boolSpec("change_color_on_hover", true), "workspaces.colors"));
         add(withGroup(colorSpec("focused_color", "primary"), "workspaces.colors"));
         add(withGroup(colorSpec("occupied_color", "secondary"), "workspaces.colors"));
         add(withGroup(colorSpec("empty_color", "secondary"), "workspaces.colors"));


### PR DESCRIPTION
## Summary

Added a **Change Color on Hover** toggle to the Workspaces bar widget’s color settings.

## Motivation

I was annoyed ever since the hover color change effect was implemented and preferred the old look. I first tried adding a **Hovered Color** dropdown like the existing color settings but that would override the empty workspaces and focused workspaces colors which I did not want so I went with the simplest solution to just add a toggle that disables the hover color change effect entirely.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

Made sure it defaults to true and works with all 3 pill styles.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/9e751150-75b2-4334-baa5-3c36b3569acd

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
