### PR TITLE
fix(session): don't cancel countdown on mouse hover

### DIFF
--- a/src/shell/session/session_panel.cpp
+++ b/src/shell/session/session_panel.cpp
@@ -200,18 +200,6 @@ Button* SessionPanel::createActionButton(const SessionPanelActionConfig& cfg, st
       .radius = Style::scaledRadiusLg(scale),
       .flexGrow = 1.0F,
       .onClick = [this, index]() { armEntry(index); },
-      .onMotion =
-          [this, index]() {
-            if (m_pendingCountdown.has_value() && m_pendingCountdown->index != index) {
-              cancelCountdown();
-            }
-          },
-      .onEnter =
-          [this, index]() {
-            if (m_pendingCountdown.has_value() && m_pendingCountdown->index != index) {
-              cancelCountdown();
-            }
-          },
       .configure =
           [](Button& control) {
             control.setDirection(FlexDirection::Vertical);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Removed the `onMotion`/`onEnter` hover handlers on session panel action buttons that were cancelling an in-progress countdown whenever the mouse hovered over a different entry. Countdown cancellation is now handled only by explicit interaction (via global cancel action keybind or arming/selecting a different entry).

## Motivation

Fixes #3771. When a countdown was armed via keyboard shortcut while the mouse was already resting over a different action, the hover handlers would immediately cancel it. Removing hover-based cancellation makes countdown behavior depend only on deliberate actions (cancel action, click outside, keyboard navigation) instead of incidental mouse position.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #3771 

## Testing

Navigate through session panel with mouse and keyboard arrows.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

https://github.com/user-attachments/assets/0c187062-a7b1-4159-b10a-decc2b2bd7a3

https://github.com/user-attachments/assets/d4e46cba-cc36-489e-af75-358afd595467


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
Double click behavior still same.