### PR TITLE
fix(weather): allow using manually configured coordinates

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -685,7 +685,8 @@
     },
     "source": {
       "address": "Address",
-      "auto": "Auto"
+      "auto": "Auto",
+      "manual": "Manual"
     }
   },
   "lockscreen": {

--- a/meson.build
+++ b/meson.build
@@ -1122,6 +1122,7 @@ if build_tests
     'jxl_decoder',
     'kde_color_scheme',
     'log',
+    'location_service',
     'math_provider',
     'notification_filter',
     'notification_history_utf8',

--- a/src/system/location_service.cpp
+++ b/src/system/location_service.cpp
@@ -72,14 +72,27 @@ bool LocationService::networkResolutionConfigured() const noexcept {
 
 bool LocationService::resolving() const noexcept { return networkResolutionConfigured() && !m_resolved; }
 
-bool LocationService::hasResolvedLocation() const noexcept { return m_resolved && coordinatesValid(); }
+bool LocationService::hasResolvedLocation() const noexcept {
+  return (m_resolved && resolvedCoordinatesValid()) || (!networkResolutionConfigured() && manualCoordinatesValid());
+}
 
 std::optional<ResolvedLocation> LocationService::resolvedLocation() const noexcept {
-  if (!hasResolvedLocation()) {
+  if (m_resolved && resolvedCoordinatesValid()) {
+    return ResolvedLocation{
+        .latitude = m_latitude, .longitude = m_longitude, .name = m_name, .sourceLabel = m_sourceLabel
+    };
+  }
+  if (networkResolutionConfigured() || !manualCoordinatesValid()) {
     return std::nullopt;
   }
+
+  const double latitude = *m_config.latitude;
+  const double longitude = *m_config.longitude;
   return ResolvedLocation{
-      .latitude = m_latitude, .longitude = m_longitude, .name = m_name, .sourceLabel = m_sourceLabel
+      .latitude = latitude,
+      .longitude = longitude,
+      .name = std::format("{:.4f}, {:.4f}", latitude, longitude),
+      .sourceLabel = i18n::tr("location.source.manual"),
   };
 }
 
@@ -137,10 +150,19 @@ void LocationService::onConfigReload() {
     return;
   }
   const bool resolutionInputsChanged = next.autoLocate != m_config.autoLocate || next.address != m_config.address;
+  const bool manualCoordinatesChanged = next.latitude != m_config.latitude || next.longitude != m_config.longitude;
   m_config = next;
+
   if (resolutionInputsChanged) {
     m_error.clear();
-    requestRefresh();
+    if (networkResolutionConfigured()) {
+      requestRefresh();
+    } else {
+      clearResolved();
+    }
+    notifyChanged();
+  } else if (!networkResolutionConfigured() && manualCoordinatesChanged) {
+    notifyChanged();
   }
 }
 
@@ -245,13 +267,21 @@ void LocationService::clearResolved() {
   m_nextRefreshAt = Clock::time_point{};
 }
 
-bool LocationService::coordinatesValid() const noexcept {
-  return std::isfinite(m_latitude)
-      && std::isfinite(m_longitude)
-      && m_latitude >= -90.0
-      && m_latitude <= 90.0
-      && m_longitude >= -180.0
-      && m_longitude <= 180.0;
+bool LocationService::resolvedCoordinatesValid() const noexcept { return coordinatesValid(m_latitude, m_longitude); }
+
+bool LocationService::manualCoordinatesValid() const noexcept {
+  return m_config.latitude.has_value()
+      && m_config.longitude.has_value()
+      && coordinatesValid(*m_config.latitude, *m_config.longitude);
+}
+
+bool LocationService::coordinatesValid(double latitude, double longitude) noexcept {
+  return std::isfinite(latitude)
+      && std::isfinite(longitude)
+      && latitude >= -90.0
+      && latitude <= 90.0
+      && longitude >= -180.0
+      && longitude <= 180.0;
 }
 
 std::filesystem::path LocationService::transportCacheDir() {
@@ -298,7 +328,7 @@ void LocationService::loadCache() {
 
     m_latitude = readNumber(json, "latitude");
     m_longitude = readNumber(json, "longitude");
-    if (!coordinatesValid()) {
+    if (!resolvedCoordinatesValid()) {
       m_latitude = 0.0;
       m_longitude = 0.0;
       return;

--- a/src/system/location_service.h
+++ b/src/system/location_service.h
@@ -13,7 +13,7 @@
 class ConfigService;
 class HttpClient;
 
-// Coordinates resolved from IP geolocation or a geocoded address.
+// Coordinates selected from IP geolocation, a geocoded address, or manual configuration.
 struct ResolvedLocation {
   double latitude = 0.0;
   double longitude = 0.0;
@@ -21,11 +21,10 @@ struct ResolvedLocation {
   std::string sourceLabel; // i18n label describing how the location was resolved
 };
 
-// Owns "where am I" for the whole shell. Resolves coordinates from IP geolocation
-// (auto_locate) or a geocoded address and publishes them to consumers (weather,
-// night light, theme auto mode). Manual latitude/longitude and fixed sunrise/sunset
-// live in LocationConfig and are read directly by those consumers; this service only
-// performs the network resolution. Runs independently of whether weather is enabled.
+// Owns "where am I" for the whole shell. Selects coordinates from IP geolocation,
+// a geocoded address, or manual latitude/longitude and publishes them to consumers.
+// Fixed sunrise/sunset schedules remain in LocationConfig. Runs independently of
+// whether weather is enabled.
 class LocationService {
 public:
   using ChangeCallback = std::function<void()>;
@@ -63,7 +62,9 @@ private:
   void scheduleRetryAfterFailure();
   void loadCache();
   void saveCache() const;
-  [[nodiscard]] bool coordinatesValid() const noexcept;
+  [[nodiscard]] bool resolvedCoordinatesValid() const noexcept;
+  [[nodiscard]] bool manualCoordinatesValid() const noexcept;
+  [[nodiscard]] static bool coordinatesValid(double latitude, double longitude) noexcept;
 
   [[nodiscard]] static std::filesystem::path transportCacheDir();
   [[nodiscard]] static std::filesystem::path stateCacheFilePath();

--- a/tests/location_service_test.cpp
+++ b/tests/location_service_test.cpp
@@ -1,0 +1,106 @@
+#include "config/config_service.h"
+#include "i18n/i18n_service.h"
+#include "net/http_client.h"
+#include "system/location_service.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <print>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+
+namespace {
+
+  int g_failures = 0;
+
+  void expect(bool condition, const std::string& message) {
+    if (!condition) {
+      std::println(stderr, "location_service_test: FAIL: {}", message);
+      ++g_failures;
+    }
+  }
+
+  bool near(double actual, double expected) { return std::abs(actual - expected) < 1e-9; }
+
+  void writeConfig(const std::filesystem::path& path, std::string_view locationConfig) {
+    std::ofstream file(path);
+    file << "[location]\n" << locationConfig;
+  }
+
+} // namespace
+
+int main() {
+  const auto root =
+      std::filesystem::temp_directory_path() / ("noctalia-location-service-test-" + std::to_string(::getpid()));
+  const auto configHome = root / "config";
+  const auto stateHome = root / "state";
+  const auto cacheHome = root / "cache";
+  const auto configDir = configHome / "noctalia";
+  const auto configPath = configDir / "config.toml";
+
+  std::filesystem::remove_all(root);
+  std::filesystem::create_directories(configDir);
+  std::filesystem::create_directories(stateHome);
+  std::filesystem::create_directories(cacheHome);
+  ::setenv("NOCTALIA_CONFIG_HOME", configHome.c_str(), 1);
+  ::setenv("NOCTALIA_STATE_HOME", stateHome.c_str(), 1);
+  ::setenv("XDG_CACHE_HOME", cacheHome.c_str(), 1);
+
+  writeConfig(configPath, "auto_locate = false\naddress = \"\"\nlatitude = 52.52\nlongitude = 13.405\n");
+  i18n::Service::instance().init("en");
+
+  {
+    ConfigService config;
+    HttpClient http;
+    http.setOfflineMode(true);
+    LocationService location(config, http);
+    location.initialize();
+
+    auto resolved = location.resolvedLocation();
+    expect(resolved.has_value(), "manual coordinates should provide a location at startup");
+    if (resolved.has_value()) {
+      expect(near(resolved->latitude, 52.52), "manual latitude was not published");
+      expect(near(resolved->longitude, 13.405), "manual longitude was not published");
+      expect(resolved->sourceLabel == "Manual", "manual location source was not labelled");
+    }
+    expect(!location.resolving(), "manual coordinates should not start network resolution");
+
+    int changes = 0;
+    location.addChangeCallback([&changes]() { ++changes; });
+
+    writeConfig(configPath, "auto_locate = false\naddress = \"\"\nlatitude = 40.7128\nlongitude = -74.006\n");
+    config.forceReload();
+    resolved = location.resolvedLocation();
+    expect(changes == 1, "changing manual coordinates should publish a location change");
+    expect(
+        resolved.has_value() && near(resolved->latitude, 40.7128) && near(resolved->longitude, -74.006),
+        "hot-reloaded manual coordinates were not published"
+    );
+
+    writeConfig(configPath, "auto_locate = false\naddress = \"\"\nlatitude = 40.7128\n");
+    config.forceReload();
+    expect(changes == 2, "removing one manual coordinate should publish a location change");
+    expect(!location.resolvedLocation().has_value(), "incomplete manual coordinates should not provide a location");
+
+    writeConfig(configPath, "auto_locate = true\naddress = \"\"\nlatitude = 51.5072\nlongitude = -0.1276\n");
+    config.forceReload();
+    expect(changes == 3, "enabling automatic location should publish a location change");
+    expect(location.resolving(), "automatic location should take priority over manual coordinates");
+    expect(!location.resolvedLocation().has_value(), "manual coordinates should not bypass automatic resolution");
+
+    writeConfig(configPath, "auto_locate = false\naddress = \"\"\nlatitude = 51.5072\nlongitude = -0.1276\n");
+    config.forceReload();
+    resolved = location.resolvedLocation();
+    expect(changes == 4, "switching back to manual coordinates should publish a location change");
+    expect(
+        resolved.has_value() && near(resolved->latitude, 51.5072) && near(resolved->longitude, -0.1276),
+        "manual coordinates were not restored after disabling automatic location"
+    );
+  }
+
+  std::filesystem::remove_all(root);
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This PR publishes manually configured latitude and longitude through `LocationService` when automatic location and address lookup are disabled.

## Motivation

<!-- What problem does this solve? -->



## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
No related issues

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

```bash
$ NOSYSBASHLOGOUT=1 just test 
Ok:                66  
Fail:              0 
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="914" height="825" alt="image" src="https://github.com/user-attachments/assets/43957b2c-0121-4f0b-a5a7-bdfe4189aa30" />

If only coordinates given, show the raw `lat, lng` on weather panel. 


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
