### PR TITLE
feat(launcher): Configurable toggle to surface desktop actions in app provider

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2305,6 +2305,10 @@
           "description": "Display text labels under shortcut icons in the home tab",
           "label": "Show Shortcut Labels"
         },
+        "launcher-app-actions": {
+          "description": "Show application action entries alongside applications in results",
+          "label": "Show App Actions"
+        },
         "launcher-app-grid": {
           "description": "Show a grid of application icons with labels underneath when results are apps only",
           "label": "App Grid View"

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -987,6 +987,7 @@ struct ShellConfig {
     bool showIcons = true;
     bool compact = false;
     bool appGrid = false;
+    bool showAppActions = false;
     bool sortByUsage = true;
     // Desktop entry IDs shown first in the launcher when it opens without a query.
     std::vector<std::string> pinned;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1324,6 +1324,7 @@ namespace noctalia::config::schema {
           field(&ShellConfig::LauncherConfig::showIcons, "show_icons"),
           field(&ShellConfig::LauncherConfig::compact, "compact"),
           field(&ShellConfig::LauncherConfig::appGrid, "app_grid"),
+          field(&ShellConfig::LauncherConfig::showAppActions, "show_app_actions"),
           field(&ShellConfig::LauncherConfig::sortByUsage, "sort_by_usage"),
           field(&ShellConfig::LauncherConfig::pinned, "pinned"),
           field(&ShellConfig::LauncherConfig::fetchExchangeRates, "fetch_exchange_rates"),

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -69,11 +69,11 @@ namespace {
       return 0.0;
     }
 
-    double nameScore = FuzzyMatch::score(pattern, action.name) * 5.0;
-    if (FuzzyMatch::isMatch(nameScore) && action.name.starts_with(pattern)) {
+    double nameScore = FuzzyMatch::score(pattern, action.nameLower) * 5.0;
+    if (FuzzyMatch::isMatch(nameScore) && action.nameLower.starts_with(pattern)) {
       nameScore += 500.0;
     }
-    const double execScore = FuzzyMatch::score(pattern, action.exec);
+    const double execScore = FuzzyMatch::score(pattern, action.execLower);
 
     return std::max(nameScore, execScore);
   }
@@ -181,6 +181,20 @@ namespace {
 AppProvider::AppProvider(ConfigService* config, CompositorPlatform* platform)
     : m_config(config), m_platform(platform) {}
 
+std::string AppProvider::actionResultId(std::string_view desktopEntryPath, std::string_view desktopActionId) {
+  constexpr std::string_view prefix = "desktop-action:";
+  const std::string pathLength = std::to_string(desktopEntryPath.size());
+  std::string result;
+  result.reserve(prefix.size() + pathLength.size() + 2 + desktopEntryPath.size() + desktopActionId.size());
+  result.append(prefix);
+  result.append(pathLength);
+  result.push_back(':');
+  result.append(desktopEntryPath);
+  result.push_back(':');
+  result.append(desktopActionId);
+  return result;
+}
+
 void AppProvider::initialize() { refreshEntriesIfNeeded(); }
 
 std::string AppProvider::displayName() const { return i18n::tr("launcher.providers.applications.title"); }
@@ -223,6 +237,7 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
   auto buildResult = [&](const DesktopEntry& entry, double s) {
     LauncherResult result;
     result.id = entry.path;
+    result.desktopEntryPath = entry.path;
     result.title = entry.name;
     result.subtitle = entry.genericName.empty() ? entry.comment : entry.genericName;
     result.origin = originLabel(entry.origin);
@@ -238,6 +253,7 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
 
   auto buildActionResult = [&](const DesktopEntry& entry, const DesktopAction& action, double s) {
     LauncherResult result = buildResult(entry, s);
+    result.id = actionResultId(entry.path, action.id);
     result.title = action.name;
     result.subtitle = entry.name;
     result.desktopActionId = action.id;
@@ -291,7 +307,7 @@ bool AppProvider::activate(const LauncherResult& result) {
   refreshEntriesIfNeeded();
 
   for (const auto& entry : m_entries) {
-    if (entry.path != result.id) {
+    if (entry.path != result.desktopEntryPath) {
       continue;
     }
 

--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -4,6 +4,7 @@
 #include "config/config_service.h"
 #include "core/log.h"
 #include "i18n/i18n.h"
+#include "launcher/launcher_provider.h"
 #include "shell/panel/panel_manager.h"
 #include "system/desktop_entry_launch.h"
 #include "util/fuzzy_match.h"
@@ -61,6 +62,20 @@ namespace {
     const double execScore = FuzzyMatch::score(pattern, entry.execLower);
 
     return std::max({nameScore, genericScore, keywordScore, catScore, idScore, execScore});
+  }
+
+  double scoreAction(std::string_view pattern, const DesktopAction& action) {
+    if (pattern.empty()) {
+      return 0.0;
+    }
+
+    double nameScore = FuzzyMatch::score(pattern, action.name) * 5.0;
+    if (FuzzyMatch::isMatch(nameScore) && action.name.starts_with(pattern)) {
+      nameScore += 500.0;
+    }
+    const double execScore = FuzzyMatch::score(pattern, action.exec);
+
+    return std::max(nameScore, execScore);
   }
 
   struct AppCategoryDef {
@@ -221,6 +236,15 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
     return result;
   };
 
+  auto buildActionResult = [&](const DesktopEntry& entry, const DesktopAction& action, double s) {
+    LauncherResult result = buildResult(entry, s);
+    result.title = action.name;
+    result.subtitle = entry.name;
+    result.desktopActionId = action.id;
+    return result;
+  };
+
+  std::vector<std::pair<double, std::pair<const DesktopEntry*, const DesktopAction*>>> scored;
   // Empty query: return all entries in alphabetical order (as stored)
   if (pattern.empty()) {
     std::vector<LauncherResult> results;
@@ -231,13 +255,23 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
     return results;
   }
 
-  std::vector<std::pair<double, const DesktopEntry*>> scored;
   for (const auto& entry : m_entries) {
     const double s = scoreEntry(pattern, entry);
     if (FuzzyMatch::isMatch(s)) {
-      scored.emplace_back(s, &entry);
+      scored.emplace_back(s, std::make_pair(&entry, nullptr));
+    }
+
+    if (!m_config->config().shell.launcher.showAppActions)
+      continue;
+
+    for (const auto& action : entry.actions) {
+      const double actionScore = scoreAction(pattern, action);
+      if (FuzzyMatch::isMatch(actionScore)) {
+        scored.emplace_back(actionScore, std::make_pair(&entry, &action));
+      }
     }
   }
+
   const auto cmp = [](const auto& a, const auto& b) { return a.first > b.first; };
   const std::size_t limit = std::min(scored.size(), kMaxSearchResults);
   std::partial_sort(scored.begin(), scored.begin() + static_cast<std::ptrdiff_t>(limit), scored.end(), cmp);
@@ -245,9 +279,11 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
   std::vector<LauncherResult> results;
   results.reserve(limit);
   for (std::size_t i = 0; i < limit; ++i) {
-    const auto& [s, entry] = scored[i];
-    results.push_back(buildResult(*entry, s));
+    const auto& [s, pair] = scored[i];
+    const auto& [entry, action] = pair;
+    results.push_back(action ? buildActionResult(*entry, *action, s) : buildResult(*entry, s));
   }
+
   return results;
 }
 

--- a/src/launcher/app_provider.h
+++ b/src/launcher/app_provider.h
@@ -12,6 +12,7 @@ class CompositorPlatform;
 class AppProvider : public LauncherProvider {
 public:
   explicit AppProvider(ConfigService* config, CompositorPlatform* platform = nullptr);
+  [[nodiscard]] static std::string actionResultId(std::string_view desktopEntryPath, std::string_view desktopActionId);
 
   [[nodiscard]] std::string_view defaultPrefix() const override { return ""; }
   [[nodiscard]] bool allowCustomPrefix() const override { return false; }

--- a/src/launcher/launcher_provider.h
+++ b/src/launcher/launcher_provider.h
@@ -33,6 +33,8 @@ struct LauncherResult {
   // A short string drawn in the leading icon slot in place of an icon (e.g. an
   // emoji or a single symbol). When set, it replaces glyphName/iconName/iconPath.
   std::string badge;
+  // AppProvider source desktop file path; empty for other providers.
+  std::string desktopEntryPath;
   // When launching an application via AppProvider, matches DesktopAction::id (primary Exec leaves this empty).
   std::string desktopActionId;
   std::string category;

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -7,6 +7,7 @@
 #include "core/input/keybind_matcher.h"
 #include "core/ui_phase.h"
 #include "i18n/i18n.h"
+#include "launcher/app_provider.h"
 #include "render/core/async_texture_cache.h"
 #include "render/core/renderer.h"
 #include "render/scene/node.h"
@@ -1122,7 +1123,7 @@ void LauncherPanel::create() {
     if (sourceIndex >= m_results.size() || targetIndex >= m_results.size()) {
       return;
     }
-    reorderPinnedApplication(m_results[sourceIndex].id, m_results[targetIndex].id);
+    reorderPinnedApplication(m_results[sourceIndex].desktopEntryPath, m_results[targetIndex].desktopEntryPath);
   });
   m_gridAdapter->setOnActivate(onActivate);
   m_gridAdapter->setOnSecondaryActivate(onSecondaryActivate);
@@ -1130,7 +1131,7 @@ void LauncherPanel::create() {
     if (sourceIndex >= m_results.size() || targetIndex >= m_results.size()) {
       return;
     }
-    reorderPinnedApplication(m_results[sourceIndex].id, m_results[targetIndex].id);
+    reorderPinnedApplication(m_results[sourceIndex].desktopEntryPath, m_results[targetIndex].desktopEntryPath);
   });
 
   body->addChild(
@@ -1712,7 +1713,7 @@ void LauncherPanel::applyPinnedApplicationOrder() {
       if (result.providerId != kApplicationsProviderId) {
         return pinnedPaths.size();
       }
-      const auto it = std::ranges::find(pinnedPaths, result.id);
+      const auto it = std::ranges::find(pinnedPaths, result.desktopEntryPath);
       return it == pinnedPaths.end() ? pinnedPaths.size() : static_cast<std::size_t>(it - pinnedPaths.begin());
     };
     return rank(a) < rank(b);
@@ -1732,8 +1733,9 @@ void LauncherPanel::updatePinnedApplicationState() {
     if (result.providerId != kApplicationsProviderId) {
       continue;
     }
-    result.pinned =
-        std::ranges::any_of(pinnedEntries, [&result](const DesktopEntry& entry) { return entry.path == result.id; });
+    result.pinned = std::ranges::any_of(pinnedEntries, [&result](const DesktopEntry& entry) {
+      return entry.path == result.desktopEntryPath;
+    });
   }
 }
 
@@ -1980,7 +1982,7 @@ bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
 
   const DesktopEntry* match = nullptr;
   for (const auto& e : desktopEntries()) {
-    if (e.path == base.id) {
+    if (e.path == base.desktopEntryPath) {
       match = &e;
       break;
     }
@@ -2077,7 +2079,6 @@ bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
   m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
                                 entryForPin = *match](const ContextMenuControlEntry& entry) {
     LauncherResult result = base;
-    result.desktopActionId.clear();
     if (entry.id == kActionPin) {
       if (m_config == nullptr
           || entryForPin.id.empty()
@@ -2103,7 +2104,9 @@ bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
       return;
     }
     if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {
-      result.desktopActionId = actionsCopy[static_cast<std::size_t>(entry.id)].id;
+      const DesktopAction& action = actionsCopy[static_cast<std::size_t>(entry.id)];
+      result.id = AppProvider::actionResultId(result.desktopEntryPath, action.id);
+      result.desktopActionId = action.id;
     } else if (entry.id != kActionOpen) {
       return;
     }

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1224,6 +1224,11 @@ namespace settings {
         ToggleSetting{cfg.shell.launcher.appGrid}, "launcher app grid icons view"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Launcher, "launcher", tr("settings.schema.panels.launcher-app-actions.label"),
+        tr("settings.schema.panels.launcher-app-actions.description"), {"shell", "launcher", "show_app_actions"},
+        ToggleSetting{cfg.shell.launcher.showAppActions}, "launcher app actions show"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Launcher, "launcher", tr("settings.schema.panels.launcher-compact.label"),
         tr("settings.schema.panels.launcher-compact.description"), {"shell", "launcher", "compact"},
         ToggleSetting{cfg.shell.launcher.compact}, "launcher compact rows dense"

--- a/src/system/desktop_entry.cpp
+++ b/src/system/desktop_entry.cpp
@@ -348,6 +348,8 @@ namespace {
                 .id = it->first,
                 .name = it->second.name,
                 .exec = it->second.exec,
+                .nameLower = StringUtils::toLower(it->second.name),
+                .execLower = StringUtils::toLower(it->second.exec),
             }
         );
       }

--- a/src/system/desktop_entry.h
+++ b/src/system/desktop_entry.h
@@ -9,6 +9,9 @@ struct DesktopAction {
   std::string id;
   std::string name;
   std::string exec;
+  // Pre-lowercased for matching
+  std::string nameLower;
+  std::string execLower;
 };
 
 enum class DesktopEntryOrigin : std::uint8_t {


### PR DESCRIPTION
## Summary
Extended `AppProvider::query` to include `DesktopAction` results in launcher search. Actions are now scored and ranked alongside their parent applications, with a configurable toggle to show/hide them in config/settings (defaulting to not showing them).

## Motivation
Users can now search for and directly launch desktop actions (custom app-specific commands) from the launcher, such as noctalia's settings action.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
N/A

## Testing
Opened app launcher and verified behaviour

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/e6361ccc-bec9-4b94-892b-0fe704250c97

(note: renamed the settings label to `Show App Actions` after this was recorded)

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A