### PR TITLE
feat(templates): expose config variables and icon theme to templates

### DIFF
--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -455,6 +455,13 @@ std::uint64_t IconResolver::themeGeneration() {
   return state.generation;
 }
 
+std::string IconResolver::activeThemeName() {
+  auto& state = iconThemeState();
+  std::scoped_lock lock(state.mutex);
+  ensureThemeStateLocked(state);
+  return state.plan.activeTheme;
+}
+
 void IconResolver::rebuild() {
   auto& state = iconThemeState();
   std::scoped_lock lock(state.mutex);

--- a/src/system/icon_resolver.h
+++ b/src/system/icon_resolver.h
@@ -29,6 +29,7 @@ public:
 
   static bool checkThemeChanged();
   static std::uint64_t themeGeneration();
+  static std::string activeThemeName();
 
 private:
   void rebuild();

--- a/src/theme/cli.cpp
+++ b/src/theme/cli.cpp
@@ -1,7 +1,7 @@
 #include "theme/cli.h"
 
-#include "config/config_service.h"
 #include "config/config_export.h"
+#include "config/config_service.h"
 #include "core/files/resource_paths.h"
 #include "core/toml.h" // IWYU pragma: keep
 #include "theme/builtin_templates.h"

--- a/src/theme/cli.cpp
+++ b/src/theme/cli.cpp
@@ -1,6 +1,7 @@
 #include "theme/cli.h"
 
 #include "config/config_service.h"
+#include "config/config_export.h"
 #include "core/files/resource_paths.h"
 #include "core/toml.h" // IWYU pragma: keep
 #include "theme/builtin_templates.h"
@@ -562,6 +563,8 @@ namespace noctalia::theme {
       options.closestColor.clear();
       options.schemeType = schemeName.starts_with("m3-") ? schemeName.substr(3) : schemeName;
       options.verbose = true;
+      ConfigService config;
+      options.configTable = std::make_shared<toml::table>(config_export::serialize(config.config()));
       TemplateEngine engine(TemplateEngine::makeThemeData(palette), std::move(options));
 
       // Custom colors from -c must be in the theme data before -r templates render.

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -1,7 +1,7 @@
 #include "theme/template_apply_service.h"
 
-#include "config/config_service.h"
 #include "config/config_export.h"
+#include "config/config_service.h"
 #include "core/deferred_call.h"
 #include "core/files/resource_paths.h"
 #include "core/log.h"
@@ -161,10 +161,9 @@ namespace noctalia::theme {
     std::function<void()> afterApplyCallback;
     {
       std::scoped_lock lock(m_mutex);
-      // Config reloads fire on every settings change, not just theme changes.
-      // Skip redundant reprocessing (and its synchronous template hooks) when
-      // nothing the templates depend on has changed. Explicit re-application
-      // (startup, IPC, template activation) passes force or carries new inputs.
+      // Skip rendering and hooks when palette and template inputs are unchanged. Config values
+      // are captured only when an application is queued; forced IPC re-application bypasses
+      // this deduplication.
       if (!force && m_lastAppliedRequest.has_value() && sameInputs(request, *m_lastAppliedRequest)) {
         if (m_afterApplyCallback && !m_inFlight) {
           afterApplyCallback = m_afterApplyCallback;
@@ -228,10 +227,12 @@ namespace noctalia::theme {
 
   TemplateApplyService::ApplyRequest
   TemplateApplyService::makeRequest(const GeneratedPalette& palette, std::string_view defaultMode) const {
-    const ThemeConfig& theme = m_config.config().theme;
+    const Config& config = m_config.config();
+    const ThemeConfig& theme = config.theme;
     return ApplyRequest{
         .palette = palette,
         .templates = theme.templates,
+        .configTable = std::make_shared<const toml::table>(config_export::serialize(config)),
         .defaultMode = std::string(defaultMode),
         .imagePath = m_config.getPaletteWallpaperPath(),
         .schemeType = schemeTypeFromConfig(theme),
@@ -245,7 +246,7 @@ namespace noctalia::theme {
     options.schemeType = request.schemeType;
     options.verbose = true;
     options.cancelRequested = [this, generation = request.generation]() { return requestSuperseded(generation); };
-    options.configTable = std::make_shared<toml::table>(config_export::serialize(m_config.config()));
+    options.configTable = request.configTable;
 
     TemplateEngine engine(TemplateEngine::makeThemeData(request.palette), options);
 

--- a/src/theme/template_apply_service.cpp
+++ b/src/theme/template_apply_service.cpp
@@ -1,6 +1,7 @@
 #include "theme/template_apply_service.h"
 
 #include "config/config_service.h"
+#include "config/config_export.h"
 #include "core/deferred_call.h"
 #include "core/files/resource_paths.h"
 #include "core/log.h"
@@ -244,6 +245,7 @@ namespace noctalia::theme {
     options.schemeType = request.schemeType;
     options.verbose = true;
     options.cancelRequested = [this, generation = request.generation]() { return requestSuperseded(generation); };
+    options.configTable = std::make_shared<toml::table>(config_export::serialize(m_config.config()));
 
     TemplateEngine engine(TemplateEngine::makeThemeData(request.palette), options);
 

--- a/src/theme/template_apply_service.h
+++ b/src/theme/template_apply_service.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "config/config_types.h"
+#include "core/toml.h" // IWYU pragma: keep
 #include "theme/palette.h"
 
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -33,6 +35,7 @@ namespace noctalia::theme {
     struct ApplyRequest {
       GeneratedPalette palette;
       ThemeConfig::TemplatesConfig templates;
+      std::shared_ptr<const toml::table> configTable;
       std::string defaultMode;
       std::string imagePath;
       std::string schemeType;

--- a/src/theme/template_engine.cpp
+++ b/src/theme/template_engine.cpp
@@ -10,6 +10,7 @@
 #include "cpp/scheme/scheme_monochrome.h"
 #include "cpp/scheme/scheme_rainbow.h"
 #include "cpp/scheme/scheme_tonal_spot.h"
+#include "system/icon_resolver.h"
 #include "theme/color.h"
 #include "theme/firefox_theme/firefox_theme.h"
 #include "theme/kde_color_scheme.h"
@@ -98,10 +99,9 @@ namespace noctalia::theme {
           m_scopes.emplace_back();
         m_scopes.back()[std::move(name)] = std::move(value);
       }
-      const ScopeValue* get(std::string_view name) const {
-        for (const auto& scope : std::views::reverse(m_scopes)) {
-          auto found = scope.find(std::string(name));
-          if (found != scope.end())
+      const ScopeValue* get(const std::string& name) const {
+        for (auto it = m_scopes.rbegin(); it != m_scopes.rend(); ++it) {
+          if (auto found = it->find(name); found != it->end())
             return &found->second;
         }
         return nullptr;
@@ -111,6 +111,36 @@ namespace noctalia::theme {
     private:
       std::vector<ScopeMap> m_scopes;
     };
+
+    ScopeValue tomlToScopeValue(const toml::node& node) {
+      if (const auto* tbl = node.as_table()) {
+        ScopeMap map;
+        for (const auto& [k, v] : *tbl) {
+          map[std::string(k.str())] = tomlToScopeValue(v);
+        }
+        return ScopeValue(std::move(map));
+      }
+      if (const auto* arr = node.as_array()) {
+        ScopeArray out;
+        for (const auto& v : *arr) {
+          out.push_back(tomlToScopeValue(v));
+        }
+        return ScopeValue(std::move(out));
+      }
+      if (const auto* str = node.as_string()) {
+        return ScopeValue(str->get());
+      }
+      if (const auto* i = node.as_integer()) {
+        return ScopeValue(static_cast<double>(i->get()));
+      }
+      if (const auto* f = node.as_floating_point()) {
+        return ScopeValue(f->get());
+      }
+      if (const auto* b = node.as_boolean()) {
+        return ScopeValue(b->get());
+      }
+      return ScopeValue();
+    }
 
     constexpr std::string_view kUnknownPrefix = "{{";
 
@@ -608,6 +638,13 @@ namespace noctalia::theme {
         size_t pos = 0;
         const auto nodes = parseNodes(tokens, pos, {});
         VariableScope scope;
+        if (m_options.configTable) {
+          ScopeMap rootVars;
+          rootVars["config"] = tomlToScopeValue(*m_options.configTable);
+          rootVars["icon_theme"] = ScopeValue(IconResolver::activeThemeName());
+          scope.push(std::move(rootVars));
+        }
+
         return {evaluateNodes(nodes, scope), m_errorCount};
       }
 
@@ -854,7 +891,15 @@ namespace noctalia::theme {
             auto it = map->find(parts[i]);
             if (it == map->end())
               return {};
-            value = it->second;
+            value = ScopeValue(it->second);
+          } else if (auto* arr = std::get_if<ScopeArray>(&value.value)) {
+            try {
+              size_t idx = std::stoul(parts[i]);
+              if (idx >= arr->size()) return {};
+              value = ScopeValue((*arr)[idx]);
+            } catch (...) {
+              return {};
+            }
           } else if (auto* str = std::get_if<std::string>(&value.value)) {
             if (str->size() >= 7 && (*str)[0] == '#' && kKnownFormats.contains(parts[i]))
               return ScopeValue(formatColor({Color::fromHex(*str), 1.0}, parts[i]));

--- a/src/theme/template_engine.cpp
+++ b/src/theme/template_engine.cpp
@@ -100,8 +100,8 @@ namespace noctalia::theme {
         m_scopes.back()[std::move(name)] = std::move(value);
       }
       const ScopeValue* get(const std::string& name) const {
-        for (auto it = m_scopes.rbegin(); it != m_scopes.rend(); ++it) {
-          if (auto found = it->find(name); found != it->end())
+        for (const auto& scope : std::views::reverse(m_scopes)) {
+          if (auto found = scope.find(name); found != scope.end())
             return &found->second;
         }
         return nullptr;
@@ -895,7 +895,8 @@ namespace noctalia::theme {
           } else if (auto* arr = std::get_if<ScopeArray>(&value.value)) {
             try {
               size_t idx = std::stoul(parts[i]);
-              if (idx >= arr->size()) return {};
+              if (idx >= arr->size())
+                return {};
               value = ScopeValue((*arr)[idx]);
             } catch (...) {
               return {};

--- a/src/theme/template_engine.h
+++ b/src/theme/template_engine.h
@@ -38,6 +38,7 @@ namespace noctalia::theme {
       std::function<bool()> cancelRequested;
       std::string schemeType = "content";
       bool verbose = true;
+      std::shared_ptr<toml::table> configTable;
     };
 
     explicit TemplateEngine(ThemeData themeData);

--- a/src/theme/template_engine.h
+++ b/src/theme/template_engine.h
@@ -38,7 +38,7 @@ namespace noctalia::theme {
       std::function<bool()> cancelRequested;
       std::string schemeType = "content";
       bool verbose = true;
-      std::shared_ptr<toml::table> configTable;
+      std::shared_ptr<const toml::table> configTable;
     };
 
     explicit TemplateEngine(ThemeData themeData);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This PR exposes the entire Noctalia configuration table to the template engine via the `config` variable, alongside an explicit `icon_theme` variable. 
    
This enables accessing all GUI settings inside templates, including:

- `{{ config.bar.main.radius }}`
- `{{ config.bar.main.font_family }}` and `{{ config.bar.main.font_weight }}`
- `{{ config.bar.main.background_opacity }}`
- `{{ config.bar.main.margin_ends }}`
- `{{ config.bar.main.shadow }}`
- `{{ icon_theme }}` (resolved dynamically via `IconResolver`)
    
Additionally, this PR fixes a silent use-after-free bug in `TemplateEngine::resolveFromScope` that previously caused the template engine to hang when trying to evaluate nested configuration nodes.

<!-- What changed and why? -->

## Motivation

Allows Noctalia to drive all UX styling in the user's WM via a rendered user template file (e.g., when the wallpaper changes), ensuring consistent design across the shell and the compositor elements without duplicating configuration.

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes [#3684]

<!-- Example: Closes #123 -->

## Testing

- Compiled locally using `meson compile -C build-debug noctalia`.
- Created a test template file containing the newly exposed variables (`config.theme.mode`, `config.bar.main.radius`, `config.osd.background_opacity`, `config.dock.icon_size`, and `icon_theme`).
- Ran `./build-debug/noctalia msg templates-apply` and verified that the rendered output file

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [x] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

To expose `icon_theme`, I added a static `activeThemeName()` method to `IconResolver` since the active icon set is dynamically read from system settings (GSettings/GTK configs) rather than natively living inside Noctalia's user TOML configuration.

<!-- Add follow-up notes, reviewer context, or known limitations. -->
