### PR TITLE
fix(tray): hide passive status notifier items

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1161,6 +1161,7 @@ if build_tests
     'system_monitor_service',
     'taskbar_widget',
     'time_format',
+    'tray_identifier',
     'triad_workspace_backend',
     'ui_tree_reconciler',
     'wayland_toplevels_identity',

--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -2118,7 +2118,7 @@ void TrayService::refreshItemMetadata(const std::string& itemId) {
           next.statusNotifierTitle = std::move(statusNotifierTitle);
           next.statusNotifierDescription = std::move(statusNotifierDescription);
           next.status = get_item_property_string_from(properties, "Status", cur.status);
-          next.needsAttention = (next.status == "NeedsAttention");
+          next.needsAttention = (StringUtils::toLower(next.status) == "needsattention");
 
           if (next.itemName == "chrome_status_icon_1" && !next.statusNotifierTitle.empty()) {
             next.itemName = next.itemName + "::" + next.statusNotifierTitle;

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -526,7 +526,7 @@ void TrayWidget::rebuild(Renderer& renderer) {
     m_drawerChevronGlyph.clear();
     bool hasDrawerItems = false;
     for (const auto& item : m_items) {
-      if (isHiddenItem(item) || isPinnedItem(item)) {
+      if (tray::isPassiveStatus(item) || isHiddenItem(item) || isPinnedItem(item)) {
         continue;
       }
       hasDrawerItems = true;
@@ -581,7 +581,7 @@ void TrayWidget::rebuild(Renderer& renderer) {
   Flex* gridRow = nullptr;
   std::size_t gridCol = 0;
   for (const auto& item : m_items) {
-    if (isHiddenItem(item)) {
+    if (tray::isPassiveStatus(item) || isHiddenItem(item)) {
       continue;
     }
     if (m_drawerMode && !isPinnedItem(item)) {

--- a/src/shell/tray/tray_drawer_panel.cpp
+++ b/src/shell/tray/tray_drawer_panel.cpp
@@ -196,6 +196,9 @@ std::size_t TrayDrawerPanel::visibleItemCount() const {
   };
   std::size_t visible = 0;
   for (const auto& item : m_tray->items()) {
+    if (tray::isPassiveStatus(item)) {
+      continue;
+    }
     const bool hidden =
         std::ranges::any_of(hiddenLower, [&](const std::string& token) { return tokenMatches(token, item); });
     const bool pinned =

--- a/src/shell/tray/tray_identifier.h
+++ b/src/shell/tray/tray_identifier.h
@@ -13,6 +13,8 @@ namespace tray {
 
   inline bool isUniqueBusName(std::string_view value) { return !value.empty() && value.front() == ':'; }
 
+  inline bool isPassiveStatus(const TrayItemInfo& item) { return StringUtils::toLower(item.status) == "passive"; }
+
   inline bool isTransientUniqueIdentifier(std::string_view value) {
     return isUniqueBusName(value) || value.contains("/:");
   }

--- a/tests/tray_identifier_test.cpp
+++ b/tests/tray_identifier_test.cpp
@@ -1,0 +1,22 @@
+#include "shell/tray/tray_identifier.h"
+
+#include <cassert>
+
+int main() {
+  TrayItemInfo item;
+
+  item.status = "Passive";
+  assert(tray::isPassiveStatus(item));
+
+  item.status = "passive";
+  assert(tray::isPassiveStatus(item));
+
+  item.status = "Active";
+  assert(!tray::isPassiveStatus(item));
+
+  item.status = "NeedsAttention";
+  assert(!tray::isPassiveStatus(item));
+
+  item.status.clear();
+  assert(!tray::isPassiveStatus(item));
+}


### PR DESCRIPTION
## Summary

- omit StatusNotifierItems whose status is `Passive` from inline tray rendering
- keep tray drawer visibility and trigger counts consistent with the rendered items
- add focused coverage for Passive, Active, NeedsAttention, empty, and case-normalized statuses

## Motivation

Clients such as udiskie implement smart tray behavior by changing their StatusNotifierItem from `Active` to `Passive` when no removable devices are available. Noctalia tracked that change but continued rendering the item, leaving a stale-looking removable-drive icon after unplugging the device.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3794

## Testing

- `meson test -C build-debug tray_identifier --print-errorlogs`
- `meson test -C build-debug tray_identifier fcitx_status icon_resolver --print-errorlogs`
- `git diff --check`
- formatted changed C++ files with clang-format 22.1.8 (`just` is not installed in the test environment)

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

The original behavior was reproduced on Labwc with udiskie 2.7.0. The patched build was covered by focused unit tests but was not installed over the running packaged Noctalia session.

## Screenshots / Videos

Not included; this changes whether an idle tray item is present rather than its visual styling.

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build and test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration or require documentation updates.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Unknown or empty status values remain visible for compatibility with incomplete third-party StatusNotifierItem implementations. Status matching is case-insensitive, consistent with the surrounding tray identifier normalization.
