### PR TITLE
fix(lockscreen): allow locking to continue while outputs are being disconnected

### DIFF
--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -549,14 +549,14 @@ bool LockScreen::shouldUseBlurredDesktop() const {
 }
 
 bool LockScreen::allSurfacesReady() const {
-  if (m_instances.empty()) {
-    return false;
-  }
   for (const auto& instance : m_instances) {
     if (instance.surface != nullptr && !instance.surface->firstFrameRendered()) {
       return false;
     }
   }
+
+  // With all outputs disconnected, no surface can ever render, so allow pending
+  // actions to run instead of waiting for the fallback timeout.
   return true;
 }
 

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <string_view>
 #include <tuple>
+#include <wayland-client-core.h>
 
 namespace {
 
@@ -552,7 +553,18 @@ LockSurface::~LockSurface() {
   }
   m_connection.unregisterSurface(m_surface);
   if (m_lockSurface != nullptr) {
-    ext_session_lock_surface_v1_destroy(m_lockSurface);
+    // If get_lock_surface raced with the output disappearing server-side, some
+    // compositors (e.g. Hyprland) silently drop the request without binding the
+    // new object id. The compositor otherwise sends the first configure event
+    // immediately, so "output gone and no configure ever received" identifies
+    // such a zombie proxy: sending its destructor request would be answered
+    // with a fatal invalid-object protocol error. Destroy it client-side only.
+    const bool outputGone = m_connection.findOutputByWl(m_output) == nullptr;
+    if (!m_receivedConfigure && outputGone) {
+      wl_proxy_destroy(reinterpret_cast<wl_proxy*>(m_lockSurface));
+    } else {
+      ext_session_lock_surface_v1_destroy(m_lockSurface);
+    }
     m_lockSurface = nullptr;
   }
 }
@@ -852,6 +864,7 @@ void LockSurface::handleConfigure(
     std::uint32_t height
 ) {
   auto* self = static_cast<LockSurface*>(data);
+  self->m_receivedConfigure = true;
   if (self->width() != width || self->height() != height) {
     self->m_firstFrameRendered = false;
   }

--- a/src/shell/lockscreen/lock_surface.h
+++ b/src/shell/lockscreen/lock_surface.h
@@ -121,6 +121,7 @@ private:
 
   ext_session_lock_surface_v1* m_lockSurface = nullptr;
   wl_output* m_output = nullptr;
+  bool m_receivedConfigure = false;
   ConfigService* m_config = nullptr;
   // Declared before m_root so it outlives the scene: ~Node cancels its animations through this manager.
   AnimationManager m_animations;


### PR DESCRIPTION
## Summary

This is an attempt to fix https://github.com/noctalia-dev/noctalia/issues/3777, a crash when Hyprland is (briefly) headless while all external monitors are unplugged during suspension (logind suspends when lid is closed and there are no other outputs).

AIL:3

This PR makes allSurfacesReady() return true if there are no outputs since it decides whether or not the suspend inhibitor is yielded. Suspension should continue even if there are no outputs, otherwise it only locks when the lid is opened and the machine unsuspends.

Also, revalidate the LockSurface's output in its destructor to avoid sending a destroy for an unconfigured surface over the wire, which causes a crash on Hyprland.

## Motivation

I would like to be able to keep using my device after unplugging my monitors without having to lock it first. :slightly_smiling_face: 

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes: https://github.com/noctalia-dev/noctalia/issues/3777

## Testing

Run the repro steps as described in the issue.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
