### PR TITLE
fix(wayland): retain output modes until finished

### DIFF
--- a/src/wayland/wayland_connection.cpp
+++ b/src/wayland/wayland_connection.cpp
@@ -268,19 +268,19 @@ namespace {
     static_cast<WaylandConnection*>(data)->onOutputHeadSerialNumber(head, serialNumber);
   }
 
-  // Mode listener: release the proxy only when the compositor sends 'finished'.
-  void modeFinished(void* /*data*/, zwlr_output_mode_v1* mode) { zwlr_output_mode_v1_release(mode); }
+  void outputModeFinished(void* data, zwlr_output_mode_v1* mode) {
+    static_cast<WaylandConnection*>(data)->onOutputModeFinished(mode);
+  }
 
   const zwlr_output_mode_v1_listener kOutputModeListener = {
       .size = [](void*, zwlr_output_mode_v1*, int32_t, int32_t) {},
       .refresh = [](void*, zwlr_output_mode_v1*, int32_t) {},
       .preferred = [](void*, zwlr_output_mode_v1*) {},
-      .finished = modeFinished,
+      .finished = outputModeFinished,
   };
 
-  // Retain mode proxies; released by mode.finished (compositor guarantees it before head.finished).
-  void outputHeadMode(void* /*data*/, zwlr_output_head_v1* /*head*/, zwlr_output_mode_v1* mode) {
-    zwlr_output_mode_v1_add_listener(mode, &kOutputModeListener, nullptr);
+  void outputHeadMode(void* data, zwlr_output_head_v1* head, zwlr_output_mode_v1* mode) {
+    static_cast<WaylandConnection*>(data)->onOutputHeadMode(head, mode);
   }
 
   void outputHeadFinished(void* data, zwlr_output_head_v1* head) {
@@ -833,6 +833,20 @@ void WaylandConnection::onOutputHeadSerialNumber(zwlr_output_head_v1* head, cons
   }
 }
 
+void WaylandConnection::onOutputHeadMode(zwlr_output_head_v1* /*head*/, zwlr_output_mode_v1* mode) {
+  if (mode == nullptr) {
+    return;
+  }
+  m_outputModes.insert(mode);
+  zwlr_output_mode_v1_add_listener(mode, &kOutputModeListener, this);
+}
+
+void WaylandConnection::onOutputModeFinished(zwlr_output_mode_v1* mode) {
+  if (m_outputModes.erase(mode) > 0) {
+    zwlr_output_mode_v1_release(mode);
+  }
+}
+
 void WaylandConnection::onOutputHeadFinished(zwlr_output_head_v1* head) {
   m_outputHeads.erase(head);
   zwlr_output_head_v1_release(head);
@@ -866,6 +880,10 @@ void WaylandConnection::matchPendingOutputHeads() {
 }
 
 void WaylandConnection::onOutputManagerFinished(zwlr_output_manager_v1* manager) {
+  for (auto* mode : m_outputModes) {
+    zwlr_output_mode_v1_release(mode);
+  }
+  m_outputModes.clear();
   for (const auto& entry : m_outputHeads) {
     zwlr_output_head_v1_release(entry.first);
   }
@@ -1354,6 +1372,10 @@ void WaylandConnection::cleanup() {
     m_screencopyManager = nullptr;
   }
 
+  for (auto* mode : m_outputModes) {
+    zwlr_output_mode_v1_release(mode);
+  }
+  m_outputModes.clear();
   for (const auto& entry : m_outputHeads) {
     zwlr_output_head_v1_release(entry.first);
   }

--- a/src/wayland/wayland_connection.h
+++ b/src/wayland/wayland_connection.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 struct wl_compositor;
@@ -49,6 +50,7 @@ struct wp_fractional_scale_manager_v1;
 struct wp_viewporter;
 struct zwlr_output_manager_v1;
 struct zwlr_output_head_v1;
+struct zwlr_output_mode_v1;
 class ClipboardService;
 class FocusGrabService;
 struct DataControlOps;
@@ -261,6 +263,8 @@ public:
   void onOutputHeadMake(zwlr_output_head_v1* head, const char* make);
   void onOutputHeadModel(zwlr_output_head_v1* head, const char* model);
   void onOutputHeadSerialNumber(zwlr_output_head_v1* head, const char* serialNumber);
+  void onOutputHeadMode(zwlr_output_head_v1* head, zwlr_output_mode_v1* mode);
+  void onOutputModeFinished(zwlr_output_mode_v1* mode);
   void onOutputHeadFinished(zwlr_output_head_v1* head);
   // wl_output.name and the done event race; call from both sides to match either order.
   void matchPendingOutputHeads();
@@ -294,6 +298,7 @@ private:
   zwlr_screencopy_manager_v1* m_screencopyManager = nullptr;
   zwlr_output_manager_v1* m_outputManager = nullptr;
   std::unordered_map<zwlr_output_head_v1*, WaylandOutputHeadInfo> m_outputHeads;
+  std::unordered_set<zwlr_output_mode_v1*> m_outputModes;
   std::unique_ptr<FocusGrabService> m_focusGrabService;
   wp_viewporter* m_viewporter = nullptr;
   bool m_backgroundEffectBlurSupported = false;


### PR DESCRIPTION
## Summary

Retain `zwlr_output_mode_v1` proxies until their Wayland lifecycle ends instead of releasing them immediately when announced.

## Motivation

Commit [`489de6f76`](https://github.com/noctalia-dev/noctalia/commit/489de6f76b61eee601731db1c00333eeeb955e4f) introduced immediate mode-proxy release while adding monitor serial-number support.

A compositor may reference an announced mode in subsequent events such as `current_mode`. On Niri, this caused libwayland to abort during startup:

```text
unknown object (...), message current_mode(o)
```

Mode proxies are now tracked independently from output heads and released when:

- The mode emits `finished`
- The output manager finishes
- The Wayland connection is cleaned up

Independent tracking avoids relying on cross-object ordering between mode and head `finished` events.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

```sh
meson setup build-debug --wipe -Dtests=enabled --buildtype=debug
meson compile -C build-debug
meson test -C build-debug --print-errorlogs
just format
```

All 68 tests passed. The original startup crash was reproduced, and initialization completed successfully with mode proxies retained on Niri 26.04.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

Not applicable; this change has no visual or UI behavior.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.