### PR TITLE
feat(theme): add "twilight" mode

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -338,7 +338,8 @@
       "dark-mode": {
         "auto": "Auto Mode",
         "dark": "Dark Mode",
-        "light": "Light Mode"
+        "light": "Light Mode",
+        "twilight": "Twilight Mode"
       },
       "keyboard-layout": "Keyboard Layout",
       "media": "Media",
@@ -1399,7 +1400,8 @@
       "theme": {
         "mode": {
           "dark": "Dark",
-          "light": "Light"
+          "light": "Light",
+          "twilight": "Twilight"
         },
         "source": {
           "built-in": "Built-In",

--- a/src/app/application_ipc.cpp
+++ b/src/app/application_ipc.cpp
@@ -759,7 +759,7 @@ void Application::initIpc() {
   m_dock.registerIpc(m_ipcService);
   m_wallpaper.registerIpc(m_ipcService);
   greeter::registerIpc(
-      m_ipcService, m_configService, [this]() { return m_themeService.resolvedMode(); }, &m_compositorPlatform,
+      m_ipcService, m_configService, [this]() { return m_themeService.resolvedInternalMode(); }, &m_compositorPlatform,
       [this]() { return m_logindService != nullptr; }
   );
   if (m_mprisService) {

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -119,11 +119,8 @@ namespace {
     }
   }
 
-  void syncGSettingsColorScheme(std::string_view mode) {
-    if (mode.empty()) {
-      return;
-    }
-    const std::string pref = mode == "light" ? "prefer-light" : "prefer-dark";
+  void syncGSettingsColorScheme(bool isLightMode) {
+    const std::string pref = isLightMode ? "prefer-light" : "prefer-dark";
     if (process::commandExists("gsettings")) {
       std::string cmd = "gsettings set org.gnome.desktop.interface color-scheme \"";
       cmd += pref;
@@ -546,7 +543,7 @@ void Application::initStyleThemeAndWayland() {
 
   // Apply theme before any UI constructs palette-dependent scene nodes.
   auto syncScriptApiWallpaperDirectory = [this]() {
-    const ThemeMode mode = m_themeService.resolvedMode() == "light" ? ThemeMode::Light : ThemeMode::Dark;
+    const ThemeMode mode = m_themeService.isInternalLightMode() ? ThemeMode::Light : ThemeMode::Dark;
     m_scriptApi.setWallpaperDirectory(
         wallpaper::resolveGlobalWallpaperDirectory(m_configService.config().wallpaper, mode)
     );
@@ -610,7 +607,7 @@ void Application::initStyleThemeAndWayland() {
                                      ) mutable {
     const std::string resolvedMode(mode);
     const std::string configuredMode(enumToKey(kThemeModes, m_themeService.configuredMode()));
-    m_scriptApi.setDarkMode(resolvedMode != "light");
+    m_scriptApi.setDarkMode(!noctalia::theme::ThemeService::isInternalLightMode(mode));
     syncScriptApiWallpaperDirectory();
     const std::optional<std::string> previousMode = lastResolvedThemeMode;
     lastResolvedThemeMode = resolvedMode;
@@ -619,7 +616,9 @@ void Application::initStyleThemeAndWayland() {
     if (colorsChanged) {
       m_templateApplyService.setAfterApplyCallback([this]() { m_hookManager.fire(HookKind::ColorsChanged); });
     }
-    m_templateApplyService.apply(generated, mode);
+    m_templateApplyService.apply(
+        generated, noctalia::theme::ThemeService::isExternalLightMode(mode) ? "light" : "dark"
+    );
     if (previousMode.has_value() && *previousMode != resolvedMode) {
       m_hookManager.fire(
           HookKind::ThemeModeChanged,
@@ -628,10 +627,10 @@ void Application::initStyleThemeAndWayland() {
            {"NOCTALIA_THEME_MODE_CONFIGURED", configuredMode}}
       );
     }
-    syncGSettingsColorScheme(resolvedMode);
+    syncGSettingsColorScheme(noctalia::theme::ThemeService::isExternalLightMode(mode));
   });
   m_themeService.apply();
-  syncGSettingsColorScheme(m_themeService.resolvedMode());
+  syncGSettingsColorScheme(m_themeService.isExternalLightMode());
   syncScriptApiWallpaperDirectory();
   syncScriptApiShellTimeFormats();
   m_configService.addReloadCallback([this]() { m_themeService.onConfigReload(); }, "theme");

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -543,7 +543,7 @@ void Application::initStyleThemeAndWayland() {
 
   // Apply theme before any UI constructs palette-dependent scene nodes.
   auto syncScriptApiWallpaperDirectory = [this]() {
-    const ThemeMode mode = m_themeService.isInternalLightMode() ? ThemeMode::Light : ThemeMode::Dark;
+    const ThemeMode mode = m_themeService.isExternalLightMode() ? ThemeMode::Light : ThemeMode::Dark;
     m_scriptApi.setWallpaperDirectory(
         wallpaper::resolveGlobalWallpaperDirectory(m_configService.config().wallpaper, mode)
     );

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -235,7 +235,8 @@ void Application::performGreeterSync(bool quiet) {
     m_polkitAgent->markNextRequestInternal();
   }
   const auto launch = greeter::syncAppearanceToGreeterAsync(
-      m_configService, m_themeService.resolvedMode(), complete, &m_compositorPlatform, m_logindService != nullptr
+      m_configService, m_themeService.resolvedInternalMode(), complete, &m_compositorPlatform,
+      m_logindService != nullptr
   );
   if (launch == greeter::GreeterSyncLaunch::Failed) {
     if (quiet) {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1406,12 +1406,14 @@ constexpr EnumOption<PaletteSource> kPaletteSources[] = {
 enum class ThemeMode : std::uint8_t {
   Dark = 0,
   Light = 1,
-  Auto = 2,
+  Twilight = 2,
+  Auto = 3,
 };
 
 constexpr EnumOption<ThemeMode> kThemeModes[] = {
     {ThemeMode::Dark, "dark", "settings.options.theme.mode.dark"},
     {ThemeMode::Light, "light", "settings.options.theme.mode.light"},
+    {ThemeMode::Twilight, "twilight", "settings.options.theme.mode.twilight"},
     {ThemeMode::Auto, "auto", "common.states.auto"},
 };
 

--- a/src/launcher/wallpaper_provider.cpp
+++ b/src/launcher/wallpaper_provider.cpp
@@ -77,8 +77,8 @@ std::vector<LauncherResult> WallpaperProvider::query(std::string_view text) cons
 
   const std::string query = StringUtils::toLower(StringUtils::trim(text));
   const ThemeMode configured = m_config->config().theme.mode;
-  const bool isLight =
-      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
+  const bool isLight = m_themeService != nullptr ? m_themeService->isExternalLightMode()
+                                                 : configured == ThemeMode::Light || configured == ThemeMode::Twilight;
   auto candidates = collectWallpapers(
       wallpaper::resolveGlobalWallpaperDirectory(
           m_config->config().wallpaper, wallpaper::effectiveThemeMode(configured, isLight)

--- a/src/launcher/wallpaper_provider.cpp
+++ b/src/launcher/wallpaper_provider.cpp
@@ -77,7 +77,8 @@ std::vector<LauncherResult> WallpaperProvider::query(std::string_view text) cons
 
   const std::string query = StringUtils::toLower(StringUtils::trim(text));
   const ThemeMode configured = m_config->config().theme.mode;
-  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
+  const bool isLight =
+      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
   auto candidates = collectWallpapers(
       wallpaper::resolveGlobalWallpaperDirectory(
           m_config->config().wallpaper, wallpaper::effectiveThemeMode(configured, isLight)

--- a/src/shell/bar/widgets/theme_mode_widget.cpp
+++ b/src/shell/bar/widgets/theme_mode_widget.cpp
@@ -57,7 +57,7 @@ void ThemeModeWidget::syncState(Renderer& renderer) {
     return;
   }
 
-  const bool isLight = m_themeService->isLightMode();
+  const bool isLight = m_themeService->isInternalLightMode();
   if (isLight == m_lastIsLight) {
     return;
   }

--- a/src/shell/control_center/shortcut_registry.cpp
+++ b/src/shell/control_center/shortcut_registry.cpp
@@ -193,6 +193,8 @@ namespace {
         return i18n::tr("control-center.shortcuts.dark-mode.dark");
       case ThemeMode::Light:
         return i18n::tr("control-center.shortcuts.dark-mode.light");
+      case ThemeMode::Twilight:
+        return i18n::tr("control-center.shortcuts.dark-mode.twilight");
       case ThemeMode::Auto:
         return i18n::tr("control-center.shortcuts.dark-mode.auto");
       }

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -61,6 +61,7 @@ namespace {
     case ThemeMode::Dark:
       return 0;
     case ThemeMode::Light:
+    case ThemeMode::Twilight:
       return 1;
     case ThemeMode::Auto:
     default:
@@ -997,7 +998,8 @@ std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
   }
   const auto& wp = m_config->config().wallpaper;
   const ThemeMode configured = m_config->config().theme.mode;
-  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
+  const bool isLight =
+      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
   const ThemeMode mode = wallpaper::effectiveThemeMode(configured, isLight);
 
   const auto& choice = m_monitorChoices[m_selectedMonitorIndex];

--- a/src/shell/wallpaper/panel/wallpaper_panel.cpp
+++ b/src/shell/wallpaper/panel/wallpaper_panel.cpp
@@ -998,8 +998,8 @@ std::filesystem::path WallpaperPanel::rootDirectoryForSelection() const {
   }
   const auto& wp = m_config->config().wallpaper;
   const ThemeMode configured = m_config->config().theme.mode;
-  const bool isLight =
-      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
+  const bool isLight = m_themeService != nullptr ? m_themeService->isExternalLightMode()
+                                                 : configured == ThemeMode::Light || configured == ThemeMode::Twilight;
   const ThemeMode mode = wallpaper::effectiveThemeMode(configured, isLight);
 
   const auto& choice = m_monitorChoices[m_selectedMonitorIndex];

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -949,8 +949,8 @@ bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate ||
 
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {
   const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
-  const bool isLight =
-      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
+  const bool isLight = m_themeService != nullptr ? m_themeService->isExternalLightMode()
+                                                 : configured == ThemeMode::Light || configured == ThemeMode::Twilight;
   return wallpaper::effectiveThemeMode(configured, isLight);
 }
 

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -949,7 +949,8 @@ bool Wallpaper::automationAllowed() const noexcept { return !m_automationGate ||
 
 ThemeMode Wallpaper::directoryThemeMode() const noexcept {
   const ThemeMode configured = m_config != nullptr ? m_config->config().theme.mode : ThemeMode::Dark;
-  const bool isLight = m_themeService != nullptr ? m_themeService->isLightMode() : configured == ThemeMode::Light;
+  const bool isLight =
+      m_themeService != nullptr ? m_themeService->isExternalLightMode() : configured == ThemeMode::Light;
   return wallpaper::effectiveThemeMode(configured, isLight);
 }
 

--- a/src/shell/wallpaper/wallpaper_paths.cpp
+++ b/src/shell/wallpaper/wallpaper_paths.cpp
@@ -3,11 +3,8 @@
 #include "config/config_types.h"
 #include "util/file_utils.h"
 
-ThemeMode wallpaper::effectiveThemeMode(ThemeMode mode, bool isLight) noexcept {
-  if (mode == ThemeMode::Auto) {
-    return isLight ? ThemeMode::Light : ThemeMode::Dark;
-  }
-  return mode;
+ThemeMode wallpaper::effectiveThemeMode(ThemeMode /*mode*/, bool isLight) noexcept {
+  return isLight ? ThemeMode::Light : ThemeMode::Dark;
 }
 
 const WallpaperMonitorOverride*

--- a/src/shell/wallpaper/wallpaper_paths.h
+++ b/src/shell/wallpaper/wallpaper_paths.h
@@ -13,7 +13,7 @@ namespace wallpaper {
 
   inline constexpr std::string_view kDefaultWallpaperDirectory = "~/Pictures/Wallpapers";
 
-  // Maps theme.mode=auto to the currently resolved light/dark appearance.
+  // Resolve theme mode to light/dark appearance.
   [[nodiscard]] ThemeMode effectiveThemeMode(ThemeMode mode, bool isLight) noexcept;
 
   [[nodiscard]] const WallpaperMonitorOverride*

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 
 namespace noctalia::theme {
 
@@ -42,19 +43,31 @@ namespace noctalia::theme {
 
     struct ResolvedTheme {
       GeneratedPalette generated;
-      Palette palette;
       std::string mode;
+      Palette internalPalette;
+      std::string internalMode;
+      Palette externalPalette;
+      std::string externalMode;
     };
 
     std::string resolvedModeName(
         const ThemeConfig& cfg, const LocationConfig& location, std::optional<double> latitude,
         std::optional<double> longitude
     ) {
-      if (cfg.mode == ThemeMode::Auto) {
+      switch (cfg.mode) {
+      case ThemeMode::Auto: {
         const auto eval = day_night_schedule::evaluate(location, latitude, longitude);
         return eval.night ? "dark" : "light";
       }
-      return cfg.mode == ThemeMode::Light ? "light" : "dark";
+      case ThemeMode::Dark:
+        return "dark";
+      case ThemeMode::Light:
+        return "light";
+      case ThemeMode::Twilight:
+        return "twilight";
+      default:
+        std::unreachable();
+      }
     }
 
     ResolvedTheme resolveBuiltin(const ThemeConfig& cfg, std::string_view mode) {
@@ -66,8 +79,13 @@ namespace noctalia::theme {
       const GeneratedPalette generated = expandBuiltinPalette(*palette);
       return {
           .generated = generated,
-          .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
+          .internalPalette =
+              mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated.light : generated.dark),
+          .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
+          .externalPalette =
+              mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated.light : generated.dark),
+          .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
       };
     }
 
@@ -206,8 +224,13 @@ namespace noctalia::theme {
       const GeneratedPalette generated = expandBuiltinPalette(bp);
       return {
           .generated = generated,
-          .palette = mapGeneratedPaletteMode(mode == "light" ? generated.light : generated.dark),
           .mode = std::string(mode),
+          .internalPalette =
+              mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated.light : generated.dark),
+          .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
+          .externalPalette =
+              mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated.light : generated.dark),
+          .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
       };
     }
 
@@ -268,6 +291,10 @@ namespace noctalia::theme {
 
   } // namespace
 
+  bool ThemeService::isInternalLightMode(std::string_view mode) { return mode == "light"; }
+
+  bool ThemeService::isExternalLightMode(std::string_view mode) { return mode != "dark"; }
+
   ThemeService::ThemeService(ConfigService& config, HttpClient& httpClient)
       : m_config(config), m_httpClient(httpClient) {}
 
@@ -305,7 +332,7 @@ namespace noctalia::theme {
   }
 
   void ThemeService::toggleLightDark() {
-    const auto next = m_isLightMode ? ThemeMode::Dark : ThemeMode::Light;
+    const auto next = isExternalLightMode() ? ThemeMode::Dark : ThemeMode::Light;
     // Persist via ConfigService → StateService. The resulting overrides-change
     // callback rebuilds the Config and fires the reload callbacks, which call
     // ThemeService::onConfigReload() to transition to the new palette.
@@ -319,6 +346,9 @@ namespace noctalia::theme {
       next = ThemeMode::Light;
       break;
     case ThemeMode::Light:
+      next = ThemeMode::Twilight;
+      break;
+    case ThemeMode::Twilight:
       next = ThemeMode::Auto;
       break;
     case ThemeMode::Auto:
@@ -330,9 +360,17 @@ namespace noctalia::theme {
 
   ThemeMode ThemeService::configuredMode() const noexcept { return m_config.config().theme.mode; }
 
-  bool ThemeService::isLightMode() const noexcept { return m_isLightMode; }
+  bool ThemeService::isInternalLightMode() const noexcept { return isInternalLightMode(m_resolvedMode); }
 
-  std::string_view ThemeService::resolvedMode() const noexcept { return m_isLightMode ? "light" : "dark"; }
+  bool ThemeService::isExternalLightMode() const noexcept { return isExternalLightMode(m_resolvedMode); }
+
+  std::string_view ThemeService::resolvedInternalMode() const noexcept {
+    return isInternalLightMode() ? "light" : "dark";
+  }
+
+  std::string_view ThemeService::resolvedExternalMode() const noexcept {
+    return isExternalLightMode() ? "light" : "dark";
+  }
 
   void ThemeService::setChangeCallback(ChangeCallback callback) { m_changeCallback = std::move(callback); }
 
@@ -473,8 +511,13 @@ namespace noctalia::theme {
       if (auto generated = resolveWallpaperGenerated(cfg, m_config.getPaletteWallpaperPath())) {
         resolved = ResolvedTheme{
             .generated = *generated,
-            .palette = mapGeneratedPaletteMode(mode == "light" ? generated->light : generated->dark),
-            .mode = mode,
+            .mode = std::string(mode),
+            .internalPalette =
+                mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated->light : generated->dark),
+            .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
+            .externalPalette =
+                mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated->light : generated->dark),
+            .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
         };
       }
     } else if (cfg.source == PaletteSource::Community && !cfg.communityPalette.empty()) {
@@ -514,22 +557,23 @@ namespace noctalia::theme {
     }
 
     if (cfg.pureBlackDark || m_config.config().accessibility.highContrast) {
-      if (resolved->mode != "light") {
-        resolved->palette = mapGeneratedPaletteMode(resolved->generated.dark);
-      } else {
-        resolved->palette = mapGeneratedPaletteMode(resolved->generated.light);
-      }
+      resolved->internalPalette = mapGeneratedPaletteMode(
+          resolved->internalMode == "light" ? resolved->generated.light : resolved->generated.dark
+      );
+      resolved->externalPalette = mapGeneratedPaletteMode(
+          resolved->externalMode == "light" ? resolved->generated.light : resolved->generated.dark
+      );
     }
 
     queueResolvedCallback(resolved->generated, resolved->mode);
-    m_isLightMode = resolved->mode == "light";
+    m_resolvedMode = resolved->mode;
 
     if (animate) {
-      setResolvedThemeLight(m_isLightMode);
+      setResolvedThemeLight(isInternalLightMode());
       notifyShellAppIconColorizationChanged();
-      startTransition(resolved->palette);
+      startTransition(resolved->internalPalette);
     } else {
-      if (m_transitionAnimId == 0 && palette == resolved->palette) {
+      if (m_transitionAnimId == 0 && palette == resolved->internalPalette) {
         flushResolvedCallback(/*defer=*/false);
         return;
       }
@@ -538,9 +582,9 @@ namespace noctalia::theme {
         m_transitionAnimId = 0;
       }
       m_transitionTimer.stop();
-      setResolvedThemeLight(m_isLightMode);
+      setResolvedThemeLight(isInternalLightMode());
       notifyShellAppIconColorizationChanged();
-      setPalette(resolved->palette);
+      setPalette(resolved->internalPalette);
       if (m_changeCallback) {
         m_changeCallback();
       }
@@ -663,19 +707,14 @@ namespace noctalia::theme {
       return "ok\n";
     });
     ipc.bind(
-        noctalia::cli::msg::themeModeGet,
-        [this](const std::string&) -> std::string {
-          std::string out(resolvedMode());
-          out.push_back('\n');
-          return out;
-        },
+        noctalia::cli::msg::themeModeGet, [this](const std::string&) -> std::string { return m_resolvedMode + "\n"; },
         IpcService::HandlerOptions{.actionEditorVisibility = IpcService::ActionEditorVisibility::Hidden}
     );
     ipc.bind(noctalia::cli::msg::themeModeSet, [this](const std::string& args) -> std::string {
       const std::string token = StringUtils::trim(args);
       const auto mode = enumFromKey(kThemeModes, token);
       if (!mode.has_value()) {
-        return "error: expected dark, light, or auto\n";
+        return "error: expected dark, light, twilight, or auto\n";
       }
       m_config.setThemeMode(*mode);
       return "ok\n";

--- a/src/theme/theme_service.cpp
+++ b/src/theme/theme_service.cpp
@@ -45,9 +45,6 @@ namespace noctalia::theme {
       GeneratedPalette generated;
       std::string mode;
       Palette internalPalette;
-      std::string internalMode;
-      Palette externalPalette;
-      std::string externalMode;
     };
 
     std::string resolvedModeName(
@@ -82,10 +79,6 @@ namespace noctalia::theme {
           .mode = std::string(mode),
           .internalPalette =
               mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated.light : generated.dark),
-          .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
-          .externalPalette =
-              mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated.light : generated.dark),
-          .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
       };
     }
 
@@ -227,10 +220,6 @@ namespace noctalia::theme {
           .mode = std::string(mode),
           .internalPalette =
               mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated.light : generated.dark),
-          .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
-          .externalPalette =
-              mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated.light : generated.dark),
-          .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
       };
     }
 
@@ -514,10 +503,6 @@ namespace noctalia::theme {
             .mode = std::string(mode),
             .internalPalette =
                 mapGeneratedPaletteMode(ThemeService::isInternalLightMode(mode) ? generated->light : generated->dark),
-            .internalMode = ThemeService::isInternalLightMode(mode) ? "light" : "dark",
-            .externalPalette =
-                mapGeneratedPaletteMode(ThemeService::isExternalLightMode(mode) ? generated->light : generated->dark),
-            .externalMode = ThemeService::isExternalLightMode(mode) ? "light" : "dark",
         };
       }
     } else if (cfg.source == PaletteSource::Community && !cfg.communityPalette.empty()) {
@@ -558,10 +543,7 @@ namespace noctalia::theme {
 
     if (cfg.pureBlackDark || m_config.config().accessibility.highContrast) {
       resolved->internalPalette = mapGeneratedPaletteMode(
-          resolved->internalMode == "light" ? resolved->generated.light : resolved->generated.dark
-      );
-      resolved->externalPalette = mapGeneratedPaletteMode(
-          resolved->externalMode == "light" ? resolved->generated.light : resolved->generated.dark
+          ThemeService::isInternalLightMode(resolved->mode) ? resolved->generated.light : resolved->generated.dark
       );
     }
 

--- a/src/theme/theme_service.h
+++ b/src/theme/theme_service.h
@@ -23,6 +23,9 @@ namespace noctalia::theme {
     using ChangeCallback = std::function<void()>;
     using ResolvedCallback = std::function<void(const GeneratedPalette&, std::string_view)>;
 
+    static bool isInternalLightMode(std::string_view mode);
+    static bool isExternalLightMode(std::string_view mode);
+
     ThemeService(ConfigService& config, HttpClient& httpClient);
 
     // Snaps the palette to the resolved theme (no fade). Used at startup.
@@ -36,8 +39,10 @@ namespace noctalia::theme {
     void toggleLightDark();
     void cycleMode();
     [[nodiscard]] ThemeMode configuredMode() const noexcept;
-    [[nodiscard]] bool isLightMode() const noexcept;
-    [[nodiscard]] std::string_view resolvedMode() const noexcept;
+    [[nodiscard]] bool isInternalLightMode() const noexcept;
+    [[nodiscard]] bool isExternalLightMode() const noexcept;
+    [[nodiscard]] std::string_view resolvedInternalMode() const noexcept;
+    [[nodiscard]] std::string_view resolvedExternalMode() const noexcept;
 
     void setChangeCallback(ChangeCallback callback);
     void setResolvedCallback(ResolvedCallback callback);
@@ -86,7 +91,7 @@ namespace noctalia::theme {
     Palette m_targetPalette{};
     AnimationManager::Id m_transitionAnimId = 0;
     bool m_transitionResolvedCallbackFlushed = false;
-    bool m_isLightMode = false;
+    std::string m_resolvedMode = "dark";
     std::optional<double> m_autoLatitude;
     std::optional<double> m_autoLongitude;
     Timer m_autoTimer;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

In this mode, Noctalia itself uses dark theme ("internal theme"), while external apps (templates and `gsettings color-theme`) use light theme ("external theme").

Details:
1. `noctalia msg theme-mode-toggle` on "twilight" returns in "dark". I.e. it's assumed that the user wants to toggle app themes instead of Noctalia, because the former takes the majority of the screen.
2. Wallpapers uses light theme in "twilight", to match app themes. Because wallpaper covers the same screen region as apps, so they should match.
3. Noctalia Greeter syncs with the internal theme.

<!-- What changed and why? -->

## Motivation

This provides a strong visual separation between system (Noctalia) and apps, and allows Noctalia to blend into display edges, while keeping apps in light theme.

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
