### PR TITLE
[Network] Add Signal Strength Label option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3669,6 +3669,10 @@
           "description": "Show the current value next to the visualization",
           "label": "Show Value"
         },
+        "show-signal-strength": {
+          "description": "Show Wi-Fi signal strength percentage in the network label when connected",
+          "label": "Show Signal Strength"
+        },
         "show-vpn-label": {
           "description": "Replaces network label with VPN label in replace mode; adds VPN label next to VPN icon in both mode",
           "label": "Show VPN Label"

--- a/src/shell/bar/widgets/network_widget.cpp
+++ b/src/shell/bar/widgets/network_widget.cpp
@@ -20,9 +20,14 @@ namespace {
 
   constexpr auto kTooltipRefreshInterval = std::chrono::seconds(1);
 
-  std::string labelForState(const NetworkState& s) {
-    if (s.kind == NetworkConnectivity::Wireless && s.connected && !s.ssid.empty()) {
-      return s.ssid;
+  std::string labelForState(const NetworkState& s, bool showSignalStrength) {
+    if (s.kind == NetworkConnectivity::Wireless && s.connected) {
+      if (showSignalStrength) {
+        return std::to_string(s.signalStrength) + "%";
+      }
+      if (!s.ssid.empty()) {
+        return s.ssid;
+      }
     }
     if (s.kind == NetworkConnectivity::Wired && s.connected) {
       return s.interfaceName.empty() ? i18n::tr("bar.widgets.network.wired") : s.interfaceName;
@@ -62,7 +67,8 @@ NetworkWidget::NetworkWidget(
     Options options
 )
     : m_network(network), m_externalIp(externalIp), m_monitor(monitor), m_showLabel(options.showLabel),
-      m_showVpnLabel(options.showVpnLabel), m_vpnStatusMode(options.vpnStatusMode) {}
+      m_showVpnLabel(options.showVpnLabel), m_showSignalStrength(options.showSignalStrength),
+      m_vpnStatusMode(options.vpnStatusMode) {}
 
 void NetworkWidget::create() {
   auto area = ui::inputArea({});
@@ -291,7 +297,7 @@ void NetworkWidget::syncState(Renderer& renderer) {
     const bool showLabel = m_showLabel;
     m_label->setVisible(showLabel);
     if (showLabel) {
-      std::string text = labelForState(s);
+      std::string text = labelForState(s, m_showSignalStrength);
       // In replace mode, vpn_label overrides the network label.
       if (m_vpnStatusMode == VpnStatusMode::Replace && m_showVpnLabel && s.vpnActive) {
         if (std::string vpnName = firstActiveVpnName(m_network->vpnConnections()); !vpnName.empty()) {

--- a/src/shell/bar/widgets/network_widget.h
+++ b/src/shell/bar/widgets/network_widget.h
@@ -26,6 +26,7 @@ public:
     VpnStatusMode vpnStatusMode = VpnStatusMode::Replace;
     bool showLabel = true;
     bool showVpnLabel = false;
+    bool showSignalStrength = false;
   };
 
   NetworkWidget(
@@ -46,6 +47,7 @@ private:
   SystemMonitorService* m_monitor = nullptr;
   bool m_showLabel = true;
   bool m_showVpnLabel = false;
+  bool m_showSignalStrength = false;
   VpnStatusMode m_vpnStatusMode = VpnStatusMode::Replace;
   Glyph* m_glyph = nullptr;
   Glyph* m_vpnGlyph = nullptr;

--- a/src/shell/bar/widgets/network_widget_definition.cpp
+++ b/src/shell/bar/widgets/network_widget_definition.cpp
@@ -2,6 +2,14 @@
 
 namespace {
 
+  settings::WidgetSettingVisibility labelVisibility() {
+    settings::WidgetSettingVisibility visibility;
+    visibility.all = {
+        {"show_label", {"true"}},
+    };
+    return visibility;
+  }
+
   settings::WidgetSettingVisibility vpnLabelVisibility() {
     settings::WidgetSettingVisibility visibility;
     visibility.all = {
@@ -46,8 +54,15 @@ const noctalia::bar::WidgetDefinition<NetworkWidget::Options>& networkWidgetDefi
           }),
           field<&Options::showVpnLabel>({
               .key = "show_vpn_label",
+              .presentation =
+                  settings::WidgetSettingPresentation{
+                      .visibleWhen = vpnLabelVisibility(),
+                  },
+          }),
+          field<&Options::showSignalStrength>({
+              .key = "show_signal_strength",
               .presentation = settings::WidgetSettingPresentation{
-                  .visibleWhen = vpnLabelVisibility(),
+                  .visibleWhen = labelVisibility(),
               },
           }),
       },


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add a new option to network widget: `Show Signal Strength` for Wi-Fi

## Motivation

<!-- What problem does this solve? -->
Mainly for visual reading, currently only the tooltip shows the signal strength. It would be better for the users to show the label in the widget directly

## Type of Change

<!-- Mark all that apply. -->

- [x] New feature

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just test` and `just build` to ensure zero compilation errors and passes every tests, while following the clang-format. Also ran the i8n-check python script

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1020" height="542" alt="image" src="https://github.com/user-attachments/assets/cff45a30-3155-40cf-a189-2e0d0ba40910" />

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge
- [x] I added or updated `assets/translations/en.json`
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.