### PR TITLE
nix: disable the nixpkgs noctalia module

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -7,6 +7,10 @@ let
   cfg = config.programs.noctalia;
 in
 {
+  # The module from this flake predates the module in nixpkgs.
+  # To avoid conflicts, we disable the nixpkgs module.
+  disabledModules = [ "programs/wayland/noctalia.nix" ];
+
   options.programs.noctalia = {
     enable = lib.mkEnableOption "Whether to enable noctalia, a lightweight Wayland shell and bar.";
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Disable the newly introduced noctalia module in nixpkgs when using the module provided by this flake

## Motivation

Fixes this error when building a NixOS configuration using this flake

```
error:
       … while checking flake output 'nixosConfigurations'
         at /(redacted)/flake.nix:47:7:
           46|
           47|       nixosConfigurations = configs.nixos;
             |       ^
           48|

       … while checking the NixOS configuration 'nixosConfigurations.(redacted)'
         at /(redacted).nix:27:3:
           26| {
           27|   ${hostName} = lib.nixosSystem {
             |   ^
           28|     inherit system;

       … while evaluating the option `system.build.toplevel':

       … while evaluating definitions from `/nix/store/lj0fr41wwbrx2mwq2378jg8qrns7b93d-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `assertions':

       … while evaluating definitions from `/nix/store/4rbfclzp14cyr9slrsp6wvi7s4j40lkz-source/nix/nixos-module.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The option `programs.noctalia.enable' in `/nix/store/lj0fr41wwbrx2mwq2378jg8qrns7b93d-source/nixos/modules/programs/wayland/noctalia.nix' is already declared in `/nix/store/4rbfclzp14cyr9slrsp6wvi7s4j40lkz-source/nix/nixos-module.nix'.
```


## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
