### PR TITLE
fix(launcher): use launcher panel's own output for app launch

### DIFF
--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -4,6 +4,7 @@
 #include "config/config_service.h"
 #include "core/log.h"
 #include "i18n/i18n.h"
+#include "shell/panel/panel_manager.h"
 #include "system/desktop_entry_launch.h"
 #include "util/fuzzy_match.h"
 #include "util/string_utils.h"
@@ -249,8 +250,15 @@ bool AppProvider::activate(const LauncherResult& result) {
 
     if (m_platform != nullptr) {
       wl_output* launchOutput = nullptr;
-      if (wl_surface* pointerSurface = m_platform->lastPointerSurface(); pointerSurface != nullptr) {
-        launchOutput = m_platform->outputForSurface(pointerSurface);
+
+      if (PanelManager& panelManager = PanelManager::instance(); panelManager.isOpenPanel("launcher")) {
+        launchOutput = panelManager.attachedPanelOutput();
+      }
+
+      if (launchOutput == nullptr) {
+        if (wl_surface* pointerSurface = m_platform->lastPointerSurface(); pointerSurface != nullptr) {
+          launchOutput = m_platform->outputForSurface(pointerSurface);
+        }
       }
       if (launchOutput == nullptr) {
         launchOutput = m_platform->preferredInteractiveOutput();


### PR DESCRIPTION
## Summary
Apps launched from the launcher now default to the launcher panel's own output, falling back to pointer focus, then `preferredInteractiveOutput()` if not resolvable.

## Motivation
`AppProvider::activate()` previously picked the launch output from `lastPointerSurface()` (falling back to `preferredInteractiveOutput()` if unset). On multi-monitor setups this could launch the app on the wrong monitor on the very first app launch after startup due to there being no previous interactions for the last pointer focus to be populated.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
Closes #3743 

## Testing
https://github.com/noctalia-dev/noctalia/issues/3743#issuecomment-5194026364

## Manual Coverage
- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
N/A