### PR TITLE
fix(settings): skip no-op writes and deduplicate deferred rebuilds

### DIFF
--- a/src/shell/settings/settings_control_factory.cpp
+++ b/src/shell/settings/settings_control_factory.cpp
@@ -829,13 +829,14 @@ namespace settings {
                   [setOverride = ctx.setOverride, clearOverride = ctx.clearOverride,
                    requestRebuild = ctx.requestRebuild, pendingKey = &ctx.pendingGestureKey,
                    pendingVerb = &ctx.pendingGestureVerb, specFor, path, verb = actionVerb,
-                   defaultAction = setting.defaultAction, execMode](const std::string& text) {
+                   defaultAction = setting.defaultAction, effectiveAction = effective,
+                   execMode](const std::string& text) {
                     const std::string trimmed = StringUtils::trim(text);
+                    std::string commandLine;
+                    bool shouldClear = false;
                     if (trimmed.empty() && (execMode || specRequiresArgument(specFor(verb)))) {
-                      // A required argument cannot produce a valid binding.
-                      clearOverride(path);
+                      shouldClear = true;
                     } else {
-                      std::string commandLine;
                       if (execMode) {
                         commandLine = std::string(noctalia::bar::kExecVerb) + " " + trimmed;
                       } else {
@@ -844,7 +845,15 @@ namespace settings {
                           commandLine += " " + trimmed;
                         }
                       }
-                      if (commandLine == defaultAction) {
+                      shouldClear = commandLine == defaultAction;
+                    }
+
+                    // setOverride/clearOverride each queue a DeferredCall. Skip them
+                    // when the value hasn't changed so rapid focus switches between
+                    // argument text fields don't pile up deferred callbacks.
+                    const bool changed = shouldClear ? !effectiveAction.empty() : commandLine != effectiveAction;
+                    if (changed) {
+                      if (shouldClear) {
                         clearOverride(path);
                       } else {
                         setOverride(path, commandLine);
@@ -852,7 +861,7 @@ namespace settings {
                     }
                     pendingKey->clear();
                     pendingVerb->clear();
-                    if (requestRebuild) {
+                    if (requestRebuild && changed) {
                       requestRebuild();
                     }
                   },

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -727,53 +727,58 @@ void SettingsWindow::maybeOpenPendingEditor() {
 }
 
 void SettingsWindow::requestSceneRebuild() {
+  m_deferredSceneRebuild = true;
+  scheduleDeferredRebuild();
+}
+
+void SettingsWindow::requestContentRebuild(bool refreshRegistry, bool refreshFilterRow, bool rebuildEditorSheet) {
+  m_deferredRefreshRegistry = m_deferredRefreshRegistry || refreshRegistry;
+  m_deferredRefreshFilterRow = m_deferredRefreshFilterRow || refreshFilterRow;
+  m_deferredRebuildEditorSheet = m_deferredRebuildEditorSheet || rebuildEditorSheet;
+  scheduleDeferredRebuild();
+}
+
+void SettingsWindow::scheduleDeferredRebuild() {
   if (m_deferredRebuildQueued) {
     return;
   }
   m_deferredRebuildQueued = true;
   DeferredCall::callLater([this]() {
     m_deferredRebuildQueued = false;
+    const bool sceneRebuild = m_deferredSceneRebuild;
+    const bool refreshRegistry = m_deferredRefreshRegistry;
+    const bool refreshFilterRow = m_deferredRefreshFilterRow;
+    const bool rebuildEditorSheet = m_deferredRebuildEditorSheet;
+    m_deferredSceneRebuild = false;
+    m_deferredRefreshRegistry = false;
+    m_deferredRefreshFilterRow = false;
+    m_deferredRebuildEditorSheet = false;
     if (m_surface == nullptr) {
       return;
     }
-    m_rebuildRequested = true;
-    m_contentRebuildRequested = false;
-    m_settingsRegistryRefreshRequested = false;
-    m_filterRowRefreshRequested = false;
-    m_surface->requestLayout();
-    // The editor sheet edits the same config: rebuild its body so override/reset controls track
-    // value changes in place, the way the inline inspector did when the whole scene rebuilt.
-    if (m_editorSheetPopup != nullptr && m_editorSheetPopup->isOpen()) {
-      m_editorSheetPopup->rebuildBody();
-    }
-  });
-}
 
-void SettingsWindow::requestContentRebuild(bool refreshRegistry, bool refreshFilterRow, bool rebuildEditorSheet) {
-  if (m_deferredRebuildQueued) {
-    return;
-  }
-  m_deferredRebuildQueued = true;
-  DeferredCall::callLater([this, refreshRegistry, refreshFilterRow, rebuildEditorSheet]() {
-    m_deferredRebuildQueued = false;
-    if (m_surface == nullptr) {
-      return;
-    }
-    if (refreshRegistry) {
-      m_settingsRegistryRefreshRequested = true;
-    }
-    if (refreshFilterRow) {
-      m_filterRowRefreshRequested = true;
-    }
-    if (m_sceneRoot == nullptr || m_contentContainer == nullptr) {
+    if (sceneRebuild) {
       m_rebuildRequested = true;
+      m_contentRebuildRequested = false;
       m_settingsRegistryRefreshRequested = false;
       m_filterRowRefreshRequested = false;
-    } else if (!m_rebuildRequested) {
-      m_contentRebuildRequested = true;
+    } else {
+      if (refreshRegistry) {
+        m_settingsRegistryRefreshRequested = true;
+      }
+      if (refreshFilterRow) {
+        m_filterRowRefreshRequested = true;
+      }
+      if (m_sceneRoot == nullptr || m_contentContainer == nullptr) {
+        m_rebuildRequested = true;
+        m_settingsRegistryRefreshRequested = false;
+        m_filterRowRefreshRequested = false;
+      } else if (!m_rebuildRequested) {
+        m_contentRebuildRequested = true;
+      }
     }
     m_surface->requestLayout();
-    if (rebuildEditorSheet && m_editorSheetPopup != nullptr && m_editorSheetPopup->isOpen()) {
+    if ((sceneRebuild || rebuildEditorSheet) && m_editorSheetPopup != nullptr && m_editorSheetPopup->isOpen()) {
       m_editorSheetPopup->rebuildBody();
     }
   });

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -727,7 +727,12 @@ void SettingsWindow::maybeOpenPendingEditor() {
 }
 
 void SettingsWindow::requestSceneRebuild() {
+  if (m_deferredRebuildQueued) {
+    return;
+  }
+  m_deferredRebuildQueued = true;
   DeferredCall::callLater([this]() {
+    m_deferredRebuildQueued = false;
     if (m_surface == nullptr) {
       return;
     }
@@ -745,7 +750,12 @@ void SettingsWindow::requestSceneRebuild() {
 }
 
 void SettingsWindow::requestContentRebuild(bool refreshRegistry, bool refreshFilterRow, bool rebuildEditorSheet) {
+  if (m_deferredRebuildQueued) {
+    return;
+  }
+  m_deferredRebuildQueued = true;
   DeferredCall::callLater([this, refreshRegistry, refreshFilterRow, rebuildEditorSheet]() {
+    m_deferredRebuildQueued = false;
     if (m_surface == nullptr) {
       return;
     }

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -146,6 +146,7 @@ private:
   void requestSceneRebuild();
   void
   requestContentRebuild(bool refreshRegistry = false, bool refreshFilterRow = false, bool rebuildEditorSheet = false);
+  void scheduleDeferredRebuild();
   void markPluginListDirty();
   void refreshPluginListIfNeeded();
   void maybeOpenPendingEditor();
@@ -264,6 +265,10 @@ private:
   bool m_settingsRegistryRefreshRequested = false;
   bool m_filterRowRefreshRequested = false;
   bool m_deferredRebuildQueued = false;
+  bool m_deferredSceneRebuild = false;
+  bool m_deferredRefreshRegistry = false;
+  bool m_deferredRefreshFilterRow = false;
+  bool m_deferredRebuildEditorSheet = false;
   bool m_focusSearchOnRebuild = false;
   Input* m_settingsSearchInput = nullptr;
   bool m_scrollToPendingContentTarget = false;

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -263,6 +263,7 @@ private:
   bool m_contentRebuildRequested = false;
   bool m_settingsRegistryRefreshRequested = false;
   bool m_filterRowRefreshRequested = false;
+  bool m_deferredRebuildQueued = false;
   bool m_focusSearchOnRebuild = false;
   Input* m_settingsSearchInput = nullptr;
   bool m_scrollToPendingContentTarget = false;


### PR DESCRIPTION

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Guard the gesture action `onSubmit` so it only calls `setOverride` / `requestRebuild` when the command line actually changed.  Gate both rebuild entry points with `m_deferredRebuildQueued` so at most one `DeferredCall` is queued at a time.

## Motivation

<!-- What problem does this solve? -->
`setOverride` fires on every focus loss from gesture action text fields, queuing a `DeferredCall` per click even when the value hasn't changed. `requestSceneRebuild` / `requestContentRebuild` also queue duplicate `DeferredCall` entries because nothing prevents a second call while the first is still pending.  Together they freeze the main loop.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3781
<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Follow the [method](https://github.com/user-attachments/assets/fe2bde8d-cb41-49c3-b008-18cbeb2867d0) in the issue to test. Before the change, the bug can be stably reproduced; after the change, it no longer occurs and behaves as expected.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
