### PR TITLE
fix(system/hardware_info) try amdgpu.ids to get correct AMD GPU name, then fallback to usual

### DIFF
--- a/src/system/hardware_info.cpp
+++ b/src/system/hardware_info.cpp
@@ -78,6 +78,52 @@ namespace {
     return name;
   }
 
+  // libdrm's amdgpu.ids maps (deviceId, revisionId) -> marketing name, e.g.:
+  //   67DF, C7, Radeon RX 580 2048SP
+  //   67DF, CF, Radeon RX 570
+  // Unlike pci.ids' subsystem IDs (which board partners often reuse across
+  // different variants of the same card), the revision ID is baked into the
+  // silicon, so this can reliably tell apart SKUs like RX 570 vs RX 580.
+  std::string lookupAmdGpuIds(const std::string& deviceId, const std::string& revisionId) {
+    std::ifstream file{"/usr/share/libdrm/amdgpu.ids"};
+    if (!file.is_open()) {
+      return {};
+    }
+
+    auto toUpper = [](std::string s) {
+      for (auto& c : s) {
+        if (c >= 'a' && c <= 'f') {
+          c = static_cast<char>(c - 32);
+        }
+      }
+      return s;
+    };
+    const auto wantDevice = toUpper(deviceId);
+    const auto wantRevision = toUpper(revisionId);
+
+    std::string line;
+    while (std::getline(file, line)) {
+      if (line.empty() || line[0] == '#') {
+        continue;
+      }
+
+      const auto firstComma = line.find(',');
+      const auto secondComma = firstComma == std::string::npos ? std::string::npos : line.find(',', firstComma + 1);
+      if (firstComma == std::string::npos || secondComma == std::string::npos) {
+        continue;
+      }
+
+      const auto fileDevice = StringUtils::trim(line.substr(0, firstComma));
+      const auto fileRevision = StringUtils::trim(line.substr(firstComma + 1, secondComma - firstComma - 1));
+
+      if (fileDevice == wantDevice && fileRevision == wantRevision) {
+        return StringUtils::trim(line.substr(secondComma + 1));
+      }
+    }
+
+    return {};
+  }
+
   std::string lookupPciIds(
       const std::string& vendorId, const std::string& deviceId, const std::string& subVendorId = {},
       const std::string& subDeviceId = {}
@@ -228,6 +274,21 @@ namespace {
       stripHexPrefix(subDeviceHex);
 
       if (!vendorHex.empty() && !deviceHex.empty()) {
+        if (vendorHex == "1002") {
+          auto revisionHex = readSysfsLine(deviceDir / "revision");
+          stripHexPrefix(revisionHex);
+          auto amdName = lookupAmdGpuIds(deviceHex, revisionHex);
+          if (!amdName.empty()) {
+            if (!amdName.contains("AMD")) {
+              amdName = "AMD " + amdName;
+            }
+            if (!std::ranges::contains(gpus, amdName)) {
+              gpus.push_back(std::move(amdName));
+            }
+            continue;
+          }
+        }
+
         auto pciName = lookupPciIds(vendorHex, deviceHex, subVendorHex, subDeviceHex);
         if (!pciName.empty()) {
           if (!std::ranges::contains(gpus, pciName)) {

--- a/src/system/hardware_info.cpp
+++ b/src/system/hardware_info.cpp
@@ -78,28 +78,13 @@ namespace {
     return name;
   }
 
-  // libdrm's amdgpu.ids maps (deviceId, revisionId) -> marketing name, e.g.:
-  //   67DF, C7, Radeon RX 580 2048SP
-  //   67DF, CF, Radeon RX 570
-  // Unlike pci.ids' subsystem IDs (which board partners often reuse across
-  // different variants of the same card), the revision ID is baked into the
-  // silicon, so this can reliably tell apart SKUs like RX 570 vs RX 580.
+  // libdrm's amdgpu.ids maps device and revision IDs to a marketing name.
+  // This is generally more specific than pci.ids subsystem names.
   std::string lookupAmdGpuIds(const std::string& deviceId, const std::string& revisionId) {
     std::ifstream file{"/usr/share/libdrm/amdgpu.ids"};
     if (!file.is_open()) {
       return {};
     }
-
-    auto toUpper = [](std::string s) {
-      for (auto& c : s) {
-        if (c >= 'a' && c <= 'f') {
-          c = static_cast<char>(c - 32);
-        }
-      }
-      return s;
-    };
-    const auto wantDevice = toUpper(deviceId);
-    const auto wantRevision = toUpper(revisionId);
 
     std::string line;
     while (std::getline(file, line)) {
@@ -116,7 +101,8 @@ namespace {
       const auto fileDevice = StringUtils::trim(line.substr(0, firstComma));
       const auto fileRevision = StringUtils::trim(line.substr(firstComma + 1, secondComma - firstComma - 1));
 
-      if (fileDevice == wantDevice && fileRevision == wantRevision) {
+      if (StringUtils::equalsInsensitive(fileDevice, deviceId)
+          && StringUtils::equalsInsensitive(fileRevision, revisionId)) {
         return StringUtils::trim(line.substr(secondComma + 1));
       }
     }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Motivation & Summary

I have an `AMD Radeon RX 580 Series` but it showed up incorrectly as `AMD Radeon RX 570 Pulse 4GB`. `fastfetch` displayed the correct GPU name, so I learned from it and tried to implement the same logic here.
`fastfetch` used combination of `device id` and `revision id` as a key into the `/usr/share/libdrm/amdgpu.ids` file to get the correct name of the gpu.  The same logic is applied here.
If the combination isnt available in the file, it falls back to the current lookup logic.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

I tested it on my system and it shows up the correct name for my GPU now.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.