### PR TITLE
fix(render): fix rounded corner blur by tightening corner AA width

### DIFF
--- a/src/render/programs/rect_program.cpp
+++ b/src/render/programs/rect_program.cpp
@@ -310,12 +310,13 @@ vec4 gradient_fill(float position) {
 
 void main() {
     float aa = max(u_softness, 0.85);
+    float corner_aa = max(u_softness * 0.55, 0.55);
     vec2 local_point = v_pixel;
     vec2 uv = clamp(local_point / u_rect_size, vec2(0.0), vec2(1.0));
 
     vec2 outer = shape_distance_with_corner(local_point, u_rect_size, u_radii, u_corner_shapes, u_logical_inset);
     float outer_distance = outer.x;
-    float outer_coverage = coverage_for(outer, aa);
+    float outer_coverage = coverage_for(outer, corner_aa);
     if (u_invert_fill == 1) outer_coverage = 1.0 - outer_coverage;
 
     if (u_outer_shadow == 1) {
@@ -368,7 +369,7 @@ void main() {
         vec4 inner_inset = max(u_logical_inset - vec4(u_border_width), vec4(0.0));
         inner = shape_distance_with_corner(inner_point, inner_size, inner_radii, u_corner_shapes, inner_inset);
     }
-    float inner_coverage = coverage_for(inner, aa);
+    float inner_coverage = coverage_for(inner, corner_aa);
 
     if (fill_base.a <= 0.0) {
         float ring_coverage = outer_coverage * (1.0 - inner_coverage);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

Fix rounded corner blurring/aliasing on controls.

## Motivation

<!-- What problem does this solve? -->

This is a regression introduced in commit 598000b76 ("rectshader: dont AA on the horizontal edges to avoid creating gaps on attached elements").

That commit changed the straight-edge anti-aliasing to snap to the pixel grid (±0.5px), but rounded corners still use an AA width of max(u_softness, 0.85). When softness is at the default of 1.0, the corner AA width ends up twice as wide as the straight-edge AA, making the corners visually much blurrier than the edges.

<img width="311" height="122" alt="Image" src="https://github.com/user-attachments/assets/318a980d-da8c-4ff5-9d7b-24d65ecf3027" />

<img width="311" height="122" alt="Image" src="https://github.com/user-attachments/assets/91d1f6e4-4aff-4d0c-a345-adeb5048faae" />

I fixed it in a non-intrusive way. The images above show the result after (first) and before (second) the fix.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

Closes #3759

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

`meson setup builddir && ninja -C builddir`, 798/798 targets.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

<img width="311" height="122" alt="Image" src="https://github.com/user-attachments/assets/318a980d-da8c-4ff5-9d7b-24d65ecf3027" />

<img width="311" height="122" alt="Image" src="https://github.com/user-attachments/assets/91d1f6e4-4aff-4d0c-a345-adeb5048faae" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
