### PR TITLE
feat(control-center): add a toggle to hide the session button in control center

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2254,6 +2254,10 @@
           "description": "Choose up to six shortcut buttons for the home tab",
           "label": "Home Shortcuts"
         },
+        "home-session-button": {
+          "description": "Show a button for session actions (lock, suspend, reboot, shutdown, logout)",
+          "label": "Show Session Button"
+        },
         "home-shortcuts-show-labels": {
           "description": "Display text labels under shortcut icons in the home tab",
           "label": "Show Shortcut Labels"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1181,6 +1181,7 @@
         "monitor-thresholds": "Highlight Thresholds",
         "monitors": "Monitors",
         "motion": "Motion",
+        "navigation": "Navigation",
         "network": "Network",
         "night-light": "Night Light",
         "notifications": "Notifications",
@@ -2255,8 +2256,8 @@
           "label": "Home Shortcuts"
         },
         "home-session-button": {
-          "description": "Show a button for session actions (lock, suspend, reboot, shutdown, logout)",
-          "label": "Show Session Button"
+          "description": "Show the session-actions button in the Home tab header",
+          "label": "Show Header Session Button"
         },
         "home-shortcuts-show-labels": {
           "description": "Display text labels under shortcut icons in the home tab",

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1465,6 +1465,7 @@ struct ControlCenterConfig {
   ControlCenterSidebarMode sidebarSectionMode = ControlCenterSidebarMode::Compact;
   std::int32_t width = kDefaultWidth; // full-sidebar logical width; compact/none modes scale down from this
   bool showShortcutLabels = true;
+  bool showSessionButton = true;
   CalendarTabConfig calendarTab;
   bool operator==(const ControlCenterConfig&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -492,6 +492,7 @@ namespace noctalia::config::schema {
         enumField(&ControlCenterConfig::sidebarSectionMode, "sidebar_section", kControlCenterSidebarModes),
         field(&ControlCenterConfig::width, "width", kControlCenterWidthRange),
         field(&ControlCenterConfig::showShortcutLabels, "show_shortcut_labels"),
+        field(&ControlCenterConfig::showSessionButton, "show_session_button"),
         field(&ControlCenterConfig::hiddenTabs, "hidden_tabs"),
         subTable(&ControlCenterConfig::calendarTab, "calendar", calendarTabSchema()),
         arrayOf<ControlCenterConfig, ShortcutConfig>(

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -653,18 +653,15 @@ std::unique_ptr<Flex> HomeTab::createHeaderActions() {
           .glyph = "settings",
           .onClick = []() { PanelManager::instance().openSettingsWindow(); },
           .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+      }),
+      ui::button({
+          .out = &m_sessionButton,
+          .glyph = "shutdown",
+          .onClick = []() { PanelManager::instance().togglePanel("session"); },
+          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
       })
   );
-  if (m_config == nullptr || m_config->config().controlCenter.showSessionButton) {
-    row->addChild(
-        ui::button({
-            .out = &m_sessionButton,
-            .glyph = "shutdown",
-            .onClick = []() { PanelManager::instance().togglePanel("session"); },
-            .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
-        })
-    );
-  }
+  syncHeaderActions();
   return row;
 }
 
@@ -1182,7 +1179,14 @@ void HomeTab::cancelCrispFade() {
   m_wallpaperCrispAnimId = 0;
 }
 
+void HomeTab::syncHeaderActions() {
+  if (m_sessionButton != nullptr) {
+    m_sessionButton->setVisible(m_config == nullptr || m_config->config().controlCenter.showSessionButton);
+  }
+}
+
 void HomeTab::doUpdate(Renderer& renderer) {
+  syncHeaderActions();
   if (!m_active) {
     m_progressTimer.stop();
     return;

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -646,21 +646,26 @@ std::unique_ptr<Flex> HomeTab::create() {
 
 std::unique_ptr<Flex> HomeTab::createHeaderActions() {
   const float scale = contentScale();
-  return ui::row(
+  auto row = ui::row(
       {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
       ui::button({
           .out = &m_settingsButton,
           .glyph = "settings",
           .onClick = []() { PanelManager::instance().openSettingsWindow(); },
           .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
-      }),
-      ui::button({
-          .out = &m_sessionButton,
-          .glyph = "shutdown",
-          .onClick = []() { PanelManager::instance().togglePanel("session"); },
-          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
       })
   );
+  if (m_config == nullptr || m_config->config().controlCenter.showSessionButton) {
+    row->addChild(
+        ui::button({
+            .out = &m_sessionButton,
+            .glyph = "shutdown",
+            .onClick = []() { PanelManager::instance().togglePanel("session"); },
+            .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+        })
+    );
+  }
+  return row;
 }
 
 void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight) {

--- a/src/shell/control_center/tabs/home_tab.h
+++ b/src/shell/control_center/tabs/home_tab.h
@@ -80,6 +80,7 @@ private:
   void warnOnOversizedAvatarSource(const std::string& path);
   void syncScaledFonts();
   void syncShortcuts();
+  void syncHeaderActions();
   bool resizeMediaArtToCard();
   void onPanelCardOpacityChanged(float opacity) override;
 

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1365,20 +1365,20 @@ namespace settings {
 
     // Control Center
     entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.placement-control-center.label"),
+        SettingsSection::ControlCenter, "layout", tr("settings.schema.panels.placement-control-center.label"),
         tr("settings.schema.panels.placement-control-center.description"),
         {"shell", "panel", "control_center_placement"},
         asSegmented(enumSelect(kPanelPlacements, cfg.shell.panel.controlCenterPlacement)),
         "attached floating bar panel position"
     ));
     entries.push_back(panelPositionEntry(
-        SettingsSection::ControlCenter, "general", "control_center",
+        SettingsSection::ControlCenter, "layout", "control_center",
         "settings.schema.panels.position-control-center.label",
         "settings.schema.panels.position-control-center.description", cfg.shell.panel.controlCenterPosition,
         &ShellConfig::PanelConfig::controlCenterPlacement
     ));
     entries.push_back(panelBarAlignmentEntry(
-        SettingsSection::ControlCenter, "general", "control_center",
+        SettingsSection::ControlCenter, "layout", "control_center",
         "settings.schema.panels.open-near-click-control-center.label",
         "settings.schema.panels.open-near-click-control-center.description", cfg.shell.panel.openNearClickControlCenter,
         &ShellConfig::PanelConfig::controlCenterPlacement, &ShellConfig::PanelConfig::controlCenterPosition
@@ -1388,40 +1388,22 @@ namespace settings {
           sliderFor(cfg.controlCenter.width, noctalia::config::schema::kControlCenterWidthRange, true);
       width.valueSuffix = "px";
       entries.push_back(makeEntry(
-          SettingsSection::ControlCenter, "general", tr("settings.schema.panels.control-center-width.label"),
+          SettingsSection::ControlCenter, "layout", tr("settings.schema.panels.control-center-width.label"),
           tr("settings.schema.panels.control-center-width.description"), {"control_center", "width"}, std::move(width),
           "size dimension wide narrow"
       ));
     }
     entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.control-center-sidebar.label"),
+        SettingsSection::ControlCenter, "navigation", tr("settings.schema.panels.control-center-sidebar.label"),
         tr("settings.schema.panels.control-center-sidebar.description"), {"control_center", "sidebar"},
         asSegmented(enumSelect(kControlCenterSidebarModes, cfg.controlCenter.sidebarMode)),
         "full compact none sidebar icons narrow hidden"
     ));
     entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.control-center-sidebar-section.label"),
+        SettingsSection::ControlCenter, "navigation", tr("settings.schema.panels.control-center-sidebar-section.label"),
         tr("settings.schema.panels.control-center-sidebar-section.description"), {"control_center", "sidebar_section"},
         asSegmented(enumSelect(kControlCenterSidebarModes, cfg.controlCenter.sidebarSectionMode)),
         "full compact none sidebar icons narrow hidden tab direct widget shortcut"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-shortcuts.label"),
-        tr("settings.schema.panels.home-shortcuts.description"), {"control_center", "shortcuts"},
-        ShortcutListSetting{
-            .items = cfg.controlCenter.shortcuts, .suggestedOptions = controlCenterShortcutOptions(cfg), .maxItems = 6
-        },
-        "quick settings shortcuts toggles wifi bluetooth caffeine night light dnd power media weather clipboard"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-shortcuts-show-labels.label"),
-        tr("settings.schema.panels.home-shortcuts-show-labels.description"), {"control_center", "show_shortcut_labels"},
-        ToggleSetting{cfg.controlCenter.showShortcutLabels}, "shortcuts labels text hide show titles"
-    ));
-    entries.push_back(makeEntry(
-        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-session-button.label"),
-        tr("settings.schema.panels.home-session-button.description"), {"control_center", "show_session_button"},
-        ToggleSetting{cfg.controlCenter.showSessionButton}, "session button show hide"
     ));
     {
       MultiSelectSetting tabs;
@@ -1436,11 +1418,29 @@ namespace settings {
       }
       tabs.persistUnselected = true;
       entries.push_back(makeEntry(
-          SettingsSection::ControlCenter, "general", tr("settings.schema.panels.control-center-tabs.label"),
+          SettingsSection::ControlCenter, "navigation", tr("settings.schema.panels.control-center-tabs.label"),
           tr("settings.schema.panels.control-center-tabs.description"), {"control_center", "hidden_tabs"},
           std::move(tabs), "tabs sections visible hide show display brightness media audio network power"
       ));
     }
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "home", tr("settings.schema.panels.home-shortcuts.label"),
+        tr("settings.schema.panels.home-shortcuts.description"), {"control_center", "shortcuts"},
+        ShortcutListSetting{
+            .items = cfg.controlCenter.shortcuts, .suggestedOptions = controlCenterShortcutOptions(cfg), .maxItems = 6
+        },
+        "quick settings shortcuts toggles wifi bluetooth caffeine night light dnd power media weather clipboard"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "home", tr("settings.schema.panels.home-shortcuts-show-labels.label"),
+        tr("settings.schema.panels.home-shortcuts-show-labels.description"), {"control_center", "show_shortcut_labels"},
+        ToggleSetting{cfg.controlCenter.showShortcutLabels}, "shortcuts labels text hide show titles"
+    ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "home", tr("settings.schema.panels.home-session-button.label"),
+        tr("settings.schema.panels.home-session-button.description"), {"control_center", "show_session_button"},
+        ToggleSetting{cfg.controlCenter.showSessionButton}, "session button show hide"
+    ));
 
     // Desktop
     entries.push_back(makeEntry(

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1418,6 +1418,11 @@ namespace settings {
         tr("settings.schema.panels.home-shortcuts-show-labels.description"), {"control_center", "show_shortcut_labels"},
         ToggleSetting{cfg.controlCenter.showShortcutLabels}, "shortcuts labels text hide show titles"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-session-button.label"),
+        tr("settings.schema.panels.home-session-button.description"), {"control_center", "show_session_button"},
+        ToggleSetting{cfg.controlCenter.showSessionButton}, "session button show hide"
+    ));
     {
       MultiSelectSetting tabs;
       const auto catalog = ControlCenterPanel::hideableTabCatalog();


### PR DESCRIPTION
## Summary

Adds a `control_center.show_session_button` toggle that hides the session button from the control center's home header. Defaults to `true`, so nothing changes for existing users.

Follows the existing `show_shortcut_labels` pattern: config field, schema entry, settings toggle, and English strings.

## Motivation

If you already have a session widget on the bar, the control center's session button is a second entry point to the same menu. This makes it optional.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes: #3713

## Testing

```
just format
just build
just test
```

Manual on Hyprland: toggled the setting on and off and confirmed the session button appears and disappears from the control center header; that the setting's label, description, and search keywords render correctly in Settings-> Control Center.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
<img width="1503" height="270" alt="toggle 1" src="https://github.com/user-attachments/assets/187bf830-8f97-4702-aadb-a5d9144e3ff4" />


<img width="1496" height="389" alt="toggle 2" src="https://github.com/user-attachments/assets/da2bfeae-00a5-483e-a2d3-cfc76f1a9b8e" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
