### PR TITLE
fix(plugin store): make ESC in plugin store detail go back to the list

### DIFF
--- a/src/shell/settings/settings_sheet_popup.cpp
+++ b/src/shell/settings/settings_sheet_popup.cpp
@@ -109,6 +109,12 @@ namespace settings {
   }
 
   void SettingsSheetPopup::close() { destroyPopup(); }
+  void SettingsSheetPopup::requestClose() {
+    if (m_onCloseRequested && m_onCloseRequested()) {
+      return;
+    }
+    close();
+  }
 
   void SettingsSheetPopup::setSheetTitle(std::string title) {
     m_sheetTitle = std::move(title);
@@ -280,10 +286,7 @@ namespace settings {
                 if (aliveGuard.expired()) {
                   return;
                 }
-                if (m_onCloseRequested && m_onCloseRequested()) {
-                  return;
-                }
-                close();
+                requestClose();
               });
             },
         })

--- a/src/shell/settings/settings_sheet_popup.h
+++ b/src/shell/settings/settings_sheet_popup.h
@@ -51,6 +51,7 @@ namespace settings {
 
     void open(SettingsSheetPopupRequest request);
     void close();
+    void requestClose();
 
     [[nodiscard]] bool isOpen() const noexcept;
     [[nodiscard]] bool onPointerEvent(const PointerEvent& event);

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -1049,7 +1049,7 @@ void SettingsWindow::onKeyboardEvent(const KeyboardEvent& event) {
       return;
     }
     if (event.pressed && KeybindMatcher::matches(KeybindAction::Cancel, event.sym, event.modifiers)) {
-      m_editorSheetPopup->close();
+      m_editorSheetPopup->requestClose();
       return;
     }
     m_editorSheetPopup->onKeyboardEvent(event);


### PR DESCRIPTION
## Summary

This PR fixes the bug where pressing ESC while a plugin store detail is open closes the whole store instead of returning to the plugin list.

## Motivation

The settings window's ESC handler closed the store list without consulting the `onCloseRequested` step-back hook the X button uses. `requestClose()` unifies both, detail steps back, list dismisses; other sheet users unchanged.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3849 

## Testing

- Ran `just format`,`just build` and `just test` no errors
- Killed noctalia `pkill noctalia` then start build mode `./build-debug/noctalia`.
- Tested Manually:- Opened plugin store, then a plugin detail, pressed ESC , returns to list. Pressed ESC again, closes store. X button unchanged; widget inspector and template store ESC-close behavior unchanged

> Sorry at merge time, both X and ESC went through requestClose(). The current behavior (X closing the whole store) was introduced by 3914's refactor, not this PR. I edited description today and i don't know why i did..maybe i am just tired. 

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/faaf88d6-1483-4c31-9f11-374873b3790d



## Checklist

- [x] This PR is ready for review
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
