### PR TITLE
fix(cli): resolve zsh nested subcommands completion and help text for…

### DIFF
--- a/src/cli/completions.cpp
+++ b/src/cli/completions.cpp
@@ -366,7 +366,7 @@ namespace noctalia::cli {
           childPath.push_back(child.name);
           output.append("        ");
           output.append(child.name);
-          output.append(") shift words; (( CURRENT-- )); _noctalia_");
+          output.append(") _noctalia_");
           output.append(stateId(childPath));
           output.append(" ;;\n");
         }

--- a/src/cli/schema_root.h
+++ b/src/cli/schema_root.h
@@ -19,9 +19,9 @@ namespace noctalia::cli {
   inline constexpr Command kCompletionsCmd{
       "completions",
       "Generate shell completion scripts",
-      "Generate a completion script from the live CLI schema.\\n\\n"
-      "Examples:\\n"
-      "  source <(noctalia completions bash)\\n"
+      "Generate a completion script from the live CLI schema.\n\n"
+      "Examples:\n"
+      "  source <(noctalia completions bash)\n"
       "  noctalia completions fish > ~/.config/fish/completions/noctalia.fish",
       {},
       {},


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This PR fixes two minor issues in the CLI schema and completions generator:
1. Removes the manual `shift words; (( CURRENT-- ));` in the Zsh completions generator (`src/cli/completions.cpp`).
2. Fixes double-escaped newlines (`\\n` to `\n`) in the help text for `kCompletionsCmd` (`src/cli/schema_root_2.h`).

## Motivation

<!-- What problem does this solve? -->
- Removed the redundant array shift. Zsh's `_arguments *::`  already shifts the array and decrements `$CURRENT` automatically, so doing it twice was breaking completions for subcommands at depth >= 3.
- `noctalia completions --help` was printing literal `\n` characters instead of actual line breaks.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
Follow-up to the recent CLI declarative schema implementation.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Compiled and generated zsh completions.
- Verified that 3rd-level subcommands like `noctalia msg <TAB>` now correctly suggest the IPC commands.
- Ran `noctalia completions --help` and verified the output is properly formatted.
- Ran `just format` and `just test`, all ok,

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor: 
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
None.