### PR TITLE
fix(test): Call FcFini() to suppress fontconfig's expected process-lifetime leaks in ASAN

### DIFF
--- a/tests/widget_definition_test.cpp
+++ b/tests/widget_definition_test.cpp
@@ -1,6 +1,7 @@
 // Every typed widget definition validates itself lazily: `field()` and `WidgetDefinition::validate()`
 // throw std::logic_error on the first resolve()/schemaFields() call, and WidgetFactory::create() does
 // not catch. Without this test a malformed definition ships as an uncaught exception at bar build.
+#include "fontconfig/fontconfig.h"
 #include "shell/bar/widget_gesture_defaults.h"
 #include "shell/bar/widgets/active_window_widget_definition.h"
 #include "shell/bar/widgets/audio_visualizer_widget_definition.h"
@@ -261,6 +262,7 @@ int main() {
   }
   checkDefinition("wallpaper", wallpaperWidgetDefinition);
   checkDefinition("weather", weatherWidgetDefinition);
+  FcFini();
 
   return g_ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
Fontconfig allocates global state on initialization that's intended to persist for the process lifetime. ASAN's LeakSanitizer flags this as a leak on exit. Explicitly call FcFini() to deallocate these resources during test cleanup.

## Motivation
fixes asan build test (widget_definition specifically) failing

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
N/A

## Testing
`just test asan widget_definition`

## Manual Coverage
- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
As far as I can tell this is a correct fix for the failing test but this is just based on the ASAN stack trace, googling and some ai (for understading how fontconfig does stuff).