### PR TITLE
fix(pipewire): recognize virtual audio sources and sinks

### DIFF
--- a/src/pipewire/pipewire_service.cpp
+++ b/src/pipewire/pipewire_service.cpp
@@ -947,6 +947,12 @@ void PipeWireService::onRegistryGlobal(std::uint32_t id, const char* type, std::
   // Track audio nodes and privacy-relevant stream nodes.
   if (std::strcmp(type, PW_TYPE_INTERFACE_Node) == 0) {
     std::string mediaClass = dictGet(props, PW_KEY_MEDIA_CLASS);
+    if (mediaClass.starts_with("Audio/Sink")) {
+      mediaClass = "Audio/Sink";
+    } else if (mediaClass.starts_with("Audio/Source")) {
+      mediaClass = "Audio/Source";
+    }
+
     if (!isTrackedNodeClass(mediaClass)) {
       return;
     }
@@ -1141,6 +1147,11 @@ void PipeWireService::onNodeInfo(std::uint32_t id, const pw_node_info* info) {
   if (info->props != nullptr) {
     std::string mediaClass = dictGet(info->props, PW_KEY_MEDIA_CLASS);
     if (!mediaClass.empty()) {
+      if (mediaClass.starts_with("Audio/Sink")) {
+        mediaClass = "Audio/Sink";
+      } else if (mediaClass.starts_with("Audio/Source")) {
+        mediaClass = "Audio/Source";
+      }
       nd.mediaClass = std::move(mediaClass);
     }
     std::string desc = dictGet(info->props, PW_KEY_NODE_DESCRIPTION);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Modified `PipeWireService` to accept virtual audio devices (such as those created by EasyEffects or JamesDSP) by normalizing their `media.class` property. 

PipeWire exposes virtual sources and sinks with a `/Virtual` suffix (e.g., `Audio/Source/Virtual`). The Noctalia service previously required an exact string match for `Audio/Source` or `Audio/Sink`, causing these virtual devices to be completely ignored. This PR intercepts the `media.class` string and strips the suffix so they are handled as standard audio endpoints.

## Motivation

This solves an issue where virtual microphones, like the "Easy Effects Source", were completely missing from the Control Center's audio dropdown. By correctly tracking devices that start with `Audio/Sink` or `Audio/Source`, users can now seamlessly select and control virtual audio routing tools directly from the Noctalia UI, and the microphone privacy indicator will correctly trigger when they are in use.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3508

## Testing

- Opened the Audio tab in Control Center.
- Verified that "Easy Effects Source" now correctly appears in the Input dropdown list.
- Tested volume slider and mute toggle synchronization.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<img width="256" height="209" alt="screenshot_20260808_144917-region" src="https://github.com/user-attachments/assets/782667f1-f630-481d-82bb-3726931a8ca5" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
