### PR TITLE
feat(launcher): Hide/Unhide and multi-backend Uninstall in the app context menu

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -644,7 +644,15 @@
     "context-menu": {
       "open": "Open",
       "pin-to-dock": "Pin to dock",
-      "unpin-from-dock": "Unpin from dock"
+      "unpin-from-dock": "Unpin from dock",
+      "hide": "Hide",
+      "unhide": "Unhide",
+      "uninstall": "Uninstall",
+      "uninstall-cancel": "Cancel",
+      "uninstall-confirm": "Uninstall",
+      "uninstall-done": "Package uninstalled:",
+      "uninstall-failed": "Uninstall failed",
+      "hide-failed": "Could not hide this app"
     },
     "empty": {
       "no-results": "No results found",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -652,6 +652,14 @@
       "uninstall-confirm": "Uninstall",
       "uninstall-done": "Package uninstalled:",
       "uninstall-failed": "Uninstall failed",
+      "uninstall-aur-suffix": " (AUR)",
+      "uninstall-flatpak-suffix": " (Flatpak)",
+      "uninstall-appimage-suffix": " (AppImage)",
+      "remove-launcher": "Remove launcher",
+      "remove-launcher-confirm": "Remove launcher for",
+      "remove-launcher-done": "Launcher removed",
+      "remove-launcher-failed": "Failed to remove launcher",
+      "appimage-not-shelly-managed": "This AppImage is not managed by Shelly; only the launcher entry will be removed automatically.",
       "hide-failed": "Could not hide this app"
     },
     "empty": {

--- a/meson.build
+++ b/meson.build
@@ -789,6 +789,7 @@ _noctalia_sources = files(
   'src/system/dependency_service.cpp',
   'src/system/desktop_entry.cpp',
   'src/system/desktop_entry_launch.cpp',
+  'src/system/desktop_entry_override.cpp',
   'src/system/terminal_launch.cpp',
   'src/system/brightness_service.cpp',
   'src/system/keyboard_backlight_service.cpp',

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -30,9 +30,11 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 
 namespace {
@@ -1623,6 +1625,29 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   constexpr std::int32_t kActionUnhide = -5;
   constexpr std::int32_t kActionUninstall = -6;
 
+  const AppSource source = resolveAppSource(*match);
+  std::string uninstallLabel;
+  switch (source.backend) {
+  case AppSourceBackend::Standard:
+    uninstallLabel = i18n::tr("launcher.context-menu.uninstall");
+    break;
+  case AppSourceBackend::Aur:
+    uninstallLabel = i18n::tr("launcher.context-menu.uninstall") + i18n::tr("launcher.context-menu.uninstall-aur-suffix");
+    break;
+  case AppSourceBackend::Flatpak:
+    uninstallLabel =
+        i18n::tr("launcher.context-menu.uninstall") + i18n::tr("launcher.context-menu.uninstall-flatpak-suffix");
+    break;
+  case AppSourceBackend::AppImage:
+    uninstallLabel = source.shellyManaged
+        ? i18n::tr("launcher.context-menu.uninstall") + i18n::tr("launcher.context-menu.uninstall-appimage-suffix")
+        : i18n::tr("launcher.context-menu.remove-launcher");
+    break;
+  case AppSourceBackend::Custom:
+    uninstallLabel = i18n::tr("launcher.context-menu.remove-launcher");
+    break;
+  }
+
   std::vector<ContextMenuControlEntry> entries;
   entries.reserve(actionsCopy.size() + 4);
   entries.push_back(
@@ -1664,17 +1689,15 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
           .hasSubmenu = false,
       }
   );
-  if (const auto package = resolveOwningPackage(match->path)) {
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = kActionUninstall,
-            .label = i18n::tr("launcher.context-menu.uninstall"),
-            .enabled = true,
-            .separator = false,
-            .hasSubmenu = false,
-        }
-    );
-  }
+  entries.push_back(
+      ContextMenuControlEntry{
+          .id = kActionUninstall,
+          .label = uninstallLabel,
+          .enabled = true,
+          .separator = false,
+          .hasSubmenu = false,
+      }
+  );
   for (std::int32_t i = 0; i < static_cast<std::int32_t>(actionsCopy.size()); ++i) {
     entries.push_back(
         ContextMenuControlEntry{
@@ -1703,7 +1726,7 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   });
 
   m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
-                                entryForPin = *match, anchorX, anchorY](const ContextMenuControlEntry& entry) {
+                                entryForPin = *match, source, anchorX, anchorY](const ContextMenuControlEntry& entry) {
     LauncherResult result = base;
     result.desktopActionId.clear();
     if (entry.id == kActionPinToDock) {
@@ -1738,12 +1761,10 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
       return;
     }
     if (entry.id == kActionUninstall) {
-      if (const auto package = resolveOwningPackage(entryForPin.path)) {
-        // Close this menu, then open the confirmation menu at the same spot.
-        m_actionsMenu->close();
-        PanelManager::instance().clearActivePopup();
-        openUninstallConfirmMenu(entryForPin, *package, anchorX, anchorY);
-      }
+      // Close this menu, then open the confirmation menu at the same spot.
+      m_actionsMenu->close();
+      PanelManager::instance().clearActivePopup();
+      openUninstallConfirmMenu(entryForPin, source, anchorX, anchorY);
       return;
     }
     if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {
@@ -1793,7 +1814,7 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
 }
 
 void LauncherPanel::openUninstallConfirmMenu(
-    const DesktopEntry& entry, std::string package, float anchorX, float anchorY
+    const DesktopEntry& entry, AppSource source, float anchorX, float anchorY
 ) {
   WaylandConnection* wl = PanelManager::instance().wayland();
   RenderContext* rc = PanelManager::instance().renderContext();
@@ -1815,6 +1836,19 @@ void LauncherPanel::openUninstallConfirmMenu(
   constexpr std::int32_t kConfirmCancel = 1;
   constexpr std::int32_t kConfirmUninstall = 2;
 
+  // Custom entries (no backend owns them) and unmanaged AppImages get "Remove
+  // launcher" copy instead of "Uninstall" — see resolveAppSource.
+  const bool isRemoveLauncher =
+      source.backend == AppSourceBackend::Custom
+      || (source.backend == AppSourceBackend::AppImage && !source.shellyManaged);
+
+  std::string confirmLabel;
+  if (isRemoveLauncher) {
+    confirmLabel = i18n::tr("launcher.context-menu.remove-launcher-confirm") + " " + entry.name;
+  } else {
+    confirmLabel = i18n::tr("launcher.context-menu.uninstall-confirm") + " " + source.identifier;
+  }
+
   std::vector<ContextMenuControlEntry> entries;
   entries.push_back(
       ContextMenuControlEntry{
@@ -1828,7 +1862,7 @@ void LauncherPanel::openUninstallConfirmMenu(
   entries.push_back(
       ContextMenuControlEntry{
           .id = kConfirmUninstall,
-          .label = i18n::tr("launcher.context-menu.uninstall-confirm") + " " + package,
+          .label = confirmLabel,
           .enabled = true,
           .separator = false,
           .hasSubmenu = false,
@@ -1843,11 +1877,16 @@ void LauncherPanel::openUninstallConfirmMenu(
     PanelManager::instance().endAttachedPopup(parentSurface);
   });
 
-  m_confirmMenu->setOnActivate([this, entry, package = std::move(package)](const ContextMenuControlEntry& item) {
+  m_confirmMenu->setOnActivate([this, entry, source = std::move(source)](const ContextMenuControlEntry& item) {
     m_confirmMenu->close();
     PanelManager::instance().clearActivePopup();
-    if (item.id == kConfirmUninstall) {
-      runUninstall(entry, package);
+    if (item.id != kConfirmUninstall) {
+      return;
+    }
+    if (source.backend == AppSourceBackend::Custom) {
+      runRemoveLauncherFile(entry);
+    } else {
+      runUninstall(entry, source);
     }
   });
 
@@ -1879,21 +1918,78 @@ void LauncherPanel::openUninstallConfirmMenu(
   );
 }
 
-void LauncherPanel::runUninstall(const DesktopEntry& entry, std::string package) {
-  (void)entry;  // Package identity is resolved by the caller; entry kept for future use.
-  // pacman needs a real TTY for "these packages will also be removed" cascades and
-  // "breaks dependency X, N packages depend on it" warnings (avahi, ABDownloadManager
-  // repros). Running it interactively in a terminal lets the user see and answer those
-  // directly — a breaking removal must be the user's decision, never --noconfirm.
+namespace {
+
+// Backend-specific shell command to run inside the interactive terminal.
+// `||` fallbacks let the shell handle "shelly missing/backend missing"
+// without a separate C++ branch — see PLAN-SHELLY.md §2.
+[[nodiscard]] std::string
+buildUninstallCommand(const DesktopEntry& entry, const AppSource& source, const std::string& escalator) {
+  switch (source.backend) {
+  case AppSourceBackend::Standard:
+    return escalator + " shelly remove standard " + StringUtils::shellQuote(source.identifier) + " || " + escalator +
+        " pacman -Rns " + StringUtils::shellQuote(source.identifier);
+
+  case AppSourceBackend::Aur:
+    return escalator + " shelly remove aur " + StringUtils::shellQuote(source.identifier) +
+        " || echo 'shelly is required to remove AUR packages; install it or run: pacman -Rns " +
+        StringUtils::shellQuote(source.identifier) + " (may leave AUR bookkeeping stale)'";
+
+  case AppSourceBackend::Flatpak:
+    return escalator + " shelly remove flatpak " + StringUtils::shellQuote(source.identifier) +
+        " || flatpak uninstall -y --app " + StringUtils::shellQuote(source.identifier);
+
+  case AppSourceBackend::AppImage:
+    if (source.shellyManaged) {
+      return escalator + " shelly remove appimage " + StringUtils::shellQuote(source.identifier);
+    }
+    return "printf 'This AppImage is not managed by Shelly.\\n'; "
+           "rm -f " +
+        StringUtils::shellQuote(entry.path) +
+        "; "
+        "printf 'Removed launcher entry.\\n'; "
+        "read -n 1 -s -r -p 'Also delete the AppImage file itself? [y/N] ' ans; echo; "
+        "if [ \"$ans\" = 'y' ] || [ \"$ans\" = 'Y' ]; then rm -f " +
+        StringUtils::shellQuote(source.identifier) + "; printf 'Deleted AppImage.\\n'; fi";
+
+  case AppSourceBackend::Custom:
+    return {};
+  }
+  return {};
+}
+
+// Cheap backend-specific check for whether the uninstall actually took.
+[[nodiscard]] bool verifyRemoved(const DesktopEntry& entry, const AppSource& source) {
+  switch (source.backend) {
+  case AppSourceBackend::Standard:
+  case AppSourceBackend::Aur:
+    return process::runSync({"pacman", "-Q", source.identifier}).exitCode != 0;
+  case AppSourceBackend::Flatpak:
+    return process::runSync({"flatpak", "info", source.identifier}).exitCode != 0;
+  case AppSourceBackend::AppImage:
+    return !std::filesystem::exists(entry.path);
+  case AppSourceBackend::Custom:
+    return !std::filesystem::exists(entry.path);
+  }
+  return false;
+}
+
+}  // namespace
+
+void LauncherPanel::runUninstall(const DesktopEntry& entry, const AppSource& source) {
+  // pacman/shelly need a real TTY for "these packages will also be removed" cascades and
+  // "breaks dependency X, N packages depend on it" warnings. Running interactively in a
+  // terminal lets the user see and answer those directly — a breaking removal must be the
+  // user's decision, never --noconfirm.
   const auto escalator = process::resolvePrivilegeEscalator();
   if (!escalator) {
     notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "no privilege escalator found");
     return;
   }
 
-  // Keep the window open after pacman exits so the user can read the output.
-  const std::string shellCmd = *escalator + " pacman -Rns " + StringUtils::shellQuote(package) +
-      "; echo; read -n 1 -s -r -p 'Press any key to close...'";
+  const std::string uninstallCmd = buildUninstallCommand(entry, source, *escalator);
+  // Keep the window open after the command exits so the user can read the output.
+  const std::string shellCmd = uninstallCmd + "; echo; read -n 1 -s -r -p 'Press any key to close...'";
 
   const auto termArgs = terminal_launch::prepareCommand(shellCmd);
   if (!termArgs) {
@@ -1904,19 +2000,16 @@ void LauncherPanel::runUninstall(const DesktopEntry& entry, std::string package)
   const bool spawned = process::runAsync(
       *termArgs,
       process::RunCallbacks{
-          .onExit = [this, package](process::RunResult /*result*/) {
-            DeferredCall::callLater([this, package]() {
-              // The terminal's own exit code, not pacman's — most emulators don't
-              // reliably forward the child's status. Re-check ownership instead of
-              // trusting exitCode; this also correctly no-ops on polkit cancel or a
-              // declined pacman prompt, since the package is still present either way.
-              const bool stillInstalled = process::runSync({"pacman", "-Q", package}).exitCode == 0;
-              if (!stillInstalled) {
-                notify::info("Noctalia", i18n::tr("launcher.context-menu.uninstall-done"), package);
+          .onExit = [this, entry, source](process::RunResult /*result*/) {
+            DeferredCall::callLater([this, entry, source]() {
+              // The terminal's own exit code, not the child's — most emulators don't
+              // reliably forward it. Re-check instead of trusting exitCode; this also
+              // correctly no-ops on polkit cancel or a declined prompt.
+              if (verifyRemoved(entry, source)) {
+                notify::info("Noctalia", i18n::tr("launcher.context-menu.uninstall-done"), source.identifier);
               }
               // Refresh regardless: a cascaded removal may drop other .desktop-owning
-              // packages even when `package` itself is still installed (user picked a
-              // different item from pacman's dependency list).
+              // packages even when the target itself is still present.
               reapplyCurrentQuery();
             });
           },
@@ -1925,6 +2018,20 @@ void LauncherPanel::runUninstall(const DesktopEntry& entry, std::string package)
   if (!spawned) {
     notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "terminal spawn failed");
   }
+}
+
+void LauncherPanel::runRemoveLauncherFile(const DesktopEntry& entry) {
+  // Custom backend only ever matches entries outside pacman/flatpak/appimage
+  // tracking, which in practice means a user-owned .desktop file. No
+  // escalation, no terminal, no subprocess needed.
+  std::error_code ec;
+  std::filesystem::remove(entry.path, ec);
+  if (ec) {
+    notify::error("Noctalia", i18n::tr("launcher.context-menu.remove-launcher-failed"), ec.message());
+    return;
+  }
+  notify::info("Noctalia", i18n::tr("launcher.context-menu.remove-launcher-done"), entry.name);
+  reapplyCurrentQuery();
 }
 
 void LauncherPanel::activateAt(std::size_t index) {

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -16,6 +16,7 @@
 #include "shell/panel/panel_manager.h"
 #include "system/desktop_entry.h"
 #include "system/desktop_entry_override.h"
+#include "system/terminal_launch.h"
 #include "ui/app_icon_colorization.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu_popup.h"
@@ -1879,31 +1880,50 @@ void LauncherPanel::openUninstallConfirmMenu(
 }
 
 void LauncherPanel::runUninstall(const DesktopEntry& entry, std::string package) {
-  // Arch-only, asynchronous, with the user already confirmed.
+  (void)entry;  // Package identity is resolved by the caller; entry kept for future use.
+  // pacman needs a real TTY for "these packages will also be removed" cascades and
+  // "breaks dependency X, N packages depend on it" warnings (avahi, ABDownloadManager
+  // repros). Running it interactively in a terminal lets the user see and answer those
+  // directly — a breaking removal must be the user's decision, never --noconfirm.
+  const auto escalator = process::resolvePrivilegeEscalator();
+  if (!escalator) {
+    notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "no privilege escalator found");
+    return;
+  }
+
+  // Keep the window open after pacman exits so the user can read the output.
+  const std::string shellCmd = *escalator + " pacman -Rns " + StringUtils::shellQuote(package) +
+      "; echo; read -n 1 -s -r -p 'Press any key to close...'";
+
+  const auto termArgs = terminal_launch::prepareCommand(shellCmd);
+  if (!termArgs) {
+    notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "no terminal emulator found");
+    return;
+  }
+
   const bool spawned = process::runAsync(
-      {"pkexec", "pacman", "-Rns", package},
+      *termArgs,
       process::RunCallbacks{
-          .stdOut = nullptr,
-          .stdErr = nullptr,
-          .onExit = [this, package](process::RunResult result) {
-            DeferredCall::callLater([this, package, exitCode = result.exitCode, err = result.err]() {
-              // 126/127 = polkit prompt dismissed/cancelled — silent no-op.
-              if (exitCode == 126 || exitCode == 127) {
-                return;
-              }
-              if (exitCode == 0) {
+          .onExit = [this, package](process::RunResult /*result*/) {
+            DeferredCall::callLater([this, package]() {
+              // The terminal's own exit code, not pacman's — most emulators don't
+              // reliably forward the child's status. Re-check ownership instead of
+              // trusting exitCode; this also correctly no-ops on polkit cancel or a
+              // declined pacman prompt, since the package is still present either way.
+              const bool stillInstalled = process::runSync({"pacman", "-Q", package}).exitCode == 0;
+              if (!stillInstalled) {
                 notify::info("Noctalia", i18n::tr("launcher.context-menu.uninstall-done"), package);
-              } else {
-                notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), err);
               }
-              // Whatever happened, re-scan: files may have changed either way.
+              // Refresh regardless: a cascaded removal may drop other .desktop-owning
+              // packages even when `package` itself is still installed (user picked a
+              // different item from pacman's dependency list).
               reapplyCurrentQuery();
             });
           },
       }
   );
   if (!spawned) {
-    notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "pkexec spawn failed");
+    notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "terminal spawn failed");
   }
 }
 

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -5,14 +5,17 @@
 #include "core/input/key_modifiers.h"
 #include "core/input/key_symbols.h"
 #include "core/input/keybind_matcher.h"
+#include "core/process/process.h"
 #include "core/ui_phase.h"
 #include "i18n/i18n.h"
+#include "notification/notifications.h"
 #include "render/core/async_texture_cache.h"
 #include "render/core/renderer.h"
 #include "render/scene/node.h"
 #include "shell/dock/pinned_apps.h"
 #include "shell/panel/panel_manager.h"
 #include "system/desktop_entry.h"
+#include "system/desktop_entry_override.h"
 #include "ui/app_icon_colorization.h"
 #include "ui/builders.h"
 #include "ui/controls/context_menu_popup.h"
@@ -1615,9 +1618,12 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   constexpr std::int32_t kActionOpen = -1;
   constexpr std::int32_t kActionPinToDock = -2;
   constexpr std::int32_t kActionUnpinFromDock = -3;
+  constexpr std::int32_t kActionHide = -4;
+  constexpr std::int32_t kActionUnhide = -5;
+  constexpr std::int32_t kActionUninstall = -6;
 
   std::vector<ContextMenuControlEntry> entries;
-  entries.reserve(actionsCopy.size() + 2);
+  entries.reserve(actionsCopy.size() + 4);
   entries.push_back(
       ContextMenuControlEntry{
           .id = kActionOpen,
@@ -1642,6 +1648,26 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
         ContextMenuControlEntry{
             .id = kActionUnpinFromDock,
             .label = i18n::tr("launcher.context-menu.unpin-from-dock"),
+            .enabled = true,
+            .separator = false,
+            .hasSubmenu = false,
+        }
+    );
+  }
+  entries.push_back(
+      ContextMenuControlEntry{
+          .id = match->noDisplay ? kActionUnhide : kActionHide,
+          .label = i18n::tr(match->noDisplay ? "launcher.context-menu.unhide" : "launcher.context-menu.hide"),
+          .enabled = true,
+          .separator = false,
+          .hasSubmenu = false,
+      }
+  );
+  if (const auto package = resolveOwningPackage(match->path)) {
+    entries.push_back(
+        ContextMenuControlEntry{
+            .id = kActionUninstall,
+            .label = i18n::tr("launcher.context-menu.uninstall"),
             .enabled = true,
             .separator = false,
             .hasSubmenu = false,
@@ -1676,7 +1702,7 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   });
 
   m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
-                                entryForPin = *match](const ContextMenuControlEntry& entry) {
+                                entryForPin = *match, anchorX, anchorY](const ContextMenuControlEntry& entry) {
     LauncherResult result = base;
     result.desktopActionId.clear();
     if (entry.id == kActionPinToDock) {
@@ -1697,6 +1723,26 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
       std::vector<std::string> pinned = m_config->config().dock.pinned;
       shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
       (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
+      return;
+    }
+    if (entry.id == kActionHide || entry.id == kActionUnhide) {
+      const bool hide = (entry.id == kActionHide);
+      std::string err;
+      if (!setDesktopEntryHidden(entryForPin, hide, &err)) {
+        notify::error("Noctalia", i18n::tr("launcher.context-menu.hide-failed"), err);
+        return;
+      }
+      // Re-gather so the app disappears (or reappears) without relaunching.
+      DeferredCall::callLater([this]() { reapplyCurrentQuery(); });
+      return;
+    }
+    if (entry.id == kActionUninstall) {
+      if (const auto package = resolveOwningPackage(entryForPin.path)) {
+        // Close this menu, then open the confirmation menu at the same spot.
+        m_actionsMenu->close();
+        PanelManager::instance().clearActivePopup();
+        openUninstallConfirmMenu(entryForPin, *package, anchorX, anchorY);
+      }
       return;
     }
     if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {
@@ -1743,6 +1789,122 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
           },
       }
   );
+}
+
+void LauncherPanel::openUninstallConfirmMenu(
+    const DesktopEntry& entry, std::string package, float anchorX, float anchorY
+) {
+  WaylandConnection* wl = PanelManager::instance().wayland();
+  RenderContext* rc = PanelManager::instance().renderContext();
+  if (wl == nullptr || rc == nullptr) {
+    return;
+  }
+  const auto parentCtx = PanelManager::instance().fallbackPopupParentContext();
+  if (!parentCtx.has_value()) {
+    return;
+  }
+
+  if (m_confirmMenu == nullptr) {
+    m_confirmMenu = std::make_unique<ContextMenuPopup>(*wl, *rc);
+  }
+  if (m_config != nullptr) {
+    m_confirmMenu->setShadowConfig(m_config->config().shell.shadow);
+  }
+
+  constexpr std::int32_t kConfirmCancel = 1;
+  constexpr std::int32_t kConfirmUninstall = 2;
+
+  std::vector<ContextMenuControlEntry> entries;
+  entries.push_back(
+      ContextMenuControlEntry{
+          .id = kConfirmCancel,
+          .label = i18n::tr("launcher.context-menu.uninstall-cancel"),
+          .enabled = true,
+          .separator = false,
+          .hasSubmenu = false,
+      }
+  );
+  entries.push_back(
+      ContextMenuControlEntry{
+          .id = kConfirmUninstall,
+          .label = i18n::tr("launcher.context-menu.uninstall-confirm") + " " + package,
+          .enabled = true,
+          .separator = false,
+          .hasSubmenu = false,
+      }
+  );
+
+  PanelManager::instance().beginAttachedPopup(parentCtx->surface);
+  PanelManager::instance().setActivePopup(m_confirmMenu.get());
+
+  m_confirmMenu->setOnDismissed([parentSurface = parentCtx->surface]() {
+    PanelManager::instance().clearActivePopup();
+    PanelManager::instance().endAttachedPopup(parentSurface);
+  });
+
+  m_confirmMenu->setOnActivate([this, entry, package = std::move(package)](const ContextMenuControlEntry& item) {
+    m_confirmMenu->close();
+    PanelManager::instance().clearActivePopup();
+    if (item.id == kConfirmUninstall) {
+      runUninstall(entry, package);
+    }
+  });
+
+  const float scale = contentScale();
+  const float inset = std::round(std::max(4.0f, Style::spaceXs * scale));
+  const auto ax = static_cast<std::int32_t>(std::round(anchorX - inset));
+  const auto ay = static_cast<std::int32_t>(std::round(anchorY - inset));
+  const auto aw = static_cast<std::int32_t>(std::round(inset * 2.0f));
+  const auto ah = static_cast<std::int32_t>(std::round(inset * 2.0f));
+
+  m_confirmMenu->open(
+      ContextMenuPopupRequest{
+          .entries = std::move(entries),
+          .minMenuWidth = 260.0f * scale,
+          .maxMenuWidth = Style::menuAutoMaxWidth * scale,
+          .maxVisible = 12,
+          .anchor =
+              PopupAnchorRect{
+                  .x = ax,
+                  .y = ay,
+                  .width = std::max(1, aw),
+                  .height = std::max(1, ah),
+              },
+          .parent = PopupSurfaceParent{
+              .layerSurface = parentCtx->layerSurface,
+              .output = parentCtx->output,
+          },
+      }
+  );
+}
+
+void LauncherPanel::runUninstall(const DesktopEntry& entry, std::string package) {
+  // Arch-only, asynchronous, with the user already confirmed.
+  const bool spawned = process::runAsync(
+      {"pkexec", "pacman", "-Rns", package},
+      process::RunCallbacks{
+          .stdOut = nullptr,
+          .stdErr = nullptr,
+          .onExit = [this, package](process::RunResult result) {
+            DeferredCall::callLater([this, package, exitCode = result.exitCode, err = result.err]() {
+              // 126/127 = polkit prompt dismissed/cancelled — silent no-op.
+              if (exitCode == 126 || exitCode == 127) {
+                return;
+              }
+              if (exitCode == 0) {
+                notify::info("Noctalia", i18n::tr("launcher.context-menu.uninstall-done"), package);
+              } else {
+                notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), err);
+              }
+              // Whatever happened, re-scan: files may have changed either way.
+              reapplyCurrentQuery();
+            });
+          },
+      }
+  );
+  if (!spawned) {
+    notify::error("Noctalia", i18n::tr("launcher.context-menu.uninstall-failed"), "pkexec spawn failed");
+  }
 }
 
 void LauncherPanel::activateAt(std::size_t index) {

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1632,7 +1632,8 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     uninstallLabel = i18n::tr("launcher.context-menu.uninstall");
     break;
   case AppSourceBackend::Aur:
-    uninstallLabel = i18n::tr("launcher.context-menu.uninstall") + i18n::tr("launcher.context-menu.uninstall-aur-suffix");
+    uninstallLabel =
+        i18n::tr("launcher.context-menu.uninstall") + i18n::tr("launcher.context-menu.uninstall-aur-suffix");
     break;
   case AppSourceBackend::Flatpak:
     uninstallLabel =
@@ -1725,8 +1726,8 @@ void LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     PanelManager::instance().endAttachedPopup(parentSurface);
   });
 
-  m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
-                                entryForPin = *match, source, anchorX, anchorY](const ContextMenuControlEntry& entry) {
+  m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy), entryForPin = *match, source, anchorX,
+                                anchorY](const ContextMenuControlEntry& entry) {
     LauncherResult result = base;
     result.desktopActionId.clear();
     if (entry.id == kActionPinToDock) {
@@ -1838,8 +1839,7 @@ void LauncherPanel::openUninstallConfirmMenu(
 
   // Custom entries (no backend owns them) and unmanaged AppImages get "Remove
   // launcher" copy instead of "Uninstall" — see resolveAppSource.
-  const bool isRemoveLauncher =
-      source.backend == AppSourceBackend::Custom
+  const bool isRemoveLauncher = source.backend == AppSourceBackend::Custom
       || (source.backend == AppSourceBackend::AppImage && !source.shellyManaged);
 
   std::string confirmLabel;
@@ -1920,61 +1920,73 @@ void LauncherPanel::openUninstallConfirmMenu(
 
 namespace {
 
-// Backend-specific shell command to run inside the interactive terminal.
-// `||` fallbacks let the shell handle "shelly missing/backend missing"
-// without a separate C++ branch — see PLAN-SHELLY.md §2.
-[[nodiscard]] std::string
-buildUninstallCommand(const DesktopEntry& entry, const AppSource& source, const std::string& escalator) {
-  switch (source.backend) {
-  case AppSourceBackend::Standard:
-    return escalator + " shelly remove standard " + StringUtils::shellQuote(source.identifier) + " || " + escalator +
-        " pacman -Rns " + StringUtils::shellQuote(source.identifier);
+  // Backend-specific shell command to run inside the interactive terminal.
+  // `||` fallbacks let the shell handle "shelly missing/backend missing"
+  // without a separate C++ branch — see PLAN-SHELLY.md §2.
+  [[nodiscard]] std::string
+  buildUninstallCommand(const DesktopEntry& entry, const AppSource& source, const std::string& escalator) {
+    switch (source.backend) {
+    case AppSourceBackend::Standard:
+      return escalator
+          + " shelly remove standard "
+          + StringUtils::shellQuote(source.identifier)
+          + " || "
+          + escalator
+          + " pacman -Rns "
+          + StringUtils::shellQuote(source.identifier);
 
-  case AppSourceBackend::Aur:
-    return escalator + " shelly remove aur " + StringUtils::shellQuote(source.identifier) +
-        " || echo 'shelly is required to remove AUR packages; install it or run: pacman -Rns " +
-        StringUtils::shellQuote(source.identifier) + " (may leave AUR bookkeeping stale)'";
+    case AppSourceBackend::Aur:
+      return escalator
+          + " shelly remove aur "
+          + StringUtils::shellQuote(source.identifier)
+          + " || echo 'shelly is required to remove AUR packages; install it or run: pacman -Rns "
+          + StringUtils::shellQuote(source.identifier)
+          + " (may leave AUR bookkeeping stale)'";
 
-  case AppSourceBackend::Flatpak:
-    return escalator + " shelly remove flatpak " + StringUtils::shellQuote(source.identifier) +
-        " || flatpak uninstall -y --app " + StringUtils::shellQuote(source.identifier);
+    case AppSourceBackend::Flatpak:
+      return escalator
+          + " shelly remove flatpak "
+          + StringUtils::shellQuote(source.identifier)
+          + " || flatpak uninstall -y --app "
+          + StringUtils::shellQuote(source.identifier);
 
-  case AppSourceBackend::AppImage:
-    if (source.shellyManaged) {
-      return escalator + " shelly remove appimage " + StringUtils::shellQuote(source.identifier);
+    case AppSourceBackend::AppImage:
+      if (source.shellyManaged) {
+        return escalator + " shelly remove appimage " + StringUtils::shellQuote(source.identifier);
+      }
+      return "printf 'This AppImage is not managed by Shelly.\\n'; "
+             "rm -f "
+          + StringUtils::shellQuote(entry.path)
+          + "; "
+            "printf 'Removed launcher entry.\\n'; "
+            "read -n 1 -s -r -p 'Also delete the AppImage file itself? [y/N] ' ans; echo; "
+            "if [ \"$ans\" = 'y' ] || [ \"$ans\" = 'Y' ]; then rm -f "
+          + StringUtils::shellQuote(source.identifier)
+          + "; printf 'Deleted AppImage.\\n'; fi";
+
+    case AppSourceBackend::Custom:
+      return {};
     }
-    return "printf 'This AppImage is not managed by Shelly.\\n'; "
-           "rm -f " +
-        StringUtils::shellQuote(entry.path) +
-        "; "
-        "printf 'Removed launcher entry.\\n'; "
-        "read -n 1 -s -r -p 'Also delete the AppImage file itself? [y/N] ' ans; echo; "
-        "if [ \"$ans\" = 'y' ] || [ \"$ans\" = 'Y' ]; then rm -f " +
-        StringUtils::shellQuote(source.identifier) + "; printf 'Deleted AppImage.\\n'; fi";
-
-  case AppSourceBackend::Custom:
     return {};
   }
-  return {};
-}
 
-// Cheap backend-specific check for whether the uninstall actually took.
-[[nodiscard]] bool verifyRemoved(const DesktopEntry& entry, const AppSource& source) {
-  switch (source.backend) {
-  case AppSourceBackend::Standard:
-  case AppSourceBackend::Aur:
-    return process::runSync({"pacman", "-Q", source.identifier}).exitCode != 0;
-  case AppSourceBackend::Flatpak:
-    return process::runSync({"flatpak", "info", source.identifier}).exitCode != 0;
-  case AppSourceBackend::AppImage:
-    return !std::filesystem::exists(entry.path);
-  case AppSourceBackend::Custom:
-    return !std::filesystem::exists(entry.path);
+  // Cheap backend-specific check for whether the uninstall actually took.
+  [[nodiscard]] bool verifyRemoved(const DesktopEntry& entry, const AppSource& source) {
+    switch (source.backend) {
+    case AppSourceBackend::Standard:
+    case AppSourceBackend::Aur:
+      return process::runSync({"pacman", "-Q", source.identifier}).exitCode != 0;
+    case AppSourceBackend::Flatpak:
+      return process::runSync({"flatpak", "info", source.identifier}).exitCode != 0;
+    case AppSourceBackend::AppImage:
+      return !std::filesystem::exists(entry.path);
+    case AppSourceBackend::Custom:
+      return !std::filesystem::exists(entry.path);
+    }
+    return false;
   }
-  return false;
-}
 
-}  // namespace
+} // namespace
 
 void LauncherPanel::runUninstall(const DesktopEntry& entry, const AppSource& source) {
   // pacman/shelly need a real TTY for "these packages will also be removed" cascades and

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -3,6 +3,7 @@
 #include "launcher/launcher_provider.h"
 #include "launcher/usage_tracker.h"
 #include "shell/panel/panel.h"
+#include "system/desktop_entry_override.h"
 #include "system/icon_resolver.h"
 #include "ui/signal.h"
 
@@ -90,8 +91,9 @@ private:
   void finishActivation(LauncherProvider& provider, const std::string& resultId, bool copied);
   [[nodiscard]] std::vector<LauncherResult> providerOverviewResults(std::string_view text) const;
   void openAppActionsMenu(std::size_t index, float anchorX, float anchorY);
-  void openUninstallConfirmMenu(const DesktopEntry& entry, std::string package, float anchorX, float anchorY);
-  void runUninstall(const DesktopEntry& entry, std::string package);
+  void openUninstallConfirmMenu(const DesktopEntry& entry, AppSource source, float anchorX, float anchorY);
+  void runUninstall(const DesktopEntry& entry, const AppSource& source);
+  void runRemoveLauncherFile(const DesktopEntry& entry);
   void rebuildCategoryFilter(const std::vector<LauncherCategory>& categories);
   void setCategoryFilterVisible(bool visible);
   void setActiveCategorySlot(std::size_t slotIndex);

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -24,6 +24,7 @@ class ScrollView;
 class VirtualGridView;
 class ConfigService;
 class AsyncTextureCache;
+struct DesktopEntry;
 
 class LauncherPanel : public Panel {
 public:
@@ -89,6 +90,8 @@ private:
   void finishActivation(LauncherProvider& provider, const std::string& resultId, bool copied);
   [[nodiscard]] std::vector<LauncherResult> providerOverviewResults(std::string_view text) const;
   void openAppActionsMenu(std::size_t index, float anchorX, float anchorY);
+  void openUninstallConfirmMenu(const DesktopEntry& entry, std::string package, float anchorX, float anchorY);
+  void runUninstall(const DesktopEntry& entry, std::string package);
   void rebuildCategoryFilter(const std::vector<LauncherCategory>& categories);
   void setCategoryFilterVisible(bool visible);
   void setActiveCategorySlot(std::size_t slotIndex);
@@ -137,6 +140,7 @@ private:
   ConfigService* m_config = nullptr;
   AsyncTextureCache* m_asyncTextures = nullptr;
   std::unique_ptr<ContextMenuPopup> m_actionsMenu;
+  std::unique_ptr<ContextMenuPopup> m_confirmMenu;
   Signal<>::ScopedConnection m_appIconColorizeConn;
   std::function<void()> m_onCopiedActivation;
 };

--- a/src/system/desktop_entry_override.cpp
+++ b/src/system/desktop_entry_override.cpp
@@ -1,0 +1,187 @@
+#include "system/desktop_entry_override.h"
+
+#include "core/log.h"
+#include "core/process/process.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Resolve $XDG_DATA_HOME/applications with the standard fallback to
+// ~/.local/share/applications. Mirrors the XDG logic in desktop_entry.cpp.
+[[nodiscard]] fs::path userApplicationsDir() {
+  const char* xdgDataHome = std::getenv("XDG_DATA_HOME");
+  if (xdgDataHome != nullptr && xdgDataHome[0] != '\0') {
+    return fs::path(xdgDataHome) / "applications";
+  }
+  const char* home = std::getenv("HOME");
+  if (home != nullptr && home[0] != '\0') {
+    return fs::path(home) / ".local" / "share" / "applications";
+  }
+  return fs::path("/tmp") / "applications";
+}
+
+[[nodiscard]] bool isUserLevelEntry(const DesktopEntry& entry) {
+  std::error_code ec;
+  const fs::path userDir = fs::weakly_canonical(userApplicationsDir(), ec);
+  const fs::path entryDir = fs::weakly_canonical(fs::path(entry.path).parent_path(), ec);
+  return !ec && entryDir == userDir;
+}
+
+// Rewrite `text` so the NoDisplay= line reflects `hidden`. If the key is
+// absent, insert it right after the [Desktop Entry] header.
+[[nodiscard]] std::string rewriteNoDisplay(std::string text, bool hidden) {
+  const std::string target = hidden ? "NoDisplay=true" : "NoDisplay=false";
+
+  std::size_t pos = 0;
+  while (pos < text.size()) {
+    const std::size_t lineStart = pos;
+    const std::size_t lineEnd = text.find('\n', pos);
+    const std::size_t lineLen = (lineEnd == std::string::npos) ? text.size() - pos : lineEnd - pos;
+    const std::string line = text.substr(lineStart, lineLen);
+
+    if (line.rfind("NoDisplay=", 0) == 0) {
+      // Flip the existing key, preserving the line terminator.
+      text.replace(lineStart, lineLen, target);
+      return text;
+    }
+    if (lineEnd == std::string::npos) {
+      break;
+    }
+    pos = lineEnd + 1;
+  }
+
+  // Key absent — insert after the [Desktop Entry] header.
+  const std::string header = "[Desktop Entry]";
+  const std::size_t headerPos = text.find(header);
+  if (headerPos != std::string::npos) {
+    const std::size_t insertPos = headerPos + header.size();
+    text.insert(insertPos, "\n" + target);
+  } else {
+    text = target + "\n" + text;
+  }
+  return text;
+}
+
+[[nodiscard]] bool writeFileAtomic(const fs::path& path, const std::string& content, std::string* err) {
+  std::error_code ec;
+  fs::create_directories(path.parent_path(), ec);
+  if (ec) {
+    if (err != nullptr) {
+      *err = "cannot create directory " + path.parent_path().string() + ": " + ec.message();
+    }
+    return false;
+  }
+
+  const fs::path tmp = path.string() + ".noctalia.tmp";
+  {
+    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      if (err != nullptr) {
+        *err = "cannot write " + tmp.string();
+      }
+      return false;
+    }
+    out << content;
+    out.flush();
+    if (!out) {
+      if (err != nullptr) {
+        *err = "failed writing " + tmp.string();
+      }
+      return false;
+    }
+  }
+
+  fs::rename(tmp, path, ec);
+  if (ec) {
+    fs::remove(tmp, ec);
+    if (err != nullptr) {
+      *err = "cannot replace " + path.string() + ": " + ec.message();
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* err) {
+  try {
+    if (entry.path.empty()) {
+      if (err != nullptr) {
+        *err = "desktop entry has no path";
+      }
+      return false;
+    }
+
+    fs::path target = entry.path;
+    if (!isUserLevelEntry(entry)) {
+      // System entry — create/reuse a user-level override with the same name.
+      target = userApplicationsDir() / fs::path(entry.path).filename();
+    }
+
+    std::error_code ec;
+    std::string content;
+    if (fs::exists(target, ec)) {
+      std::ifstream in(target, std::ios::binary);
+      if (!in) {
+        if (err != nullptr) {
+          *err = "cannot read " + target.string();
+        }
+        return false;
+      }
+      content.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+      if (content.empty() || content.rfind("[Desktop Entry]", 0) != 0) {
+        // Override file exists but isn't a plain desktop file (or is a stub
+        // that inherits via merge). Replace it with a full copy of the system
+        // file so the override is complete, then flip NoDisplay below.
+        std::ifstream sys(entry.path, std::ios::binary);
+        if (sys) {
+          content.assign(std::istreambuf_iterator<char>(sys), std::istreambuf_iterator<char>());
+        }
+      }
+    } else {
+      // No override yet — seed from the system file so Exec/Icon survive.
+      std::ifstream sys(entry.path, std::ios::binary);
+      if (sys) {
+        content.assign(std::istreambuf_iterator<char>(sys), std::istreambuf_iterator<char>());
+      }
+    }
+
+    const std::string rewritten = rewriteNoDisplay(content, hidden);
+    return writeFileAtomic(target, rewritten, err);
+  } catch (const std::exception& ex) {
+    if (err != nullptr) {
+      *err = ex.what();
+    }
+    return false;
+  }
+}
+
+std::optional<std::string> resolveOwningPackage(std::string_view desktopFilePath) {
+  if (desktopFilePath.empty()) {
+    return std::nullopt;
+  }
+  const process::RunResult result = process::runSync({"pacman", "-Qo", std::string(desktopFilePath)});
+  if (result.exitCode != 0) {
+    return std::nullopt;
+  }
+  // Output: "/path/to/file.desktop is owned by <pkgname> <version>"
+  const std::string& out = result.out;
+  constexpr std::string_view kMarker = "is owned by ";
+  const std::size_t marker = out.find(kMarker);
+  if (marker == std::string::npos) {
+    return std::nullopt;
+  }
+  const std::size_t nameStart = marker + kMarker.size();
+  const std::size_t nameEnd = out.find_first_of(" \t\n", nameStart);
+  if (nameStart >= out.size() || nameEnd == std::string::npos || nameEnd <= nameStart) {
+    return std::nullopt;
+  }
+  return out.substr(nameStart, nameEnd - nameStart);
+}

--- a/src/system/desktop_entry_override.cpp
+++ b/src/system/desktop_entry_override.cpp
@@ -3,12 +3,11 @@
 #include "core/log.h"
 #include "core/process/process.h"
 
-#include <nlohmann/json.hpp>
-
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <string_view>
 #include <system_error>
 
@@ -16,155 +15,155 @@ namespace fs = std::filesystem;
 
 namespace {
 
-// Resolve $XDG_DATA_HOME/applications with the standard fallback to
-// ~/.local/share/applications. Mirrors the XDG logic in desktop_entry.cpp.
-[[nodiscard]] fs::path userApplicationsDir() {
-  const char* xdgDataHome = std::getenv("XDG_DATA_HOME");
-  if (xdgDataHome != nullptr && xdgDataHome[0] != '\0') {
-    return fs::path(xdgDataHome) / "applications";
-  }
-  const char* home = std::getenv("HOME");
-  if (home != nullptr && home[0] != '\0') {
-    return fs::path(home) / ".local" / "share" / "applications";
-  }
-  return fs::path("/tmp") / "applications";
-}
-
-[[nodiscard]] bool isUserLevelEntry(const DesktopEntry& entry) {
-  std::error_code ec;
-  const fs::path userDir = fs::weakly_canonical(userApplicationsDir(), ec);
-  const fs::path entryDir = fs::weakly_canonical(fs::path(entry.path).parent_path(), ec);
-  return !ec && entryDir == userDir;
-}
-
-// Rewrite `text` so the NoDisplay= line reflects `hidden`. If the key is
-// absent, insert it right after the [Desktop Entry] header.
-[[nodiscard]] std::string rewriteNoDisplay(std::string text, bool hidden) {
-  const std::string target = hidden ? "NoDisplay=true" : "NoDisplay=false";
-
-  std::size_t pos = 0;
-  while (pos < text.size()) {
-    const std::size_t lineStart = pos;
-    const std::size_t lineEnd = text.find('\n', pos);
-    const std::size_t lineLen = (lineEnd == std::string::npos) ? text.size() - pos : lineEnd - pos;
-    const std::string line = text.substr(lineStart, lineLen);
-
-    if (line.rfind("NoDisplay=", 0) == 0) {
-      // Flip the existing key, preserving the line terminator.
-      text.replace(lineStart, lineLen, target);
-      return text;
+  // Resolve $XDG_DATA_HOME/applications with the standard fallback to
+  // ~/.local/share/applications. Mirrors the XDG logic in desktop_entry.cpp.
+  [[nodiscard]] fs::path userApplicationsDir() {
+    const char* xdgDataHome = std::getenv("XDG_DATA_HOME");
+    if (xdgDataHome != nullptr && xdgDataHome[0] != '\0') {
+      return fs::path(xdgDataHome) / "applications";
     }
-    if (lineEnd == std::string::npos) {
-      break;
+    const char* home = std::getenv("HOME");
+    if (home != nullptr && home[0] != '\0') {
+      return fs::path(home) / ".local" / "share" / "applications";
     }
-    pos = lineEnd + 1;
+    return fs::path("/tmp") / "applications";
   }
 
-  // Key absent — insert after the [Desktop Entry] header.
-  const std::string header = "[Desktop Entry]";
-  const std::size_t headerPos = text.find(header);
-  if (headerPos != std::string::npos) {
-    const std::size_t insertPos = headerPos + header.size();
-    text.insert(insertPos, "\n" + target);
-  } else {
-    text = target + "\n" + text;
+  [[nodiscard]] bool isUserLevelEntry(const DesktopEntry& entry) {
+    std::error_code ec;
+    const fs::path userDir = fs::weakly_canonical(userApplicationsDir(), ec);
+    const fs::path entryDir = fs::weakly_canonical(fs::path(entry.path).parent_path(), ec);
+    return !ec && entryDir == userDir;
   }
-  return text;
-}
 
-[[nodiscard]] bool writeFileAtomic(const fs::path& path, const std::string& content, std::string* err) {
-  std::error_code ec;
-  fs::create_directories(path.parent_path(), ec);
-  if (ec) {
-    if (err != nullptr) {
-      *err = "cannot create directory " + path.parent_path().string() + ": " + ec.message();
+  // Rewrite `text` so the NoDisplay= line reflects `hidden`. If the key is
+  // absent, insert it right after the [Desktop Entry] header.
+  [[nodiscard]] std::string rewriteNoDisplay(std::string text, bool hidden) {
+    const std::string target = hidden ? "NoDisplay=true" : "NoDisplay=false";
+
+    std::size_t pos = 0;
+    while (pos < text.size()) {
+      const std::size_t lineStart = pos;
+      const std::size_t lineEnd = text.find('\n', pos);
+      const std::size_t lineLen = (lineEnd == std::string::npos) ? text.size() - pos : lineEnd - pos;
+      const std::string line = text.substr(lineStart, lineLen);
+
+      if (line.rfind("NoDisplay=", 0) == 0) {
+        // Flip the existing key, preserving the line terminator.
+        text.replace(lineStart, lineLen, target);
+        return text;
+      }
+      if (lineEnd == std::string::npos) {
+        break;
+      }
+      pos = lineEnd + 1;
     }
-    return false;
+
+    // Key absent — insert after the [Desktop Entry] header.
+    const std::string header = "[Desktop Entry]";
+    const std::size_t headerPos = text.find(header);
+    if (headerPos != std::string::npos) {
+      const std::size_t insertPos = headerPos + header.size();
+      text.insert(insertPos, "\n" + target);
+    } else {
+      text = target + "\n" + text;
+    }
+    return text;
   }
 
-  const fs::path tmp = path.string() + ".noctalia.tmp";
-  {
-    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
-    if (!out) {
+  [[nodiscard]] bool writeFileAtomic(const fs::path& path, const std::string& content, std::string* err) {
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    if (ec) {
       if (err != nullptr) {
-        *err = "cannot write " + tmp.string();
+        *err = "cannot create directory " + path.parent_path().string() + ": " + ec.message();
       }
       return false;
     }
-    out << content;
-    out.flush();
-    if (!out) {
+
+    const fs::path tmp = path.string() + ".noctalia.tmp";
+    {
+      std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+      if (!out) {
+        if (err != nullptr) {
+          *err = "cannot write " + tmp.string();
+        }
+        return false;
+      }
+      out << content;
+      out.flush();
+      if (!out) {
+        if (err != nullptr) {
+          *err = "failed writing " + tmp.string();
+        }
+        return false;
+      }
+    }
+
+    fs::rename(tmp, path, ec);
+    if (ec) {
+      fs::remove(tmp, ec);
       if (err != nullptr) {
-        *err = "failed writing " + tmp.string();
+        *err = "cannot replace " + path.string() + ": " + ec.message();
       }
       return false;
     }
+    return true;
   }
 
-  fs::rename(tmp, path, ec);
-  if (ec) {
-    fs::remove(tmp, ec);
-    if (err != nullptr) {
-      *err = "cannot replace " + path.string() + ": " + ec.message();
+  // Scan `path` for a top-level "key=value" line (no section awareness needed —
+  // these are freedesktop custom keys, unlikely to collide across sections).
+  [[nodiscard]] std::optional<std::string> readDesktopKey(std::string_view path, std::string_view key) {
+    std::ifstream in(std::string(path), std::ios::binary);
+    if (!in) {
+      return std::nullopt;
     }
-    return false;
-  }
-  return true;
-}
-
-// Scan `path` for a top-level "key=value" line (no section awareness needed —
-// these are freedesktop custom keys, unlikely to collide across sections).
-[[nodiscard]] std::optional<std::string> readDesktopKey(std::string_view path, std::string_view key) {
-  std::ifstream in(std::string(path), std::ios::binary);
-  if (!in) {
+    const std::string prefix = std::string(key) + "=";
+    std::string line;
+    while (std::getline(in, line)) {
+      if (line.rfind(prefix, 0) == 0) {
+        return line.substr(prefix.size());
+      }
+    }
     return std::nullopt;
   }
-  const std::string prefix = std::string(key) + "=";
-  std::string line;
-  while (std::getline(in, line)) {
-    if (line.rfind(prefix, 0) == 0) {
-      return line.substr(prefix.size());
-    }
+
+  [[nodiscard]] bool containsAppImagePath(std::string_view exec) {
+    const std::string lower = [&] {
+      std::string s(exec);
+      for (char& c : s) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+      }
+      return s;
+    }();
+    return lower.find(".appimage") != std::string::npos;
   }
-  return std::nullopt;
-}
 
-[[nodiscard]] bool containsAppImagePath(std::string_view exec) {
-  const std::string lower = [&] {
-    std::string s(exec);
-    for (char& c : s) {
-      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  // Pull the whitespace-delimited Exec/TryExec token that ends in .AppImage,
+  // stripping surrounding quotes.
+  [[nodiscard]] std::string extractAppImagePath(std::string_view exec) {
+    std::size_t pos = 0;
+    while (pos < exec.size()) {
+      std::size_t end = exec.find(' ', pos);
+      if (end == std::string_view::npos) {
+        end = exec.size();
+      }
+      std::string_view token = exec.substr(pos, end - pos);
+      if (!token.empty() && (token.front() == '"' || token.front() == '\'')) {
+        token.remove_prefix(1);
+      }
+      if (!token.empty() && (token.back() == '"' || token.back() == '\'')) {
+        token.remove_suffix(1);
+      }
+      if (containsAppImagePath(token)) {
+        return std::string(token);
+      }
+      pos = end + 1;
     }
-    return s;
-  }();
-  return lower.find(".appimage") != std::string::npos;
-}
-
-// Pull the whitespace-delimited Exec/TryExec token that ends in .AppImage,
-// stripping surrounding quotes.
-[[nodiscard]] std::string extractAppImagePath(std::string_view exec) {
-  std::size_t pos = 0;
-  while (pos < exec.size()) {
-    std::size_t end = exec.find(' ', pos);
-    if (end == std::string_view::npos) {
-      end = exec.size();
-    }
-    std::string_view token = exec.substr(pos, end - pos);
-    if (!token.empty() && (token.front() == '"' || token.front() == '\'')) {
-      token.remove_prefix(1);
-    }
-    if (!token.empty() && (token.back() == '"' || token.back() == '\'')) {
-      token.remove_suffix(1);
-    }
-    if (containsAppImagePath(token)) {
-      return std::string(token);
-    }
-    pos = end + 1;
+    return {};
   }
-  return {};
-}
 
-}  // namespace
+} // namespace
 
 bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* err) {
   try {
@@ -275,7 +274,8 @@ AppSource resolveAppSource(const DesktopEntry& entry) {
     return {AppSourceBackend::Flatpak, *appid, false};
   }
 
-  if (readDesktopKey(entry.path, "X-AppImage-Name") || readDesktopKey(entry.path, "X-AppImage-Version")
+  if (readDesktopKey(entry.path, "X-AppImage-Name")
+      || readDesktopKey(entry.path, "X-AppImage-Version")
       || containsAppImagePath(entry.exec)) {
     std::string appImagePath = extractAppImagePath(entry.exec);
     const bool managed = shellyListsAppImage(appImagePath);

--- a/src/system/desktop_entry_override.cpp
+++ b/src/system/desktop_entry_override.cpp
@@ -3,9 +3,13 @@
 #include "core/log.h"
 #include "core/process/process.h"
 
+#include <nlohmann/json.hpp>
+
+#include <cctype>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <string_view>
 #include <system_error>
 
 namespace fs = std::filesystem;
@@ -108,6 +112,58 @@ namespace {
   return true;
 }
 
+// Scan `path` for a top-level "key=value" line (no section awareness needed —
+// these are freedesktop custom keys, unlikely to collide across sections).
+[[nodiscard]] std::optional<std::string> readDesktopKey(std::string_view path, std::string_view key) {
+  std::ifstream in(std::string(path), std::ios::binary);
+  if (!in) {
+    return std::nullopt;
+  }
+  const std::string prefix = std::string(key) + "=";
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.rfind(prefix, 0) == 0) {
+      return line.substr(prefix.size());
+    }
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] bool containsAppImagePath(std::string_view exec) {
+  const std::string lower = [&] {
+    std::string s(exec);
+    for (char& c : s) {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return s;
+  }();
+  return lower.find(".appimage") != std::string::npos;
+}
+
+// Pull the whitespace-delimited Exec/TryExec token that ends in .AppImage,
+// stripping surrounding quotes.
+[[nodiscard]] std::string extractAppImagePath(std::string_view exec) {
+  std::size_t pos = 0;
+  while (pos < exec.size()) {
+    std::size_t end = exec.find(' ', pos);
+    if (end == std::string_view::npos) {
+      end = exec.size();
+    }
+    std::string_view token = exec.substr(pos, end - pos);
+    if (!token.empty() && (token.front() == '"' || token.front() == '\'')) {
+      token.remove_prefix(1);
+    }
+    if (!token.empty() && (token.back() == '"' || token.back() == '\'')) {
+      token.remove_suffix(1);
+    }
+    if (containsAppImagePath(token)) {
+      return std::string(token);
+    }
+    pos = end + 1;
+  }
+  return {};
+}
+
 }  // namespace
 
 bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* err) {
@@ -184,4 +240,52 @@ std::optional<std::string> resolveOwningPackage(std::string_view desktopFilePath
     return std::nullopt;
   }
   return out.substr(nameStart, nameEnd - nameStart);
+}
+
+bool shellyListsAppImage(const std::string& appImagePath) {
+  if (appImagePath.empty()) {
+    return false;
+  }
+  const process::RunResult result = process::runSync({"shelly", "list", "appimage", "-j"});
+  if (result.exitCode != 0 || result.out.empty()) {
+    return false;
+  }
+  std::error_code ec;
+  const std::string resolved = fs::weakly_canonical(appImagePath, ec).string();
+  const std::string& target = ec ? appImagePath : resolved;
+  try {
+    const auto entries = nlohmann::json::parse(result.out);
+    if (!entries.is_array()) {
+      return false;
+    }
+    for (const auto& item : entries) {
+      const auto path = item.find("Path");
+      if (path != item.end() && path->is_string() && path->get<std::string>() == target) {
+        return true;
+      }
+    }
+  } catch (const nlohmann::json::exception&) {
+    return false;
+  }
+  return false;
+}
+
+AppSource resolveAppSource(const DesktopEntry& entry) {
+  if (auto appid = readDesktopKey(entry.path, "X-Flatpak")) {
+    return {AppSourceBackend::Flatpak, *appid, false};
+  }
+
+  if (readDesktopKey(entry.path, "X-AppImage-Name") || readDesktopKey(entry.path, "X-AppImage-Version")
+      || containsAppImagePath(entry.exec)) {
+    std::string appImagePath = extractAppImagePath(entry.exec);
+    const bool managed = shellyListsAppImage(appImagePath);
+    return {AppSourceBackend::AppImage, std::move(appImagePath), managed};
+  }
+
+  if (auto pkg = resolveOwningPackage(entry.path)) {
+    const bool foreign = process::runSync({"pacman", "-Qm", *pkg}).exitCode == 0;
+    return {foreign ? AppSourceBackend::Aur : AppSourceBackend::Standard, *pkg, false};
+  }
+
+  return {AppSourceBackend::Custom, {}, false};
 }

--- a/src/system/desktop_entry_override.cpp
+++ b/src/system/desktop_entry_override.cpp
@@ -48,7 +48,7 @@ namespace {
       const std::size_t lineLen = (lineEnd == std::string::npos) ? text.size() - pos : lineEnd - pos;
       const std::string line = text.substr(lineStart, lineLen);
 
-      if (line.rfind("NoDisplay=", 0) == 0) {
+      if (line.starts_with("NoDisplay=")) {
         // Flip the existing key, preserving the line terminator.
         text.replace(lineStart, lineLen, target);
         return text;
@@ -121,7 +121,7 @@ namespace {
     const std::string prefix = std::string(key) + "=";
     std::string line;
     while (std::getline(in, line)) {
-      if (line.rfind(prefix, 0) == 0) {
+      if (line.starts_with(prefix)) {
         return line.substr(prefix.size());
       }
     }
@@ -136,7 +136,7 @@ namespace {
       }
       return s;
     }();
-    return lower.find(".appimage") != std::string::npos;
+    return lower.contains(".appimage");
   }
 
   // Pull the whitespace-delimited Exec/TryExec token that ends in .AppImage,
@@ -191,7 +191,7 @@ bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* 
         return false;
       }
       content.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
-      if (content.empty() || content.rfind("[Desktop Entry]", 0) != 0) {
+      if (content.empty() || !content.starts_with("[Desktop Entry]")) {
         // Override file exists but isn't a plain desktop file (or is a stub
         // that inherits via merge). Replace it with a full copy of the system
         // file so the override is complete, then flip NoDisplay below.

--- a/src/system/desktop_entry_override.h
+++ b/src/system/desktop_entry_override.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "system/desktop_entry.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+// Toggle the freedesktop NoDisplay= key for a desktop entry.
+//
+// - Entries already living under $XDG_DATA_HOME/applications (user-level) are
+//   edited in place.
+// - Entries from any other directory (system dirs like /usr/share/applications)
+//   get a user-level override file: a full copy of the system file with
+//   NoDisplay flipped, written atomically. The override shadows the system file
+//   entirely (no .desktop merge), so a full copy preserves Icon/Exec/etc.
+//
+// Returns true on success. On failure the caller may surface err.
+bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* err = nullptr);
+
+// Resolve the pacman package that owns a .desktop file (Arch-only).
+//
+// Runs `pacman -Qo <path>`. Returns std::nullopt when pacman is missing, the
+// path is not owned by any package, or the query fails — which also covers
+// non-Arch systems, AppImages, Steam shortcuts and hand-made launchers.
+std::optional<std::string> resolveOwningPackage(std::string_view desktopFilePath);

--- a/src/system/desktop_entry_override.h
+++ b/src/system/desktop_entry_override.h
@@ -24,3 +24,25 @@ bool setDesktopEntryHidden(const DesktopEntry& entry, bool hidden, std::string* 
 // path is not owned by any package, or the query fails — which also covers
 // non-Arch systems, AppImages, Steam shortcuts and hand-made launchers.
 std::optional<std::string> resolveOwningPackage(std::string_view desktopFilePath);
+
+// Which mechanism, if any, owns/installed an app behind a .desktop entry.
+enum class AppSourceBackend {
+  Standard,  // official-repo ALPM package
+  Aur,       // foreign (AUR/manually-built) ALPM package
+  Flatpak,   // X-Flatpak= key present
+  AppImage,  // X-AppImage-* key present, or Exec/TryExec targets a *.AppImage file
+  Custom,    // none of the above: hand-made .desktop, Steam shortcut, PWA shortcut, etc.
+};
+
+struct AppSource {
+  AppSourceBackend backend = AppSourceBackend::Custom;
+  std::string identifier;    // pkg name / flatpak appid / appimage path — backend-dependent
+  bool shellyManaged = false; // AppImage only: true iff `shelly list appimage` tracks this path
+};
+
+// Detect which backend (if any) owns the app behind this desktop entry.
+[[nodiscard]] AppSource resolveAppSource(const DesktopEntry& entry);
+
+// True iff `shelly list appimage -j` reports an entry whose Path matches
+// appImagePath. Returns false if shelly is missing or the query fails.
+[[nodiscard]] bool shellyListsAppImage(const std::string& appImagePath);

--- a/src/system/desktop_entry_override.h
+++ b/src/system/desktop_entry_override.h
@@ -27,16 +27,16 @@ std::optional<std::string> resolveOwningPackage(std::string_view desktopFilePath
 
 // Which mechanism, if any, owns/installed an app behind a .desktop entry.
 enum class AppSourceBackend {
-  Standard,  // official-repo ALPM package
-  Aur,       // foreign (AUR/manually-built) ALPM package
-  Flatpak,   // X-Flatpak= key present
-  AppImage,  // X-AppImage-* key present, or Exec/TryExec targets a *.AppImage file
-  Custom,    // none of the above: hand-made .desktop, Steam shortcut, PWA shortcut, etc.
+  Standard, // official-repo ALPM package
+  Aur,      // foreign (AUR/manually-built) ALPM package
+  Flatpak,  // X-Flatpak= key present
+  AppImage, // X-AppImage-* key present, or Exec/TryExec targets a *.AppImage file
+  Custom,   // none of the above: hand-made .desktop, Steam shortcut, PWA shortcut, etc.
 };
 
 struct AppSource {
   AppSourceBackend backend = AppSourceBackend::Custom;
-  std::string identifier;    // pkg name / flatpak appid / appimage path — backend-dependent
+  std::string identifier;     // pkg name / flatpak appid / appimage path — backend-dependent
   bool shellyManaged = false; // AppImage only: true iff `shelly list appimage` tracks this path
 };
 


### PR DESCRIPTION
## Summary

Adds a right-click context menu for apps in the launcher's Browse Apps view with three actions:

1. **Hide / Unhide** — toggles the freedesktop `NoDisplay=` key on the `.desktop` entry. System entries (`/usr/share/applications`) get a user-level override copy in `~/.local/share/applications` (full copy, atomic write), preserving `Exec`/`Icon`. Works on every distro — pure freedesktop standard.

2. **Uninstall** — runtime-detected, per-backend removal, Arch-focused but distro-safe:
   - **Standard/AUR**: `shelly remove standard|aur <pkg>` with `pacman -Rns` fallback
   - **Flatpak**: `shelly remove flatpak <id>` with `flatpak uninstall -y --app <id>` fallback
   - **AppImage**: `shelly remove appimage <path>` when shelly-managed
   - **Custom/unowned** (Steam shortcuts, PWAs, hand-made launchers): **Remove launcher** — plain `.desktop` unlink, no escalation
   
   Uninstall runs **interactively in a terminal** (via `terminal_launch::prepareCommand` + `resolvePrivilegeEscalator`) so pacman/shelly prompts — dependency-cascade confirmations, "breaks packages" warnings, polkit — are seen and answered by the user, never silently forced with `--noconfirm`.

3. **Post-action verification + list refresh** — backend-specific checks (`pacman -Q`, `flatpak info`, file existence) drive the toast, and the launcher re-gathers results unconditionally.

## Why this design

- No hard dependencies: pacman/shelly/flatpak presence is detected at runtime. On non-Arch distros the menu degrades gracefully to Hide + Remove launcher only.
- `resolveAppSource()` classifies each entry (X-Flatpak key, X-AppImage keys/Exec, pacman `-Qo`/`-Qm`) — see `src/system/desktop_entry_override.{h,cpp}`.
- The interactive-terminal pattern fixes real failures where non-interactive `pkexec pacman -Rns` stalls on cascade/break warnings.

## Files changed

- `src/system/desktop_entry_override.{h,cpp}` — new: `setDesktopEntryHidden()`, `resolveAppSource()`, `resolveOwningPackage()`, `shellyListsAppImage()`
- `src/shell/launcher/launcher_panel.{h,cpp}` — context menu entries, per-backend dispatch, confirm dialog, `runUninstall()`/`runRemoveLauncherFile()`
- `assets/translations/en.json` — new `launcher.context-menu.*` keys (en only, per contributing guide)
- `meson.build` — register new source file

## Checks

- `clang-format` clean, `clang-tidy` clean, `i18n-check.py` OK
- `meson test`: 66/66 pass
- Manually tested: Hide/Unhide, standard uninstall (avahi break-warning case), cascade confirmation, Flatpak backend, AppImage (shelly-managed), custom "Remove launcher"