### PR TITLE
fix(control-center): honor explicit tab requests even when tab is hidden

### DIFF
--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -503,8 +503,9 @@ bool ControlCenterPanel::isTabVisible(TabId tab) const {
   if (!isTabFeatureAvailable(tab)) {
     return false;
   }
-  // Home is always shown so the panel never opens to an empty surface.
-  if (tab == TabId::Home || m_config == nullptr) {
+  // Home and the currently active tab are always shown so the panel never opens
+  // to an empty surface, even when the active tab was hidden via settings.
+  if (tab == TabId::Home || tab == m_activeTab || m_config == nullptr) {
     return true;
   }
   const auto& hidden = m_config->config().controlCenter.hiddenTabs;
@@ -759,10 +760,6 @@ void ControlCenterPanel::selectAdjacentVisibleTab(int direction) {
 }
 
 void ControlCenterPanel::selectTab(TabId tab, bool animated) {
-  if (!isTabVisible(tab)) {
-    tab = firstVisibleTab();
-  }
-
   const TabId previousTab = m_activeTab;
   const bool tabChanged = tab != previousTab;
 
@@ -836,7 +833,7 @@ ControlCenterSidebarMode ControlCenterPanel::sidebarModeForOpen(std::string_view
 ControlCenterPanel::TabId ControlCenterPanel::tabFromContext(std::string_view context) const {
   for (const auto& tab : kTabs) {
     if (context == tab.key) {
-      return isTabVisible(tab.id) ? tab.id : firstVisibleTab();
+      return tab.id;
     }
   }
   return TabId::Home;

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -385,7 +385,7 @@ void ControlCenterPanel::doLayout(Renderer& renderer, float width, float height)
 }
 
 void ControlCenterPanel::doUpdate(Renderer& renderer) {
-  if (!isTabVisible(m_activeTab)) {
+  if (!isTabFeatureAvailable(m_activeTab) || (!m_activeTabForced && !isTabVisible(m_activeTab))) {
     selectTab(firstVisibleTab());
   } else {
     syncTabVisibility();
@@ -503,13 +503,19 @@ bool ControlCenterPanel::isTabVisible(TabId tab) const {
   if (!isTabFeatureAvailable(tab)) {
     return false;
   }
-  // Home and the currently active tab are always shown so the panel never opens
-  // to an empty surface, even when the active tab was hidden via settings.
-  if (tab == TabId::Home || tab == m_activeTab || m_config == nullptr) {
+  // Home is always shown so the panel never opens to an empty surface.
+  if (tab == TabId::Home || m_config == nullptr) {
     return true;
   }
   const auto& hidden = m_config->config().controlCenter.hiddenTabs;
   return !std::ranges::contains(hidden, tabKey(tab));
+}
+
+bool ControlCenterPanel::isTabShown(TabId tab) const {
+  if (tab == m_activeTab && m_activeTabForced) {
+    return isTabFeatureAvailable(tab);
+  }
+  return isTabVisible(tab);
 }
 
 std::vector<ControlCenterPanel::TabCatalogEntry> ControlCenterPanel::hideableTabCatalog() {
@@ -545,7 +551,7 @@ ControlCenterPanel::TabId ControlCenterPanel::firstVisibleTab() const {
 void ControlCenterPanel::syncTabVisibility() {
   for (const auto& meta : kTabs) {
     const std::size_t idx = tabIndex(meta.id);
-    const bool visible = isTabVisible(meta.id);
+    const bool visible = isTabShown(meta.id);
     if (m_tabButtons[idx] != nullptr) {
       m_tabButtons[idx]->setVisible(visible);
     }
@@ -563,7 +569,7 @@ void ControlCenterPanel::syncTabVisibility() {
 void ControlCenterPanel::updateTabChrome(TabId tab) {
   for (const auto& meta : kTabs) {
     const std::size_t idx = tabIndex(meta.id);
-    const bool tabEnabled = isTabVisible(meta.id);
+    const bool tabEnabled = isTabShown(meta.id);
     if (m_tabs[idx] != nullptr) {
       m_tabs[idx]->setActive(tabEnabled && meta.id == tab);
     }
@@ -593,7 +599,7 @@ void ControlCenterPanel::updateTabChrome(TabId tab) {
 void ControlCenterPanel::applyTabContainerVisibility(TabId activeTab) {
   for (const auto& meta : kTabs) {
     const std::size_t idx = tabIndex(meta.id);
-    const bool tabEnabled = isTabVisible(meta.id);
+    const bool tabEnabled = isTabShown(meta.id);
     if (m_tabContainers[idx] != nullptr) {
       m_tabContainers[idx]->setVisible(tabEnabled && meta.id == activeTab);
     }
@@ -649,7 +655,7 @@ void ControlCenterPanel::resetTabContainerTransforms() {
 int ControlCenterPanel::visibleTabOrdinal(TabId tab) const {
   int ordinal = 0;
   for (const auto& meta : kTabs) {
-    if (!isTabVisible(meta.id)) {
+    if (!isTabShown(meta.id)) {
       continue;
     }
     if (meta.id == tab) {
@@ -745,7 +751,7 @@ void ControlCenterPanel::selectAdjacentVisibleTab(int direction) {
 
   int ordinal = 0;
   for (const auto& meta : kTabs) {
-    if (!isTabVisible(meta.id)) {
+    if (!isTabShown(meta.id)) {
       continue;
     }
     if (ordinal == targetOrdinal) {
@@ -760,6 +766,11 @@ void ControlCenterPanel::selectAdjacentVisibleTab(int direction) {
 }
 
 void ControlCenterPanel::selectTab(TabId tab, bool animated) {
+  if (!isTabFeatureAvailable(tab)) {
+    tab = firstVisibleTab();
+  }
+  m_activeTabForced = !isTabVisible(tab);
+
   const TabId previousTab = m_activeTab;
   const bool tabChanged = tab != previousTab;
 

--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -153,6 +153,7 @@ private:
   void syncTabVisibility();
   [[nodiscard]] bool isTabFeatureAvailable(TabId tab) const;
   [[nodiscard]] bool isTabVisible(TabId tab) const;
+  [[nodiscard]] bool isTabShown(TabId tab) const;
   [[nodiscard]] static std::string_view tabKey(TabId tab);
   [[nodiscard]] TabId firstVisibleTab() const;
   [[nodiscard]] TabId tabFromContext(std::string_view context) const;
@@ -181,6 +182,7 @@ private:
   std::array<Flex*, kTabCount> m_tabContainers{};
   std::array<Flex*, kTabCount> m_tabHeaderActions{};
   TabId m_activeTab = TabId::Home;
+  bool m_activeTabForced = false;
   ConfigService* m_config = nullptr;
   MprisService* m_mpris = nullptr;
   NotificationManager* m_notificationManager = nullptr;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Fixed the behavior when invoking hidden tabs in the control center via specific triggers. They are now correctly displayed instead of showing the Home tab. This applies, for example, when clicking a notification widget or using methods like `noctalia msg panel-open control-center notifications`.

## Motivation

<!-- What problem does this solve? -->
Previously, invoking a hidden tab would display the Home tab, which was counterintuitive. This change aligns the behavior with user expectations and makes the feature actually usable.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #3749

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`meson setup builddir && ninja -C builddir`

`noctalia msg panel-open control-center notifications`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1201" height="1100" alt="图片" src="https://github.com/user-attachments/assets/f461811f-ce83-4ea7-b2be-9e45195836c7" />

<img width="1509" height="333" alt="图片" src="https://github.com/user-attachments/assets/066e30ad-b21b-4e4f-876b-99a103dea726" />


As shown in the first two screenshots, the notification tab is set to hidden.

<img width="1177" height="1099" alt="图片" src="https://github.com/user-attachments/assets/da623838-d685-4a0e-9350-e0414923e26e" />

As shown in the third screenshot, when invoked via `noctalia msg panel-open control-center notifications` or similar, the notification tab is still displayed instead of the Home tab.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
*I am a non-native English speaker and have used AI-assisted translation for this description. Please feel free to point out any errors or ambiguities, Thanks!*