### PR TITLE
feat(visualizer): add reversed bar direction option

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -518,6 +518,7 @@
         "opacity": "Opacity",
         "primary-color": "Primary Color",
         "reset-defaults": "Reset to Defaults",
+        "reversed": "Reversed",
         "ring-opacity": "Ring Opacity",
         "rotation-speed": "Rotation Speed",
         "scroll-step": "Scroll Step",
@@ -3619,6 +3620,10 @@
         "pinned-opacity": {
           "description": "Opacity of pinned apps that are not currently running",
           "label": "Pinned App Opacity"
+        },
+        "reversed": {
+          "description": "Reverse the low-to-high frequency order of the bars",
+          "label": "Reversed"
         },
         "scale": {
           "description": "Scale this widget relative to the bar content scale",

--- a/src/render/core/render_styles.h
+++ b/src/render/core/render_styles.h
@@ -177,6 +177,7 @@ struct AudioSpectrumStyle {
   Color color2{};
   AudioSpectrumOrientation orientation = AudioSpectrumOrientation::Horizontal;
   bool mirrored = false;
+  bool reversed = false;
   bool centered = false;
 };
 
@@ -185,6 +186,7 @@ constexpr bool operator==(const AudioSpectrumStyle& lhs, const AudioSpectrumStyl
       && lhs.color2 == rhs.color2
       && lhs.orientation == rhs.orientation
       && lhs.mirrored == rhs.mirrored
+      && lhs.reversed == rhs.reversed
       && lhs.centered == rhs.centered;
 }
 

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -161,7 +161,8 @@ void AudioSpectrumProgram::draw(
   m_vertices.reserve(static_cast<std::size_t>(barCount) * 6U * 6U);
 
   for (int i = 0; i < barCount; ++i) {
-    const int valueIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;
+    const int slot = style.reversed ? barCount - 1 - i : i;
+    const int valueIndex = style.mirrored ? (slot < valueCount ? valueCount - 1 - slot : slot - valueCount) : slot;
     const float rawValue = valueIndex >= 0 && valueIndex < valueCount
         ? std::clamp(values[static_cast<std::size_t>(valueIndex)], 0.0f, 1.0f)
         : 0.0f;

--- a/src/render/programs/audio_spectrum_program.cpp
+++ b/src/render/programs/audio_spectrum_program.cpp
@@ -161,8 +161,8 @@ void AudioSpectrumProgram::draw(
   m_vertices.reserve(static_cast<std::size_t>(barCount) * 6U * 6U);
 
   for (int i = 0; i < barCount; ++i) {
-    const int slot = style.reversed ? barCount - 1 - i : i;
-    const int valueIndex = style.mirrored ? (slot < valueCount ? valueCount - 1 - slot : slot - valueCount) : slot;
+    const int baseIndex = style.mirrored ? (i < valueCount ? valueCount - 1 - i : i - valueCount) : i;
+    const int valueIndex = style.reversed ? valueCount - 1 - baseIndex : baseIndex;
     const float rawValue = valueIndex >= 0 && valueIndex < valueCount
         ? std::clamp(values[static_cast<std::size_t>(valueIndex)], 0.0f, 1.0f)
         : 0.0f;

--- a/src/shell/bar/widgets/audio_visualizer_widget.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget.cpp
@@ -13,8 +13,8 @@
 
 AudioVisualizerWidget::AudioVisualizerWidget(PipeWireSpectrum* spectrum, Options options)
     : m_spectrum(spectrum), m_width(static_cast<float>(options.width)), m_bands(options.bands),
-      m_mirrored(options.mirrored), m_centered(options.centered), m_showWhenIdle(options.showWhenIdle),
-      m_color1(options.color1), m_color2(options.color2) {}
+      m_mirrored(options.mirrored), m_reversed(options.reversed), m_centered(options.centered),
+      m_showWhenIdle(options.showWhenIdle), m_color1(options.color1), m_color2(options.color2) {}
 
 AudioVisualizerWidget::~AudioVisualizerWidget() {
   cancelVisibilityAnimation();
@@ -32,6 +32,7 @@ void AudioVisualizerWidget::create() {
   visualizer->setOrientation(AudioSpectrumOrientation::Horizontal);
   visualizer->setCentered(m_centered);
   visualizer->setMirrored(m_mirrored);
+  visualizer->setReversed(m_reversed);
   visualizer->setGradient(m_color1, m_color2);
   m_visualizer = visualizer.get();
   root->addChild(std::move(visualizer));

--- a/src/shell/bar/widgets/audio_visualizer_widget.h
+++ b/src/shell/bar/widgets/audio_visualizer_widget.h
@@ -14,6 +14,7 @@ public:
     int width = 56;
     int bands = 16;
     bool mirrored = true;
+    bool reversed = false;
     bool centered = true;
     bool showWhenIdle = false;
     ColorSpec color1 = colorSpecFromRole(ColorRole::Primary);
@@ -41,6 +42,7 @@ private:
   float m_width = 56.0f;
   int m_bands = 16;
   bool m_mirrored = false;
+  bool m_reversed = false;
   bool m_centered = true;
   bool m_showWhenIdle = false;
   ColorSpec m_color1 = colorSpecFromRole(ColorRole::Primary);

--- a/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
+++ b/src/shell/bar/widgets/audio_visualizer_widget_definition.cpp
@@ -22,6 +22,9 @@ const noctalia::bar::WidgetDefinition<AudioVisualizerWidget::Options>& audioVisu
           field<&Options::mirrored>({
               .key = "mirrored",
           }),
+          field<&Options::reversed>({
+              .key = "reversed",
+          }),
           field<&Options::centered>({
               .key = "centered",
           }),

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -217,6 +217,7 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
         DesktopAudioVisualizerWidget::Options{
             .bands = getIntSetting(settings, "bands", 32),
             .mirrored = getBoolSetting(settings, "mirrored", true),
+            .reversed = getBoolSetting(settings, "reversed", false),
             .centered = getBoolSetting(settings, "centered", true),
             .showWhenIdle = getBoolSetting(settings, "show_when_idle", true),
             .color1 = getColorSpecSetting(settings, "color_1", colorSpecFromRole(ColorRole::Primary)),

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -270,6 +270,7 @@ namespace desktop_settings {
     } else if (type == "audio_visualizer") {
       add(intSpec("bands", 32, 4.0, 128.0, 4.0));
       add(boolSpec("mirrored", true));
+      add(boolSpec("reversed", false));
       add(boolSpec("centered", true));
       add(boolSpec("show_when_idle", true));
       add(colorSpec("color_1", "primary"));

--- a/src/shell/desktop/widgets/desktop_audio_visualizer_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_audio_visualizer_widget.cpp
@@ -23,8 +23,8 @@ namespace {
 
 DesktopAudioVisualizerWidget::DesktopAudioVisualizerWidget(PipeWireSpectrum* spectrum, Options options)
     : m_spectrum(spectrum), m_bands(std::max(1, options.bands)), m_mirrored(options.mirrored),
-      m_centered(options.centered), m_showWhenIdle(options.showWhenIdle), m_color1(options.color1),
-      m_color2(options.color2) {}
+      m_reversed(options.reversed), m_centered(options.centered), m_showWhenIdle(options.showWhenIdle),
+      m_color1(options.color1), m_color2(options.color2) {}
 
 DesktopAudioVisualizerWidget::~DesktopAudioVisualizerWidget() {
   cancelVisibilityAnimation();
@@ -41,6 +41,7 @@ void DesktopAudioVisualizerWidget::create() {
   visualizer->setOrientation(AudioSpectrumOrientation::Horizontal);
   visualizer->setCentered(m_centered);
   visualizer->setMirrored(m_mirrored);
+  visualizer->setReversed(m_reversed);
   visualizer->setGradient(m_color1, m_color2);
   m_visualizer = visualizer.get();
   rootNode->addChild(std::move(visualizer));
@@ -78,6 +79,14 @@ bool DesktopAudioVisualizerWidget::applySetting(
     if (const auto* v = std::get_if<bool>(&value)) {
       m_mirrored = *v;
       m_visualizer->setMirrored(m_mirrored);
+      return true;
+    }
+    return false;
+  }
+  if (key == "reversed") {
+    if (const auto* v = std::get_if<bool>(&value)) {
+      m_reversed = *v;
+      m_visualizer->setReversed(m_reversed);
       return true;
     }
     return false;

--- a/src/shell/desktop/widgets/desktop_audio_visualizer_widget.h
+++ b/src/shell/desktop/widgets/desktop_audio_visualizer_widget.h
@@ -14,6 +14,7 @@ public:
   struct Options {
     int bands = 32;
     bool mirrored = true;
+    bool reversed = false;
     bool centered = true;
     bool showWhenIdle = true;
     ColorSpec color1 = colorSpecFromRole(ColorRole::Primary);
@@ -48,6 +49,7 @@ private:
   PipeWireSpectrum* m_spectrum = nullptr;
   int m_bands = 32;
   bool m_mirrored = true;
+  bool m_reversed = false;
   bool m_centered = true;
   bool m_showWhenIdle = false;
   bool m_editorPreview = false;

--- a/src/ui/visuals/audio_visualizer.cpp
+++ b/src/ui/visuals/audio_visualizer.cpp
@@ -82,6 +82,12 @@ void AudioVisualizer::setMirrored(bool mirrored) {
   setStyle(next);
 }
 
+void AudioVisualizer::setReversed(bool reversed) {
+  auto next = style();
+  next.reversed = reversed;
+  setStyle(next);
+}
+
 void AudioVisualizer::setCentered(bool centered) {
   auto next = style();
   next.centered = centered;

--- a/src/ui/visuals/audio_visualizer.h
+++ b/src/ui/visuals/audio_visualizer.h
@@ -15,6 +15,7 @@ public:
   void setGradient(const Color& color1, const Color& color2);
   void setOrientation(AudioSpectrumOrientation orientation);
   void setMirrored(bool mirrored);
+  void setReversed(bool reversed);
   void setCentered(bool centered);
   void setSmoothingTimeMs(float tauMs) noexcept { m_smoothingTauMs = std::max(0.0f, tauMs); }
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds a `reversed` option to the `audio_visualizer` bar widget and desktop widget, sitting next to the existing `mirrored` and `centered` options. When enabled, it reverses the low-to-high frequency draw order of the spectrum bars.

## Motivation

On a vertical bar layout, the fixed low-to-high order puts low frequencies at one end, which some users find backwards relative to their intuition. This adds a toggle rather than changing the default.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3773

## Testing

Ran locally:
- `just format`
- `python3 tools/i18n-check.py`
- `just build` (debug)
- `just test debug --print-errorlogs` — 67/67 passed
- `just lint` — clang-tidy `-warnings-as-errors=*` clean

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

No isolated Wayland test session was available in this environment, so the widget was not visually exercised at runtime. The change is a straight structural clone of the existing `mirrored` option (same files, same pattern), verified by build/tests/lint above, but manual visual/compositor testing has not been done. Happy to add screenshots/video if a maintainer or CI flags a visual issue.

## Screenshots / Videos

Not included — see note above under Manual Coverage.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Known limitation: `mirrored` produces a symmetric bar array, so `reversed` has no visible effect when `mirrored` is enabled. It only changes anything when `mirrored` is `false`. Kept intentionally simple rather than adding visibility-gating between the two options.
