### PR TITLE
feat(control-center): add a toggle to hide the settings and close buttons in control center

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2236,6 +2236,10 @@
           "description": "Draw an outline on floating panels",
           "label": "Borders"
         },
+        "control-center-close-button": {
+          "description": "Show a close button on the control center panel",
+          "label": "Show Close Button"
+        },
         "control-center-sidebar": {
           "description": "Choose how to display the sidebar",
           "label": "Sidebar"

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2260,6 +2260,10 @@
           "description": "Gap in pixels between a floating or detached panel and the bar edge",
           "label": "Floating Offset"
         },
+        "home-settings-button": {
+          "description": "Show a button for opening Noctalia settings",
+          "label": "Show Settings Button"
+        },
         "home-shortcuts": {
           "description": "Choose up to six shortcut buttons for the home tab",
           "label": "Home Shortcuts"

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1484,6 +1484,7 @@ struct ControlCenterConfig {
   ControlCenterSidebarMode sidebarSectionMode = ControlCenterSidebarMode::Compact;
   std::int32_t width = kDefaultWidth; // full-sidebar logical width; compact/none modes scale down from this
   bool showShortcutLabels = true;
+  bool showSettingsButton = true;
   CalendarTabConfig calendarTab;
   bool operator==(const ControlCenterConfig&) const = default;
 };

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1485,6 +1485,7 @@ struct ControlCenterConfig {
   std::int32_t width = kDefaultWidth; // full-sidebar logical width; compact/none modes scale down from this
   bool showShortcutLabels = true;
   bool showSettingsButton = true;
+  bool showCloseButton = true;
   CalendarTabConfig calendarTab;
   bool operator==(const ControlCenterConfig&) const = default;
 };

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -492,6 +492,7 @@ namespace noctalia::config::schema {
         enumField(&ControlCenterConfig::sidebarSectionMode, "sidebar_section", kControlCenterSidebarModes),
         field(&ControlCenterConfig::width, "width", kControlCenterWidthRange),
         field(&ControlCenterConfig::showShortcutLabels, "show_shortcut_labels"),
+        field(&ControlCenterConfig::showSettingsButton, "show_settings_button"),
         field(&ControlCenterConfig::hiddenTabs, "hidden_tabs"),
         subTable(&ControlCenterConfig::calendarTab, "calendar", calendarTabSchema()),
         arrayOf<ControlCenterConfig, ShortcutConfig>(

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -493,6 +493,7 @@ namespace noctalia::config::schema {
         field(&ControlCenterConfig::width, "width", kControlCenterWidthRange),
         field(&ControlCenterConfig::showShortcutLabels, "show_shortcut_labels"),
         field(&ControlCenterConfig::showSettingsButton, "show_settings_button"),
+        field(&ControlCenterConfig::showCloseButton, "show_close_button"),
         field(&ControlCenterConfig::hiddenTabs, "hidden_tabs"),
         subTable(&ControlCenterConfig::calendarTab, "calendar", calendarTabSchema()),
         arrayOf<ControlCenterConfig, ShortcutConfig>(

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -270,14 +270,16 @@ void ControlCenterPanel::create() {
     }
   }
 
-  m_contentHeaderActions->addChild(
-      ui::button({
-          .out = &m_closeButton,
-          .glyph = "close",
-          .onClick = []() { PanelManager::instance().close(); },
-          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
-      })
-  );
+  if (m_config == nullptr || m_config->config().controlCenter.showCloseButton) {
+    m_contentHeaderActions->addChild(
+        ui::button({
+            .out = &m_closeButton,
+            .glyph = "close",
+            .onClick = []() { PanelManager::instance().close(); },
+            .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+        })
+    );
+  }
   header->addChild(std::move(headerActions));
 
   content->addChild(std::move(header));

--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -646,14 +646,18 @@ std::unique_ptr<Flex> HomeTab::create() {
 
 std::unique_ptr<Flex> HomeTab::createHeaderActions() {
   const float scale = contentScale();
-  return ui::row(
-      {.align = FlexAlign::Center, .gap = Style::spaceSm * scale},
-      ui::button({
-          .out = &m_settingsButton,
-          .glyph = "settings",
-          .onClick = []() { PanelManager::instance().openSettingsWindow(); },
-          .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
-      }),
+  auto row = ui::row({.align = FlexAlign::Center, .gap = Style::spaceSm * scale});
+  if (m_config == nullptr || m_config->config().controlCenter.showSettingsButton) {
+    row->addChild(
+        ui::button({
+            .out = &m_settingsButton,
+            .glyph = "settings",
+            .onClick = []() { PanelManager::instance().openSettingsWindow(); },
+            .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
+        })
+    );
+  }
+  row->addChild(
       ui::button({
           .out = &m_sessionButton,
           .glyph = "shutdown",
@@ -661,6 +665,7 @@ std::unique_ptr<Flex> HomeTab::createHeaderActions() {
           .configure = [scale](Button& button) { panel_button_style::configureHeaderIconButton(button, scale); },
       })
   );
+  return row;
 }
 
 void HomeTab::doLayout(Renderer& renderer, float contentWidth, float bodyHeight) {

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1423,6 +1423,11 @@ namespace settings {
         tr("settings.schema.panels.home-settings-button.description"), {"control_center", "show_settings_button"},
         ToggleSetting{cfg.controlCenter.showSettingsButton}, "settings button show hide"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.control-center-close-button.label"),
+        tr("settings.schema.panels.control-center-close-button.description"), {"control_center", "show_close_button"},
+        ToggleSetting{cfg.controlCenter.showCloseButton}, "close button show hide"
+    ));
     {
       MultiSelectSetting tabs;
       const auto catalog = ControlCenterPanel::hideableTabCatalog();

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1418,6 +1418,11 @@ namespace settings {
         tr("settings.schema.panels.home-shortcuts-show-labels.description"), {"control_center", "show_shortcut_labels"},
         ToggleSetting{cfg.controlCenter.showShortcutLabels}, "shortcuts labels text hide show titles"
     ));
+    entries.push_back(makeEntry(
+        SettingsSection::ControlCenter, "general", tr("settings.schema.panels.home-settings-button.label"),
+        tr("settings.schema.panels.home-settings-button.description"), {"control_center", "show_settings_button"},
+        ToggleSetting{cfg.controlCenter.showSettingsButton}, "settings button show hide"
+    ));
     {
       MultiSelectSetting tabs;
       const auto catalog = ControlCenterPanel::hideableTabCatalog();


### PR DESCRIPTION
## Summary

Adds two more toggles to hide control center header buttons, matching the session-button toggle from #3716: one for the settings button, one for the close button.

## Motivation

Follow-up from https://github.com/noctalia-dev/noctalia/issues/3713#issuecomment-5152667589. Since I made the toggle for session, it makes sense to let people do the same for the settings and close buttons also.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

#3713 (companion to #3716)
Closes #3397

## Testing

- `just build debug` — clean, no warnings
- `just test debug` — 66/66 passing
- `just format` — no diff
- `python3 tools/i18n-check.py` — OK

## Manual Coverage

- [x] Tested on Hyprland
- [ ] Tested on Niri
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="1471" height="190" alt="toggle 3" src="https://github.com/user-attachments/assets/7802e6a2-f5cf-41cc-a127-7abcb16971f0" />

<img width="1477" height="201" alt="toggle 4" src="https://github.com/user-attachments/assets/f8300289-d3fa-4794-9c83-59678c239d28" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Same pattern as the session button toggle (`showSessionButton`). `showSettingsButton` gates the button in `HomeTab::createHeaderActions()`, `showCloseButton` gates it in `ControlCenterPanel::create()` since that one lives at the panel level, not per-tab.