### PR TITLE
fix(bar): make screen-edge click working again for plugin widgets

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1225,6 +1225,9 @@ namespace {
     }
     if (screenEdgeClick) {
       auto extendHitTestOutsetToScreenEdge = [&](Node* node, bool start) {
+        if (node == nullptr) {
+          return;
+        }
         auto hitTestOutset = node->hitTestOutset();
         if (start) {
           if (isVertical) {

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -1224,25 +1224,32 @@ namespace {
       placeGhostPills(instance.endWidgets);
     }
     if (screenEdgeClick) {
-      if (!instance.startSection->children().empty()) {
-        auto node = instance.startSection->children().front().get();
+      auto extendHitTestOutsetToScreenEdge = [&](Node* node, bool start) {
         auto hitTestOutset = node->hitTestOutset();
-        if (isVertical) {
-          hitTestOutset.top += paddingInsideSection;
+        if (start) {
+          if (isVertical) {
+            hitTestOutset.top += paddingInsideSection;
+          } else {
+            hitTestOutset.left += paddingInsideSection;
+          }
         } else {
-          hitTestOutset.left += paddingInsideSection;
+          if (isVertical) {
+            hitTestOutset.bottom += paddingInsideSection;
+          } else {
+            hitTestOutset.right += paddingInsideSection;
+          }
         }
         node->setHitTestOutset(hitTestOutset);
+      };
+      if (!instance.startWidgets.empty()) {
+        auto* widget = instance.startWidgets.front().get();
+        extendHitTestOutsetToScreenEdge(widget->outerNode(), true);
+        extendHitTestOutsetToScreenEdge(widget->root(), true);
       }
-      if (!instance.endSection->children().empty()) {
-        auto node = instance.endSection->children().back().get();
-        auto hitTestOutset = node->hitTestOutset();
-        if (isVertical) {
-          hitTestOutset.bottom += paddingInsideSection;
-        } else {
-          hitTestOutset.right += paddingInsideSection;
-        }
-        node->setHitTestOutset(hitTestOutset);
+      if (!instance.endWidgets.empty()) {
+        auto* widget = instance.endWidgets.back().get();
+        extendHitTestOutsetToScreenEdge(widget->outerNode(), false);
+        extendHitTestOutsetToScreenEdge(widget->root(), false);
       }
     }
   }


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Broken in 9736af2.

<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
#3668

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
