### PR TITLE
fix(wallpaper): use transparent clear color for startup transition

### DIFF
--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -1409,7 +1409,7 @@ void Wallpaper::loadWallpaper(WallpaperInstance& instance, const std::string& pa
     if (wpConfig.transitionOnStartup && !wpConfig.transitions.empty()) {
       instance.currentSourceKind = WallpaperSourceKind::Color;
       instance.currentTexture = {};
-      instance.currentColor = rgba(0.0F, 0.0F, 0.0F, 1.0F);
+      instance.currentColor = rgba(0.0F, 0.0F, 0.0F, 0.0F);
       instance.nextSourceKind = newSourceKind;
       instance.nextTexture = newTex;
       instance.nextColor = newColor;


### PR DESCRIPTION
Previously the transition-on-startup source color was opaque black, so enabling transitionOnStartup always faded in from black regardless of what was behind it. Using a transparent color instead lets the transition start from whatever was already showing (another wallpaper, or the compositor's background color) and fade into the new wallpaper.

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

This is a minimal change, specific to enabling "transition on startup", that changes the clear color from black to transparent

## Motivation

This makes Noctalia transition from whatever the previous backdrop would have been (Compositor's background color or another wallpaper program) to the wallpaper set in Noctalia. This enhances the functionality of "Animate on startup".

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Started Noctalia multiple times with and without the change to verify everything was working well. Noctalia blends properly between the previous background (solid color, or another wallpaper program) to the wallpaper set by Noctalia, with the proper transition

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
https://github.com/user-attachments/assets/43c7f2ec-9612-45b7-b1d0-04994434d675

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
