### PR TITLE
fix(bar): prevent premature collapse when hovering capsule group accordion elements

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1050,8 +1050,12 @@ namespace {
                                                             : std::max(0.0f, std::min(shellW, shellH) * 0.5f);
         bg->setRadius(capsuleRadius);
         placeCapsuleHoverBoxes(run, isVertical, shellW, shellH, contentX, contentY, capsuleRadius, widgetHoverPadding);
-        // Members outside the reveal window are clipped out; they must not take pointer input either.
+        // Members outside the reveal window are clipped out; when fully collapsed, non-primary
+        // members are pointer-suppressed so their hidden slots don't capture clicks. When expanded
+        // or expanding, all valid layout members must stay unsuppressed so hover tracking and
+        // member interactions remain active.
         if (run.accordion) {
+          const bool isExpandingOrExpanded = run.accordionExpanded || run.accordionProgress > 0.0f;
           for (Widget* widget : run.widgets) {
             const Node* node = widget != nullptr ? widget->outerNode() : nullptr;
             if (widget == nullptr || node == nullptr || !node->visible() || !node->participatesInLayout()) {
@@ -1060,11 +1064,15 @@ namespace {
               }
               continue;
             }
-            const float memberStart = contentMain + memberMainPos(node);
-            const float memberEnd = memberStart + memberMainExtent(node);
-            widget->setBarPointerSuppressed(
-                !(memberStart >= padMain - 0.5f && memberEnd <= padMain + revealMain + 0.5f)
-            );
+            if (isExpandingOrExpanded) {
+              widget->setBarPointerSuppressed(false);
+            } else {
+              const float memberStart = contentMain + memberMainPos(node);
+              const float memberEnd = memberStart + memberMainExtent(node);
+              widget->setBarPointerSuppressed(
+                  !(memberStart >= padMain - 0.5f && memberEnd <= padMain + revealMain + 0.5f)
+              );
+            }
           }
         }
       }
@@ -2778,13 +2786,31 @@ void Bar::animateWidgetHoverHighlight(BarInstance& instance, Widget& widget, boo
 
 void Bar::updateAccordionExpansion(BarInstance& instance, InputArea* hoveredArea) {
   Widget* target = widgetFromHoveredArea(instance, hoveredArea);
+
+  auto isPointerInsideRunShell = [&instance](const BarCapsuleRun& run) -> bool {
+    if (run.shell == nullptr || !instance.pointerInside) {
+      return false;
+    }
+    float lx = 0.0f;
+    float ly = 0.0f;
+    if (Node::mapFromScene(run.shell, instance.lastPointerSx, instance.lastPointerSy, lx, ly)) {
+      return lx >= -0.5f && lx <= run.shell->width() + 0.5f && ly >= -0.5f && ly <= run.shell->height() + 0.5f;
+    }
+    return false;
+  };
+
   bool changed = false;
   auto updateRuns = [&](std::vector<BarCapsuleRun>& runs) {
     for (auto& run : runs) {
       if (!run.accordion || run.shell == nullptr) {
         continue;
       }
-      const bool want = target != nullptr && std::ranges::contains(run.widgets, target);
+      bool want = target != nullptr && std::ranges::contains(run.widgets, target);
+      if (!want && (run.accordionExpanded || run.accordionProgress > 0.0f)) {
+        if (isPointerInsideRunShell(run)) {
+          want = true;
+        }
+      }
       if (want == run.accordionExpanded) {
         continue;
       }
@@ -3413,6 +3439,7 @@ bool Bar::onPointerEvent(const PointerEvent& event) {
     if (m_hoveredInstance != nullptr) {
       m_hoveredInstance->pointerInside = false;
       m_hoveredInstance->inputDispatcher.pointerLeave();
+      updateAccordionExpansion(*m_hoveredInstance, nullptr);
       const bool suppressAutoHide =
           (m_autoHideSuppressionCallback != nullptr) ? m_autoHideSuppressionCallback(*m_hoveredInstance) : false;
       if (barPointerHideAllowed(*m_hoveredInstance) && !suppressAutoHide) {
@@ -3434,6 +3461,7 @@ bool Bar::onPointerEvent(const PointerEvent& event) {
     if (m_hoveredInstance != hovered) {
       break;
     }
+    updateAccordionExpansion(*hovered, hovered->inputDispatcher.hoveredArea());
     break;
   }
   case PointerEvent::Type::Button: {

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1050,12 +1050,11 @@ namespace {
                                                             : std::max(0.0f, std::min(shellW, shellH) * 0.5f);
         bg->setRadius(capsuleRadius);
         placeCapsuleHoverBoxes(run, isVertical, shellW, shellH, contentX, contentY, capsuleRadius, widgetHoverPadding);
-        // Members outside the reveal window are clipped out; when fully collapsed, non-primary
-        // members are pointer-suppressed so their hidden slots don't capture clicks. When expanded
-        // or expanding, all valid layout members must stay unsuppressed so hover tracking and
-        // member interactions remain active.
+        // Members outside the reveal window are clipped out; while collapsed (or collapsing) the
+        // non-primary members are pointer-suppressed by reveal window so their hidden slots don't
+        // capture clicks. While expanded, every valid layout member stays unsuppressed so hover
+        // tracking and member interactions remain active across the reveal animation.
         if (run.accordion) {
-          const bool isExpandingOrExpanded = run.accordionExpanded || run.accordionProgress > 0.0f;
           for (Widget* widget : run.widgets) {
             const Node* node = widget != nullptr ? widget->outerNode() : nullptr;
             if (widget == nullptr || node == nullptr || !node->visible() || !node->participatesInLayout()) {
@@ -1064,7 +1063,7 @@ namespace {
               }
               continue;
             }
-            if (isExpandingOrExpanded) {
+            if (run.accordionExpanded) {
               widget->setBarPointerSuppressed(false);
             } else {
               const float memberStart = contentMain + memberMainPos(node);
@@ -2788,15 +2787,7 @@ void Bar::updateAccordionExpansion(BarInstance& instance, InputArea* hoveredArea
   Widget* target = widgetFromHoveredArea(instance, hoveredArea);
 
   auto isPointerInsideRunShell = [&instance](const BarCapsuleRun& run) -> bool {
-    if (run.shell == nullptr || !instance.pointerInside) {
-      return false;
-    }
-    float lx = 0.0f;
-    float ly = 0.0f;
-    if (Node::mapFromScene(run.shell, instance.lastPointerSx, instance.lastPointerSy, lx, ly)) {
-      return lx >= -0.5f && lx <= run.shell->width() + 0.5f && ly >= -0.5f && ly <= run.shell->height() + 0.5f;
-    }
-    return false;
+    return instance.pointerInside && pointInsideNode(run.shell, instance.lastPointerSx, instance.lastPointerSy);
   };
 
   bool changed = false;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Fixes an issue with accordion in capsule groups where the grouped widgets when visible on hover, doesn't allow the user to hover over the elements correctly

## Motivation

<!-- What problem does this solve? -->
The current accordion functionality is quite buggy, which is shown in the below video showcase (before)

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Ran `just format`, `just test` and `just build` to ensure zero compilation errors, passes all tests and code uses clang-format

## Manual Coverage

<!-- Mark what applies to this PR. -->
- [x] Tested on Hyprland

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

**Before**

https://github.com/user-attachments/assets/4df75645-3b98-4d6b-ae05-676380e54c3e

**After**

https://github.com/user-attachments/assets/f61ce111-b60d-482a-869c-1df563bf89c3

## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration or behavior.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.