### PR TITLE
feat(capture): add draggable resize and move handles to screenshot re…

### DIFF
--- a/src/capture/screenshot_region_overlay.cpp
+++ b/src/capture/screenshot_region_overlay.cpp
@@ -67,7 +67,7 @@ namespace capture {
       bool nearTop = distTop <= kHandleMargin;
       bool nearBottom = distBottom <= kHandleMargin;
 
-      // Resolve overlaps by picking the closest edge mathematically
+      // Narrow selections can overlap opposing hit zones; bind the pointer to the nearer edge.
       if (nearLeft && nearRight) {
         if (distLeft < distRight)
           nearRight = false;
@@ -296,11 +296,6 @@ namespace capture {
       m_startGlobalY = static_cast<double>(initialRegion->y);
       m_currentGlobalX = static_cast<double>(initialRegion->x + initialRegion->width);
       m_currentGlobalY = static_cast<double>(initialRegion->y + initialRegion->height);
-
-      // Initialize badge anchor safely on region restoration
-      m_cursorGlobalX = m_currentGlobalX;
-      m_cursorGlobalY = m_currentGlobalY;
-
       m_confirming = true;
     }
     ensureSurfaces();
@@ -463,6 +458,9 @@ namespace capture {
       return;
     }
 
+    // The overlay's EGL surface could not be made current (e.g. EGL_BAD_ALLOC when the
+    // driver is out of video memory). Painting would be a no-op, leaving an invisible
+    // fullscreen surface that eats input, so tear down and report instead of spinning.
     if (!m_renderContext->makeCurrent(inst.surface->renderTarget())) {
       abortWithError(i18n::tr("bar.screenshot.overlay-alloc-failed"));
       return;
@@ -519,7 +517,7 @@ namespace capture {
           if (!m_dragging)
             return;
           m_dragging = false;
-          // Re-evaluate mouse position for cursor change
+          // completeSelection() tears down surfaces; defer past InputDispatcher::pointerButton.
           DeferredCall::callLater([this]() { completeSelection(); });
           return;
         }
@@ -561,8 +559,6 @@ namespace capture {
         } else if (m_dragMode == DragMode::Move) {
           m_moveOffsetX = globalX;
           m_moveOffsetY = globalY;
-          m_dragAnchorX = m_startGlobalX;
-          m_dragAnchorY = m_currentGlobalX;
         } else {
           // Calculate anchors (the opposite side of what we are dragging)
           const double x0 = std::min(m_startGlobalX, m_currentGlobalX);
@@ -641,10 +637,6 @@ namespace capture {
           m_startGlobalY += deltaY;
           m_currentGlobalY += deltaY;
 
-          // Translate badge anchor along with the selection
-          m_cursorGlobalX += deltaX;
-          m_cursorGlobalY += deltaY;
-
           m_moveOffsetX = globalX;
           m_moveOffsetY = globalY;
         } else {
@@ -707,8 +699,12 @@ namespace capture {
       inst.backdrop = static_cast<Image*>(input->addChild(std::move(backdrop)));
     }
 
+    // Dim the screen with four strips that frame the selected region. The
+    // region itself stays fully transparent so it shows real colors and never
+    // tints the captured pixels.
     auto makeDimStrip = [&]() {
       auto strip = ui::box({
+          // Fixed black scrim so it darkens under every theme.
           .fill = fixedColorSpec(rgba(0.0F, 0.0F, 0.0F, 1.0F)),
           .width = 0.0F,
           .height = 0.0F,
@@ -901,9 +897,11 @@ namespace capture {
     if (!m_active) {
       return;
     }
+    // Stop further frames from re-triggering the abort while teardown is pending.
     m_active = false;
     kLog.warn("aborting screenshot region overlay: {}", message);
     FailureCallback onFailure = m_onFailure;
+    // Defer past the surface's prepareFrame callback before destroying its surfaces.
     DeferredCall::callLater([this, onFailure, message]() {
       cancel();
       if (onFailure) {
@@ -913,6 +911,8 @@ namespace capture {
   }
 
   void ScreenshotRegionOverlay::updateSelectionVisuals() {
+    // Lay out the four dim strips so they cover the surface except for the hole
+    // rect (surface-local). An empty hole dims the whole surface.
     const auto layoutDimFrame = [](Instance& inst, float surfaceW, float surfaceH, float hx0, float hy0, float hx1,
                                    float hy1) {
       hx0 = std::clamp(hx0, 0.0F, surfaceW);
@@ -1011,6 +1011,8 @@ namespace capture {
       const auto holeY1 = static_cast<float>(iy1 - outTop);
       layoutDimFrame(*inst, surfaceW, surfaceH, holeX0, holeY0, holeX1, holeY1);
 
+      // The outline is inset, so expand it outward to keep the border out of the
+      // captured (undimmed) region.
       inst->selection->setVisible(true);
       inst->selection->setPosition(holeX0 - kSelectionBorderWidth, holeY0 - kSelectionBorderWidth);
       inst->selection->setSize(
@@ -1018,16 +1020,10 @@ namespace capture {
       );
 
       if (inst->dimensionsBadge != nullptr && inst->dimensionsLabel != nullptr && m_renderContext != nullptr) {
-
-        // Show the badge during resize or confirmation. Hide it during move operations.
-        const bool showBadge = (m_dragging && m_dragMode != DragMode::Move) || (!m_dragging && m_confirming);
-
-        // The badge always stays near the last known cursor position (even after releasing the mouse).
+        const bool showBadge = m_dragging && m_dragMode != DragMode::Move;
         const double targetX = m_cursorGlobalX;
         const double targetY = m_cursorGlobalY;
-
-        const bool badgeOnOutput =
-            targetX >= outLeft && targetX <= outRight && targetY >= outTop && targetY <= outBottom;
+        const bool badgeOnOutput = targetX >= outLeft && targetX < outRight && targetY >= outTop && targetY < outBottom;
 
         if (showBadge && badgeOnOutput) {
           inst->dimensionsLabel->setText(dimensionText);

--- a/src/capture/screenshot_region_overlay.cpp
+++ b/src/capture/screenshot_region_overlay.cpp
@@ -50,16 +50,36 @@ namespace capture {
 
     [[nodiscard]] capture::DragMode hitTestSelection(double x, double y, double x0, double y0, double x1, double y1) {
       constexpr double kHandleMargin = 15.0; // Hitbox size in pixels
-      const bool nearLeft = std::abs(x - x0) <= kHandleMargin;
-      const bool nearRight = std::abs(x - x1) <= kHandleMargin;
-      const bool nearTop = std::abs(y - y0) <= kHandleMargin;
-      const bool nearBottom = std::abs(y - y1) <= kHandleMargin;
 
       const bool withinX = x >= x0 - kHandleMargin && x <= x1 + kHandleMargin;
       const bool withinY = y >= y0 - kHandleMargin && y <= y1 + kHandleMargin;
 
       if (!withinX || !withinY)
         return capture::DragMode::None;
+
+      const double distLeft = std::abs(x - x0);
+      const double distRight = std::abs(x - x1);
+      const double distTop = std::abs(y - y0);
+      const double distBottom = std::abs(y - y1);
+
+      bool nearLeft = distLeft <= kHandleMargin;
+      bool nearRight = distRight <= kHandleMargin;
+      bool nearTop = distTop <= kHandleMargin;
+      bool nearBottom = distBottom <= kHandleMargin;
+
+      // Resolve overlaps by picking the closest edge mathematically
+      if (nearLeft && nearRight) {
+        if (distLeft < distRight)
+          nearRight = false;
+        else
+          nearLeft = false;
+      }
+      if (nearTop && nearBottom) {
+        if (distTop < distBottom)
+          nearBottom = false;
+        else
+          nearTop = false;
+      }
 
       if (nearTop && nearLeft)
         return capture::DragMode::TopLeftCorner;
@@ -276,6 +296,11 @@ namespace capture {
       m_startGlobalY = static_cast<double>(initialRegion->y);
       m_currentGlobalX = static_cast<double>(initialRegion->x + initialRegion->width);
       m_currentGlobalY = static_cast<double>(initialRegion->y + initialRegion->height);
+
+      // Initialize badge anchor safely on region restoration
+      m_cursorGlobalX = m_currentGlobalX;
+      m_cursorGlobalY = m_currentGlobalY;
+
       m_confirming = true;
     }
     ensureSurfaces();
@@ -439,9 +464,6 @@ namespace capture {
     }
 
     if (!m_renderContext->makeCurrent(inst.surface->renderTarget())) {
-      // The overlay's EGL surface could not be made current (e.g. EGL_BAD_ALLOC when the
-      // driver is out of video memory). Painting would be a no-op, leaving an invisible
-      // fullscreen surface that eats input, so tear down and report instead of spinning.
       abortWithError(i18n::tr("bar.screenshot.overlay-alloc-failed"));
       return;
     }
@@ -533,11 +555,14 @@ namespace capture {
           m_startGlobalY = globalY;
           m_currentGlobalX = globalX;
           m_currentGlobalY = globalY;
+
+          m_cursorGlobalX = globalX;
+          m_cursorGlobalY = globalY;
         } else if (m_dragMode == DragMode::Move) {
           m_moveOffsetX = globalX;
           m_moveOffsetY = globalY;
           m_dragAnchorX = m_startGlobalX;
-          m_dragAnchorY = m_currentGlobalX; // Using as temp storage for width mapping
+          m_dragAnchorY = m_currentGlobalX;
         } else {
           // Calculate anchors (the opposite side of what we are dragging)
           const double x0 = std::min(m_startGlobalX, m_currentGlobalX);
@@ -572,6 +597,9 @@ namespace capture {
             m_startGlobalY = y0;
             m_currentGlobalY = globalY;
           }
+
+          m_cursorGlobalX = globalX;
+          m_cursorGlobalY = globalY;
         }
 
         updateSelectionVisuals();
@@ -613,6 +641,10 @@ namespace capture {
           m_startGlobalY += deltaY;
           m_currentGlobalY += deltaY;
 
+          // Translate badge anchor along with the selection
+          m_cursorGlobalX += deltaX;
+          m_cursorGlobalY += deltaY;
+
           m_moveOffsetX = globalX;
           m_moveOffsetY = globalY;
         } else {
@@ -622,6 +654,9 @@ namespace capture {
           if (m_dragMode != DragMode::LeftEdge && m_dragMode != DragMode::RightEdge) {
             m_currentGlobalY = globalY;
           }
+
+          m_cursorGlobalX = globalX;
+          m_cursorGlobalY = globalY;
         }
 
         updateSelectionVisuals();
@@ -672,12 +707,8 @@ namespace capture {
       inst.backdrop = static_cast<Image*>(input->addChild(std::move(backdrop)));
     }
 
-    // Dim the screen with four strips that frame the selected region. The
-    // region itself stays fully transparent so it shows real colors and never
-    // tints the captured pixels.
     auto makeDimStrip = [&]() {
       auto strip = ui::box({
-          // Fixed black scrim so it darkens under every theme.
           .fill = fixedColorSpec(rgba(0.0F, 0.0F, 0.0F, 1.0F)),
           .width = 0.0F,
           .height = 0.0F,
@@ -870,10 +901,8 @@ namespace capture {
     if (!m_active) {
       return;
     }
-    // Stop further frames from re-triggering the abort while teardown is pending.
     m_active = false;
     kLog.warn("aborting screenshot region overlay: {}", message);
-    // Defer past the surface's prepareFrame callback before destroying its surfaces.
     FailureCallback onFailure = m_onFailure;
     DeferredCall::callLater([this, onFailure, message]() {
       cancel();
@@ -884,8 +913,6 @@ namespace capture {
   }
 
   void ScreenshotRegionOverlay::updateSelectionVisuals() {
-    // Lay out the four dim strips so they cover the surface except for the hole
-    // rect (surface-local). An empty hole dims the whole surface.
     const auto layoutDimFrame = [](Instance& inst, float surfaceW, float surfaceH, float hx0, float hy0, float hx1,
                                    float hy1) {
       hx0 = std::clamp(hx0, 0.0F, surfaceW);
@@ -940,8 +967,6 @@ namespace capture {
     const int globalY1 = static_cast<int>(std::ceil(std::max(m_startGlobalY, m_currentGlobalY)));
     const int selectionWidth = globalX1 - globalX0;
     const int selectionHeight = globalY1 - globalY0;
-    const int cursorGlobalX = static_cast<int>(std::lround(m_currentGlobalX));
-    const int cursorGlobalY = static_cast<int>(std::lround(m_currentGlobalY));
 
     char dimensionText[32];
     std::snprintf(dimensionText, sizeof(dimensionText), "%dx%d", selectionWidth, selectionHeight);
@@ -986,34 +1011,46 @@ namespace capture {
       const auto holeY1 = static_cast<float>(iy1 - outTop);
       layoutDimFrame(*inst, surfaceW, surfaceH, holeX0, holeY0, holeX1, holeY1);
 
-      // The outline is inset, so expand it outward to keep the border out of the
-      // captured (undimmed) region.
       inst->selection->setVisible(true);
       inst->selection->setPosition(holeX0 - kSelectionBorderWidth, holeY0 - kSelectionBorderWidth);
       inst->selection->setSize(
           (holeX1 - holeX0) + (kSelectionBorderWidth * 2.0F), (holeY1 - holeY0) + (kSelectionBorderWidth * 2.0F)
       );
 
-      if (inst->dimensionsBadge != nullptr
-          && inst->dimensionsLabel != nullptr
-          && m_renderContext != nullptr
-          && m_dragging) {
-        const bool cursorOnOutput = cursorGlobalX >= outLeft
-            && cursorGlobalX < outRight
-            && cursorGlobalY >= outTop
-            && cursorGlobalY < outBottom;
-        if (cursorOnOutput) {
+      if (inst->dimensionsBadge != nullptr && inst->dimensionsLabel != nullptr && m_renderContext != nullptr) {
+
+        // Show the badge during resize or confirmation. Hide it during move operations.
+        const bool showBadge = (m_dragging && m_dragMode != DragMode::Move) || (!m_dragging && m_confirming);
+
+        // The badge always stays near the last known cursor position (even after releasing the mouse).
+        const double targetX = m_cursorGlobalX;
+        const double targetY = m_cursorGlobalY;
+
+        const bool badgeOnOutput =
+            targetX >= outLeft && targetX <= outRight && targetY >= outTop && targetY <= outBottom;
+
+        if (showBadge && badgeOnOutput) {
           inst->dimensionsLabel->setText(dimensionText);
-          Renderer& renderer = inst->surface->renderTarget().renderer();
-          inst->dimensionsLabel->measure(renderer);
+          inst->dimensionsLabel->measure(inst->surface->renderTarget().renderer());
+
           const float badgeWidth = inst->dimensionsLabel->width() + (kDimensionPaddingX * 2.0F);
           const float badgeHeight = inst->dimensionsLabel->height() + (kDimensionPaddingY * 2.0F);
           inst->dimensionsBadge->setSize(badgeWidth, badgeHeight);
 
-          float badgeX = static_cast<float>(cursorGlobalX - outLeft) + kDimensionCursorOffsetX;
-          float badgeY = static_cast<float>(cursorGlobalY - outTop) + kDimensionCursorOffsetY;
+          const double selX0 = std::min(m_startGlobalX, m_currentGlobalX);
+          const double selX1 = std::max(m_startGlobalX, m_currentGlobalX);
+          const double selY0 = std::min(m_startGlobalY, m_currentGlobalY);
+          const double selY1 = std::max(m_startGlobalY, m_currentGlobalY);
+
+          const double badgeCursorX = std::clamp(targetX, selX0, selX1);
+          const double badgeCursorY = std::clamp(targetY, selY0, selY1);
+
+          float badgeX = static_cast<float>(badgeCursorX - outLeft) + kDimensionCursorOffsetX;
+          float badgeY = static_cast<float>(badgeCursorY - outTop) + kDimensionCursorOffsetY;
+
           const float maxX = std::max(0.0F, surfaceW - badgeWidth);
           const float maxY = std::max(0.0F, surfaceH - badgeHeight);
+
           badgeX = std::clamp(badgeX, 0.0F, maxX);
           badgeY = std::clamp(badgeY, 0.0F, maxY);
 

--- a/src/capture/screenshot_region_overlay.cpp
+++ b/src/capture/screenshot_region_overlay.cpp
@@ -48,6 +48,64 @@ namespace capture {
     constexpr float kSelectionBorderWidth = 2.0F;
     constexpr float kDimOpacity = 0.65F;
 
+    [[nodiscard]] capture::DragMode hitTestSelection(double x, double y, double x0, double y0, double x1, double y1) {
+      constexpr double kHandleMargin = 15.0; // Hitbox size in pixels
+      const bool nearLeft = std::abs(x - x0) <= kHandleMargin;
+      const bool nearRight = std::abs(x - x1) <= kHandleMargin;
+      const bool nearTop = std::abs(y - y0) <= kHandleMargin;
+      const bool nearBottom = std::abs(y - y1) <= kHandleMargin;
+
+      const bool withinX = x >= x0 - kHandleMargin && x <= x1 + kHandleMargin;
+      const bool withinY = y >= y0 - kHandleMargin && y <= y1 + kHandleMargin;
+
+      if (!withinX || !withinY)
+        return capture::DragMode::None;
+
+      if (nearTop && nearLeft)
+        return capture::DragMode::TopLeftCorner;
+      if (nearTop && nearRight)
+        return capture::DragMode::TopRightCorner;
+      if (nearBottom && nearLeft)
+        return capture::DragMode::BottomLeftCorner;
+      if (nearBottom && nearRight)
+        return capture::DragMode::BottomRightCorner;
+
+      if (nearTop && x >= x0 && x <= x1)
+        return capture::DragMode::TopEdge;
+      if (nearBottom && x >= x0 && x <= x1)
+        return capture::DragMode::BottomEdge;
+      if (nearLeft && y >= y0 && y <= y1)
+        return capture::DragMode::LeftEdge;
+      if (nearRight && y >= y0 && y <= y1)
+        return capture::DragMode::RightEdge;
+
+      if (x > x0 && x < x1 && y > y0 && y < y1)
+        return capture::DragMode::Move;
+
+      return capture::DragMode::None;
+    }
+
+    [[nodiscard]] std::uint32_t cursorShapeForDragMode(capture::DragMode mode) {
+      switch (mode) {
+      case capture::DragMode::TopEdge:
+      case capture::DragMode::BottomEdge:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NS_RESIZE;
+      case capture::DragMode::LeftEdge:
+      case capture::DragMode::RightEdge:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_EW_RESIZE;
+      case capture::DragMode::TopLeftCorner:
+      case capture::DragMode::BottomRightCorner:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NWSE_RESIZE;
+      case capture::DragMode::TopRightCorner:
+      case capture::DragMode::BottomLeftCorner:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NESW_RESIZE;
+      case capture::DragMode::Move:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_ALL_SCROLL;
+      default:
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+      }
+    }
+
     [[nodiscard]] const WaylandOutput* findOutput(const WaylandConnection& wayland, wl_output* output) {
       for (const auto& entry : wayland.outputs()) {
         if (entry.output == output) {
@@ -432,53 +490,144 @@ namespace capture {
       });
     } else {
       input->setOnPress([this, output = inst.output](const InputArea::PointerData& data) {
-        if (data.button != BTN_LEFT) {
+        if (data.button != BTN_LEFT)
           return;
-        }
+
         if (!data.pressed) {
-          if (!m_dragging) {
+          if (!m_dragging)
             return;
-          }
           m_dragging = false;
-          // completeSelection() tears down surfaces; defer past InputDispatcher::pointerButton.
+          // Re-evaluate mouse position for cursor change
           DeferredCall::callLater([this]() { completeSelection(); });
           return;
         }
-        if (m_confirming) {
-          m_confirming = false;
-        }
+
         const auto* out = findOutput(*m_wayland, output);
-        if (out == nullptr) {
+        if (out == nullptr)
           return;
-        }
+
+        const double globalX = static_cast<double>(out->logicalX) + static_cast<double>(data.localX);
+        const double globalY = static_cast<double>(out->logicalY) + static_cast<double>(data.localY);
+
         m_dragging = true;
-        m_startGlobalX = static_cast<double>(out->logicalX) + static_cast<double>(data.localX);
-        m_startGlobalY = static_cast<double>(out->logicalY) + static_cast<double>(data.localY);
-        m_currentGlobalX = m_startGlobalX;
-        m_currentGlobalY = m_startGlobalY;
+
+        if (m_confirming) {
+          const double x0 = std::min(m_startGlobalX, m_currentGlobalX);
+          const double y0 = std::min(m_startGlobalY, m_currentGlobalY);
+          const double x1 = std::max(m_startGlobalX, m_currentGlobalX);
+          const double y1 = std::max(m_startGlobalY, m_currentGlobalY);
+
+          m_dragMode = hitTestSelection(globalX, globalY, x0, y0, x1, y1);
+
+          if (m_dragMode == DragMode::None) {
+            // Clicked outside the selection, start a new one
+            m_confirming = false;
+            m_dragMode = DragMode::NewSelection;
+          }
+        } else {
+          m_dragMode = DragMode::NewSelection;
+        }
+
+        if (m_dragMode == DragMode::NewSelection) {
+          m_startGlobalX = globalX;
+          m_startGlobalY = globalY;
+          m_currentGlobalX = globalX;
+          m_currentGlobalY = globalY;
+        } else if (m_dragMode == DragMode::Move) {
+          m_moveOffsetX = globalX;
+          m_moveOffsetY = globalY;
+          m_dragAnchorX = m_startGlobalX;
+          m_dragAnchorY = m_currentGlobalX; // Using as temp storage for width mapping
+        } else {
+          // Calculate anchors (the opposite side of what we are dragging)
+          const double x0 = std::min(m_startGlobalX, m_currentGlobalX);
+          const double y0 = std::min(m_startGlobalY, m_currentGlobalY);
+          const double x1 = std::max(m_startGlobalX, m_currentGlobalX);
+          const double y1 = std::max(m_startGlobalY, m_currentGlobalY);
+
+          if (m_dragMode == DragMode::LeftEdge
+              || m_dragMode == DragMode::TopLeftCorner
+              || m_dragMode == DragMode::BottomLeftCorner) {
+            m_startGlobalX = x1;
+            m_currentGlobalX = globalX;
+          } else if (
+              m_dragMode == DragMode::RightEdge
+              || m_dragMode == DragMode::TopRightCorner
+              || m_dragMode == DragMode::BottomRightCorner
+          ) {
+            m_startGlobalX = x0;
+            m_currentGlobalX = globalX;
+          }
+
+          if (m_dragMode == DragMode::TopEdge
+              || m_dragMode == DragMode::TopLeftCorner
+              || m_dragMode == DragMode::TopRightCorner) {
+            m_startGlobalY = y1;
+            m_currentGlobalY = globalY;
+          } else if (
+              m_dragMode == DragMode::BottomEdge
+              || m_dragMode == DragMode::BottomLeftCorner
+              || m_dragMode == DragMode::BottomRightCorner
+          ) {
+            m_startGlobalY = y0;
+            m_currentGlobalY = globalY;
+          }
+        }
+
         updateSelectionVisuals();
         for (auto& instance : m_instances) {
-          if (instance->surface != nullptr) {
+          if (instance->surface != nullptr)
             instance->surface->requestRedraw();
-          }
         }
       });
 
-      input->setOnMotion([this, output = inst.output](const InputArea::PointerData& data) {
-        if (!m_dragging) {
-          return;
-        }
+      input->setOnMotion([this, output = inst.output, inputPtr = input.get()](const InputArea::PointerData& data) {
         const auto* out = findOutput(*m_wayland, output);
-        if (out == nullptr) {
+        if (out == nullptr)
+          return;
+
+        const double globalX = static_cast<double>(out->logicalX) + static_cast<double>(data.localX);
+        const double globalY = static_cast<double>(out->logicalY) + static_cast<double>(data.localY);
+
+        if (!m_dragging) {
+          if (m_confirming) {
+            const double x0 = std::min(m_startGlobalX, m_currentGlobalX);
+            const double y0 = std::min(m_startGlobalY, m_currentGlobalY);
+            const double x1 = std::max(m_startGlobalX, m_currentGlobalX);
+            const double y1 = std::max(m_startGlobalY, m_currentGlobalY);
+
+            DragMode hoverMode = hitTestSelection(globalX, globalY, x0, y0, x1, y1);
+            inputPtr->setCursorShape(cursorShapeForDragMode(hoverMode));
+          } else {
+            inputPtr->setCursorShape(WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR);
+          }
           return;
         }
-        m_currentGlobalX = static_cast<double>(out->logicalX) + static_cast<double>(data.localX);
-        m_currentGlobalY = static_cast<double>(out->logicalY) + static_cast<double>(data.localY);
+
+        if (m_dragMode == DragMode::Move) {
+          const double deltaX = globalX - m_moveOffsetX;
+          const double deltaY = globalY - m_moveOffsetY;
+
+          m_startGlobalX += deltaX;
+          m_currentGlobalX += deltaX;
+          m_startGlobalY += deltaY;
+          m_currentGlobalY += deltaY;
+
+          m_moveOffsetX = globalX;
+          m_moveOffsetY = globalY;
+        } else {
+          if (m_dragMode != DragMode::TopEdge && m_dragMode != DragMode::BottomEdge) {
+            m_currentGlobalX = globalX;
+          }
+          if (m_dragMode != DragMode::LeftEdge && m_dragMode != DragMode::RightEdge) {
+            m_currentGlobalY = globalY;
+          }
+        }
+
         updateSelectionVisuals();
         for (auto& instance : m_instances) {
-          if (instance->surface != nullptr) {
+          if (instance->surface != nullptr)
             instance->surface->requestRedraw();
-          }
         }
       });
     }

--- a/src/capture/screenshot_region_overlay.h
+++ b/src/capture/screenshot_region_overlay.h
@@ -15,6 +15,19 @@ struct PointerEvent;
 namespace capture {
 
   enum class ConfirmAction { None, ForceClipboard, ForceSave };
+  enum class DragMode {
+    None,
+    NewSelection,
+    TopEdge,
+    BottomEdge,
+    LeftEdge,
+    RightEdge,
+    TopLeftCorner,
+    TopRightCorner,
+    BottomLeftCorner,
+    BottomRightCorner,
+    Move
+  };
 
   struct FrozenScreenshot {
     wl_output* output = nullptr;
@@ -52,6 +65,12 @@ namespace capture {
 
   private:
     struct Instance;
+
+    DragMode m_dragMode = DragMode::None;
+    double m_dragAnchorX = 0.0;
+    double m_dragAnchorY = 0.0;
+    double m_moveOffsetX = 0.0;
+    double m_moveOffsetY = 0.0;
 
     void ensureSurfaces();
     void destroySurfaces();

--- a/src/capture/screenshot_region_overlay.h
+++ b/src/capture/screenshot_region_overlay.h
@@ -71,6 +71,8 @@ namespace capture {
     double m_dragAnchorY = 0.0;
     double m_moveOffsetX = 0.0;
     double m_moveOffsetY = 0.0;
+    double m_cursorGlobalX = 0.0;
+    double m_cursorGlobalY = 0.0;
 
     void ensureSurfaces();
     void destroySurfaces();

--- a/src/capture/screenshot_region_overlay.h
+++ b/src/capture/screenshot_region_overlay.h
@@ -67,8 +67,6 @@ namespace capture {
     struct Instance;
 
     DragMode m_dragMode = DragMode::None;
-    double m_dragAnchorX = 0.0;
-    double m_dragAnchorY = 0.0;
     double m_moveOffsetX = 0.0;
     double m_moveOffsetY = 0.0;
     double m_cursorGlobalX = 0.0;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added interactive resize and move capabilities to the screenshot region overlay.

## Motivation

<!-- What problem does this solve? -->
This implements the requested feature to improve screenshot UX.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Closes #3839

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Initiated a region screenshot (Confirm Region must be enabled).
- Hovered over edges and corners, verifying that the cursor changes shape correctly.
- Dragged all 4 edges and all 4 corners to resize the selection box.
- Clicked and dragged inside the selection box to move the entire region.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/50e5c8a9-e047-4f95-b19c-44ec13d178ec

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

Docs update noctalia-dev/noctalia-docs#220