### PR TITLE
fix(lockscreen): fix crash after hotplugging monitor during deferred lock

### DIFF
--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -38,6 +38,13 @@ namespace {
     return resolveColorSpec(*config.fillColor);
   }
 
+  // An output can only carry a lock surface once it is complete and has real geometry.
+  bool hasUsableOutput(const WaylandConnection& wayland) {
+    return std::ranges::any_of(wayland.outputs(), [](const WaylandOutput& output) {
+      return output.done && output.output != nullptr && output.hasUsableGeometry();
+    });
+  }
+
   const ext_session_lock_v1_listener kSessionLockListener = {
       .locked = &LockScreen::handleLocked,
       .finished = &LockScreen::handleFinished,
@@ -116,7 +123,7 @@ bool LockScreen::lock() {
     kLog.warn("session lock protocol unavailable");
     return false;
   }
-  if (m_wayland->outputs().empty()) {
+  if (!hasUsableOutput(*m_wayland)) {
     m_lockDeferred = true;
     kLog.warn("no outputs available for lock screen; lock deferred until an output is connected");
     // No output can ever show a lock surface, so run any pending post-lock action (e.g. suspend)


### PR DESCRIPTION
## Summary

There's a regression on beta8 which causes a crash when hotplugging a monitor with deferred lock (beta7 was OK). I think it's caused by this commit: https://github.com/noctalia-dev/noctalia/commit/489de6f7

Steps to reproduce:

1) Configure idle lock (also happens with idle suspend using `lock_and_suspend`)

```
[idle.behavior.lock]
enabled = true
# Just 10 seconds to make it happen quickly
timeout = 10
action = "lock"
```

2) Unplug monitor and wait for lock
3) Replug monitor and noctalia crashes with: `[ERR] fatal: failed to dispatch pending Wayland events after poll`

```
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.636 [WRN] [lockscreen] no outputs available for lock screen
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.638 [INF] [backdrop] creating on DP-2 (Samsung Electric Company - Odyssey G81SF - DP-2), path=/home/matthewv/Pictures/Wallpapers/>
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.639 [INF] [render] graphics reset status polling enabled
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.676 [INF] [texcache] uploaded /home/matthewv/Pictures/Wallpapers/wallpaper05.jpg
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.676 [INF] [bar] creating #0 "default" on DP-2 (Samsung Electric Company - Odyssey G81SF - DP-2), thickness=40 position=top reserv>
Aug 10 16:58:03 archlinux noctalia[11591]: [destroyed object]: error 1: Session is not locked.
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.760 [INF] [logind] logind sleep delay inhibit released
Aug 10 16:58:03 archlinux noctalia[11591]: 16:58:03.761 [ERR] fatal: failed to dispatch pending Wayland events after poll: display_error=71 (Protocol 

```
## Motivation

N/A

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

Tested deferred lock and lock_and_suspend idle modes triggered when no monitor is connected. Hotplug works without crashing Noctalia.

## Manual Coverage

- [X] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

N/A
