### PR TITLE
feat(taskbar): launch new instance of pinned apps with Super+Left-Mouse-Click

### DIFF
--- a/src/render/scene/input_area.cpp
+++ b/src/render/scene/input_area.cpp
@@ -200,12 +200,12 @@ void InputArea::dispatchMotion(float localX, float localY) {
   }
 }
 
-void InputArea::dispatchPress(float localX, float localY, std::uint32_t button, bool isPressed) {
+void InputArea::dispatchPress(float localX, float localY, std::uint32_t button, bool isPressed, std::uint32_t modifiers) {
   if (isPressed) {
     m_pressed = true;
     m_pressedButton = button;
     if (m_onPress) {
-      m_onPress({.localX = localX, .localY = localY, .button = button, .pressed = true});
+      m_onPress({.localX = localX, .localY = localY, .button = button, .pressed = true, .modifiers = modifiers});
     }
   } else {
     const bool releasedInside = containsLocalPoint(localX, localY, true);
@@ -214,12 +214,12 @@ void InputArea::dispatchPress(float localX, float localY, std::uint32_t button, 
     m_pressedButton = 0;
 
     if (m_onPress) {
-      m_onPress({.localX = localX, .localY = localY, .button = button, .pressed = false});
+      m_onPress({.localX = localX, .localY = localY, .button = button, .pressed = false, .modifiers = modifiers});
     }
 
     // Click: release inside the same InputArea that received the press.
     if (shouldClick) {
-      m_onClick({.localX = localX, .localY = localY, .button = button, .pressed = false});
+      m_onClick({.localX = localX, .localY = localY, .button = button, .pressed = false, .modifiers = modifiers});
     }
   }
 }

--- a/src/render/scene/input_area.cpp
+++ b/src/render/scene/input_area.cpp
@@ -200,7 +200,9 @@ void InputArea::dispatchMotion(float localX, float localY) {
   }
 }
 
-void InputArea::dispatchPress(float localX, float localY, std::uint32_t button, bool isPressed, std::uint32_t modifiers) {
+void InputArea::dispatchPress(
+    float localX, float localY, std::uint32_t button, bool isPressed, std::uint32_t modifiers
+) {
   if (isPressed) {
     m_pressed = true;
     m_pressedButton = button;

--- a/src/render/scene/input_area.h
+++ b/src/render/scene/input_area.h
@@ -34,6 +34,7 @@ public:
     float axisLines = 0.0f;
     float axisSteps = 0.0f;
     bool axisStepStartsGesture = false;
+    std::uint32_t modifiers = 0;
 
     [[nodiscard]] float scrollDelta(float wheelStep) const noexcept {
       if (axisLines != 0.0f) {
@@ -174,7 +175,7 @@ public:
   void dispatchEnter(float localX, float localY);
   void dispatchLeave();
   void dispatchMotion(float localX, float localY);
-  void dispatchPress(float localX, float localY, std::uint32_t button, bool isPressed);
+  void dispatchPress(float localX, float localY, std::uint32_t button, bool isPressed, std::uint32_t modifiers = 0);
   void dispatchCancel();
   [[nodiscard]] bool dispatchAxis(
       float localX, float localY, std::uint32_t axis, std::uint32_t axisSource, double axisValue,

--- a/src/render/scene/input_dispatcher.cpp
+++ b/src/render/scene/input_dispatcher.cpp
@@ -146,7 +146,7 @@ void InputDispatcher::pointerMotion(float x, float y, std::uint32_t serial) {
   updateHover(x, y, m_lastSerial);
 }
 
-bool InputDispatcher::pointerButton(float x, float y, std::uint32_t button, bool pressed) {
+bool InputDispatcher::pointerButton(float x, float y, std::uint32_t button, bool pressed, std::uint32_t modifiers) {
   m_lastPointerX = x;
   m_lastPointerY = y;
   m_hasPointerPosition = true;
@@ -199,7 +199,7 @@ bool InputDispatcher::pointerButton(float x, float y, std::uint32_t button, bool
       m_capturedArea = target;
       trackArea(target);
     }
-    target->dispatchPress(localX, localY, button, pressed);
+    target->dispatchPress(localX, localY, button, pressed, modifiers);
     if (pressed) {
       if (m_capturedArea == nullptr) {
         updateHover(x, y, m_lastSerial);

--- a/src/render/scene/input_dispatcher.h
+++ b/src/render/scene/input_dispatcher.h
@@ -33,7 +33,7 @@ public:
   void pointerMotion(float x, float y, std::uint32_t serial);
   void syncPointerHover();
   // Returns true if the event was consumed by a scene widget
-  bool pointerButton(float x, float y, std::uint32_t button, bool pressed);
+  bool pointerButton(float x, float y, std::uint32_t button, bool pressed, std::uint32_t modifiers = 0);
   bool pointerAxis(
       float x, float y, std::uint32_t axis, std::uint32_t axisSource, double value, std::int32_t discrete,
       std::int32_t value120, float lines, std::uint32_t axisGestureSerial = 0

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -2225,6 +2225,7 @@ void Bar::createInstance(const WaylandOutput& output, std::size_t barIndex, cons
       .marginRight = surfaceSpec.marginRight,
       .marginBottom = surfaceSpec.marginBottom,
       .marginLeft = surfaceSpec.marginLeft,
+      .keyboard = LayerShellKeyboard::OnDemand,
       .defaultHeight = surfaceSpec.surfaceHeight,
   };
 

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -3444,7 +3444,7 @@ bool Bar::onPointerEvent(const PointerEvent& event) {
     const auto sx = static_cast<float>(event.sx);
     const auto sy = static_cast<float>(event.sy);
     bool pressed = event.pressed;
-    consumed = m_hoveredInstance->inputDispatcher.pointerButton(sx, sy, event.button, pressed);
+    consumed = m_hoveredInstance->inputDispatcher.pointerButton(sx, sy, event.button, pressed, event.modifiers);
     if (pressed && !consumed) {
       if (handleBarDeadZoneButton(*m_hoveredInstance, sx, sy, event.button, m_platform, m_actionDispatcher)) {
         consumed = true;

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -2450,6 +2450,9 @@ void TaskbarWidget::updateModels() {
     }
     return;
   }
+  if (std::ranges::any_of(m_taskTileAreas, [](const InputArea* area) { return area != nullptr && area->pressed(); })) {
+    return;
+  }
   ++m_taskGeneration;
   m_tasks = std::move(nextTasks);
   m_workspaces = std::move(nextWorkspaces);

--- a/src/shell/bar/widgets/taskbar_widget.cpp
+++ b/src/shell/bar/widgets/taskbar_widget.cpp
@@ -773,7 +773,11 @@ void TaskbarWidget::buildTaskButtons(Renderer& renderer) {
             return;
           }
           if (data.button == BTN_LEFT) {
-            activateOrLaunchPinned(*current);
+            if ((data.modifiers & KeyMod::Super) != 0) {
+              launchDesktopEntry(*current);
+            } else {
+              activateOrLaunchPinned(*current);
+            }
             return;
           }
           if (data.button == BTN_RIGHT && areaPtr != nullptr) {

--- a/src/wayland/wayland_seat.cpp
+++ b/src/wayland/wayland_seat.cpp
@@ -314,6 +314,7 @@ void WaylandSeat::handlePointerButton(
           .time = time,
           .button = button,
           .pressed = (state == WL_POINTER_BUTTON_STATE_PRESSED),
+          .modifiers = self->activeModifiers(),
       }
   );
 }
@@ -874,4 +875,19 @@ WaylandSeat::LockKeysState WaylandSeat::lockKeysState() const {
   state.numLock = xkb_state_led_name_is_active(m_xkbState, XKB_LED_NAME_NUM) != 0;
   state.scrollLock = xkb_state_led_name_is_active(m_xkbState, XKB_LED_NAME_SCROLL) != 0;
   return state;
+}
+
+std::uint32_t WaylandSeat::activeModifiers() const {
+  std::uint32_t mods = 0;
+  if (m_xkbState != nullptr) {
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_SHIFT, XKB_STATE_MODS_EFFECTIVE) > 0)
+      mods |= KeyMod::Shift;
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_CTRL, XKB_STATE_MODS_EFFECTIVE) > 0)
+      mods |= KeyMod::Ctrl;
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_ALT, XKB_STATE_MODS_EFFECTIVE) > 0)
+      mods |= KeyMod::Alt;
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_LOGO, XKB_STATE_MODS_EFFECTIVE) > 0)
+      mods |= KeyMod::Super;
+  }
+  return mods;
 }

--- a/src/wayland/wayland_seat.h
+++ b/src/wayland/wayland_seat.h
@@ -41,6 +41,7 @@ struct PointerEvent {
   std::int32_t axisValue120 = 0;
   float axisLines = 0.0f;
   std::uint32_t axisGestureSerial = 0;
+  std::uint32_t modifiers = 0;
 };
 
 struct KeyboardEvent {
@@ -147,6 +148,7 @@ public:
   [[nodiscard]] std::string currentLayoutName() const;
   [[nodiscard]] std::vector<std::string> layoutNames() const;
   [[nodiscard]] LockKeysState lockKeysState() const;
+  [[nodiscard]] std::uint32_t activeModifiers() const;
   [[nodiscard]] InputSource lastInputSource() const noexcept { return m_lastInputSource; }
 
   [[nodiscard]] double userIdleSeconds() const noexcept;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Implemented a new feature that allows launching new instances of pinned applications from the taskbar using `Super + Left-Mouse-Click`.  Modifiers from WaylandSeat are now passed down via PointerEvents to InputArea callbacks, and the taskbar interprets the Super modifier.


<!-- What changed and why? -->

## Motivation

Resolves a workflow pain point where opening a new instance of an already running pinned application required right-clicking and using a menu. This provides a quick keyboard+mouse shortcut for spawning multiple instances.

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3708 

<!-- Example: Closes #123 -->

## Testing

- Compiled locally using `meson compile -C build-debug noctalia`
-  Verified locally that `Super + Left-Mouse-Click` on a pinned taskbar app spawns a new instance. Verified that a normal left-click retains standard behavior (focuses if running, launches if not).


<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/faacbde3-bbb5-4c0e-85e1-8b448b5d422a


<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
