### PR TITLE
Feat(taskbar): drag to reorder pinned taskbar applications 

### DIFF
--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -915,6 +915,8 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       if (m_drag.active) {
         m_suppressTileClick = true;
         if (commitDragReorder()) {
+          // Mark drag as inactive so doLayout() cleans up spacer even if config write fails.
+          m_drag.active = false;
           // The deferred config write rebuilds the strip and destroys these nodes; restoring them
           // now would briefly relayout at the old order and snap the tile back. Park the tile in
           // the gap the spacer is holding so the strip looks settled while that write lands.
@@ -922,7 +924,6 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
             m_drag.area->setPosition(m_drag.spacer->x(), m_drag.spacer->y());
           }
           m_drag.area = nullptr;
-          m_drag.spacer = nullptr;
         }
       } else if (m_drag.armed) {
         m_suppressTileClick = true;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -42,9 +42,6 @@
 namespace {
 
   constexpr auto kDragHoldDelay = std::chrono::milliseconds(300);
-  // Main-axis travel that starts a drag outright, so picking a tile up does not have to wait out
-  // the hold delay. Large enough that an unsteady click cannot trip it.
-  constexpr float kDragArmDistance = 8.0F;
 
   // Integer centering; optional odd spare pixel on the end side (right/bottom).
   [[nodiscard]] float centeredOffset(float extent, float content, float inset = 0.0F, bool oddSpareOnEnd = true) {
@@ -939,7 +936,9 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           return;
         }
         const float main = pointerMainOnStrip(*dragArea, data.localX, data.localY);
-        if (!m_drag.armed && !m_drag.active && std::abs(main - m_drag.startMain) >= kDragArmDistance) {
+        if (!m_drag.armed
+            && !m_drag.active
+            && std::abs(main - m_drag.startMain) >= Style::dragStartThreshold * m_contentScale) {
           m_drag.holdTimer.stop();
           m_drag.armed = true;
         }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -920,6 +920,10 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           m_drag.area = nullptr;
           m_drag.spacer = nullptr;
         }
+      } else if (m_drag.armed) {
+        m_suppressTileClick = true;
+        // Armed but not active means the user pressed and held long enough to arm, but never moved far enough to start
+        // a drag. Treat it as a click that was suppressed.
       }
       endDragVisual();
       m_drag = {};

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -385,9 +385,9 @@ void TaskbarWidget::beginDragVisual() {
   m_drag.restMain = m_vertical ? m_drag.area->y() : m_drag.area->x();
   m_drag.restCross = m_vertical ? m_drag.area->x() : m_drag.area->y();
   m_drag.pinnedCount = pinnedConfigIds().size();
-  m_drag.area->setParticipatesInLayout(false);
-  m_drag.area->setZIndex(200);
-  // Don't create spacer here; doLayout() will handle it.
+  if (Node* container = root(); container != nullptr) {
+    container->markLayoutDirty();
+  }
 }
 
 void TaskbarWidget::updateDragVisual() {
@@ -414,10 +414,7 @@ void TaskbarWidget::endDragVisual() {
   if (m_drag.area == nullptr) {
     return;
   }
-  m_drag.area->setZIndex(0);
-  m_drag.area->setParticipatesInLayout(true);
-  m_drag.area = nullptr;
-  // Spacer cleanup happens in doLayout().
+  // doLayout() restores the tile and removes the spacer together.
   requestRedraw();
 }
 
@@ -426,7 +423,13 @@ void TaskbarWidget::syncDragSpacer() {
   if (m_taskStrip == nullptr || m_drag.area == nullptr) {
     return;
   }
-  m_drag.targetIndex = computeDragTargetIndex();
+  const std::size_t targetIndex = computeDragTargetIndex();
+  if (targetIndex != m_drag.targetIndex) {
+    m_drag.targetIndex = targetIndex;
+    if (Node* container = root(); container != nullptr) {
+      container->markLayoutDirty();
+    }
+  }
 }
 
 bool TaskbarWidget::taskMatchesDesktopEntry(const TaskModel& task, const DesktopEntry& entry) {
@@ -681,27 +684,38 @@ void TaskbarWidget::doLayout(Renderer& renderer, float containerWidth, float con
     m_rebuildPending = false;
   }
 
-  m_root->layout(renderer);
   // Manage spacer lifecycle during drag-to-reorder.
   if (m_drag.active && m_taskStrip != nullptr && m_drag.area != nullptr) {
+    m_drag.area->setParticipatesInLayout(false);
+    m_drag.area->setZIndex(200);
     // Create or reposition spacer to hold the drop gap.
     const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
     if (m_drag.spacer == nullptr) {
       auto spacer = ui::box({
+          .fill = clearColorSpec(),
+          .border = clearColorSpec(),
+          .borderWidth = 0.0F,
           .width = m_drag.area->width(),
           .height = m_drag.area->height(),
+          .configure = [](Box& box) { box.setHitTestVisible(false); },
       });
-      m_drag.spacer = std::unique_ptr<Box>(static_cast<Box*>(m_taskStrip->insertChildAt(insertAt, std::move(spacer))));
+      m_drag.spacer = static_cast<Box*>(m_taskStrip->insertChildAt(insertAt, std::move(spacer)));
     } else {
       // Spacer exists; reposition if targetIndex changed.
-      auto held = m_taskStrip->removeChild(m_drag.spacer.get());
+      auto held = m_taskStrip->removeChild(m_drag.spacer);
       m_taskStrip->insertChildAt(insertAt, std::move(held));
     }
   } else if (m_drag.spacer != nullptr && m_taskStrip != nullptr) {
     // Drag ended or was aborted; clean up spacer.
-    m_taskStrip->removeChild(m_drag.spacer.get());
+    m_taskStrip->removeChild(m_drag.spacer);
     m_drag.spacer = nullptr;
   }
+  if (!m_drag.active && m_drag.area != nullptr) {
+    m_drag.area->setZIndex(0);
+    m_drag.area->setParticipatesInLayout(true);
+    m_drag.area = nullptr;
+  }
+  m_root->layout(renderer);
   if (Node* container = root(); container != nullptr && container != m_root) {
     container->setFrameSize(m_root->width(), m_root->height());
   }
@@ -728,6 +742,7 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
   m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   m_taskTiles.clear();
   m_taskTiles.reserve(m_tasks.size());
+  m_drag = {};
   clearChildren(m_taskStrip);
   buildTaskButtons(renderer);
 }
@@ -915,23 +930,34 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       if (m_drag.active) {
         m_suppressTileClick = true;
         if (commitDragReorder()) {
-          // Mark drag as inactive so doLayout() cleans up spacer even if config write fails.
-          m_drag.active = false;
-          // The deferred config write rebuilds the strip and destroys these nodes; restoring them
-          // now would briefly relayout at the old order and snap the tile back. Park the tile in
-          // the gap the spacer is holding so the strip looks settled while that write lands.
           if (m_drag.area != nullptr && m_drag.spacer != nullptr) {
             m_drag.area->setPosition(m_drag.spacer->x(), m_drag.spacer->y());
           }
-          m_drag.area = nullptr;
+          DeferredCall::callLater([this]() {
+            if (!m_drag.active) {
+              return;
+            }
+            m_drag.active = false;
+            endDragVisual();
+            if (Node* container = root(); container != nullptr) {
+              container->markLayoutDirty();
+            }
+          });
+        } else {
+          m_drag.active = false;
+          endDragVisual();
+          if (Node* container = root(); container != nullptr) {
+            container->markLayoutDirty();
+          }
         }
       } else if (m_drag.armed) {
         m_suppressTileClick = true;
         // Armed but not active means the user pressed and held long enough to arm, but never moved far enough to start
         // a drag. Treat it as a click that was suppressed.
+        m_drag = {};
+      } else {
+        m_drag = {};
       }
-      endDragVisual();
-      m_drag = {};
     });
     if (tileDraggable) {
       area->setOnMotion([this, dragArea, taskRef](const InputArea::PointerData& data) {
@@ -959,11 +985,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           beginDragVisual();
         }
         m_drag.currentMain = main;
-        const std::size_t next = computeDragTargetIndex();
-        if (next != m_drag.targetIndex) {
-          m_drag.targetIndex = next;
-          syncDragSpacer();
-        }
+        syncDragSpacer();
         updateDragVisual();
       });
       area->setOnCancel([this, taskRef]() {
@@ -973,8 +995,11 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
           return;
         }
         if (m_drag.sourceIndex == taskRef.index) {
+          m_drag.active = false;
           endDragVisual();
-          m_drag = {};
+          if (Node* container = root(); container != nullptr) {
+            container->markLayoutDirty();
+          }
         }
       });
     }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <functional>
 #include <linux/input-event-codes.h>
@@ -39,6 +40,11 @@
 #include <wayland-client-protocol.h>
 
 namespace {
+
+  constexpr auto kDragHoldDelay = std::chrono::milliseconds(300);
+  // Main-axis travel that starts a drag outright, so picking a tile up does not have to wait out
+  // the hold delay. Large enough that an unsteady click cannot trip it.
+  constexpr float kDragArmDistance = 8.0F;
 
   // Integer centering; optional odd spare pixel on the end side (right/bottom).
   [[nodiscard]] float centeredOffset(float extent, float content, float inset = 0.0F, bool oddSpareOnEnd = true) {
@@ -326,6 +332,121 @@ void TaskbarWidget::closeTaskModel(const TaskModel& task) {
 }
 
 const std::vector<std::string>& TaskbarWidget::pinnedConfigIds() const noexcept { return m_configOptions.pinned; }
+
+bool TaskbarWidget::reorderEnabled() const {
+  if (m_groupByWorkspace || m_widgetName.empty()) {
+    return false;
+  }
+  return pinnedConfigIds().size() >= 2;
+}
+
+float TaskbarWidget::pointerMainOnStrip(const InputArea& area, float localX, float localY) const {
+  return m_vertical ? area.y() + localY : area.x() + localX;
+}
+
+std::size_t TaskbarWidget::computeDragTargetIndex() const {
+  // Snapshotted at drag start so the target keeps referring to the list the drag began against,
+  // even if the pin list changes underneath.
+  const std::size_t pinnedCount = m_drag.pinnedCount;
+  if (m_tilePitchMain <= 0.0F || pinnedCount == 0) {
+    return m_drag.sourceIndex;
+  }
+  const float slots = (m_drag.currentMain - m_drag.startMain) / m_tilePitchMain;
+  const auto shifted =
+      static_cast<std::ptrdiff_t>(m_drag.sourceIndex) + static_cast<std::ptrdiff_t>(std::lround(slots));
+  return static_cast<std::size_t>(std::clamp<std::ptrdiff_t>(shifted, 0, static_cast<std::ptrdiff_t>(pinnedCount) - 1));
+}
+
+bool TaskbarWidget::commitDragReorder() {
+  if (m_widgetName.empty() || m_drag.sourceIndex == m_drag.targetIndex) {
+    return false;
+  }
+  std::vector<std::string> pinned = pinnedConfigIds();
+  if (m_drag.sourceIndex >= pinned.size() || m_drag.targetIndex >= pinned.size()) {
+    return false;
+  }
+
+  std::string moved = std::move(pinned[m_drag.sourceIndex]);
+  pinned.erase(pinned.begin() + static_cast<std::ptrdiff_t>(m_drag.sourceIndex));
+  pinned.insert(pinned.begin() + static_cast<std::ptrdiff_t>(m_drag.targetIndex), std::move(moved));
+
+  // Writing config rebuilds the taskbar, which can destroy the InputArea whose handler we are
+  // inside — defer so the write happens after this event finishes dispatching.
+  ConfigService* config = &m_configService;
+  DeferredCall::callLater([config, widgetName = m_widgetName, pinned = std::move(pinned)]() mutable {
+    (void)config->setOverride({"widget", widgetName, "pinned"}, std::move(pinned));
+  });
+  return true;
+}
+
+void TaskbarWidget::beginDragVisual() {
+  if (m_drag.area == nullptr) {
+    return;
+  }
+  // Capture the resting position before leaving the flow — afterwards Flex closes the gap and the
+  // neighbours move, but this node keeps whatever position we give it.
+  m_drag.restMain = m_vertical ? m_drag.area->y() : m_drag.area->x();
+  m_drag.restCross = m_vertical ? m_drag.area->x() : m_drag.area->y();
+  m_drag.pinnedCount = pinnedConfigIds().size();
+  m_drag.area->setParticipatesInLayout(false);
+  m_drag.area->setZIndex(200);
+  syncDragSpacer();
+}
+
+void TaskbarWidget::updateDragVisual() {
+  if (m_drag.area == nullptr || !m_drag.active) {
+    return;
+  }
+  // Slot i sits at restMain + (i - sourceIndex) * pitch, so clamping travel to the first and last
+  // slots keeps the tile from wandering somewhere it could never be dropped.
+  const auto source = static_cast<std::ptrdiff_t>(m_drag.sourceIndex);
+  const auto last = static_cast<std::ptrdiff_t>(m_drag.pinnedCount) - 1;
+  const float minMain = m_drag.restMain - static_cast<float>(source) * m_tilePitchMain;
+  const float maxMain = m_drag.restMain + static_cast<float>(last - source) * m_tilePitchMain;
+  const float travelled = m_drag.restMain + (m_drag.currentMain - m_drag.startMain);
+  const float main = (last > 0) ? std::clamp(travelled, minMain, maxMain) : travelled;
+  if (m_vertical) {
+    m_drag.area->setPosition(m_drag.restCross, main);
+  } else {
+    m_drag.area->setPosition(main, m_drag.restCross);
+  }
+  requestRedraw();
+}
+
+void TaskbarWidget::endDragVisual() {
+  if (m_drag.area == nullptr) {
+    return;
+  }
+  if (m_drag.spacer != nullptr && m_taskStrip != nullptr) {
+    (void)m_taskStrip->removeChild(m_drag.spacer);
+    m_drag.spacer = nullptr;
+  }
+  m_drag.area->setZIndex(0);
+  m_drag.area->setParticipatesInLayout(true);
+  m_drag.area = nullptr;
+  requestRedraw();
+}
+
+void TaskbarWidget::syncDragSpacer() {
+  if (m_taskStrip == nullptr || m_drag.area == nullptr) {
+    return;
+  }
+  // The dragged tile still holds a slot in the child vector but no longer participates in layout,
+  // so a target past the source needs one extra slot to land in the right visual gap.
+  const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
+
+  std::unique_ptr<Node> held;
+  if (m_drag.spacer != nullptr) {
+    held = m_taskStrip->removeChild(m_drag.spacer);
+  } else {
+    held = ui::node({
+        .frameWidth = m_drag.area->width(),
+        .frameHeight = m_drag.area->height(),
+        .hitTestVisible = false,
+    });
+  }
+  m_drag.spacer = m_taskStrip->insertChildAt(insertAt, std::move(held));
+}
 
 bool TaskbarWidget::taskMatchesDesktopEntry(const TaskModel& task, const DesktopEntry& entry) {
   const std::string entryIdLower = StringUtils::toLower(entry.id);
@@ -734,6 +855,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     };
   };
 
+  const std::size_t draggableTileCount = reorderEnabled() ? pinnedConfigIds().size() : 0;
   auto createTaskTile = [&](TaskRef taskRef, std::vector<TaskRef> cycleCandidates = {}, std::string cycleKey = {},
                             std::size_t badgeCount = 1) {
     // Unreachable at build time: every ref is built from a live m_tasks element at the current
@@ -753,6 +875,101 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     }
     area->setOpacity(tileOpacity);
     area->setAcceptedButtons(InputArea::buttonMask({BTN_LEFT, BTN_RIGHT, BTN_MIDDLE}));
+    auto* dragArea = area.get();
+    const bool tileDraggable = taskRef.index < draggableTileCount;
+    area->setOnPress([this, dragArea, taskRef, tileDraggable](const InputArea::PointerData& data) {
+      if (data.pressed) {
+        // Any new press supersedes suppression left over from a drag that ended outside its tile.
+        m_suppressTileClick = false;
+      }
+      if (data.button != BTN_LEFT) {
+        return;
+      }
+      if (data.pressed) {
+        if (!tileDraggable) {
+          return;
+        }
+        m_drag = {};
+        m_drag.generation = m_taskGeneration;
+        m_drag.sourceIndex = taskRef.index;
+        m_drag.targetIndex = taskRef.index;
+        m_drag.startMain = pointerMainOnStrip(*dragArea, data.localX, data.localY);
+        m_drag.currentMain = m_drag.startMain;
+        m_drag.area = dragArea;
+        m_drag.holdTimer.start(kDragHoldDelay, [this, taskRef]() {
+          if (m_drag.sourceIndex == taskRef.index && !m_drag.active) {
+            m_drag.armed = true;
+          }
+        });
+        return;
+      }
+      if (!tileDraggable || m_drag.sourceIndex != taskRef.index) {
+        return;
+      }
+      if (m_drag.generation != m_taskGeneration) {
+        m_drag = {};
+        return;
+      }
+      m_drag.holdTimer.stop();
+      if (m_drag.active) {
+        m_suppressTileClick = true;
+        if (commitDragReorder()) {
+          // The deferred config write rebuilds the strip and destroys these nodes; restoring them
+          // now would briefly relayout at the old order and snap the tile back. Park the tile in
+          // the gap the spacer is holding so the strip looks settled while that write lands.
+          if (m_drag.area != nullptr && m_drag.spacer != nullptr) {
+            m_drag.area->setPosition(m_drag.spacer->x(), m_drag.spacer->y());
+          }
+          m_drag.area = nullptr;
+          m_drag.spacer = nullptr;
+        }
+      }
+      endDragVisual();
+      m_drag = {};
+    });
+    if (tileDraggable) {
+      area->setOnMotion([this, dragArea, taskRef](const InputArea::PointerData& data) {
+        if (m_drag.generation != m_taskGeneration) {
+          m_drag = {};
+          return;
+        }
+        // area is set on press and cleared on release, so it doubles as "this tile is held".
+        // Without it a plain hover would satisfy the distance check below and start a drag.
+        if (m_drag.area == nullptr || m_drag.sourceIndex != taskRef.index) {
+          return;
+        }
+        const float main = pointerMainOnStrip(*dragArea, data.localX, data.localY);
+        if (!m_drag.armed && !m_drag.active && std::abs(main - m_drag.startMain) >= kDragArmDistance) {
+          m_drag.holdTimer.stop();
+          m_drag.armed = true;
+        }
+        if (!m_drag.armed && !m_drag.active) {
+          return;
+        }
+        if (!m_drag.active) {
+          m_drag.active = true;
+          beginDragVisual();
+        }
+        m_drag.currentMain = main;
+        const std::size_t next = computeDragTargetIndex();
+        if (next != m_drag.targetIndex) {
+          m_drag.targetIndex = next;
+          syncDragSpacer();
+        }
+        updateDragVisual();
+      });
+      area->setOnCancel([this, taskRef]() {
+        if (m_drag.generation != m_taskGeneration) {
+          // The strip was rebuilt under us, so m_drag.area no longer points at a live node.
+          m_drag = {};
+          return;
+        }
+        if (m_drag.sourceIndex == taskRef.index) {
+          endDragVisual();
+          m_drag = {};
+        }
+      });
+    }
 
     const WorkspaceModel* taskWorkspace = nullptr;
     if (m_groupByWorkspace && !task.workspaceKey.empty()) {
@@ -774,6 +991,10 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
                         cycleKey = std::move(cycleKey)](const InputArea::PointerData& data) {
         const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
         if (current == nullptr) {
+          return;
+        }
+        if (m_suppressTileClick) {
+          m_suppressTileClick = false;
           return;
         }
 
@@ -1386,6 +1607,7 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
   }
   m_taskStrip->setPadding(0.0F, 0.0F, 0.0F, 0.0F);
   m_taskStrip->setGap(tileGap);
+  m_tilePitchMain = (m_vertical ? tileSize : tileWidthWithTitle) + tileGap;
   std::unordered_set<std::string> pinnedCycleKeysThisFrame;
   for (std::size_t i = 0; i < m_tasks.size(); ++i) {
     const auto& task = m_tasks[i];

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -387,7 +387,7 @@ void TaskbarWidget::beginDragVisual() {
   m_drag.pinnedCount = pinnedConfigIds().size();
   m_drag.area->setParticipatesInLayout(false);
   m_drag.area->setZIndex(200);
-  syncDragSpacer();
+  // Don't create spacer here; doLayout() will handle it.
 }
 
 void TaskbarWidget::updateDragVisual() {
@@ -414,35 +414,19 @@ void TaskbarWidget::endDragVisual() {
   if (m_drag.area == nullptr) {
     return;
   }
-  if (m_drag.spacer != nullptr && m_taskStrip != nullptr) {
-    (void)m_taskStrip->removeChild(m_drag.spacer);
-    m_drag.spacer = nullptr;
-  }
   m_drag.area->setZIndex(0);
   m_drag.area->setParticipatesInLayout(true);
   m_drag.area = nullptr;
+  // Spacer cleanup happens in doLayout().
   requestRedraw();
 }
 
 void TaskbarWidget::syncDragSpacer() {
+  // Just compute and store target index; doLayout() creates/positions the spacer.
   if (m_taskStrip == nullptr || m_drag.area == nullptr) {
     return;
   }
-  // The dragged tile still holds a slot in the child vector but no longer participates in layout,
-  // so a target past the source needs one extra slot to land in the right visual gap.
-  const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
-
-  std::unique_ptr<Node> held;
-  if (m_drag.spacer != nullptr) {
-    held = m_taskStrip->removeChild(m_drag.spacer);
-  } else {
-    held = ui::node({
-        .frameWidth = m_drag.area->width(),
-        .frameHeight = m_drag.area->height(),
-        .hitTestVisible = false,
-    });
-  }
-  m_drag.spacer = m_taskStrip->insertChildAt(insertAt, std::move(held));
+  m_drag.targetIndex = computeDragTargetIndex();
 }
 
 bool TaskbarWidget::taskMatchesDesktopEntry(const TaskModel& task, const DesktopEntry& entry) {
@@ -698,6 +682,26 @@ void TaskbarWidget::doLayout(Renderer& renderer, float containerWidth, float con
   }
 
   m_root->layout(renderer);
+  // Manage spacer lifecycle during drag-to-reorder.
+  if (m_drag.active && m_taskStrip != nullptr && m_drag.area != nullptr) {
+    // Create or reposition spacer to hold the drop gap.
+    const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
+    if (m_drag.spacer == nullptr) {
+      auto spacer = ui::box({
+          .width = m_drag.area->width(),
+          .height = m_drag.area->height(),
+      });
+      m_drag.spacer = std::unique_ptr<Box>(static_cast<Box*>(m_taskStrip->insertChildAt(insertAt, std::move(spacer))));
+    } else {
+      // Spacer exists; reposition if targetIndex changed.
+      auto held = m_taskStrip->removeChild(m_drag.spacer.get());
+      m_taskStrip->insertChildAt(insertAt, std::move(held));
+    }
+  } else if (m_drag.spacer != nullptr && m_taskStrip != nullptr) {
+    // Drag ended or was aborted; clean up spacer.
+    m_taskStrip->removeChild(m_drag.spacer.get());
+    m_drag.spacer = nullptr;
+  }
   if (Node* container = root(); container != nullptr && container != m_root) {
     container->setFrameSize(m_root->width(), m_root->height());
   }

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -11,6 +11,7 @@
 #include "render/scene/input_area.h"
 #include "shell/dock/pinned_apps.h"
 #include "shell/panel/panel_manager.h"
+#include "shell/tooltip/tooltip_manager.h"
 #include "system/app_identity.h"
 #include "system/desktop_entry.h"
 #include "system/desktop_entry_launch.h"
@@ -42,6 +43,8 @@
 namespace {
 
   constexpr auto kDragHoldDelay = std::chrono::milliseconds(300);
+  // Lifts the dragged tile above the rest of the strip while it follows the pointer.
+  constexpr std::int32_t kDragTileZIndex = 200;
 
   // Integer centering; optional odd spare pixel on the end side (right/bottom).
   [[nodiscard]] float centeredOffset(float extent, float content, float inset = 0.0F, bool oddSpareOnEnd = true) {
@@ -258,7 +261,7 @@ void TaskbarWidget::syncWorkspaceGroupingCapability() {
   }
 }
 
-TaskbarWidget::~TaskbarWidget() = default;
+TaskbarWidget::~TaskbarWidget() { m_aliveGuard.reset(); }
 
 bool TaskbarWidget::taskInWorkspaceGroup(const TaskModel& task, const WorkspaceModel& ws) {
   if (task.workspaceKey.empty()) {
@@ -376,21 +379,40 @@ bool TaskbarWidget::commitDragReorder() {
   return true;
 }
 
-void TaskbarWidget::beginDragVisual() {
+void TaskbarWidget::requestDragLayout() {
+  if (Node* container = root(); container != nullptr) {
+    container->markLayoutDirty();
+  }
+  // Only requestUpdate() marks the surface as needing a layout pass; requestRedraw() would paint
+  // the scene again without ever running doLayout(), leaving the drag visuals stale.
+  requestUpdate();
+}
+
+void TaskbarWidget::beginDrag() {
   if (m_drag.area == nullptr) {
     return;
   }
+  m_drag.active = true;
   // Capture the resting position before leaving the flow — afterwards Flex closes the gap and the
   // neighbours move, but this node keeps whatever position we give it.
   m_drag.restMain = m_vertical ? m_drag.area->y() : m_drag.area->x();
   m_drag.restCross = m_vertical ? m_drag.area->x() : m_drag.area->y();
   m_drag.pinnedCount = pinnedConfigIds().size();
-  if (Node* container = root(); container != nullptr) {
-    container->markLayoutDirty();
+  // The press that started this gesture has already shown the tile's tooltip; it would hang over
+  // the strip for the whole drag.
+  TooltipManager::instance().onHoverChange(nullptr, static_cast<zwlr_layer_surface_v1*>(nullptr), nullptr);
+  requestDragLayout();
+}
+
+void TaskbarWidget::updateDragTarget() {
+  const std::size_t targetIndex = computeDragTargetIndex();
+  if (targetIndex != m_drag.targetIndex) {
+    m_drag.targetIndex = targetIndex;
+    requestDragLayout();
   }
 }
 
-void TaskbarWidget::updateDragVisual() {
+void TaskbarWidget::moveDragTile() {
   if (m_drag.area == nullptr || !m_drag.active) {
     return;
   }
@@ -410,25 +432,90 @@ void TaskbarWidget::updateDragVisual() {
   requestRedraw();
 }
 
-void TaskbarWidget::endDragVisual() {
-  if (m_drag.area == nullptr) {
+void TaskbarWidget::endDrag(bool commit) {
+  m_drag.holdTimer.stop();
+  const bool wasActive = m_drag.active;
+  if (wasActive || m_drag.armed) {
+    // A consumed gesture must not also activate or launch the app on release.
+    m_suppressTileClick = true;
+  }
+  const bool reordered = wasActive && commit && commitDragReorder();
+  if (reordered && m_drag.area != nullptr && m_dragSpacer != nullptr) {
+    // Park the tile in the gap so the strip looks settled while the deferred write lands.
+    m_drag.area->setPosition(m_dragSpacer->x(), m_dragSpacer->y());
+  }
+  // m_dragFloatTile and m_dragSpacer deliberately survive this reset: applyDragLayout() restores
+  // the tile and drops the spacer on the next layout pass, whichever path ended the gesture.
+  m_drag = {};
+  if (!wasActive) {
     return;
   }
-  // doLayout() restores the tile and removes the spacer together.
-  requestRedraw();
+  if (!reordered) {
+    requestDragLayout();
+    return;
+  }
+  // Restoring now would put the tile back in the pre-write order for a frame, so it visibly jumps
+  // to an edge before the reordered strip appears. Deferred calls run FIFO, so this lands after
+  // the write — which normally destroys this widget outright, because a `widget.*` config change
+  // reloads the bar. It therefore only runs when the write failed or changed nothing.
+  m_dragParked = true;
+  DeferredCall::callLater([this, alive = std::weak_ptr<void>(m_aliveGuard)]() {
+    if (alive.expired()) {
+      return;
+    }
+    m_dragParked = false;
+    requestDragLayout();
+  });
 }
 
-void TaskbarWidget::syncDragSpacer() {
-  // Just compute and store target index; doLayout() creates/positions the spacer.
-  if (m_taskStrip == nullptr || m_drag.area == nullptr) {
+void TaskbarWidget::applyDragLayout() {
+  if (m_taskStrip == nullptr) {
     return;
   }
-  const std::size_t targetIndex = computeDragTargetIndex();
-  if (targetIndex != m_drag.targetIndex) {
-    m_drag.targetIndex = targetIndex;
-    if (Node* container = root(); container != nullptr) {
-      container->markLayoutDirty();
+  if (m_dragParked) {
+    // A committed drop is holding its tile in the target gap until the write lands.
+    return;
+  }
+  InputArea* const floatTile = (m_drag.active && m_drag.area != nullptr) ? m_drag.area : nullptr;
+  if (m_dragFloatTile != nullptr && m_dragFloatTile != floatTile) {
+    m_dragFloatTile->setZIndex(0);
+    m_dragFloatTile->setParticipatesInLayout(true);
+    m_dragFloatTile = nullptr;
+  }
+  if (floatTile == nullptr) {
+    if (m_dragSpacer != nullptr) {
+      m_taskStrip->removeChild(m_dragSpacer);
+      m_dragSpacer = nullptr;
     }
+    return;
+  }
+
+  m_dragFloatTile = floatTile;
+  floatTile->setParticipatesInLayout(false);
+  floatTile->setZIndex(kDragTileZIndex);
+  // The dragged tile is still a child at sourceIndex, just outside the flow, so a target past the
+  // source needs the gap one slot further along.
+  const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
+  if (m_dragSpacer == nullptr) {
+    // The fill is not redundant: a Box copies RectNode's default style, whose fill is opaque black,
+    // and only resolves a ColorSpec once one is set. Setting it also resolves the zero-width border.
+    m_taskStrip->insertChildAt(
+        insertAt,
+        ui::box({
+            .out = &m_dragSpacer,
+            .fill = clearColorSpec(),
+            .width = floatTile->width(),
+            .height = floatTile->height(),
+            .configure = [](Box& box) { box.setHitTestVisible(false); },
+        })
+    );
+    return;
+  }
+  // Re-seating the spacer dirties the strip, so only move it when the slot actually changed.
+  const auto& children = m_taskStrip->children();
+  const auto it = std::ranges::find_if(children, [this](const auto& child) { return child.get() == m_dragSpacer; });
+  if (it != children.end() && static_cast<std::size_t>(std::distance(children.begin(), it)) != insertAt) {
+    m_taskStrip->insertChildAt(insertAt, m_taskStrip->removeChild(m_dragSpacer));
   }
 }
 
@@ -684,37 +771,7 @@ void TaskbarWidget::doLayout(Renderer& renderer, float containerWidth, float con
     m_rebuildPending = false;
   }
 
-  // Manage spacer lifecycle during drag-to-reorder.
-  if (m_drag.active && m_taskStrip != nullptr && m_drag.area != nullptr) {
-    m_drag.area->setParticipatesInLayout(false);
-    m_drag.area->setZIndex(200);
-    // Create or reposition spacer to hold the drop gap.
-    const std::size_t insertAt = m_drag.targetIndex > m_drag.sourceIndex ? m_drag.targetIndex + 1 : m_drag.targetIndex;
-    if (m_drag.spacer == nullptr) {
-      auto spacer = ui::box({
-          .fill = clearColorSpec(),
-          .border = clearColorSpec(),
-          .borderWidth = 0.0F,
-          .width = m_drag.area->width(),
-          .height = m_drag.area->height(),
-          .configure = [](Box& box) { box.setHitTestVisible(false); },
-      });
-      m_drag.spacer = static_cast<Box*>(m_taskStrip->insertChildAt(insertAt, std::move(spacer)));
-    } else {
-      // Spacer exists; reposition if targetIndex changed.
-      auto held = m_taskStrip->removeChild(m_drag.spacer);
-      m_taskStrip->insertChildAt(insertAt, std::move(held));
-    }
-  } else if (m_drag.spacer != nullptr && m_taskStrip != nullptr) {
-    // Drag ended or was aborted; clean up spacer.
-    m_taskStrip->removeChild(m_drag.spacer);
-    m_drag.spacer = nullptr;
-  }
-  if (!m_drag.active && m_drag.area != nullptr) {
-    m_drag.area->setZIndex(0);
-    m_drag.area->setParticipatesInLayout(true);
-    m_drag.area = nullptr;
-  }
+  applyDragLayout();
   m_root->layout(renderer);
   if (Node* container = root(); container != nullptr && container != m_root) {
     container->setFrameSize(m_root->width(), m_root->height());
@@ -742,7 +799,12 @@ void TaskbarWidget::rebuild(Renderer& renderer) {
   m_activeUsesFocusedColor = !m_focusedOutputOnly || isFocusedOutput();
   m_taskTiles.clear();
   m_taskTiles.reserve(m_tasks.size());
+  // The strip's children are about to be destroyed; drop the gesture and its visuals so nothing
+  // outlives the nodes they point at.
   m_drag = {};
+  m_dragFloatTile = nullptr;
+  m_dragSpacer = nullptr;
+  m_dragParked = false;
   clearChildren(m_taskStrip);
   buildTaskButtons(renderer);
 }
@@ -894,113 +956,76 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
     auto* dragArea = area.get();
     const bool tileDraggable = taskRef.index < draggableTileCount;
     area->setOnPress([this, dragArea, taskRef, tileDraggable](const InputArea::PointerData& data) {
-      if (data.pressed) {
-        // Any new press supersedes suppression left over from a drag that ended outside its tile.
-        m_suppressTileClick = false;
+      // m_drag.area is set on press and cleared when the gesture ends, so pointer identity alone
+      // says whether this tile owns the live gesture.
+      const bool ownsGesture = m_drag.area == dragArea;
+      if (!data.pressed) {
+        if (data.button != BTN_LEFT || !ownsGesture) {
+          return;
+        }
+        // Only commit against the pin list the drag was measured on.
+        endDrag(m_drag.generation == m_taskGeneration);
+        return;
       }
       if (data.button != BTN_LEFT) {
-        return;
-      }
-      if (data.pressed) {
-        if (!tileDraggable) {
-          return;
+        // A second button during a live gesture must not clear its click suppression, otherwise the
+        // release opens a context menu on top of the drag.
+        if (!m_drag.active && !m_drag.armed) {
+          m_suppressTileClick = false;
         }
-        m_drag = {};
-        m_drag.generation = m_taskGeneration;
-        m_drag.sourceIndex = taskRef.index;
-        m_drag.targetIndex = taskRef.index;
-        m_drag.startMain = pointerMainOnStrip(*dragArea, data.localX, data.localY);
-        m_drag.currentMain = m_drag.startMain;
-        m_drag.area = dragArea;
-        m_drag.holdTimer.start(kDragHoldDelay, [this, taskRef]() {
-          if (m_drag.sourceIndex == taskRef.index && !m_drag.active) {
-            m_drag.armed = true;
-          }
-        });
         return;
       }
-      if (!tileDraggable || m_drag.sourceIndex != taskRef.index) {
+      // A left press always starts fresh: abandon a tile still held from a lost release or grab,
+      // then drop suppression left over from a gesture that ended outside its tile.
+      endDrag(false);
+      m_suppressTileClick = false;
+      if (!tileDraggable) {
         return;
       }
-      if (m_drag.generation != m_taskGeneration) {
-        m_drag = {};
-        return;
-      }
-      m_drag.holdTimer.stop();
-      if (m_drag.active) {
-        m_suppressTileClick = true;
-        if (commitDragReorder()) {
-          if (m_drag.area != nullptr && m_drag.spacer != nullptr) {
-            m_drag.area->setPosition(m_drag.spacer->x(), m_drag.spacer->y());
-          }
-          DeferredCall::callLater([this]() {
-            if (!m_drag.active) {
-              return;
-            }
-            m_drag.active = false;
-            endDragVisual();
-            if (Node* container = root(); container != nullptr) {
-              container->markLayoutDirty();
-            }
-          });
-        } else {
-          m_drag.active = false;
-          endDragVisual();
-          if (Node* container = root(); container != nullptr) {
-            container->markLayoutDirty();
-          }
+      m_drag.generation = m_taskGeneration;
+      m_drag.sourceIndex = taskRef.index;
+      m_drag.targetIndex = taskRef.index;
+      m_drag.startMain = pointerMainOnStrip(*dragArea, data.localX, data.localY);
+      m_drag.currentMain = m_drag.startMain;
+      m_drag.area = dragArea;
+      m_drag.holdTimer.start(kDragHoldDelay, [this, dragArea]() {
+        if (m_drag.area == dragArea && !m_drag.active) {
+          m_drag.armed = true;
         }
-      } else if (m_drag.armed) {
-        m_suppressTileClick = true;
-        // Armed but not active means the user pressed and held long enough to arm, but never moved far enough to start
-        // a drag. Treat it as a click that was suppressed.
-        m_drag = {};
-      } else {
-        m_drag = {};
-      }
+      });
     });
     if (tileDraggable) {
-      area->setOnMotion([this, dragArea, taskRef](const InputArea::PointerData& data) {
-        if (m_drag.generation != m_taskGeneration) {
-          m_drag = {};
+      area->setOnMotion([this, dragArea](const InputArea::PointerData& data) {
+        // Without the ownership check a plain hover would satisfy the distance check below and
+        // start a drag on a tile nobody is holding.
+        if (m_drag.area != dragArea) {
           return;
         }
-        // area is set on press and cleared on release, so it doubles as "this tile is held".
-        // Without it a plain hover would satisfy the distance check below and start a drag.
-        if (m_drag.area == nullptr || m_drag.sourceIndex != taskRef.index) {
+        if (m_drag.generation != m_taskGeneration) {
+          endDrag(false);
           return;
         }
         const float main = pointerMainOnStrip(*dragArea, data.localX, data.localY);
-        if (!m_drag.armed
-            && !m_drag.active
-            && std::abs(main - m_drag.startMain) >= Style::dragStartThreshold * m_contentScale) {
+        if (!m_drag.active) {
+          const bool travelled = std::abs(main - m_drag.startMain) >= Style::dragStartThreshold * m_contentScale;
+          if (!m_drag.armed && !travelled) {
+            return;
+          }
           m_drag.holdTimer.stop();
           m_drag.armed = true;
-        }
-        if (!m_drag.armed && !m_drag.active) {
-          return;
-        }
-        if (!m_drag.active) {
-          m_drag.active = true;
-          beginDragVisual();
+          beginDrag();
         }
         m_drag.currentMain = main;
-        syncDragSpacer();
-        updateDragVisual();
+        updateDragTarget();
+        moveDragTile();
       });
-      area->setOnCancel([this, taskRef]() {
-        if (m_drag.generation != m_taskGeneration) {
-          // The strip was rebuilt under us, so m_drag.area no longer points at a live node.
-          m_drag = {};
+      area->setOnCancel([this, dragArea]() {
+        if (m_drag.area != dragArea) {
           return;
         }
-        if (m_drag.sourceIndex == taskRef.index) {
-          m_drag.active = false;
-          endDragVisual();
-          if (Node* container = root(); container != nullptr) {
-            container->markLayoutDirty();
-          }
-        }
+        // Pointer capture is gone (leave or compositor grab), so no release will arrive: tear the
+        // whole gesture down, hold timer included.
+        endDrag(false);
       });
     }
 
@@ -1022,12 +1047,17 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
       auto* areaPtr = area.get();
       area->setOnClick([this, taskRef, areaPtr, cycleCandidates = std::move(cycleCandidates),
                         cycleKey = std::move(cycleKey)](const InputArea::PointerData& data) {
-        const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
-        if (current == nullptr) {
+        if (m_drag.active || m_drag.armed) {
+          // A click arriving mid-gesture is a second button pressed during a drag: it must neither
+          // activate the app nor open a context menu over the moving tile.
           return;
         }
         if (m_suppressTileClick) {
           m_suppressTileClick = false;
+          return;
+        }
+        const TaskModel* current = resolveTask(m_tasks, taskRef, m_taskGeneration);
+        if (current == nullptr) {
           return;
         }
 

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -5,6 +5,7 @@
 #include "shell/bar/widget.h"
 #include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
+#include "ui/controls/box.h"
 #include "ui/palette.h"
 #include "ui/signal.h"
 
@@ -166,8 +167,8 @@ private:
     InputArea* area = nullptr;
     float restMain = 0.0F;
     float restCross = 0.0F;
-    Node* spacer = nullptr;      // invisible placeholder that holds the drop gap open
-    std::size_t pinnedCount = 0; // pin count when the drag began; bounds the travel range
+    std::unique_ptr<Box> spacer = nullptr; // invisible placeholder that holds the drop gap open
+    std::size_t pinnedCount = 0;           // pin count when the drag began; bounds the travel range
     Timer holdTimer;
   };
 

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -5,7 +5,6 @@
 #include "shell/bar/widget.h"
 #include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
-#include "ui/controls/box.h"
 #include "ui/palette.h"
 #include "ui/signal.h"
 
@@ -22,7 +21,6 @@ class Box;
 class Flex;
 class InputArea;
 class Label;
-class Node;
 class TaskbarWidgetTestAccess;
 struct wl_output;
 struct zwlr_foreign_toplevel_handle_v1;
@@ -152,22 +150,24 @@ private:
     Box* activeIndicator = nullptr;
   };
 
-  // Drag-to-reorder for pinned tiles in the flat strip.
+  // Gesture state for drag-to-reorder of pinned tiles in the flat strip. Holds no obligation to
+  // restore the scene: that lives in m_dragFloatTile / m_dragSpacer, so resetting a gesture can
+  // never leave a tile stranded outside the layout flow.
   struct DragState {
     bool active = false;
     bool armed = false; // hold fired; goes active on the next motion
     std::size_t sourceIndex = 0;
     std::size_t targetIndex = 0;
-    // m_taskGeneration when the drag began; a layout change invalidates the indices above.
+    // m_taskGeneration when the drag began; a rebuild invalidates the indices above.
     std::uint64_t generation = 0;
     // Pointer position along the strip's layout axis: x when horizontal, y when vertical.
     float startMain = 0.0F;
     float currentMain = 0.0F;
-    // Visuals: the dragged tile leaves the layout flow so Flex stops repositioning it.
+    // The held tile; also the "this tile owns the gesture" marker for motion and cancel.
     InputArea* area = nullptr;
+    // Resting position of the held tile, captured before it left the layout flow.
     float restMain = 0.0F;
     float restCross = 0.0F;
-    Box* spacer = nullptr;       // invisible placeholder that holds the drop gap open
     std::size_t pinnedCount = 0; // pin count when the drag began; bounds the travel range
     Timer holdTimer;
   };
@@ -217,10 +217,12 @@ private:
   [[nodiscard]] float pointerMainOnStrip(const InputArea& area, float localX, float localY) const;
   [[nodiscard]] std::size_t computeDragTargetIndex() const;
   [[nodiscard]] bool commitDragReorder();
-  void beginDragVisual();
-  void updateDragVisual();
-  void endDragVisual();
-  void syncDragSpacer();
+  void beginDrag();
+  void updateDragTarget();
+  void moveDragTile();
+  void endDrag(bool commit);
+  void applyDragLayout();
+  void requestDragLayout();
   [[nodiscard]] static bool taskMatchesDesktopEntry(const TaskModel& task, const DesktopEntry& entry);
   void setEntryPinned(const DesktopEntry& entry, bool pinned);
   [[nodiscard]] std::optional<DesktopEntry> desktopEntryForTask(const TaskModel& task) const;
@@ -258,7 +260,16 @@ private:
   std::string m_barName;
   std::string m_widgetName;
   DragState m_drag;
+  // Drag visuals, owned by the Layout phase and outliving the gesture: the tile currently lifted
+  // out of the flow, and the placeholder holding its drop gap open (the strip owns the node).
+  InputArea* m_dragFloatTile = nullptr;
+  Box* m_dragSpacer = nullptr;
+  // Set by a committed drop: layout must hold the tile parked in its target gap until the deferred
+  // pin-list write lands, otherwise it snaps back to the pre-write order for a frame.
+  bool m_dragParked = false;
   bool m_suppressTileClick = false;
+  // Guards deferred callbacks: writing the pin list reloads the bar, which destroys this widget.
+  std::shared_ptr<void> m_aliveGuard = std::make_shared<int>(0);
 
   float m_tilePitchMain = 0.0F; // Main-axis distance between adjacent tiles; set while building the flat strip.
   bool m_rebuildPending = true;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "compositors/compositor_platform.h"
+#include "core/timer_manager.h"
 #include "shell/bar/widget.h"
 #include "system/desktop_entry.h"
 #include "system/icon_resolver.h"
@@ -20,6 +21,7 @@ class Box;
 class Flex;
 class InputArea;
 class Label;
+class Node;
 class TaskbarWidgetTestAccess;
 struct wl_output;
 struct zwlr_foreign_toplevel_handle_v1;
@@ -149,6 +151,26 @@ private:
     Box* activeIndicator = nullptr;
   };
 
+  // Drag-to-reorder for pinned tiles in the flat strip.
+  struct DragState {
+    bool active = false;
+    bool armed = false; // hold fired; goes active on the next motion
+    std::size_t sourceIndex = 0;
+    std::size_t targetIndex = 0;
+    // m_taskGeneration when the drag began; a layout change invalidates the indices above.
+    std::uint64_t generation = 0;
+    // Pointer position along the strip's layout axis: x when horizontal, y when vertical.
+    float startMain = 0.0F;
+    float currentMain = 0.0F;
+    // Visuals: the dragged tile leaves the layout flow so Flex stops repositioning it.
+    InputArea* area = nullptr;
+    float restMain = 0.0F;
+    float restCross = 0.0F;
+    Node* spacer = nullptr;      // invisible placeholder that holds the drop gap open
+    std::size_t pinnedCount = 0; // pin count when the drag began; bounds the travel range
+    Timer holdTimer;
+  };
+
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
 
@@ -190,6 +212,14 @@ private:
   void activateOrLaunchPinned(const TaskModel& task);
   void launchDesktopEntry(const TaskModel& task);
   [[nodiscard]] const std::vector<std::string>& pinnedConfigIds() const noexcept;
+  [[nodiscard]] bool reorderEnabled() const;
+  [[nodiscard]] float pointerMainOnStrip(const InputArea& area, float localX, float localY) const;
+  [[nodiscard]] std::size_t computeDragTargetIndex() const;
+  [[nodiscard]] bool commitDragReorder();
+  void beginDragVisual();
+  void updateDragVisual();
+  void endDragVisual();
+  void syncDragSpacer();
   [[nodiscard]] static bool taskMatchesDesktopEntry(const TaskModel& task, const DesktopEntry& entry);
   void setEntryPinned(const DesktopEntry& entry, bool pinned);
   [[nodiscard]] std::optional<DesktopEntry> desktopEntryForTask(const TaskModel& task) const;
@@ -226,6 +256,10 @@ private:
   std::string m_barPosition;
   std::string m_barName;
   std::string m_widgetName;
+  DragState m_drag;
+  bool m_suppressTileClick = false;
+
+  float m_tilePitchMain = 0.0F; // Main-axis distance between adjacent tiles; set while building the flat strip.
   bool m_rebuildPending = true;
   bool m_vertical = false;
   float m_containerWidth = 0.0F;

--- a/src/shell/bar/widgets/taskbar_widget.h
+++ b/src/shell/bar/widgets/taskbar_widget.h
@@ -167,8 +167,8 @@ private:
     InputArea* area = nullptr;
     float restMain = 0.0F;
     float restCross = 0.0F;
-    std::unique_ptr<Box> spacer = nullptr; // invisible placeholder that holds the drop gap open
-    std::size_t pinnedCount = 0;           // pin count when the drag began; bounds the travel range
+    Box* spacer = nullptr;       // invisible placeholder that holds the drop gap open
+    std::size_t pinnedCount = 0; // pin count when the drag began; bounds the travel range
     Timer holdTimer;
   };
 


### PR DESCRIPTION
## Summary

Adds drag-to-reorder for pinned tiles in the taskbar widget: press a pinned tile, drag it along the bar, and drop it in a new position. The new order is written to `widget.<name>.pinned`, so it persists.

How it works:

- **Arming** — a drag starts once the pointer travels 8px along the bar while pressed, or after a 300ms hold if you press without moving. Plain clicks, middle-click close, and right-click context menus are unaffected.
- **Visuals** — the dragged tile leaves the layout flow (`setParticipatesInLayout(false)`) so `Flex` stops repositioning it, and an invisible spacer of the same size is inserted at the target index to hold the drop gap open. Neighbours reflow around it, and the strip keeps its width. On drop the tile is parked in the gap so the strip looks settled while the config write lands.
- **Persistence** — on release, the pin list is reordered and written via `setOverride`, deferred through `DeferredCall::callLater` because the write rebuilds the taskbar and would otherwise destroy the `InputArea` whose handler is still running.

Reordering is enabled only when there are at least two pinned entries, the widget has a config name to persist to, and `group_by_workspace` is off (in that mode the flat pinned order isn't what's on screen).

## Motivation

Pinned tiles land in whatever order they were pinned, and the only way to rearrange them is to unpin and re-pin in sequence. Dragging is what people expect from a taskbar.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None

## Testing

```
just format
just build
just test
```

On Hyprland with a horizontal bottom bar and 6 pinned apps: dragging in both directions, dropping at both ends, dropping back on the origin (no write), plain/middle/right clicks on pinned and unpinned tiles, and clicks immediately following a drag. Reordered state verified in `settings.toml` and after restarting noctalia.


https://github.com/user-attachments/assets/0bfee7e3-ff3d-4667-bde4-b1ebc6c5dd4a

Notice the unpinned apps (VSC and Claude) on the right are not affected.


## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

**Untested paths.** Only tested on a horizontal bottom bar with one output. The vertical-bar path is implemented (all geometry is expressed along a "main axis" that follows `m_vertical`). Also multi-monitor is likewise untested.

**No `--insertAt` correction.** `Dock::endDrag` decrements the insert position when the target is past the source, because its `computeDragTargetIndex` returns an *insertion slot*. This one returns a *destination index* (`sourceIndex + lround(travel / pitch)`, clamped), so after erasing the source, inserting at the target is already correct. Copying the dock's correction here would shift rightward drags one slot short.

**Drop latency.** There's a ~55ms gap between release and the rebuild, which is `setOverride` writing the file and running `loadAll()` — the same cost as any other settings change. The tile is parked in its final position first so this isn't visible, but I mention it in case the config reload path is something you'd want to look at separately.

**Disclosure:** I used Claude Code as a pair-programming assistant on this feature; for reading unfamiliar parts of the scene graph and layout code, and for review. The design decisions, testing, and verification are all mine.
