### PR TITLE
feat(ipc): Add `smart` option to bar-auto-hide-set IPC

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -3749,17 +3749,20 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
 
   const auto parts = noctalia::ipc::splitWords(args);
   if (parts.empty() || parts.size() > 3) {
-    return "error: usage: bar-auto-hide-set <on|off|true|false|1|0> [bar-name] [monitor-selector]\n";
+    return "error: usage: bar-auto-hide-set <on|off|smart|true|false|1|0> [bar-name] [monitor-selector]\n";
   }
 
   const std::string& value = parts[0];
   bool enabled = false;
+  bool smart = false;
   if (value == "on" || value == "true" || value == "1") {
     enabled = true;
   } else if (value == "off" || value == "false" || value == "0") {
     enabled = false;
+  } else if (value == "smart") {
+    smart = true;
   } else {
-    return "error: invalid value (use on/off, true/false, 1/0)\n";
+    return "error: invalid value (use on/off/smart, true/false, 1/0)\n";
   }
 
   std::optional<std::string> barName;
@@ -3776,7 +3779,7 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
     return *collectError;
   }
 
-  auto applyTransientAutoHide = [this, enabled](BarInstance& instance) {
+  auto applyTransientAutoHide = [this, enabled, smart](BarInstance& instance) {
     auto applySurfaceSpec = [this](BarInstance& inst) {
       if (inst.surface == nullptr) {
         return;
@@ -3790,8 +3793,10 @@ std::string Bar::setBarAutoHideIpc(std::string_view args) {
     instance.autoHideDisablePending = false;
     instance.animations.cancelForOwner(instance.slideRoot);
 
-    if (enabled) {
-      instance.barConfig.autoHide = true;
+    instance.barConfig.autoHide = enabled;
+    instance.barConfig.smartAutoHide = smart;
+
+    if (enabled || smart) {
       applySurfaceSpec(instance);
       if (instance.slideRoot != nullptr) {
         instance.slideRoot->setOpacity(1.0f);
@@ -3968,7 +3973,7 @@ void Bar::registerIpc(IpcService& ipc) {
 
   ipc.registerHandler(
       "bar-auto-hide-set", [this](const std::string& args) -> std::string { return setBarAutoHideIpc(args); },
-      "<on|off|true|false|1|0> [bar-name] [monitor-selector]", "Set auto-hide state for a bar"
+      "<on|off|smart|true|false|1|0> [bar-name] [monitor-selector]", "Set auto-hide state for a bar"
   );
 
   ipc.registerHandler(


### PR DESCRIPTION
## Summary

Add smart as a valid argument to `Bar::setBarAutoHideIpc` / `bar-auto-hide-set` to allow enabling smart auto hide via the IPC

## Motivation
No programmatic way to enable smart auto hide was present previously

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
Closes #3730

## Testing
Toggled auto hide to on/off/smart using the IPC, verifying proper switching between all possible transistions.

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/813f6a51-6492-4ffa-8d13-2f2e6ab35737

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
N/A
