### PR TITLE
fix(cc/bt): preserve expansion of device rows

### DIFF
--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -699,11 +699,18 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
     devices = sortedDevices(m_service->devices());
   }
   const std::string nextKey = structureKey(devices);
-  if (listWidth == m_lastListWidth && nextKey == m_lastStructureKey) {
+  const bool structureChanged = nextKey != m_lastStructureKey;
+  if (listWidth == m_lastListWidth && !structureChanged) {
     return;
   }
   m_lastListWidth = listWidth;
   m_lastStructureKey = nextKey;
+
+  if (!structureChanged) {
+    m_list->layout(renderer);
+    return;
+  }
+
   const float scale = contentScale();
 
   m_powerToggle = nullptr;

--- a/src/shell/control_center/tabs/bluetooth_tab.cpp
+++ b/src/shell/control_center/tabs/bluetooth_tab.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 using namespace control_center;
@@ -713,6 +714,13 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
 
   const float scale = contentScale();
 
+  std::unordered_set<std::string> expandedPaths;
+  for (const auto& [path, row] : m_deviceRows) {
+    if (row->expanded()) {
+      expandedPaths.insert(path);
+    }
+  }
+
   m_powerToggle = nullptr;
   m_discoverableToggle = nullptr;
   m_scanSpinner = nullptr;
@@ -887,6 +895,7 @@ void BluetoothTab::rebuildDeviceList(Renderer& renderer) {
     auto row = std::make_unique<BluetoothDeviceRow>(device, m_service, scale);
     auto* rowPtr = row.get();
     bucketCard->addChild(std::move(row));
+    rowPtr->setExpandedImmediate(expandedPaths.contains(device.path));
     rowPtr->startConnectingSpinner();
     m_deviceRows.emplace(rowPtr->devicePath(), rowPtr);
   }


### PR DESCRIPTION
## Summary
Two independent changes to `BluetoothTab::rebuildDeviceList`, both to deal with unintended collapsing of rows on rebuilds.

`re-layout instead of rebuilding on width-only changes`: fixes expanding into a scrollable not persisting expansion state and collapsing everything back down again

`replay row expansion onto rebuilt rows`: fixes a connection failure (and maybe some other edge cases where rebuilds can be triggered when some busy work is being done by the bluetooth service) from collapsing rows due to it triggering a rebuild (especially noticeable just after startup when auto-reconnect is firing.)

## Motivation
Fix unintended collapsing of expanded rows

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
N/A

## Testing
observe expansion being maintained in both cases

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
https://github.com/user-attachments/assets/0a9aeba0-cc49-4e5e-8eb4-e5bcc1a22e81

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
N/A