### PR TITLE
fix(cc/network): disconnect from all active vpns when header is toggled

### DIFF
--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -934,7 +934,7 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
               .toggleSize = ToggleSize::Medium,
               .scale = scale,
               .onChange = [this, vpns](bool checked) {
-                if (!checked) {
+                if (!checked && m_network != nullptr) {
                   for (const auto& vpn : vpns) {
                     if (vpn.active) {
                       m_network->deactivateVpnConnection(vpn);

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -933,7 +933,14 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
               .checkedImmediate = m_vpnVisible,
               .toggleSize = ToggleSize::Medium,
               .scale = scale,
-              .onChange = [this](bool checked) {
+              .onChange = [this, vpns](bool checked) {
+                if (!checked) {
+                  for (const auto& vpn : vpns) {
+                    if (vpn.active) {
+                      m_network->deactivateVpnConnection(vpn);
+                    }
+                  }
+                }
                 m_vpnVisible = checked;
                 PanelManager::instance().refresh();
               },


### PR DESCRIPTION
## Summary
Disconnect from all active vpns when the vpn header is toggled in the network tab of the control center

## Motivation
Previously, this was an operation that only hid the VPNs from the UI, which is unintuitive.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
Closes #3768 

## Testing
Connected to VPN then used toggle in the header to disconnect.
```
05:18:51.561 [INF] [network] activating vpn name=<redacted> active=/org/freedesktop/NetworkManager/ActiveConnection/34
05:18:55.577 [INF] [network] deactivated vpn name=<redacted> active=/org/freedesktop/NetworkManager/ActiveConnection/34
```
## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A
