### PR TITLE
fix(settings): skip no-op writes and deduplicate deferred rebuilds

### DIFF
--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -829,13 +829,14 @@ namespace settings {
                   [setOverride = ctx.setOverride, clearOverride = ctx.clearOverride,
                    requestRebuild = ctx.requestRebuild, pendingKey = &ctx.pendingGestureKey,
                    pendingVerb = &ctx.pendingGestureVerb, specFor, path, verb = actionVerb,
-                   defaultAction = setting.defaultAction, execMode](const std::string& text) {
+                   defaultAction = setting.defaultAction, effectiveAction = effective,
+                   execMode](const std::string& text) {
                     const std::string trimmed = StringUtils::trim(text);
+                    std::string commandLine;
+                    bool shouldClear = false;
                     if (trimmed.empty() && (execMode || specRequiresArgument(specFor(verb)))) {
-                      // A required argument cannot produce a valid binding.
-                      clearOverride(path);
+                      shouldClear = true;
                     } else {
-                      std::string commandLine;
                       if (execMode) {
                         commandLine = std::string(noctalia::bar::kExecVerb) + " " + trimmed;
                       } else {
@@ -844,7 +845,16 @@ namespace settings {
                           commandLine += " " + trimmed;
                         }
                       }
-                      if (commandLine == defaultAction) {
+                      shouldClear = commandLine == defaultAction;
+                    }
+
+                    // setOverride/clearOverride each queue a DeferredCall. Skip them
+                    // when the value hasn't changed so rapid focus switches between
+                    // argument text fields don't pile up deferred callbacks.
+                    const bool changed = shouldClear ? !effectiveAction.empty()
+                                                     : commandLine != effectiveAction;
+                    if (changed) {
+                      if (shouldClear) {
                         clearOverride(path);
                       } else {
                         setOverride(path, commandLine);
@@ -852,7 +862,7 @@ namespace settings {
                     }
                     pendingKey->clear();
                     pendingVerb->clear();
-                    if (requestRebuild) {
+                    if (requestRebuild && changed) {
                       requestRebuild();
                     }
                   },

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -727,7 +727,12 @@ void SettingsWindow::maybeOpenPendingEditor() {
 }
 
 void SettingsWindow::requestSceneRebuild() {
+  if (m_deferredRebuildQueued) {
+    return;
+  }
+  m_deferredRebuildQueued = true;
   DeferredCall::callLater([this]() {
+    m_deferredRebuildQueued = false;
     if (m_surface == nullptr) {
       return;
     }
@@ -745,7 +750,12 @@ void SettingsWindow::requestSceneRebuild() {
 }
 
 void SettingsWindow::requestContentRebuild(bool refreshRegistry, bool refreshFilterRow, bool rebuildEditorSheet) {
+  if (m_deferredRebuildQueued) {
+    return;
+  }
+  m_deferredRebuildQueued = true;
   DeferredCall::callLater([this, refreshRegistry, refreshFilterRow, rebuildEditorSheet]() {
+    m_deferredRebuildQueued = false;
     if (m_surface == nullptr) {
       return;
     }

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -263,6 +263,7 @@ private:
   bool m_contentRebuildRequested = false;
   bool m_settingsRegistryRefreshRequested = false;
   bool m_filterRowRefreshRequested = false;
+  bool m_deferredRebuildQueued = false;
   bool m_focusSearchOnRebuild = false;
   Input* m_settingsSearchInput = nullptr;
   bool m_scrollToPendingContentTarget = false;


### PR DESCRIPTION
setOverride fires on every focus loss from gesture action text fields, queuing a DeferredCall per click even when the value hasn't changed. requestSceneRebuild / requestContentRebuild also queue duplicate DeferredCall entries because nothing prevents a second call while the first is still pending.  Together they freeze the main loop.

Guard the gesture action onSubmit so it only calls setOverride / requestRebuild when the command line actually changed.  Gate both rebuild entry points with m_deferredRebuildQueued so at most one DeferredCall is queued at a time.

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [ ] This PR is ready for review, or it is marked as Draft.
- [ ] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [ ] I ran the relevant build or test commands, or explained why they were not run.
- [ ] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
