### PR TITLE
feat(notification): Clearing all notifications closes the notification panel

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2189,6 +2189,10 @@
           "description": "Slide remaining toasts to close gaps when one is dismissed",
           "label": "Collapse on Dismiss"
         },
+        "auto-close-panel-on-clear-all": {
+          "description": "Automatically close the notification history panel when all notifications are cleared",
+          "label": "Auto-close Panel on Clear All"
+        },
         "daemon": {
           "description": "Enable the built-in notification daemon",
           "label": "Notification Daemon"

--- a/example.toml
+++ b/example.toml
@@ -164,6 +164,7 @@ tint_intensity         = 0.3        # 0.0 = no tint, 1.0 = opaque
 enable_daemon      = true
 show_app_name      = true
 show_actions       = true           # show action buttons; when false, clicking a toast triggers its default action
+auto_close_panel_on_clear_all = true     # close the panel after clearing all notifications
 layer              = "top"          # top | overlay
 scale              = 1.0            # notification size multiplier applied on top of accessibility.ui_scale
 background_opacity = 0.97

--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -271,7 +271,11 @@ void Application::initIpc() {
       [this](const std::string&) -> std::string {
         m_notificationManager.clearHistory();
         if (m_panelManager.isOpenPanel("control-center")) {
-          m_panelManager.refresh();
+          if (m_configService.config().notification.autoClosePanelOnClearAll && m_notificationManager.all().empty()) {
+            m_panelManager.close();
+          } else {
+            m_panelManager.refresh();
+          }
         }
         return "ok\n";
       },

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -741,6 +741,7 @@ struct NotificationConfig {
   int offsetY = 8;                 // absolute vertical margin from the screen edge
   std::vector<std::string> monitors;
   bool collapseOnDismiss = true;
+  bool autoClosePanelOnClearAll = false;
   int historyRetentionHours = 0;
 
   std::vector<NotificationFilterConfig> filters;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -253,6 +253,7 @@ namespace noctalia::config::schema {
         field(&NotificationConfig::offsetY, "offset_y"),
         field(&NotificationConfig::monitors, "monitors"),
         field(&NotificationConfig::collapseOnDismiss, "collapse_on_dismiss"),
+        field(&NotificationConfig::autoClosePanelOnClearAll, "auto_close_panel_on_clear_all"),
         field(&NotificationConfig::historyRetentionHours, "history_retention_hours", Range<std::int64_t>{0, 8760}),
         custom<NotificationConfig>(
             "blacklist",

--- a/src/shell/control_center/control_center_panel.cpp
+++ b/src/shell/control_center/control_center_panel.cpp
@@ -61,7 +61,7 @@ ControlCenterPanel::ControlCenterPanel(const ControlCenterServices& services) {
   );
   m_tabs[tabIndex(TabId::Weather)] = std::make_unique<WeatherTab>(services.weather, services.config);
   m_tabs[tabIndex(TabId::Calendar)] = std::make_unique<CalendarTab>(services.config, services.calendar);
-  m_tabs[tabIndex(TabId::Notifications)] = std::make_unique<NotificationsTab>(services.notifications);
+  m_tabs[tabIndex(TabId::Notifications)] = std::make_unique<NotificationsTab>(services.notifications, services.config);
   m_tabs[tabIndex(TabId::Network)] =
       std::make_unique<NetworkTab>(services.network, services.networkSecrets, services.externalIp);
   m_tabs[tabIndex(TabId::Bluetooth)] = std::make_unique<BluetoothTab>(services.bluetooth, services.bluetoothAgent);

--- a/src/shell/control_center/tabs/notifications_tab.cpp
+++ b/src/shell/control_center/tabs/notifications_tab.cpp
@@ -948,7 +948,7 @@ void NotificationsTab::clearAllNotifications() {
   if (m_list != nullptr) {
     m_list->notifyDataChanged();
   }
-  PanelManager::instance().refresh();
+  PanelManager::instance().close();
 }
 
 void NotificationsTab::toggleDoNotDisturb() {

--- a/src/shell/control_center/tabs/notifications_tab.cpp
+++ b/src/shell/control_center/tabs/notifications_tab.cpp
@@ -1,5 +1,6 @@
 #include "shell/control_center/tabs/notifications_tab.h"
 
+#include "config/config_service.h"
 #include "core/log.h"
 #include "i18n/i18n.h"
 #include "net/uri.h"
@@ -639,7 +640,8 @@ private:
   float m_fillOpacity = 1.0F;
 };
 
-NotificationsTab::NotificationsTab(NotificationManager* notifications) : m_notifications(notifications) {}
+NotificationsTab::NotificationsTab(NotificationManager* notifications, ConfigService* config)
+    : m_notifications(notifications), m_config(config) {}
 
 NotificationsTab::~NotificationsTab() = default;
 
@@ -948,7 +950,11 @@ void NotificationsTab::clearAllNotifications() {
   if (m_list != nullptr) {
     m_list->notifyDataChanged();
   }
-  PanelManager::instance().close();
+  if (m_config != nullptr && m_config->config().notification.autoClosePanelOnClearAll) {
+    PanelManager::instance().close();
+  } else {
+    PanelManager::instance().refresh();
+  }
 }
 
 void NotificationsTab::toggleDoNotDisturb() {

--- a/src/shell/control_center/tabs/notifications_tab.h
+++ b/src/shell/control_center/tabs/notifications_tab.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 class NotificationManager;
+class ConfigService;
 struct NotificationHistoryEntry;
 class Button;
 class Segmented;
@@ -22,7 +23,7 @@ class NotificationHistoryAdapter;
 
 class NotificationsTab : public Tab {
 public:
-  explicit NotificationsTab(NotificationManager* notifications);
+  explicit NotificationsTab(NotificationManager* notifications, ConfigService* config);
   ~NotificationsTab() override;
 
   std::unique_ptr<Flex> create() override;
@@ -51,6 +52,7 @@ private:
   [[nodiscard]] bool filterSlideOutActive() const;
 
   NotificationManager* m_notifications = nullptr;
+  ConfigService* m_config = nullptr;
   IconResolver m_iconResolver;
   std::unique_ptr<NotificationHistoryAdapter> m_adapter;
   std::vector<const NotificationHistoryEntry*> m_filtered;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2861,6 +2861,13 @@ namespace settings {
         ToggleSetting{cfg.notification.collapseOnDismiss}, "reorder stack slide"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Notifications, "general",
+        tr("settings.schema.notifications.auto-close-panel-on-clear-all.label"),
+        tr("settings.schema.notifications.auto-close-panel-on-clear-all.description"),
+        {"notification", "auto_close_panel_on_clear_all"}, ToggleSetting{cfg.notification.autoClosePanelOnClearAll},
+        "clear all auto-close panel"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Notifications, "toasts", tr("settings.schema.notifications.layer.label"),
         tr("settings.schema.notifications.layer.description"), {"notification", "layer"},
         asSegmented(plainSelect(

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -377,6 +377,7 @@ location = "https://example.invalid/bad"
         .offsetY = 6,
         .monitors = {"DP-2"},
         .collapseOnDismiss = false,
+        .autoClosePanelOnClearAll = true,
         .historyRetentionHours = 48,
         .filters = {NotificationFilterConfig{
             .name = "discord",


### PR DESCRIPTION
## Summary

Adds an "Auto-close Panel on Clear All" toggle (Settings -> Notifications -> General,default off to keep behaviour unchanged for existing users).

When enabled:-
- Clearing all notifications closes the notification panel automatically.
- The noctalia msg notification-clear-history IPC command also closes the panel 

Single-notification clear and the clear-all history behavior are unaffected. Off by default keeps it opt-in per review feedback.

## Motivation

I also find kinda annoying that after clearing all notification why i have to close the panel manually.. why not it closes after clearing all notification.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3819

## Testing

- Ran `just format`, `just build` no issue.
- Ran `just test` all 72 tests passed.
- Then `just lint` all clear no errors.
- Killed the current running noctalia `pkill noctalia` then started new feature one `./build-debug/noctalia`
- Then tested manually by `notify-send msgs` then clearing all notification and notification panel closed. Worked as expected. 
- Also used IPC with niri keybind, it works correctly.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/058e5f4e-8a0a-4ebd-8f04-b1b6424f3041



## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

