### PR TITLE
fix(cc/network): stop wifi toggle from snapping back before state catches up

### DIFF
--- a/src/dbus/network/inetwork_service.h
+++ b/src/dbus/network/inetwork_service.h
@@ -2,7 +2,6 @@
 
 #include "dbus/network/network_types.h"
 
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -15,6 +14,7 @@ class INetworkService {
 public:
   using ChangeCallback = std::function<void(const NetworkState&, NetworkChangeOrigin)>;
   using WirelessFeedbackCallback = std::function<void(bool enabled)>;
+  using WirelessEnabledCompletion = std::function<void(bool success)>;
 
   virtual ~INetworkService() = default;
 
@@ -33,7 +33,7 @@ public:
   virtual bool deactivateVpnConnection(const VpnConnectionInfo& vpn) = 0;
   [[nodiscard]] virtual bool canActivateWiredConnection() const noexcept { return false; }
   virtual bool activateWiredConnection() { return false; }
-  virtual void setWirelessEnabled(bool enabled) = 0;
+  virtual void setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete = {}) = 0;
   virtual void disconnect() = 0;
   virtual void forgetSsid(const std::string& ssid) = 0;
   [[nodiscard]] virtual bool hasSavedConnection(const std::string& ssid) const = 0;

--- a/src/dbus/network/iwd_service.cpp
+++ b/src/dbus/network/iwd_service.cpp
@@ -340,9 +340,10 @@ bool IwdService::activateAccessPoint(const AccessPointInfo& ap, const std::strin
   return activateAccessPoint(ap);
 }
 
-void IwdService::setWirelessEnabled(bool enabled) {
+void IwdService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete) {
   const bool softBlocked = !enabled;
   bool rfkillDone = false;
+  bool hardBlocked = false;
   for (const auto& [stationPath, ifname] : m_deviceNames) {
     (void)stationPath;
     if (ifname.empty()) {
@@ -351,6 +352,8 @@ void IwdService::setWirelessEnabled(bool enabled) {
     const RfkillSwitchResult result = setRfkillSoftBlockedForNetInterface(ifname, softBlocked);
     if (result.hardBlocked) {
       kLog.warn("setWirelessEnabled: rfkill hard block on {}", ifname);
+      hardBlocked = enabled;
+      rfkillDone = !enabled;
       break;
     }
     if (result.success) {
@@ -363,6 +366,8 @@ void IwdService::setWirelessEnabled(bool enabled) {
     const RfkillSwitchResult fallback = setRfkillSoftBlocked(RfkillDeviceType::Wlan, softBlocked);
     if (fallback.hardBlocked) {
       kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
+      hardBlocked = enabled;
+      rfkillDone = !enabled;
     } else if (fallback.success) {
       rfkillDone = true;
     } else if (!fallback.detail.empty()) {
@@ -370,17 +375,22 @@ void IwdService::setWirelessEnabled(bool enabled) {
     }
   }
 
+  bool poweredUpdated = false;
   for (const auto& [stationPath, ifname] : m_deviceNames) {
     (void)ifname;
     try {
       auto device = sdbus::createProxy(m_bus.connection(), kIwdBusName, sdbus::ObjectPath{stationPath});
       device->setProperty("Powered").onInterface(kDeviceInterface).toValue(enabled);
+      poweredUpdated = true;
     } catch (const sdbus::Error& e) {
       kLog.debug("setting IWD Powered failed on {}: {}", stationPath, e.what());
     }
   }
 
   refresh();
+  if (onComplete) {
+    onComplete(!hardBlocked && (rfkillDone || poweredUpdated));
+  }
 }
 
 void IwdService::disconnect() {

--- a/src/dbus/network/iwd_service.h
+++ b/src/dbus/network/iwd_service.h
@@ -39,7 +39,7 @@ public:
   bool activateAccessPoint(const AccessPointInfo& ap, const std::string& psk) override;
   bool activateVpnConnection(const VpnConnectionInfo& /*vpn*/) override { return false; }
   bool deactivateVpnConnection(const VpnConnectionInfo& /*vpn*/) override { return false; }
-  void setWirelessEnabled(bool enabled) override;
+  void setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete = {}) override;
   void disconnect() override;
   void forgetSsid(const std::string& ssid) override;
   [[nodiscard]] bool hasSavedConnection(const std::string& ssid) const override;

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -164,11 +164,18 @@ NetworkManagerService::NetworkManagerService(SystemBus& bus) : m_bus(bus) {
           return;
         }
         bool wirelessNowOn = false;
+        bool wirelessNowOff = false;
         if (auto it = changedProperties.find("WirelessEnabled"); it != changedProperties.end()) {
           try {
-            wirelessNowOn = it->second.get<bool>();
+            const bool enabled = it->second.get<bool>();
+            wirelessNowOn = enabled;
+            wirelessNowOff = !enabled;
+            ++m_wirelessGeneration;
           } catch (const sdbus::Error&) {
           }
+        }
+        if (wirelessNowOff) {
+          endScan();
         }
         if (changedProperties.contains("PrimaryConnection")
             || changedProperties.contains("ActiveConnections")
@@ -183,12 +190,12 @@ NetworkManagerService::NetworkManagerService(SystemBus& bus) : m_bus(bus) {
           // NM starts its own scan as soon as the device reaches Disconnected;
           // just mark ourselves scanning and snapshot LastScan so the device
           // PropertiesChanged watcher clears the flag when the scan finishes.
-          collectWifiDevices([this](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
-            if (devicePaths.empty()) {
+          const std::uint64_t generation = m_wirelessGeneration;
+          collectWifiDevices([this, generation](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
+            if (devicePaths.empty() || generation != m_wirelessGeneration) {
               return;
             }
-            m_scanning = true;
-            m_scanBaselineLastScan = lastScanBaseline;
+            beginScan(lastScanBaseline);
             refresh();
           });
         }
@@ -274,7 +281,12 @@ void NetworkManagerService::refresh() {
 
 void NetworkManagerService::requestScan() {
   const std::weak_ptr<int> lifetimeToken = m_lifetimeToken;
-  collectWifiDevices([this, lifetimeToken](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
+  const std::uint64_t generation = m_wirelessGeneration;
+  collectWifiDevices([this, lifetimeToken,
+                      generation](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
+    if (generation != m_wirelessGeneration) {
+      return;
+    }
     for (const auto& devicePath : devicePaths) {
       try {
         auto device = std::shared_ptr<sdbus::IProxy>(
@@ -284,9 +296,9 @@ void NetworkManagerService::requestScan() {
         device->callMethodAsync("RequestScan")
             .onInterface(kNmDeviceWirelessInterface)
             .withArguments(options)
-            .uponReplyInvoke([this, lifetimeToken, device, devicePath,
-                              lastScanBaseline](std::optional<sdbus::Error> err) {
-              if (lifetimeToken.expired()) {
+            .uponReplyInvoke([this, lifetimeToken, device, devicePath, lastScanBaseline,
+                              generation](std::optional<sdbus::Error> err) {
+              if (lifetimeToken.expired() || generation != m_wirelessGeneration) {
                 return;
               }
               if (err.has_value()) {
@@ -294,8 +306,7 @@ void NetworkManagerService::requestScan() {
                 return;
               }
               if (!m_scanning) {
-                m_scanning = true;
-                m_scanBaselineLastScan = lastScanBaseline;
+                beginScan(lastScanBaseline);
                 refresh();
               }
             });
@@ -1438,8 +1449,9 @@ void NetworkManagerService::ensureWifiDeviceSubscribed(const std::string& device
             if (auto it = changedProperties.find("LastScan"); it != changedProperties.end()) {
               try {
                 const auto lastScan = it->second.get<std::int64_t>();
-                if (m_scanning && lastScan > m_scanBaselineLastScan) {
-                  m_scanning = false;
+                // NM resets LastScan to -1 when the device goes unavailable.
+                if (m_scanning && (lastScan < 0 || lastScan > m_scanBaselineLastScan)) {
+                  endScan();
                 }
               } catch (const sdbus::Error&) {
               }
@@ -2382,6 +2394,28 @@ void NetworkManagerService::readStateAsync(std::function<void(NetworkState)> onC
   } catch (const sdbus::Error&) {
     readActiveConnectionState();
   }
+}
+
+void NetworkManagerService::beginScan(std::int64_t lastScanBaseline) {
+  m_scanning = true;
+  m_scanBaselineLastScan = lastScanBaseline;
+  m_scanTimeoutTimer.start(kScanTimeout, [this]() {
+    if (!m_scanning) {
+      return;
+    }
+    kLog.debug("scan timed out after {}s without a LastScan update", kScanTimeout.count());
+    endScan();
+    m_emitOnNextRefresh = true;
+    refresh();
+  });
+}
+
+void NetworkManagerService::endScan() {
+  if (!m_scanning) {
+    return;
+  }
+  m_scanning = false;
+  m_scanTimeoutTimer.stop();
 }
 
 NetworkChangeOrigin NetworkManagerService::consumeWirelessEnabledChangeOrigin(bool enabled) {

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -170,7 +170,7 @@ NetworkManagerService::NetworkManagerService(SystemBus& bus) : m_bus(bus) {
             const bool enabled = it->second.get<bool>();
             wirelessNowOn = enabled;
             wirelessNowOff = !enabled;
-            ++m_wirelessGeneration;
+            ++m_scanGeneration;
           } catch (const sdbus::Error&) {
           }
         }
@@ -190,9 +190,9 @@ NetworkManagerService::NetworkManagerService(SystemBus& bus) : m_bus(bus) {
           // NM starts its own scan as soon as the device reaches Disconnected;
           // just mark ourselves scanning and snapshot LastScan so the device
           // PropertiesChanged watcher clears the flag when the scan finishes.
-          const std::uint64_t generation = m_wirelessGeneration;
+          const std::uint64_t generation = m_scanGeneration;
           collectWifiDevices([this, generation](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
-            if (devicePaths.empty() || generation != m_wirelessGeneration) {
+            if (devicePaths.empty() || generation != m_scanGeneration) {
               return;
             }
             beginScan(lastScanBaseline);
@@ -281,12 +281,13 @@ void NetworkManagerService::refresh() {
 
 void NetworkManagerService::requestScan() {
   const std::weak_ptr<int> lifetimeToken = m_lifetimeToken;
-  const std::uint64_t generation = m_wirelessGeneration;
+  const std::uint64_t generation = ++m_scanGeneration;
   collectWifiDevices([this, lifetimeToken,
                       generation](std::vector<std::string> devicePaths, std::int64_t lastScanBaseline) {
-    if (generation != m_wirelessGeneration) {
+    if (generation != m_scanGeneration) {
       return;
     }
+    auto scanStarted = std::make_shared<bool>(false);
     for (const auto& devicePath : devicePaths) {
       try {
         auto device = std::shared_ptr<sdbus::IProxy>(
@@ -296,16 +297,17 @@ void NetworkManagerService::requestScan() {
         device->callMethodAsync("RequestScan")
             .onInterface(kNmDeviceWirelessInterface)
             .withArguments(options)
-            .uponReplyInvoke([this, lifetimeToken, device, devicePath, lastScanBaseline,
-                              generation](std::optional<sdbus::Error> err) {
-              if (lifetimeToken.expired() || generation != m_wirelessGeneration) {
+            .uponReplyInvoke([this, lifetimeToken, device, devicePath, lastScanBaseline, generation,
+                              scanStarted](std::optional<sdbus::Error> err) {
+              if (lifetimeToken.expired() || generation != m_scanGeneration) {
                 return;
               }
               if (err.has_value()) {
                 kLog.debug("RequestScan failed on {}: {}", devicePath, err->what());
                 return;
               }
-              if (!m_scanning) {
+              if (!*scanStarted) {
+                *scanStarted = true;
                 beginScan(lastScanBaseline);
                 refresh();
               }
@@ -802,11 +804,14 @@ void NetworkManagerService::tryActivateWiredConnection(
   }
 }
 
-void NetworkManagerService::setWirelessEnabled(bool enabled) {
+void NetworkManagerService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete) {
   if (enabled) {
     const RfkillSwitchResult rfkillResult = setRfkillSoftBlocked(RfkillDeviceType::Wlan, false);
     if (rfkillResult.hardBlocked) {
       kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
+      if (onComplete) {
+        onComplete(false);
+      }
       return;
     }
     if (!rfkillResult.success) {
@@ -823,20 +828,34 @@ void NetworkManagerService::setWirelessEnabled(bool enabled) {
     m_nm->setPropertyAsync("WirelessEnabled")
         .onInterface(kNmInterface)
         .toValue(enabled)
-        .uponReplyInvoke([this, lifetimeToken, enabled](std::optional<sdbus::Error> err) {
-          if (lifetimeToken.expired() || !err.has_value()) {
+        .uponReplyInvoke([this, lifetimeToken, enabled, onComplete](std::optional<sdbus::Error> err) {
+          if (lifetimeToken.expired()) {
             return;
           }
-          if (m_pendingLocalWirelessEnabled == enabled) {
-            m_pendingLocalWirelessEnabled.reset();
+          if (err.has_value()) {
+            if (m_pendingLocalWirelessEnabled == enabled) {
+              m_pendingLocalWirelessEnabled.reset();
+            }
+            kLog.warn("WirelessEnabled write failed: {}", err->what());
+            if (onComplete) {
+              onComplete(false);
+            }
+            return;
           }
-          kLog.warn("WirelessEnabled write failed: {}", err->what());
+          m_emitOnNextRefresh = true;
+          refresh();
+          if (onComplete) {
+            onComplete(true);
+          }
         });
   } catch (const sdbus::Error& e) {
     if (m_pendingLocalWirelessEnabled == enabled) {
       m_pendingLocalWirelessEnabled.reset();
     }
     kLog.warn("WirelessEnabled write dispatch failed: {}", e.what());
+    if (onComplete) {
+      onComplete(false);
+    }
   }
 }
 

--- a/src/dbus/network/network_manager_service.h
+++ b/src/dbus/network/network_manager_service.h
@@ -57,7 +57,7 @@ public:
   bool activateWiredConnection() override;
 
   // Enable / disable the Wi-Fi radio.
-  void setWirelessEnabled(bool enabled) override;
+  void setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete = {}) override;
 
   // Disconnect the active physical connection.
   void disconnect() override;
@@ -138,7 +138,7 @@ private:
   bool m_anyVpnConnected = false;
   std::int64_t m_scanBaselineLastScan = 0;
   Timer m_scanTimeoutTimer;
-  std::uint64_t m_wirelessGeneration = 0;
+  std::uint64_t m_scanGeneration = 0;
   std::optional<bool> m_pendingLocalWirelessEnabled;
   bool m_hasStateSnapshot = false;
   ChangeCallback m_changeCallback;

--- a/src/dbus/network/network_manager_service.h
+++ b/src/dbus/network/network_manager_service.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "core/timer_manager.h"
 #include "dbus/network/inetwork_service.h"
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -102,6 +104,8 @@ private:
   void tryActivateWiredConnection(std::shared_ptr<std::vector<std::string>> candidates, std::size_t index);
   void readStateAsync(std::function<void(NetworkState)> onComplete);
   [[nodiscard]] NetworkChangeOrigin consumeWirelessEnabledChangeOrigin(bool enabled);
+  void beginScan(std::int64_t lastScanBaseline);
+  void endScan();
 
   struct PendingAccessPointActivation;
 
@@ -133,7 +137,11 @@ private:
   bool m_scanning = false;
   bool m_anyVpnConnected = false;
   std::int64_t m_scanBaselineLastScan = 0;
+  Timer m_scanTimeoutTimer;
+  std::uint64_t m_wirelessGeneration = 0;
   std::optional<bool> m_pendingLocalWirelessEnabled;
   bool m_hasStateSnapshot = false;
   ChangeCallback m_changeCallback;
+
+  static constexpr std::chrono::seconds kScanTimeout = std::chrono::seconds(30);
 };

--- a/src/dbus/network/wpa_supplicant_service.cpp
+++ b/src/dbus/network/wpa_supplicant_service.cpp
@@ -302,11 +302,10 @@ void WpaSupplicantService::disconnect() {
   }
 }
 
-void WpaSupplicantService::setWirelessEnabled(bool enabled) {
-  m_wirelessEnabledOverride = enabled;
-
+void WpaSupplicantService::setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete) {
   const bool softBlocked = !enabled;
   bool rfkillDone = false;
+  bool hardBlocked = false;
   for (const auto& [ifacePath, proxy] : m_interfaces) {
     (void)ifacePath;
     const auto ifname = getPropertyOr<std::string>(*proxy, kWpaIfaceInterface, "Ifname", "");
@@ -316,6 +315,8 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled) {
     const RfkillSwitchResult result = setRfkillSoftBlockedForNetInterface(ifname, softBlocked);
     if (result.hardBlocked) {
       kLog.warn("setWirelessEnabled: rfkill hard block on {}", ifname);
+      hardBlocked = enabled;
+      rfkillDone = !enabled;
       break;
     }
     if (result.success) {
@@ -328,6 +329,8 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled) {
     const RfkillSwitchResult fallback = setRfkillSoftBlocked(RfkillDeviceType::Wlan, softBlocked);
     if (fallback.hardBlocked) {
       kLog.warn("setWirelessEnabled: wlan rfkill hard block is active");
+      hardBlocked = enabled;
+      rfkillDone = !enabled;
     } else if (fallback.success) {
       rfkillDone = true;
     } else if (!fallback.detail.empty()) {
@@ -335,21 +338,31 @@ void WpaSupplicantService::setWirelessEnabled(bool enabled) {
     }
   }
 
+  bool fallbackCommandSucceeded = false;
   if (!rfkillDone) {
     auto* iface = firstInterface();
     if (iface != nullptr) {
       try {
-        if (enabled)
+        if (enabled) {
           iface->callMethod("Reconnect").onInterface(kWpaIfaceInterface);
-        else
+        } else {
           iface->callMethod("Disconnect").onInterface(kWpaIfaceInterface);
+        }
+        fallbackCommandSucceeded = true;
       } catch (const sdbus::Error& e) {
         kLog.warn("setWirelessEnabled({}) fallback failed: {}", enabled, e.what());
       }
     }
   }
 
+  const bool success = !hardBlocked && (rfkillDone || fallbackCommandSucceeded);
+  if (success) {
+    m_wirelessEnabledOverride = enabled;
+  }
   rebuildState();
+  if (onComplete) {
+    onComplete(success);
+  }
 }
 
 void WpaSupplicantService::forgetSsid(const std::string& ssid) {

--- a/src/dbus/network/wpa_supplicant_service.h
+++ b/src/dbus/network/wpa_supplicant_service.h
@@ -40,7 +40,7 @@ public:
   bool activateAccessPoint(const AccessPointInfo& ap, const std::string& psk) override;
   bool activateVpnConnection(const VpnConnectionInfo& /*vpn*/) override { return false; }
   bool deactivateVpnConnection(const VpnConnectionInfo& /*vpn*/) override { return false; }
-  void setWirelessEnabled(bool enabled) override;
+  void setWirelessEnabled(bool enabled, WirelessEnabledCompletion onComplete = {}) override;
   void disconnect() override;
   void forgetSsid(const std::string& ssid) override;
   [[nodiscard]] bool hasSavedConnection(const std::string& ssid) const override;

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -626,7 +626,9 @@ void NetworkTab::onClose() {
   m_actionPending = false;
   m_actionPendingTimer.stop();
   m_wifiTogglePending = false;
-  m_wifiTogglePendingTimer.stop();
+  m_wifiToggleWriteComplete = false;
+  m_wifiToggleTargetObserved = false;
+  ++m_wifiToggleRequestGeneration;
 }
 
 void NetworkTab::syncPasswordCard() {
@@ -729,14 +731,15 @@ void NetworkTab::syncCurrentCard() {
     }
   }
   if (m_wifiTogglePending) {
-    const bool confirmed = s.wirelessEnabled == m_wifiToggleTarget && m_wifiToggleLastSeen != m_wifiToggleTarget;
-    const bool timedOut = std::chrono::steady_clock::now() - m_wifiTogglePendingSince > kActionPendingTimeout;
-    if (confirmed || timedOut) {
+    if (s.wirelessEnabled == m_wifiToggleTarget) {
+      m_wifiToggleTargetObserved = true;
+    }
+    if (m_wifiToggleWriteComplete && m_wifiToggleTargetObserved) {
       m_wifiTogglePending = false;
-      m_wifiTogglePendingTimer.stop();
+      m_wifiToggleWriteComplete = false;
+      m_wifiToggleTargetObserved = false;
     }
   }
-  m_wifiToggleLastSeen = s.wirelessEnabled;
   static const std::string kNoExternalIp;
   const std::string& externalIp = m_externalIpService != nullptr ? m_externalIpService->externalIp() : kNoExternalIp;
   m_currentTitle->setText(currentTitle(s));
@@ -750,6 +753,7 @@ void NetworkTab::syncCurrentCard() {
   }
   if (m_wifiToggle != nullptr) {
     m_wifiToggle->setChecked(m_wifiTogglePending ? m_wifiToggleTarget : s.wirelessEnabled);
+    m_wifiToggle->setEnabled(!m_wifiTogglePending);
   }
   if (m_scanSpinner != nullptr) {
     m_scanSpinner->setVisible(s.scanning);
@@ -765,25 +769,44 @@ void NetworkTab::beginPendingAction(bool wasConnected) {
   m_actionPending = true;
   m_actionPendingConnected = wasConnected;
   m_actionPendingSince = std::chrono::steady_clock::now();
-  armPendingTimeout(m_actionPendingTimer);
+  m_actionPendingTimer.start(kActionPendingTimeout + std::chrono::milliseconds(50), []() {
+    PanelManager::instance().requestUpdateOnly();
+    PanelManager::instance().requestRedraw();
+  });
   if (m_disconnectButton != nullptr) {
     m_disconnectButton->setEnabled(false);
   }
 }
 
-void NetworkTab::beginWifiTogglePending(bool target) {
+void NetworkTab::requestWirelessEnabled(bool enabled) {
   m_wifiTogglePending = true;
-  m_wifiToggleTarget = target;
-  m_wifiToggleLastSeen = m_network != nullptr && m_network->state().wirelessEnabled;
-  m_wifiTogglePendingSince = std::chrono::steady_clock::now();
-  armPendingTimeout(m_wifiTogglePendingTimer);
+  m_wifiToggleTarget = enabled;
+  m_wifiToggleWriteComplete = false;
+  m_wifiToggleTargetObserved = false;
+  const std::uint64_t generation = ++m_wifiToggleRequestGeneration;
+  if (m_wifiToggle != nullptr) {
+    m_wifiToggle->setEnabled(false);
+  }
+  if (m_network == nullptr) {
+    handleWirelessEnabledCompletion(generation, false);
+    return;
+  }
+  m_network->setWirelessEnabled(enabled, [this, generation](bool success) {
+    handleWirelessEnabledCompletion(generation, success);
+  });
 }
 
-void NetworkTab::armPendingTimeout(Timer& timer) {
-  timer.start(kActionPendingTimeout + std::chrono::milliseconds(50), []() {
-    PanelManager::instance().requestUpdateOnly();
-    PanelManager::instance().requestRedraw();
-  });
+void NetworkTab::handleWirelessEnabledCompletion(std::uint64_t generation, bool success) {
+  if (!m_wifiTogglePending || generation != m_wifiToggleRequestGeneration) {
+    return;
+  }
+  m_wifiToggleWriteComplete = success;
+  if (!success) {
+    m_wifiTogglePending = false;
+    m_wifiToggleTargetObserved = false;
+  }
+  PanelManager::instance().requestUpdateOnly();
+  PanelManager::instance().requestRedraw();
 }
 
 // Identity of the built list: which rows exist, in which order, and which controls
@@ -1038,12 +1061,7 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
               .checkedImmediate = m_network->state().wirelessEnabled,
               .toggleSize = ToggleSize::Medium,
               .scale = scale,
-              .onChange = [this](bool checked) {
-                beginWifiTogglePending(checked);
-                if (m_network != nullptr) {
-                  m_network->setWirelessEnabled(checked);
-                }
-              },
+              .onChange = [this](bool checked) { requestWirelessEnabled(checked); },
           })
       );
       wifiCard->addChild(std::move(wifiHeader));

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -624,6 +624,9 @@ void NetworkTab::onClose() {
   m_pendingAccessPoint.reset();
   m_active = false;
   m_actionPending = false;
+  m_actionPendingTimer.stop();
+  m_wifiTogglePending = false;
+  m_wifiTogglePendingTimer.stop();
 }
 
 void NetworkTab::syncPasswordCard() {
@@ -722,8 +725,18 @@ void NetworkTab::syncCurrentCard() {
     const bool timedOut = std::chrono::steady_clock::now() - m_actionPendingSince > kActionPendingTimeout;
     if (flipped || timedOut) {
       m_actionPending = false;
+      m_actionPendingTimer.stop();
     }
   }
+  if (m_wifiTogglePending) {
+    const bool confirmed = s.wirelessEnabled == m_wifiToggleTarget && m_wifiToggleLastSeen != m_wifiToggleTarget;
+    const bool timedOut = std::chrono::steady_clock::now() - m_wifiTogglePendingSince > kActionPendingTimeout;
+    if (confirmed || timedOut) {
+      m_wifiTogglePending = false;
+      m_wifiTogglePendingTimer.stop();
+    }
+  }
+  m_wifiToggleLastSeen = s.wirelessEnabled;
   static const std::string kNoExternalIp;
   const std::string& externalIp = m_externalIpService != nullptr ? m_externalIpService->externalIp() : kNoExternalIp;
   m_currentTitle->setText(currentTitle(s));
@@ -736,16 +749,8 @@ void NetworkTab::syncCurrentCard() {
     m_disconnectButton->setEnabled(!m_actionPending);
   }
   if (m_wifiToggle != nullptr) {
-    if (m_wifiTogglePending) {
-      const bool flipped = s.wirelessEnabled == m_wifiToggleTarget;
-      const bool timedOut = std::chrono::steady_clock::now() - m_wifiTogglePendingSince > kActionPendingTimeout;
-      if (flipped || timedOut) {
-        m_wifiTogglePending = false;
-      }
-    }
     m_wifiToggle->setChecked(m_wifiTogglePending ? m_wifiToggleTarget : s.wirelessEnabled);
   }
-
   if (m_scanSpinner != nullptr) {
     m_scanSpinner->setVisible(s.scanning);
     if (s.scanning && !m_scanSpinner->spinning()) {
@@ -760,9 +765,25 @@ void NetworkTab::beginPendingAction(bool wasConnected) {
   m_actionPending = true;
   m_actionPendingConnected = wasConnected;
   m_actionPendingSince = std::chrono::steady_clock::now();
+  armPendingTimeout(m_actionPendingTimer);
   if (m_disconnectButton != nullptr) {
     m_disconnectButton->setEnabled(false);
   }
+}
+
+void NetworkTab::beginWifiTogglePending(bool target) {
+  m_wifiTogglePending = true;
+  m_wifiToggleTarget = target;
+  m_wifiToggleLastSeen = m_network != nullptr && m_network->state().wirelessEnabled;
+  m_wifiTogglePendingSince = std::chrono::steady_clock::now();
+  armPendingTimeout(m_wifiTogglePendingTimer);
+}
+
+void NetworkTab::armPendingTimeout(Timer& timer) {
+  timer.start(kActionPendingTimeout + std::chrono::milliseconds(50), []() {
+    PanelManager::instance().requestUpdateOnly();
+    PanelManager::instance().requestRedraw();
+  });
 }
 
 // Identity of the built list: which rows exist, in which order, and which controls
@@ -1018,12 +1039,10 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
               .toggleSize = ToggleSize::Medium,
               .scale = scale,
               .onChange = [this](bool checked) {
+                beginWifiTogglePending(checked);
                 if (m_network != nullptr) {
                   m_network->setWirelessEnabled(checked);
                 }
-                m_wifiToggleTarget = checked;
-                m_wifiTogglePending = true;
-                m_wifiTogglePendingSince = std::chrono::steady_clock::now();
               },
           })
       );

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -719,7 +719,7 @@ void NetworkTab::syncCurrentCard() {
   const NetworkState& s = m_network->state();
   if (m_actionPending) {
     const bool flipped = s.connected != m_actionPendingConnected;
-    const bool timedOut = std::chrono::steady_clock::now() - m_actionPendingSince > std::chrono::seconds(6);
+    const bool timedOut = std::chrono::steady_clock::now() - m_actionPendingSince > kActionPendingTimeout;
     if (flipped || timedOut) {
       m_actionPending = false;
     }
@@ -736,8 +736,16 @@ void NetworkTab::syncCurrentCard() {
     m_disconnectButton->setEnabled(!m_actionPending);
   }
   if (m_wifiToggle != nullptr) {
-    m_wifiToggle->setChecked(s.wirelessEnabled);
+    if (m_wifiTogglePending) {
+      const bool flipped = s.wirelessEnabled == m_wifiToggleTarget;
+      const bool timedOut = std::chrono::steady_clock::now() - m_wifiTogglePendingSince > kActionPendingTimeout;
+      if (flipped || timedOut) {
+        m_wifiTogglePending = false;
+      }
+    }
+    m_wifiToggle->setChecked(m_wifiTogglePending ? m_wifiToggleTarget : s.wirelessEnabled);
   }
+
   if (m_scanSpinner != nullptr) {
     m_scanSpinner->setVisible(s.scanning);
     if (s.scanning && !m_scanSpinner->spinning()) {
@@ -1013,6 +1021,9 @@ void NetworkTab::rebuildApList(Renderer& renderer) {
                 if (m_network != nullptr) {
                   m_network->setWirelessEnabled(checked);
                 }
+                m_wifiToggleTarget = checked;
+                m_wifiTogglePending = true;
+                m_wifiTogglePendingSince = std::chrono::steady_clock::now();
               },
           })
       );

--- a/src/shell/control_center/tabs/network_tab.h
+++ b/src/shell/control_center/tabs/network_tab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/timer_manager.h"
 #include "dbus/network/network_secret_agent.h"
 #include "dbus/network/network_types.h"
 #include "shell/control_center/tab.h"
@@ -39,6 +40,8 @@ private:
 
   void syncCurrentCard();
   void beginPendingAction(bool wasConnected);
+  void beginWifiTogglePending(bool target);
+  void armPendingTimeout(Timer& timer);
   void rebuildApList(Renderer& renderer);
   // Pushes live signal values into the existing rows. Returns true if any changed.
   bool syncApRows();
@@ -92,7 +95,11 @@ private:
 
   bool m_wifiTogglePending = false;
   bool m_wifiToggleTarget = false;
+  bool m_wifiToggleLastSeen = false;
   std::chrono::steady_clock::time_point m_wifiTogglePendingSince;
+
+  Timer m_actionPendingTimer;
+  Timer m_wifiTogglePendingTimer;
 
   static constexpr std::chrono::seconds kActionPendingTimeout = std::chrono::seconds(6);
 };

--- a/src/shell/control_center/tabs/network_tab.h
+++ b/src/shell/control_center/tabs/network_tab.h
@@ -6,6 +6,7 @@
 #include "shell/control_center/tab.h"
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -40,8 +41,8 @@ private:
 
   void syncCurrentCard();
   void beginPendingAction(bool wasConnected);
-  void beginWifiTogglePending(bool target);
-  void armPendingTimeout(Timer& timer);
+  void requestWirelessEnabled(bool enabled);
+  void handleWirelessEnabledCompletion(std::uint64_t generation, bool success);
   void rebuildApList(Renderer& renderer);
   // Pushes live signal values into the existing rows. Returns true if any changed.
   bool syncApRows();
@@ -95,11 +96,11 @@ private:
 
   bool m_wifiTogglePending = false;
   bool m_wifiToggleTarget = false;
-  bool m_wifiToggleLastSeen = false;
-  std::chrono::steady_clock::time_point m_wifiTogglePendingSince;
+  bool m_wifiToggleWriteComplete = false;
+  bool m_wifiToggleTargetObserved = false;
+  std::uint64_t m_wifiToggleRequestGeneration = 0;
 
   Timer m_actionPendingTimer;
-  Timer m_wifiTogglePendingTimer;
 
   static constexpr std::chrono::seconds kActionPendingTimeout = std::chrono::seconds(6);
 };

--- a/src/shell/control_center/tabs/network_tab.h
+++ b/src/shell/control_center/tabs/network_tab.h
@@ -89,4 +89,10 @@ private:
   bool m_actionPending = false;
   bool m_actionPendingConnected = false;
   std::chrono::steady_clock::time_point m_actionPendingSince;
+
+  bool m_wifiTogglePending = false;
+  bool m_wifiToggleTarget = false;
+  std::chrono::steady_clock::time_point m_wifiTogglePendingSince;
+
+  static constexpr std::chrono::seconds kActionPendingTimeout = std::chrono::seconds(6);
 };


### PR DESCRIPTION
## Summary

Add a wifi-specific pending state (target/since/ flag) that holds the toggle at the requested value until state confirms the flip or a timeout elapses, reusing same pattern as the existing connect/disconnect m_actionPending guard, but tracked separately.

## Motivation

Previously, the toggle was synced to s.wirelessEnabled unconditionally every frame, so a user click could get reverted/flicker while the backend was still applying the change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
Closes #3837 

## Testing
Verify no jitter when toggling wifi

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/09011c1c-4456-43bb-af9a-459bc0dcb291

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] This PR does not change user-facing configuration or behavior.
- [x] This PR adds no new user-facing strings.
- [x] I did not edit non-English translation files.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A