### PR TITLE
feat(templates): adding pretty gradient for hyprland active borders

### DIFF
--- a/assets/templates/hyprland/hyprland.conf
+++ b/assets/templates/hyprland/hyprland.conf
@@ -6,18 +6,18 @@ $tertiary = rgb({{colors.tertiary.default.hex_stripped}})
 $surface_lowest = rgb({{colors.surface_container_lowest.default.hex_stripped}})
 
 general {
-    col.active_border = $primary
+    col.active_border = $primary $tertiary 45deg
     col.inactive_border = $surface
 }
 
 group {
-    col.border_active = $secondary
+    col.border_active = $secondary $tertiary 45deg
     col.border_inactive = $surface
     col.border_locked_active = $error
     col.border_locked_inactive = $surface
 
     groupbar {
-        col.active = $secondary
+        col.active = $secondary $tertiary 45deg
         col.inactive = $surface
         col.locked_active = $error
         col.locked_inactive = $surface

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -4,19 +4,26 @@ local primary = "rgb({{colors.primary.default.hex_stripped}})"
 local surface = "rgb({{colors.surface.default.hex_stripped}})"
 local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
+local tertiary = "rgb({{colors.tertiary.default.hex_stripped}})"
 
 local function apply_theme()
     hl.config({
         general = {
             col = {
-                active_border = primary,
+                active_border = {
+                    colors = { primary, tertiary },
+                    angle = 45,
+                },
                 inactive_border = surface,
             },
         },
 
         group = {
             col = {
-                border_active = secondary,
+                border_active = {
+                    colors = { secondary, tertiary },
+                    angle = 45,
+                },
                 border_inactive = surface,
                 border_locked_active = error,
                 border_locked_inactive = surface,
@@ -24,7 +31,10 @@ local function apply_theme()
 
             groupbar = {
                 col = {
-                    active = secondary,
+                    active = {
+                        colors = { secondary, tertiary },
+                        angle = 45,
+                    },
                     inactive = surface,
                     locked_active = error,
                     locked_inactive = surface,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adding a 45 degree gradient to active windows for the official Hyprland template

## Motivation

Changes visuals to show off a feature of Hyprland via Noctalia templates

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

n/a

## Testing

Using on current machine

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="479" height="643" alt="image" src="https://github.com/user-attachments/assets/426f77f9-acf5-4589-a9ce-b1c596a387c4" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
