### PR TITLE
feat(caffeine): caffeine disables sleep when laptop lid is closed

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2071,6 +2071,10 @@
           "description": "Named idle actions with presets (lock, screen off, suspend) or custom commands, timeouts, resume pairing, and order",
           "label": "Behaviors"
         },
+        "caffeine-lid-handling": {
+          "description": "While Caffeine is on, prevent lid-close sleep. Noctalia powers off a lone laptop display; docked display handling remains controlled by the compositor",
+          "label": "Caffeine Lid Handling"
+        },
         "pre-action-fade": {
           "description": "Seconds of fullscreen dim before the idle command (0 disables)",
           "label": "Idle Dim"

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -776,6 +776,8 @@ void Application::initWaylandCallbacks() {
     );
   }
   m_idleInhibitor.initialize(m_wayland);
+  m_idleInhibitor.setLidHandlingEnabled(m_configService.config().idle.caffeineLidHandling);
+  m_idleInhibitor.setOutputPowerCallback([this](bool on) { return m_compositorPlatform.setOutputPower(on); });
   m_idleInhibitor.setChangeCallback([this, shouldRefreshControlCenter]() {
     if (m_configService.config().osd.kinds.caffeine) {
       m_osdOverlay.show(caffeineOsdContent(m_idleInhibitor.enabled()));
@@ -785,6 +787,14 @@ void Application::initWaylandCallbacks() {
       m_panelManager.refresh();
     }
   });
+  m_configService.addReloadCallback(
+      [this]() {
+        if (m_configService.lastChange().idle) {
+          m_idleInhibitor.setLidHandlingEnabled(m_configService.config().idle.caffeineLidHandling);
+        }
+      },
+      "caffeine-lid-handling"
+  );
 }
 
 void Application::initAuxServicesAndHooks() {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -292,6 +292,9 @@ struct NotificationFilterConfig {
 
 struct IdleConfig {
   std::vector<IdleBehaviorConfig> behaviors;
+  /// When caffeine is active, also inhibit logind's lid-switch action. If the laptop display is the only active
+  /// output, power it off while the lid is closed; otherwise leave output handling to the compositor.
+  bool caffeineLidHandling = true;
   /// When > 0, after the compositor reports idle the shell fades a fullscreen overlay (surface color)
   /// from transparent to opaque over this many seconds, then runs `command`. Compositor activity during
   /// the fade cancels. When 0, the idle command runs immediately with no overlay.

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -877,6 +877,7 @@ namespace noctalia::config::schema {
 
   const Schema<IdleConfig>& idleSchema() {
     static const Schema<IdleConfig> s = {
+        field(&IdleConfig::caffeineLidHandling, "caffeine_lid_handling"),
         field(&IdleConfig::preActionFadeSeconds, "pre_action_fade_seconds", Range<float>{0.0F, 120.0F}),
         // behavior_order is emitted here (vector order); the actual reorder runs
         // last, after the behavior map has been read.

--- a/src/dbus/logind/logind_service.cpp
+++ b/src/dbus/logind/logind_service.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdlib>
 #include <fcntl.h>
+#include <map>
 #include <optional>
 #include <sdbus-c++/Error.h>
 #include <sdbus-c++/IProxy.h>
@@ -12,6 +13,7 @@
 #include <string>
 #include <unistd.h>
 #include <utility>
+#include <vector>
 
 namespace {
   constexpr Logger kLog("logind");
@@ -20,6 +22,7 @@ namespace {
   const sdbus::ObjectPath kLogindObjectPath{"/org/freedesktop/login1"};
   constexpr auto kLogindManagerInterface = "org.freedesktop.login1.Manager";
   constexpr auto kLogindSessionInterface = "org.freedesktop.login1.Session";
+  constexpr auto kPropertiesInterface = "org.freedesktop.DBus.Properties";
 
   // Inhibit locks stay alive until every duplicate of the fd is closed. Our detached
   // process launcher double-forks without closing fds, so without CLOEXEC `systemctl
@@ -72,6 +75,20 @@ LogindService::LogindService(SystemBus& bus) : m_bus(bus) {
       m_prepareForSleepCallback(sleeping);
     }
   });
+  m_managerProxy->uponSignal("PropertiesChanged")
+      .onInterface(kPropertiesInterface)
+      .call([this](
+                const std::string& interfaceName, const std::map<std::string, sdbus::Variant>& changedProperties,
+                const std::vector<std::string>& /*invalidatedProperties*/
+            ) {
+        if (interfaceName != kLogindManagerInterface) {
+          return;
+        }
+        const auto it = changedProperties.find("LidClosed");
+        if (it != changedProperties.end() && m_lidStateCallback) {
+          m_lidStateCallback(it->second.get<bool>());
+        }
+      });
 }
 
 LogindService::~LogindService() {
@@ -134,6 +151,19 @@ void LogindService::setLockCallback(SessionLockCallback callback) { m_lockCallba
 
 void LogindService::setUnlockCallback(SessionLockCallback callback) { m_unlockCallback = std::move(callback); }
 
+void LogindService::setLidStateCallback(LidStateCallback callback) {
+  m_lidStateCallback = std::move(callback);
+  if (!m_lidStateCallback || m_managerProxy == nullptr) {
+    return;
+  }
+  try {
+    const bool closed = m_managerProxy->getProperty("LidClosed").onInterface(kLogindManagerInterface).get<bool>();
+    m_lidStateCallback(closed);
+  } catch (const sdbus::Error& e) {
+    kLog.debug("failed to read initial lid state: {}", e.what());
+  }
+}
+
 void LogindService::syncSessionLocked() {
   if (!m_sessionLockIntegrationEnabled || m_sessionProxy == nullptr) {
     return;
@@ -162,9 +192,12 @@ bool LogindService::supportsIdleInhibit() const noexcept { return m_managerProxy
 
 bool LogindService::hasIdleInhibit() const noexcept { return m_idleInhibitFd >= 0; }
 
-bool LogindService::acquireIdleInhibit() {
+bool LogindService::acquireIdleInhibit(bool handleLidSwitch) {
   if (m_idleInhibitFd >= 0) {
-    return true;
+    if (m_idleInhibitHandlesLid == handleLidSwitch) {
+      return true;
+    }
+    releaseIdleInhibit();
   }
   if (m_managerProxy == nullptr) {
     return false;
@@ -174,7 +207,10 @@ bool LogindService::acquireIdleInhibit() {
     sdbus::UnixFd fd;
     m_managerProxy->callMethod("Inhibit")
         .onInterface(kLogindManagerInterface)
-        .withArguments(std::string("idle"), std::string("noctalia"), std::string("Caffeine"), std::string("block"))
+        .withArguments(
+            std::string(handleLidSwitch ? "idle:handle-lid-switch" : "idle"), std::string("noctalia"),
+            std::string("Caffeine"), std::string("block")
+        )
         .storeResultsTo(fd);
     m_idleInhibitFd = fd.release();
     if (m_idleInhibitFd < 0) {
@@ -187,6 +223,7 @@ bool LogindService::acquireIdleInhibit() {
       m_idleInhibitFd = -1;
       return false;
     }
+    m_idleInhibitHandlesLid = handleLidSwitch;
     kLog.info("logind idle inhibit acquired");
     return true;
   } catch (const sdbus::Error& e) {
@@ -201,6 +238,7 @@ void LogindService::releaseIdleInhibit() {
   }
   ::close(m_idleInhibitFd);
   m_idleInhibitFd = -1;
+  m_idleInhibitHandlesLid = false;
   kLog.debug("logind idle inhibit released");
 }
 

--- a/src/dbus/logind/logind_service.h
+++ b/src/dbus/logind/logind_service.h
@@ -13,6 +13,7 @@ class LogindService {
 public:
   using PrepareForSleepCallback = std::function<void(bool sleeping)>;
   using SessionLockCallback = std::function<void()>;
+  using LidStateCallback = std::function<void(bool closed)>;
 
   explicit LogindService(SystemBus& bus);
   ~LogindService();
@@ -20,6 +21,7 @@ public:
   void setPrepareForSleepCallback(PrepareForSleepCallback callback);
   void setLockCallback(SessionLockCallback callback);
   void setUnlockCallback(SessionLockCallback callback);
+  void setLidStateCallback(LidStateCallback callback);
 
   void setSessionLockIntegrationEnabled(bool enabled);
   // Sleep-delay inhibit for lock-before-suspend. Released when session lock integration is off.
@@ -29,7 +31,7 @@ public:
 
   [[nodiscard]] bool supportsIdleInhibit() const noexcept;
   [[nodiscard]] bool hasIdleInhibit() const noexcept;
-  bool acquireIdleInhibit();
+  bool acquireIdleInhibit(bool handleLidSwitch);
   void releaseIdleInhibit();
 
   // Delay-type sleep inhibit: holds off suspend/hibernate until released so the
@@ -48,6 +50,8 @@ private:
   PrepareForSleepCallback m_prepareForSleepCallback;
   SessionLockCallback m_lockCallback;
   SessionLockCallback m_unlockCallback;
+  LidStateCallback m_lidStateCallback;
   int m_idleInhibitFd = -1;
+  bool m_idleInhibitHandlesLid = false;
   int m_sleepDelayInhibitFd = -1;
 };

--- a/src/idle/idle_inhibitor.cpp
+++ b/src/idle/idle_inhibitor.cpp
@@ -7,16 +7,24 @@
 #include "wayland/wayland_connection.h"
 
 #include <algorithm>
+#include <string_view>
 
 namespace {
 
   constexpr Logger kLog("idle");
+
+  [[nodiscard]] bool isInternalDisplayConnector(std::string_view name) {
+    return name.starts_with("eDP") || name.starts_with("LVDS") || name.starts_with("DSI");
+  }
 
 } // namespace
 
 IdleInhibitor::IdleInhibitor() = default;
 
 IdleInhibitor::~IdleInhibitor() {
+  if (m_logind != nullptr) {
+    m_logind->setLidStateCallback({});
+  }
   destroyWaylandInhibitors(false);
   releaseLogindInhibit();
 }
@@ -32,7 +40,38 @@ bool IdleInhibitor::initialize(WaylandConnection& wayland) {
   return true;
 }
 
-void IdleInhibitor::setLogindService(LogindService* logind) { m_logind = logind; }
+void IdleInhibitor::setLogindService(LogindService* logind) {
+  if (m_logind != nullptr) {
+    m_logind->setLidStateCallback({});
+  }
+  m_logind = logind;
+  if (m_logind != nullptr) {
+    m_logind->setLidStateCallback([this](bool closed) { handleLidState(closed); });
+  }
+}
+
+void IdleInhibitor::setLidHandlingEnabled(bool enabled) {
+  if (m_lidHandlingEnabled == enabled) {
+    return;
+  }
+  m_lidHandlingEnabled = enabled;
+  if (m_outputPowerCallback) {
+    if (!enabled && m_screenOffForLid) {
+      m_screenOffForLid = false;
+      (void)m_outputPowerCallback(true);
+    } else if (enabled && m_enabled && m_lidClosed && !m_screenOffForLid && hasSingleInternalOutput()) {
+      m_screenOffForLid = m_outputPowerCallback(false);
+    }
+  }
+  if (m_enabled) {
+    releaseLogindInhibit();
+    syncInhibitor(false);
+  }
+}
+
+void IdleInhibitor::setOutputPowerCallback(OutputPowerCallback callback) {
+  m_outputPowerCallback = std::move(callback);
+}
 
 void IdleInhibitor::setAnchorSurfacesProvider(AnchorSurfacesProvider provider) {
   m_anchorSurfacesProvider = std::move(provider);
@@ -57,6 +96,14 @@ void IdleInhibitor::setEnabled(bool enabled) {
   }
 
   syncInhibitor(m_enabled);
+  if (m_enabled
+      && m_lidHandlingEnabled
+      && m_lidClosed
+      && !m_screenOffForLid
+      && m_outputPowerCallback
+      && hasSingleInternalOutput()) {
+    m_screenOffForLid = m_outputPowerCallback(false);
+  }
   if (wasEnabled && !m_enabled) {
     kLog.info("idle inhibitor disabled");
   }
@@ -124,7 +171,7 @@ void IdleInhibitor::syncLogindInhibit(bool logTransitions) {
     return;
   }
 
-  if (m_logind->acquireIdleInhibit() && logTransitions && !m_loggedLogindEnable) {
+  if (m_logind->acquireIdleInhibit(m_lidHandlingEnabled) && logTransitions && !m_loggedLogindEnable) {
     kLog.info("idle inhibitor enabled via logind");
     m_loggedLogindEnable = true;
   }
@@ -149,6 +196,49 @@ void IdleInhibitor::releaseLogindInhibit() {
   }
   m_logind->releaseIdleInhibit();
   m_loggedLogindEnable = false;
+}
+
+void IdleInhibitor::handleLidState(bool closed) {
+  if (m_lidStateKnown && m_lidClosed == closed) {
+    return;
+  }
+  m_lidStateKnown = true;
+  m_lidClosed = closed;
+  if (!m_lidHandlingEnabled) {
+    return;
+  }
+  if (!m_outputPowerCallback) {
+    return;
+  }
+  if (closed) {
+    if (!m_enabled) {
+      return;
+    }
+    // Global DPMS commands would blank external displays. In a docked setup the compositor owns
+    // lid-driven output topology, including any user-defined switch bindings.
+    if (!hasSingleInternalOutput()) {
+      return;
+    }
+    m_screenOffForLid = m_outputPowerCallback(false);
+    if (!m_screenOffForLid) {
+      kLog.warn("failed to turn screen off after laptop lid closed");
+    }
+    return;
+  }
+  if (m_screenOffForLid) {
+    m_screenOffForLid = false;
+    if (!m_outputPowerCallback(true)) {
+      kLog.warn("failed to turn screen on after laptop lid opened");
+    }
+  }
+}
+
+bool IdleInhibitor::hasSingleInternalOutput() const {
+  if (m_wayland == nullptr || m_wayland->outputs().size() != 1) {
+    return false;
+  }
+  const WaylandOutput& output = m_wayland->outputs().front();
+  return isInternalDisplayConnector(output.connectorName) || isInternalDisplayConnector(output.interfaceName);
 }
 
 void IdleInhibitor::notifyChanged() {

--- a/src/idle/idle_inhibitor.h
+++ b/src/idle/idle_inhibitor.h
@@ -16,6 +16,7 @@ public:
   using ChangeCallback = std::function<void()>;
   using StateFeedbackCallback = std::function<void(bool enabled)>;
   using AnchorSurfacesProvider = std::function<std::vector<wl_surface*>()>;
+  using OutputPowerCallback = std::function<bool(bool on)>;
 
   IdleInhibitor();
   ~IdleInhibitor();
@@ -25,6 +26,8 @@ public:
 
   bool initialize(WaylandConnection& wayland);
   void setLogindService(LogindService* logind);
+  void setLidHandlingEnabled(bool enabled);
+  void setOutputPowerCallback(OutputPowerCallback callback);
   void setAnchorSurfacesProvider(AnchorSurfacesProvider provider);
   void toggle();
   void setEnabled(bool enabled);
@@ -44,6 +47,8 @@ private:
   void syncLogindInhibit(bool logTransitions);
   void destroyWaylandInhibitors(bool logDisable = false);
   void releaseLogindInhibit();
+  void handleLidState(bool closed);
+  [[nodiscard]] bool hasSingleInternalOutput() const;
   void notifyChanged();
 
   WaylandConnection* m_wayland = nullptr;
@@ -51,7 +56,12 @@ private:
   zwp_idle_inhibit_manager_v1* m_manager = nullptr;
   std::unordered_map<wl_surface*, zwp_idle_inhibitor_v1*> m_inhibitors;
   AnchorSurfacesProvider m_anchorSurfacesProvider;
+  OutputPowerCallback m_outputPowerCallback;
   ChangeCallback m_changeCallback;
+  bool m_lidStateKnown = false;
+  bool m_lidClosed = false;
+  bool m_screenOffForLid = false;
+  bool m_lidHandlingEnabled = true;
   bool m_enabled = false;
   bool m_loggedWaylandEnable = false;
   bool m_loggedLogindEnable = false;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2741,6 +2741,12 @@ namespace settings {
 
     // Idle
     entries.push_back(makeEntry(
+        SettingsSection::Power, "idle", tr("settings.schema.idle.caffeine-lid-handling.label"),
+        tr("settings.schema.idle.caffeine-lid-handling.description"), {"idle", "caffeine_lid_handling"},
+        ToggleSetting{.checked = cfg.idle.caffeineLidHandling},
+        "caffeine laptop lid close sleep suspend screen external monitor"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Power, "idle", tr("settings.schema.idle.pre-action-fade.label"),
         tr("settings.schema.idle.pre-action-fade.description"), {"idle", "pre_action_fade_seconds"},
         StepperSetting{


### PR DESCRIPTION
When caffeine is turned on, noctalia disables sleep when a laptop lid is closed. A relevant setting options is added to idle section (default on).

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

- Add a default-on `idle.caffeine_lid_handling` setting in Settings > Power > Idle.
- When Caffeine is active, inhibit logind's lid-close action to prevent laptop suspend.
- Monitor logind's `LidClosed` state and turn off the screen while the lid is closed when the laptop's internal display is the only output.
- Preserve compositor-controlled output topology in docked or multi-monitor setups, avoiding global DPMS changes that could blank external displays.
- Reload the setting live and restore the display when Noctalia had powered it off and lid handling is disabled or the lid reopens.


## Motivation

<!-- What problem does this solve? -->
Caffeine previously prevented idle sleep but did not prevent logind from suspending a laptop when its lid is closed. This change lets users keep a laptop running with Caffeine enabled. This is useful when you want to keep a long running task (like an agent) while on the go.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Needs testing with a docked laptop with external display. I do not own any external displays unfortunately.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
Disclamer: made with the help of AI agent.
