### PR TITLE
fix(tray): prevent hover highlight from clipping on edges

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -19,6 +19,7 @@
 #include "shell/bar/widget_gesture_defaults.h"
 #include "shell/bar/widgets/plugin_widget.h"
 #include "shell/bar/widgets/taskbar_widget.h"
+#include "shell/bar/widgets/tray_widget.h"
 #include "shell/panel/panel_manager.h"
 #include "shell/surface/shadow.h"
 #include "shell/tooltip/tooltip_manager.h"
@@ -2472,6 +2473,10 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
           PanelManager::instance().togglePanel(std::string(panelId), request);
         }
       });
+      if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {
+        tray->setHoverOverlayParent(instance.hoverUnderlay);
+      }
+
       widget->create();
       if (widget->outerNode() != nullptr) {
         instance.widgetByRoot[widget->outerNode()] = widget.get();

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -305,6 +305,7 @@ void TrayWidget::doLayout(Renderer& renderer, float containerWidth, float contai
     }
     m_container->setGap(resolvedInlineEntryGap());
     m_container->layout(renderer);
+    layoutHoverOverlays();
     return;
   }
   const bool vertical = containerHeight > containerWidth;
@@ -328,6 +329,7 @@ void TrayWidget::doLayout(Renderer& renderer, float containerWidth, float contai
 
   m_container->setGap(resolvedInlineEntryGap());
   m_container->layout(renderer);
+  layoutHoverOverlays();
 }
 
 void TrayWidget::doUpdate(Renderer& renderer) {
@@ -451,6 +453,19 @@ void TrayWidget::rebuild(Renderer& renderer) {
   m_loadedImages.clear();
   m_colorizedAppIcons.clear();
 
+  if (m_hoverOverlayParent != nullptr) {
+    for (auto& entry : m_hoverOverlays) {
+      if (entry.area != nullptr) {
+        entry.area->setOnEnter(nullptr);
+        entry.area->setOnLeave(nullptr);
+      }
+      if (entry.box != nullptr) {
+        m_hoverOverlayParent->removeChild(entry.box);
+      }
+    }
+  }
+  m_hoverOverlays.clear();
+
   while (!m_container->children().empty()) {
     m_container->removeChild(m_container->children().back().get());
   }
@@ -459,24 +474,32 @@ void TrayWidget::rebuild(Renderer& renderer) {
     if (!barCapsuleSpec().hoverHighlight) {
       return;
     }
+
     Box* hoverBoxPtr = nullptr;
     ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
     hoverFill.alpha = 0.0F;
     const float padding = Style::spaceXs * m_contentScale;
-    area.addChild(
-        ui::box({
-            .out = &hoverBoxPtr,
-            .fill = hoverFill,
-            .radius = resolvedBarCapsuleRadius(size + padding * 2.0F, size + padding * 2.0F),
-            .width = size + padding * 2.0F,
-            .height = size + padding * 2.0F,
-            .configure = [padding](Box& box) {
-              box.setZIndex(-1);
-              box.setHitTestVisible(false);
-              box.setPosition(-padding, -padding);
-            },
-        })
-    );
+    const float boxSize = size + padding * 2.0F;
+
+    auto hoverBox = ui::box({
+        .out = &hoverBoxPtr,
+        .fill = hoverFill,
+        .radius = resolvedBarCapsuleRadius(boxSize, boxSize),
+        .width = boxSize,
+        .height = boxSize,
+        .configure = [](Box& box) {
+          box.setZIndex(-1);
+          box.setHitTestVisible(false);
+        },
+    });
+
+    if (m_hoverOverlayParent != nullptr) {
+      m_hoverOverlayParent->addChild(std::move(hoverBox));
+      m_hoverOverlays.push_back({.area = &area, .box = hoverBoxPtr, .padding = padding});
+    } else {
+      hoverBoxPtr->setPosition(-padding, -padding);
+      area.addChild(std::move(hoverBox));
+    }
 
     auto progress = std::make_shared<float>(0.0F);
     area.setOnEnter([this, hoverBoxPtr, progress](const InputArea::PointerData&) {
@@ -1032,4 +1055,22 @@ std::string TrayWidget::iconForItem(const TrayItemInfo& item) const {
     return "warning";
   }
   return "menu-2";
+}
+void TrayWidget::layoutHoverOverlays() {
+  if (m_hoverOverlayParent == nullptr || m_hoverOverlays.empty()) {
+    return;
+  }
+  float underlayX = 0.0F;
+  float underlayY = 0.0F;
+  Node::absolutePosition(m_hoverOverlayParent, underlayX, underlayY);
+
+  for (auto& entry : m_hoverOverlays) {
+    if (entry.area == nullptr || entry.box == nullptr) {
+      continue;
+    }
+    float areaX = 0.0F;
+    float areaY = 0.0F;
+    Node::absolutePosition(entry.area, areaX, areaY);
+    entry.box->setPosition(areaX - underlayX - entry.padding, areaY - underlayY - entry.padding);
+  }
 }

--- a/src/shell/bar/widgets/tray_widget.h
+++ b/src/shell/bar/widgets/tray_widget.h
@@ -19,6 +19,7 @@ class Flex;
 class Image;
 class InputArea;
 class Glyph;
+class Box;
 
 class TrayWidget : public Widget {
 public:
@@ -39,11 +40,17 @@ public:
   };
 
   TrayWidget(ConfigService& config, TrayService* tray, Options options);
-
+  void setHoverOverlayParent(Node* node) noexcept { m_hoverOverlayParent = node; }
   void create() override;
   [[nodiscard]] bool wantsBarHoverHighlight() const noexcept override { return false; }
 
 private:
+  struct HoverOverlayEntry {
+    InputArea* area = nullptr;
+    Box* box = nullptr;
+    float padding = 0.0F;
+  };
+
   void doLayout(Renderer& renderer, float containerWidth, float containerHeight) override;
   void doUpdate(Renderer& renderer) override;
   void buildDesktopIconIndex();
@@ -88,10 +95,12 @@ private:
   bool m_matchAdjacentSpacing = false;
   std::optional<float> m_customItemSize;
   bool m_appIconColorizeDirty = false;
-
+  void layoutHoverOverlays();
   InputArea* m_drawerTrigger = nullptr;
   Glyph* m_drawerChevron = nullptr;
   std::string m_drawerChevronGlyph;
   Signal<>::ScopedConnection m_paletteConn;
   Signal<>::ScopedConnection m_appIconColorizeConn;
+  Node* m_hoverOverlayParent = nullptr;
+  std::vector<HoverOverlayEntry> m_hoverOverlays;
 };


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Moved the rendering of the tray widget's hover highlight boxes from its internal clipped `InputArea` to the bar's unclipped `hoverUnderlay`.

## Motivation

<!-- What problem does this solve? -->
This solves the visual clipping issue where the tray's hover highlight gets cut off when it has no adjacent widgets (or sits at the edge of the bar). 

Because the hover highlight extends beyond the icon's base dimensions due to padding, it was previously being cut off by the section slot's strict clip boundaries. By rendering the hover pill on the global `hoverUnderlay` layer, it can now safely bleed past the tray's logical footprint without being clipped, maintaining a consistent and clean UI.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #3838

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Disable capsules, place tray widget in the center with no adjacent widgets.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

<img width="62" height="40" alt="screenshot_20260808_133540-region" src="https://github.com/user-attachments/assets/71e506ce-db06-489b-b808-87cd0b9afe8b" />

<img width="125" height="39" alt="screenshot_20260808_133611-region" src="https://github.com/user-attachments/assets/c5da945e-6213-4be8-9265-e777575b579e" />

<img width="125" height="39" alt="screenshot_20260808_133736-region" src="https://github.com/user-attachments/assets/25b5224a-9b66-4772-add6-c51c688c248f" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
