### PR TITLE
feat(launcher): allow marking apps as favorites

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -644,7 +644,11 @@
     "context-menu": {
       "open": "Open",
       "pin-to-dock": "Pin to dock",
-      "unpin-from-dock": "Unpin from dock"
+      "unpin-from-dock": "Unpin from dock",
+      "favorites-add": "Add to favorites",
+      "favorites-remove": "Remove from favorites",
+      "favorites-move-up": "Move up",
+      "favorites-move-down": "Move down"
     },
     "empty": {
       "no-results": "No results found",
@@ -2355,6 +2359,10 @@
         "launcher-sort-by-usage": {
           "description": "Boost frequently used apps toward the top and show a Recently Used category filter",
           "label": "Sort by Usage"
+        },
+        "launcher-enable-favorites": {
+          "description": "Allow marking apps as favorites and show them on top in results",
+          "label": "Enable Favorites"
         },
         "list-item-background": {
           "description": "Draw a rounded background behind each launcher and clipboard list item",

--- a/meson.build
+++ b/meson.build
@@ -502,6 +502,7 @@ _noctalia_sources = files(
   'src/launcher/dmenu_socket_path.cpp',
   'src/launcher/dmenu_stdin_provider.cpp',
   'src/launcher/emoji_provider.cpp',
+  'src/launcher/favorites_store.cpp',
   'src/launcher/math_provider.cpp',
   'src/launcher/plugin_launcher_provider.cpp',
   'src/launcher/session_provider.cpp',

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -985,6 +985,7 @@ struct ShellConfig {
     bool compact = false;
     bool appGrid = false;
     bool sortByUsage = true;
+    bool enableFavorites = true;
     /// When true, refresh currency exchange rates from libqalculate's online sources.
     bool fetchExchangeRates = true;
     std::string providerPrefix = "/";

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -1301,6 +1301,7 @@ namespace noctalia::config::schema {
           field(&ShellConfig::LauncherConfig::compact, "compact"),
           field(&ShellConfig::LauncherConfig::appGrid, "app_grid"),
           field(&ShellConfig::LauncherConfig::sortByUsage, "sort_by_usage"),
+          field(&ShellConfig::LauncherConfig::enableFavorites, "enable_favorites"),
           field(&ShellConfig::LauncherConfig::fetchExchangeRates, "fetch_exchange_rates"),
           field(&ShellConfig::LauncherConfig::providerPrefix, "provider_prefix"),
           enumField(&ShellConfig::LauncherConfig::autoPaste, "auto_paste", kClipboardAutoPasteModes),

--- a/src/launcher/favorites_store.cpp
+++ b/src/launcher/favorites_store.cpp
@@ -101,9 +101,10 @@ void FavoritesStore::load() {
 
 void FavoritesStore::save() const {
   std::error_code ec;
-  std::filesystem::create_directories(std::filesystem::path(m_favoritesPath).parent_path(), ec);
+  const auto parent = std::filesystem::path(m_favoritesPath).parent_path();
+  std::filesystem::create_directories(parent, ec);
   if (ec) {
-    kLog.error("Failed to create directory {}, error: {}", m_favoritesPath, ec.message());
+    kLog.error("Failed to create directory {}, error: {}", parent.string(), ec.message());
     return;
   }
   nlohmann::json json = m_favorites;

--- a/src/launcher/favorites_store.cpp
+++ b/src/launcher/favorites_store.cpp
@@ -22,7 +22,7 @@ void FavoritesStore::add(std::string_view providerId, std::string_view resultId)
   if (getPos(providerId, resultId) > 0) {
     return;
   }
-  m_favorites[std::string(providerId)].push_back(std::string(resultId));
+  m_favorites[std::string(providerId)].emplace_back(resultId);
   rebuildIndex(providerId);
   save();
 }
@@ -32,7 +32,7 @@ void FavoritesStore::remove(std::string_view providerId, std::string_view result
     return;
   }
   auto& favorites = m_favorites[std::string(providerId)];
-  favorites.erase(std::remove(favorites.begin(), favorites.end(), std::string(resultId)), favorites.end());
+  std::erase(favorites, resultId);
   if (favorites.empty()) {
     m_favorites.erase(std::string(providerId));
     m_favoritesIndex.erase(std::string(providerId));
@@ -44,7 +44,7 @@ void FavoritesStore::remove(std::string_view providerId, std::string_view result
 
 void FavoritesStore::moveUp(std::string_view providerId, std::string_view resultId) {
   auto& favorites = m_favorites[std::string(providerId)];
-  auto it = std::find(favorites.begin(), favorites.end(), std::string(resultId));
+  auto it = std::ranges::find(favorites, resultId);
   if (it != favorites.end() && it != favorites.begin()) {
     std::swap(*it, *(it - 1));
     rebuildIndex(providerId);
@@ -54,7 +54,7 @@ void FavoritesStore::moveUp(std::string_view providerId, std::string_view result
 
 void FavoritesStore::moveDown(std::string_view providerId, std::string_view resultId) {
   auto& favorites = m_favorites[std::string(providerId)];
-  auto it = std::find(favorites.begin(), favorites.end(), std::string(resultId));
+  auto it = std::ranges::find(favorites, resultId);
   if (it != favorites.end() && (it + 1) != favorites.end()) {
     std::swap(*it, *(it + 1));
     rebuildIndex(providerId);

--- a/src/launcher/favorites_store.cpp
+++ b/src/launcher/favorites_store.cpp
@@ -1,0 +1,125 @@
+#include "launcher/favorites_store.h"
+
+#include "core/log.h"
+#include "util/file_utils.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+namespace {
+  constexpr Logger kLog("launcher.favorites-store");
+}
+
+FavoritesStore::FavoritesStore() {
+  const std::string dir = FileUtils::stateDir();
+  m_favoritesPath = (dir.empty() ? "." : dir) + "/favorites.json";
+  load();
+}
+
+void FavoritesStore::add(std::string_view providerId, std::string_view resultId) {
+  if (getPos(providerId, resultId) > 0) {
+    return;
+  }
+  m_favorites[std::string(providerId)].push_back(std::string(resultId));
+  rebuildIndex(providerId);
+  save();
+}
+
+void FavoritesStore::remove(std::string_view providerId, std::string_view resultId) {
+  if (getPos(providerId, resultId) == 0) {
+    return;
+  }
+  auto& favorites = m_favorites[std::string(providerId)];
+  favorites.erase(std::remove(favorites.begin(), favorites.end(), std::string(resultId)), favorites.end());
+  if (favorites.empty()) {
+    m_favorites.erase(std::string(providerId));
+    m_favoritesIndex.erase(std::string(providerId));
+  } else {
+    rebuildIndex(providerId);
+  }
+  save();
+}
+
+void FavoritesStore::moveUp(std::string_view providerId, std::string_view resultId) {
+  auto& favorites = m_favorites[std::string(providerId)];
+  auto it = std::find(favorites.begin(), favorites.end(), std::string(resultId));
+  if (it != favorites.end() && it != favorites.begin()) {
+    std::swap(*it, *(it - 1));
+    rebuildIndex(providerId);
+    save();
+  }
+}
+
+void FavoritesStore::moveDown(std::string_view providerId, std::string_view resultId) {
+  auto& favorites = m_favorites[std::string(providerId)];
+  auto it = std::find(favorites.begin(), favorites.end(), std::string(resultId));
+  if (it != favorites.end() && (it + 1) != favorites.end()) {
+    std::swap(*it, *(it + 1));
+    rebuildIndex(providerId);
+    save();
+  }
+}
+
+int FavoritesStore::getPos(std::string_view providerId, std::string_view resultId) const {
+  const auto provIt = m_favoritesIndex.find(std::string(providerId));
+  if (provIt == m_favoritesIndex.end()) {
+    return 0;
+  }
+  const auto idIt = provIt->second.find(std::string(resultId));
+  return idIt != provIt->second.end() ? idIt->second : 0;
+}
+
+std::deque<std::string> FavoritesStore::getFavorites(std::string_view providerId) const {
+  const auto provIt = m_favorites.find(std::string(providerId));
+  if (provIt == m_favorites.end()) {
+    return {};
+  }
+  return provIt->second;
+}
+
+std::size_t FavoritesStore::getFavoritesCount(std::string_view providerId) const {
+  const auto provIt = m_favorites.find(std::string(providerId));
+  return provIt != m_favorites.end() ? provIt->second.size() : 0;
+}
+
+void FavoritesStore::load() {
+  std::ifstream file(m_favoritesPath);
+  if (file.is_open()) {
+    try {
+      const auto json = nlohmann::json::parse(file);
+      for (const auto& [provider, ids] : json.items()) {
+        m_favorites[provider].assign(ids.begin(), ids.end());
+        rebuildIndex(provider);
+      }
+    } catch (const nlohmann::json::exception&) {
+      // Ignore malformed file — starts fresh
+    }
+  }
+}
+
+void FavoritesStore::save() const {
+  std::error_code ec;
+  std::filesystem::create_directories(std::filesystem::path(m_favoritesPath).parent_path(), ec);
+  if (ec) {
+    kLog.error("Failed to create directory {}, error: {}", m_favoritesPath, ec.message());
+    return;
+  }
+  nlohmann::json json = m_favorites;
+  std::ofstream file(m_favoritesPath, std::ios::trunc);
+  file << json.dump(2) << '\n';
+  file.close();
+  if (!file) {
+    kLog.error("Failed to save favorites to {}", m_favoritesPath);
+  }
+}
+
+void FavoritesStore::rebuildIndex(std::string_view provider) {
+  const auto& favorites = m_favorites[std::string(provider)];
+  auto& index = m_favoritesIndex[std::string(provider)];
+  index.clear();
+  for (std::size_t i = 0; i < favorites.size(); ++i) {
+    index[favorites[i]] = static_cast<int>(favorites.size() - i);
+  }
+}

--- a/src/launcher/favorites_store.h
+++ b/src/launcher/favorites_store.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <deque>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+class FavoritesStore {
+public:
+  FavoritesStore();
+
+  void add(std::string_view providerId, std::string_view resultId);
+  void remove(std::string_view providerId, std::string_view resultId);
+  void moveUp(std::string_view providerId, std::string_view resultId);
+  void moveDown(std::string_view providerId, std::string_view resultId);
+  // Returns the position of the favorite, larger is closer to the front. Returns 0 if not a favorite.
+  [[nodiscard]] int getPos(std::string_view providerId, std::string_view resultId) const;
+  [[nodiscard]] std::deque<std::string> getFavorites(std::string_view providerId) const;
+  [[nodiscard]] std::size_t getFavoritesCount(std::string_view providerId) const;
+
+private:
+  void load();
+  void save() const;
+  void rebuildIndex(std::string_view provider);
+
+  std::string m_favoritesPath;
+  std::unordered_map<std::string, std::deque<std::string>> m_favorites;
+  std::unordered_map<std::string, std::unordered_map<std::string, int>> m_favoritesIndex;
+};

--- a/src/launcher/launcher_provider.h
+++ b/src/launcher/launcher_provider.h
@@ -37,6 +37,7 @@ struct LauncherResult {
   std::optional<std::string> query;
   double score = 0.0;
   int recentlyUsedIndex = 0; // Higher is more recent. <=0 means no record or too old.
+  int favoriteIndex = 0;     // Higher is in front. <=0 means not a favorite.
 };
 
 class LauncherProvider {

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -102,8 +102,13 @@ namespace {
     return id;
   }
 
-  void sortResultsByScore(std::vector<LauncherResult>& results) {
-    std::ranges::stable_sort(results, std::ranges::greater{}, &LauncherResult::score);
+  void sortResultsByFavoriteAndScore(std::vector<LauncherResult>& results) {
+    std::ranges::stable_sort(results, [](const LauncherResult& a, const LauncherResult& b) {
+      if (a.favoriteIndex != b.favoriteIndex) {
+        return a.favoriteIndex > b.favoriteIndex;
+      }
+      return a.score > b.score;
+    });
   }
 
   struct LauncherListStyle {
@@ -272,6 +277,15 @@ namespace {
               })
           )
       );
+
+      m_row->addChild(
+          ui::glyph({
+              .out = &m_star,
+              .glyph = "star-filled",
+              .glyphSize = Style::fontSizeBody * m_style.scale,
+              .visible = false,
+          })
+      );
     }
 
     void setListStyle(LauncherListStyle style) { m_style = style; }
@@ -280,6 +294,7 @@ namespace {
     bind(Renderer& renderer, const LauncherResult& result, float width, float height, bool selected, bool hovered) {
       m_selected = selected;
       m_hovered = hovered;
+      m_favorite = result.favoriteIndex > 0;
       m_iconPath = result.iconPath;
       m_fallbackGlyph = result.glyphName.empty() ? "app-window" : result.glyphName;
       const float iconSize = launcherIconSize(m_style);
@@ -339,6 +354,8 @@ namespace {
         m_subtitle->setMaxWidth(textWidth);
       }
 
+      m_star->setVisible(m_favorite);
+
       applyVisualState();
     }
 
@@ -392,12 +409,17 @@ namespace {
       m_glyph->setColor(foreground);
       m_title->setColor(foreground);
       m_subtitle->setColor(mutedForeground);
+
+      if (m_favorite) {
+        m_star->setColor(colorSpecFromRole((m_selected || m_hovered) ? ColorRole::OnSurface : ColorRole::Primary));
+      }
     }
 
     LauncherListStyle m_style{};
     float m_rowHeight = 0.0F;
     bool m_selected = false;
     bool m_hovered = false;
+    bool m_favorite = false;
     Flex* m_row = nullptr;
     Label* m_badgeLabel = nullptr;
     Image* m_image = nullptr;
@@ -405,6 +427,7 @@ namespace {
     Flex* m_textCol = nullptr;
     Label* m_title = nullptr;
     Label* m_subtitle = nullptr;
+    Glyph* m_star = nullptr;
     AsyncTextureCache* m_asyncTextures = nullptr;
     std::string m_iconPath;
     std::string m_fallbackGlyph;
@@ -468,6 +491,15 @@ namespace {
               .configure = [](Label& label) { label.setTextAlign(TextAlign::Center); },
           })
       );
+
+      addChild(
+          ui::glyph({
+              .out = &m_star,
+              .glyph = "star-filled",
+              .glyphSize = Style::fontSizeBody * m_style.scale,
+              .visible = false,
+          })
+      );
     }
 
     void setListStyle(LauncherListStyle style) { m_style = style; }
@@ -476,6 +508,7 @@ namespace {
     bind(Renderer& renderer, const LauncherResult& result, float width, float height, bool selected, bool hovered) {
       m_selected = selected;
       m_hovered = hovered;
+      m_favorite = result.favoriteIndex > 0;
       m_iconPath = result.iconPath;
       m_fallbackGlyph = result.glyphName.empty() ? "app-window" : result.glyphName;
       const float iconSize = launcherIconSize(m_style);
@@ -513,6 +546,8 @@ namespace {
       m_title->setText(singleLinePreview(result.title));
       m_title->setMaxWidth(textWidth);
 
+      m_star->setVisible(m_favorite);
+
       applyVisualState();
     }
 
@@ -546,6 +581,10 @@ namespace {
       if (m_style.showIcons && !m_iconPath.empty()) {
         (void)refreshAsyncIcon(renderer);
       }
+      if (m_favorite) {
+        const float gap = Style::spaceXs * m_style.scale;
+        m_star->setPosition(width() - m_star->width() - gap, gap);
+      }
       Node::doLayout(renderer);
     }
 
@@ -564,15 +603,21 @@ namespace {
       const ColorSpec foreground = colorSpecFromRole(active ? activeRole : ColorRole::OnSurface);
       m_glyph->setColor(foreground);
       m_title->setColor(foreground);
+
+      if (m_favorite) {
+        m_star->setColor(colorSpecFromRole((m_selected || m_hovered) ? ColorRole::OnSurface : ColorRole::Primary));
+      }
     }
 
     LauncherListStyle m_style{};
     bool m_selected = false;
     bool m_hovered = false;
+    bool m_favorite = false;
     Flex* m_col = nullptr;
     Image* m_image = nullptr;
     Glyph* m_glyph = nullptr;
     Label* m_title = nullptr;
+    Glyph* m_star = nullptr;
     AsyncTextureCache* m_asyncTextures = nullptr;
     std::string m_iconPath;
     std::string m_fallbackGlyph;
@@ -818,7 +863,7 @@ void LauncherPanel::create() {
   m_gridAdapter->setResults(&m_results);
   const auto onActivate = [this](std::size_t index) { activateAt(index); };
   const auto onSecondaryActivate = [this](std::size_t index, float ax, float ay) {
-    (void)openAppActionsMenu(index, ax, ay);
+    (void)openActionsMenu(index, ax, ay);
   };
   m_listAdapter->setOnActivate(onActivate);
   m_listAdapter->setOnSecondaryActivate(onSecondaryActivate);
@@ -1152,6 +1197,10 @@ void LauncherPanel::syncUsageTrackingState() {
   }
 }
 
+bool LauncherPanel::favoritesEnabled() const {
+  return m_config != nullptr && m_config->config().shell.launcher.enableFavorites;
+}
+
 void LauncherPanel::reapplyCurrentQuery() {
   std::string selectedProvider;
   std::string selectedId;
@@ -1227,6 +1276,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
   }
 
   m_query = text;
+  m_queryText = text;
   m_allResults.clear();
 
   std::vector<LauncherCategory> newCategories;
@@ -1237,17 +1287,16 @@ void LauncherPanel::onInputChanged(const std::string& text) {
       if (provider->id() != m_scopedProviderId) {
         continue;
       }
-      m_allResults = provider->query(text);
+      m_allResults = provider->query(m_queryText);
       for (auto& result : m_allResults) {
         result.providerId = provider->id();
       }
-      sortResultsByScore(m_allResults);
+      sortResultsByFavoriteAndScore(m_allResults);
       break;
     }
   } else {
     // Route query to providers
     LauncherProvider* activeProvider = nullptr;
-    std::string_view queryText = text;
 
     // Check for prefix match (longest first)
     for (auto& provider : m_providers) {
@@ -1259,32 +1308,35 @@ void LauncherPanel::onInputChanged(const std::string& text) {
           && std::string_view(text).starts_with(prefix)
           && (activeProvider == nullptr || prefix.size() > activeProvider->prefix().size())) {
         activeProvider = provider.get();
-        queryText = std::string_view(text).substr(prefix.size());
+        m_queryText = std::string_view(text).substr(prefix.size());
       }
     }
     // Trim leading space after prefix
-    if (activeProvider != nullptr && !queryText.empty() && queryText.front() == ' ') {
-      queryText = queryText.substr(1);
+    if (activeProvider != nullptr && !m_queryText.empty() && m_queryText.front() == ' ') {
+      m_queryText = m_queryText.substr(1);
     }
 
-    const bool typedQuery = !queryText.empty();
+    const bool typedQuery = !m_queryText.empty();
+    const bool enableFavorites = favoritesEnabled();
     const bool sortByUsage = m_config != nullptr && m_config->config().shell.launcher.sortByUsage;
 
-    auto applyUsageBoost = [&](std::vector<LauncherResult>& results, const LauncherProvider& provider) {
-      if (!sortByUsage) {
-        return;
-      }
+    auto applyFavoritesAndUsageBoost = [&](std::vector<LauncherResult>& results, const LauncherProvider& provider) {
       for (auto& result : results) {
-        const int usageCount = m_usageTracker.getCount(provider.id(), result.id);
-        result.score += usageBoostForScore(result.score, usageCount, typedQuery);
-        result.recentlyUsedIndex = m_usageTracker.getRecentlyUsedIndex(provider.id(), result.id);
+        if (enableFavorites) {
+          result.favoriteIndex = m_favoritesStore.getPos(provider.id(), result.id);
+        }
+        if (sortByUsage) {
+          const int usageCount = m_usageTracker.getCount(provider.id(), result.id);
+          result.score += usageBoostForScore(result.score, usageCount, typedQuery);
+          result.recentlyUsedIndex = m_usageTracker.getRecentlyUsedIndex(provider.id(), result.id);
+        }
       }
     };
 
     if (activeProvider != nullptr) {
-      m_allResults = activeProvider->queryPrefixed(queryText);
+      m_allResults = activeProvider->queryPrefixed(m_queryText);
       if (activeProvider->trackUsage()) {
-        applyUsageBoost(m_allResults, *activeProvider);
+        applyFavoritesAndUsageBoost(m_allResults, *activeProvider);
         if (sortByUsage && m_usageTracker.getRecentlyUsedCount(activeProvider->id()) > 0) {
           hasRecentlyUsed = true;
         }
@@ -1292,7 +1344,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
       for (auto& result : m_allResults) {
         result.providerId = activeProvider->id();
       }
-      sortResultsByScore(m_allResults);
+      sortResultsByFavoriteAndScore(m_allResults);
       newCategories = activeProvider->categories();
     } else if (startsWithLauncherPrefix(text)) {
       m_allResults = providerOverviewResults(text);
@@ -1301,15 +1353,15 @@ void LauncherPanel::onInputChanged(const std::string& text) {
       // Prefixed opt-in providers (e.g. Session) only contribute once the query is long enough,
       // so opening the launcher with no/short input does not flood it with their entries.
       const bool allowGlobalOptIn =
-          StringUtils::trimRightView(StringUtils::trimLeftView(queryText)).size() >= kGlobalOptInMinChars;
+          StringUtils::trimRightView(StringUtils::trimLeftView(m_queryText)).size() >= kGlobalOptInMinChars;
       for (auto& provider : m_providers) {
         const bool isDefault = provider->prefix().empty();
         if (!isDefault && (!provider->includeInGlobalSearch() || !allowGlobalOptIn)) {
           continue;
         }
-        auto results = provider->query(queryText);
+        auto results = provider->query(m_queryText);
         if (provider->trackUsage()) {
-          applyUsageBoost(results, *provider);
+          applyFavoritesAndUsageBoost(results, *provider);
           if (sortByUsage && m_usageTracker.getRecentlyUsedCount(provider->id()) > 0) {
             hasRecentlyUsed = true;
           }
@@ -1325,7 +1377,7 @@ void LauncherPanel::onInputChanged(const std::string& text) {
           newCategories.push_back(std::move(cat));
         }
       }
-      sortResultsByScore(m_allResults);
+      sortResultsByFavoriteAndScore(m_allResults);
     }
   }
 
@@ -1483,7 +1535,7 @@ std::vector<LauncherResult> LauncherPanel::providerOverviewResults(std::string_v
   }
 
   if (!filter.empty()) {
-    sortResultsByScore(results);
+    sortResultsByFavoriteAndScore(results);
   }
   return results;
 }
@@ -1576,22 +1628,11 @@ void LauncherPanel::bindDetailResult() {
   m_detailScroll->setScrollOffset(0.0F);
 }
 
-bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float anchorY) {
+bool LauncherPanel::openActionsMenu(std::size_t index, float anchorX, float anchorY) {
   if (index >= m_results.size()) {
     return false;
   }
   const LauncherResult& base = m_results[index];
-
-  const DesktopEntry* match = nullptr;
-  for (const auto& e : desktopEntries()) {
-    if (e.path == base.id) {
-      match = &e;
-      break;
-    }
-  }
-  if (match == nullptr) {
-    return false;
-  }
 
   WaylandConnection* wl = PanelManager::instance().wayland();
   RenderContext* rc = PanelManager::instance().renderContext();
@@ -1608,59 +1649,141 @@ bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     m_actionsMenu = std::make_unique<ContextMenuPopup>(*wl, *rc);
   }
 
-  std::vector<DesktopAction> actionsCopy = match->actions;
-  const bool dockPinned =
-      m_config != nullptr && shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, *match);
-  const bool canPinToDock = m_config != nullptr && !dockPinned;
-  const bool canUnpinFromDock = m_config != nullptr && dockPinned;
-
   constexpr std::int32_t kActionOpen = -1;
   constexpr std::int32_t kActionPinToDock = -2;
   constexpr std::int32_t kActionUnpinFromDock = -3;
+  constexpr std::int32_t kActionFavoritesAdd = -4;
+  constexpr std::int32_t kActionFavoritesMoveUp = -5;
+  constexpr std::int32_t kActionFavoritesMoveDown = -6;
+  constexpr std::int32_t kActionFavoritesRemove = -7;
 
   std::vector<ContextMenuControlEntry> entries;
-  entries.reserve(actionsCopy.size() + 2);
-  entries.push_back(
-      ContextMenuControlEntry{
-          .id = kActionOpen,
-          .label = i18n::tr("launcher.context-menu.open"),
-          .enabled = true,
-          .separator = false,
-          .hasSubmenu = false,
-      }
-  );
-  // Desktop actions sit above pin/unpin so pin stays last in the menu.
-  for (std::int32_t i = 0; i < static_cast<std::int32_t>(actionsCopy.size()); ++i) {
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = i,
-            .label = actionsCopy[static_cast<std::size_t>(i)].name,
-            .enabled = true,
-            .separator = false,
-            .hasSubmenu = false,
-        }
-    );
+  std::vector<DesktopAction> actionsCopy;
+
+  const DesktopEntry* match = nullptr;
+  for (const auto& e : desktopEntries()) {
+    if (e.path == base.id) {
+      match = &e;
+      break;
+    }
   }
-  if (canPinToDock) {
+  if (match != nullptr) {
+    actionsCopy = match->actions;
+    const bool dockPinned =
+        m_config != nullptr && shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, *match);
+    const bool canPinToDock = m_config != nullptr && !dockPinned;
+    const bool canUnpinFromDock = m_config != nullptr && dockPinned;
+
+    entries.reserve(actionsCopy.size() + 2);
     entries.push_back(
         ContextMenuControlEntry{
-            .id = kActionPinToDock,
-            .label = i18n::tr("launcher.context-menu.pin-to-dock"),
+            .id = kActionOpen,
+            .label = i18n::tr("launcher.context-menu.open"),
             .enabled = true,
             .separator = false,
             .hasSubmenu = false,
         }
     );
-  } else if (canUnpinFromDock) {
-    entries.push_back(
-        ContextMenuControlEntry{
-            .id = kActionUnpinFromDock,
-            .label = i18n::tr("launcher.context-menu.unpin-from-dock"),
-            .enabled = true,
-            .separator = false,
-            .hasSubmenu = false,
+    // Desktop actions sit above pin/unpin so pin stays last in the menu.
+    for (std::int32_t i = 0; i < static_cast<std::int32_t>(actionsCopy.size()); ++i) {
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = i,
+              .label = actionsCopy[static_cast<std::size_t>(i)].name,
+              .enabled = true,
+              .separator = false,
+              .hasSubmenu = false,
+          }
+      );
+    }
+    if (canPinToDock) {
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = kActionPinToDock,
+              .label = i18n::tr("launcher.context-menu.pin-to-dock"),
+              .enabled = true,
+              .separator = false,
+              .hasSubmenu = false,
+          }
+      );
+    } else if (canUnpinFromDock) {
+      entries.push_back(
+          ContextMenuControlEntry{
+              .id = kActionUnpinFromDock,
+              .label = i18n::tr("launcher.context-menu.unpin-from-dock"),
+              .enabled = true,
+              .separator = false,
+              .hasSubmenu = false,
+          }
+      );
+    }
+  }
+
+  if (favoritesEnabled()) {
+    for (const auto& provider : m_providers) {
+      if (provider->id() == base.providerId) {
+        if (provider->trackUsage()) {
+          if (entries.empty()) {
+            entries.push_back(
+                ContextMenuControlEntry{
+                    .id = kActionOpen,
+                    .label = i18n::tr("launcher.context-menu.open"),
+                    .enabled = true,
+                    .separator = false,
+                    .hasSubmenu = false,
+                }
+            );
+          }
+
+          if (base.favoriteIndex == 0) {
+            entries.push_back(
+                ContextMenuControlEntry{
+                    .id = kActionFavoritesAdd,
+                    .label = i18n::tr("launcher.context-menu.favorites-add"),
+                    .enabled = true,
+                    .separator = false,
+                    .hasSubmenu = false,
+                }
+            );
+          } else {
+            if (m_activeCategoryType == All && m_queryText.empty()) {
+              entries.push_back(
+                  ContextMenuControlEntry{
+                      .id = kActionFavoritesMoveUp,
+                      .label = i18n::tr("launcher.context-menu.favorites-move-up"),
+                      .enabled =
+                          base.favoriteIndex < static_cast<int>(m_favoritesStore.getFavoritesCount(base.providerId)),
+                      .separator = false,
+                      .hasSubmenu = false,
+                  }
+              );
+              entries.push_back(
+                  ContextMenuControlEntry{
+                      .id = kActionFavoritesMoveDown,
+                      .label = i18n::tr("launcher.context-menu.favorites-move-down"),
+                      .enabled = base.favoriteIndex > 1,
+                      .separator = false,
+                      .hasSubmenu = false,
+                  }
+              );
+            }
+            entries.push_back(
+                ContextMenuControlEntry{
+                    .id = kActionFavoritesRemove,
+                    .label = i18n::tr("launcher.context-menu.favorites-remove"),
+                    .enabled = true,
+                    .separator = false,
+                    .hasSubmenu = false,
+                }
+            );
+          }
         }
-    );
+        break;
+      }
+    }
+  }
+  if (entries.empty()) {
+    return false;
   }
 
   const float scale = contentScale();
@@ -1678,48 +1801,70 @@ bool LauncherPanel::openAppActionsMenu(std::size_t index, float anchorX, float a
     PanelManager::instance().endAttachedPopup(parentSurface);
   });
 
-  m_actionsMenu->setOnActivate([this, base, actionsCopy = std::move(actionsCopy),
-                                entryForPin = *match](const ContextMenuControlEntry& entry) {
-    LauncherResult result = base;
-    result.desktopActionId.clear();
-    if (entry.id == kActionPinToDock) {
-      if (m_config == nullptr
-          || entryForPin.id.empty()
-          || shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, entryForPin)) {
-        return;
-      }
-      std::vector<std::string> pinned = m_config->config().dock.pinned;
-      pinned.push_back(entryForPin.id);
-      (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
-      return;
-    }
-    if (entry.id == kActionUnpinFromDock) {
-      if (m_config == nullptr) {
-        return;
-      }
-      std::vector<std::string> pinned = m_config->config().dock.pinned;
-      shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
-      (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
-      return;
-    }
-    if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {
-      result.desktopActionId = actionsCopy[static_cast<std::size_t>(entry.id)].id;
-    } else if (entry.id != kActionOpen) {
-      return;
-    }
+  m_actionsMenu->setOnActivate(
+      [this, base, actionsCopy = std::move(actionsCopy),
+       entryForPin = (match != nullptr ? *match : DesktopEntry{})](const ContextMenuControlEntry& entry) {
+        LauncherResult result = base;
+        result.desktopActionId.clear();
+        if (entry.id == kActionPinToDock) {
+          if (m_config == nullptr
+              || entryForPin.id.empty()
+              || shell::dock::pinned_apps::containsEntry(m_config->config().dock.pinned, entryForPin)) {
+            return;
+          }
+          std::vector<std::string> pinned = m_config->config().dock.pinned;
+          pinned.push_back(entryForPin.id);
+          (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
+          return;
+        }
+        if (entry.id == kActionUnpinFromDock) {
+          if (m_config == nullptr) {
+            return;
+          }
+          std::vector<std::string> pinned = m_config->config().dock.pinned;
+          shell::dock::pinned_apps::removeEntry(pinned, entryForPin);
+          (void)m_config->setOverride({"dock", "pinned"}, std::move(pinned));
+          return;
+        }
+        if (entry.id == kActionFavoritesAdd) {
+          m_favoritesStore.add(result.providerId, result.id);
+          reapplyCurrentQuery();
+          return;
+        }
+        if (entry.id == kActionFavoritesMoveUp) {
+          m_favoritesStore.moveUp(result.providerId, result.id);
+          reapplyCurrentQuery();
+          return;
+        }
+        if (entry.id == kActionFavoritesMoveDown) {
+          m_favoritesStore.moveDown(result.providerId, result.id);
+          reapplyCurrentQuery();
+          return;
+        }
+        if (entry.id == kActionFavoritesRemove) {
+          m_favoritesStore.remove(result.providerId, result.id);
+          reapplyCurrentQuery();
+          return;
+        }
+        if (entry.id >= 0 && entry.id < static_cast<std::int32_t>(actionsCopy.size())) {
+          result.desktopActionId = actionsCopy[static_cast<std::size_t>(entry.id)].id;
+        } else if (entry.id != kActionOpen) {
+          return;
+        }
 
-    for (auto& provider : m_providers) {
-      if (provider->id() != std::string_view(result.providerId)) {
-        continue;
-      }
-      if (!provider->activate(result)) {
+        for (auto& provider : m_providers) {
+          if (provider->id() != std::string_view(result.providerId)) {
+            continue;
+          }
+          if (!provider->activate(result)) {
+            return;
+          }
+          finishActivation(*provider, result.id, provider->supportsAutoPaste());
+          return;
+        }
         return;
       }
-      finishActivation(*provider, result.id, provider->supportsAutoPaste());
-      return;
-    }
-    return;
-  });
+  );
 
   const float inset = std::round(std::max(4.0F, Style::spaceXs * scale));
   const auto ax = static_cast<std::int32_t>(std::round(anchorX - inset));
@@ -1885,7 +2030,7 @@ bool LauncherPanel::handleKeyEvent(std::uint32_t sym, std::uint32_t modifiers) {
         anchorY += m_grid->height() * 0.5F;
       }
     }
-    return openAppActionsMenu(m_selectedIndex, anchorX, anchorY);
+    return openActionsMenu(m_selectedIndex, anchorX, anchorY);
   }
 
   if (KeybindMatcher::matches(KeybindAction::Validate, sym, modifiers)) {

--- a/src/shell/launcher/launcher_panel.h
+++ b/src/shell/launcher/launcher_panel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "launcher/favorites_store.h"
 #include "launcher/launcher_provider.h"
 #include "launcher/usage_tracker.h"
 #include "shell/panel/panel.h"
@@ -88,7 +89,7 @@ private:
   void applyProviderConfig(LauncherProvider& provider) const;
   void finishActivation(LauncherProvider& provider, const std::string& resultId, bool copied);
   [[nodiscard]] std::vector<LauncherResult> providerOverviewResults(std::string_view text) const;
-  [[nodiscard]] bool openAppActionsMenu(std::size_t index, float anchorX, float anchorY);
+  [[nodiscard]] bool openActionsMenu(std::size_t index, float anchorX, float anchorY);
   void rebuildCategoryFilter(const std::vector<LauncherCategory>& categories);
   void setCategoryFilterVisible(bool visible);
   void setActiveCategorySlot(std::size_t slotIndex);
@@ -99,11 +100,13 @@ private:
   void refreshLauncherAppIconColorization();
   void updateLauncherGridMetrics(Renderer& renderer);
   [[nodiscard]] bool shouldTrackUsage() const;
+  [[nodiscard]] bool favoritesEnabled() const;
 
   std::vector<std::unique_ptr<LauncherProvider>> m_providers;
   std::vector<LauncherResult> m_results;
   std::vector<LauncherResult> m_allResults;
   UsageTracker m_usageTracker;
+  FavoritesStore m_favoritesStore;
   IconResolver m_iconResolver;
 
   Flex* m_container = nullptr;
@@ -119,6 +122,7 @@ private:
   std::unique_ptr<LauncherAppGridAdapter> m_gridAdapter;
 
   std::string m_query;
+  std::string m_queryText; // Query excluding the launcher prefix
   std::string m_scopedProviderId;
   std::string m_scopedPlaceholder;
   ActiveCategoryType m_activeCategoryType = All;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -1234,6 +1234,11 @@ namespace settings {
         ToggleSetting{cfg.shell.launcher.sortByUsage}, "launcher sort usage recently used frequency"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Launcher, "launcher", tr("settings.schema.panels.launcher-enable-favorites.label"),
+        tr("settings.schema.panels.launcher-enable-favorites.description"), {"shell", "launcher", "enable_favorites"},
+        ToggleSetting{cfg.shell.launcher.enableFavorites}, "launcher enable favorites"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Launcher, "launcher", tr("settings.schema.panels.launcher-currency-exchange.label"),
         tr("settings.schema.panels.launcher-currency-exchange.description"),
         {"shell", "launcher", "fetch_exchange_rates"}, ToggleSetting{cfg.shell.launcher.fetchExchangeRates},


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This includes:
1. A new "favorites.json" file in the state directory.
2. New context menu actions for managing favorites (add, move up, move down, remove).
3. A blue star for favorite items.
4. Order favorite items on top (except in Recently Used).

Favorites is only enabled for providers with trackUsage()==true.

Move up/down is only shown when the active category is "All" and the query text is empty, because the semantics in other cases is unclear.

## Motivation

<!-- What problem does this solve? -->

When I install a new app and uses it frequently, it would take a lot of time to boost it up by usage count. Favorites allows manually putting apps to the top.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1488" height="1326" alt="screenshot_20260806_170638-region" src="https://github.com/user-attachments/assets/1f756d69-2db3-47bb-85ef-f3dd052bea84" />
<img width="1513" height="1333" alt="screenshot_20260806_170602-region" src="https://github.com/user-attachments/assets/69b30555-412c-44d1-9cfc-20a2a4f383ae" />
<img width="1860" height="443" alt="screenshot_20260806_170711-region" src="https://github.com/user-attachments/assets/575a21c2-2443-465e-bce4-cee7ba559b2b" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
