### PR TITLE
fix(hyprland): order workspaces by id

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3592,7 +3592,7 @@
         "max-label-chars": {
           "description": "Maximum number of characters to show for workspace names",
           "label": "Max Label Characters",
-          "workspaces-description": "Maximum characters for workspace name labels"
+          "workspaces-description": "Maximum characters for non-numeric workspace labels"
         },
         "max-length": {
           "description": "Maximum widget length in pixels",

--- a/meson.build
+++ b/meson.build
@@ -1138,6 +1138,7 @@ if build_tests
     'fcitx_status',
     'google_client_calendar_list',
     'hook_manager',
+    'hyprland_workspace_backend',
     'i18n_language_tag',
     'i18n_supported_languages',
     'ical_parser',

--- a/src/compositors/hyprland/hyprland_workspace_backend.cpp
+++ b/src/compositors/hyprland/hyprland_workspace_backend.cpp
@@ -892,16 +892,10 @@ bool HyprlandWorkspaceBackend::isSpecial(const WorkspaceState& state) {
   return state.id < 0 && (state.name == "special" || state.name.starts_with("special:"));
 }
 
+// Hyprland traverses workspaces by ascending id (`workspace m+1`, `workspace m~1`), and named
+// workspaces get negative ids, so they belong before the numbered ones.
 bool HyprlandWorkspaceBackend::workspaceOrderLess(const WorkspaceState* a, const WorkspaceState* b) {
-  const bool aNamed = a->id < 0;
-  const bool bNamed = b->id < 0;
-  if (aNamed != bNamed) {
-    return !aNamed; // numbered workspaces before named ones
-  }
-  if (!aNamed) {
-    return a->id < b->id; // numbered: ascending id
-  }
-  return a->name < b->name; // named: alphabetical
+  return a->id < b->id;
 }
 
 Workspace HyprlandWorkspaceBackend::toWorkspace(const WorkspaceState& state) {

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -1393,11 +1393,12 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
     }
   } else {
     label = !workspace.name.empty() ? workspace.name : workspace.id;
-    // Only truncate non-numeric labels (words like "VESKTOP" → "VE").
-    // Numeric labels (workspace IDs like "10", "11") stay as-is.
-    if (!isNumericLabel(label) && m_maxLabelChars > 0) {
-      label = StringUtils::truncateUtf8CodePoints(label, m_maxLabelChars);
-    }
+  }
+
+  // Only truncate non-numeric labels (words like "VESKTOP" → "VE").
+  // Numeric labels (workspace IDs like "10", "11") stay as-is.
+  if (!isNumericLabel(label) && m_maxLabelChars > 0) {
+    label = StringUtils::truncateUtf8CodePoints(label, m_maxLabelChars);
   }
 
   return label;

--- a/src/shell/bar/widgets/workspaces_widget.cpp
+++ b/src/shell/bar/widgets/workspaces_widget.cpp
@@ -1385,6 +1385,9 @@ std::string WorkspacesWidget::workspaceLabel(const Workspace& workspace, std::si
       label = std::to_string(workspace.index);
     } else if (const auto numericId = numericWorkspaceId(workspace); numericId.has_value()) {
       label = std::to_string(*numericId);
+    } else if (!workspace.name.empty()) {
+      // Named workspaces have no numeric id, so the name beats labeling them by bar position.
+      label = workspace.name;
     } else {
       label = std::to_string(displayIndex + 1);
     }

--- a/src/shell/bar/widgets/workspaces_widget_definition.cpp
+++ b/src/shell/bar/widgets/workspaces_widget_definition.cpp
@@ -18,16 +18,6 @@ namespace {
     return visibility;
   }
 
-  // Only name labels are truncated; ID labels are left alone.
-  settings::WidgetSettingVisibility nameLabelsShown() {
-    settings::WidgetSettingVisibility visibility;
-    visibility.all = {
-        {"show_labels", {"true"}},
-        {"label_source", {"name"}},
-    };
-    return visibility;
-  }
-
   settings::WidgetSettingVisibility regularStyleOnly() {
     settings::WidgetSettingVisibility visibility;
     visibility.all = {{"style", {"regular"}}};
@@ -100,7 +90,7 @@ const noctalia::bar::WidgetDefinition<WorkspacesWidget::Options>& workspacesWidg
                       settings::WidgetSettingPresentation{
                           .descriptionKey = "settings.widgets.settings.max-label-chars.workspaces-description",
                           .group = "workspaces.list",
-                          .visibleWhen = nameLabelsShown(),
+                          .visibleWhen = labelsShown(),
                       },
               }),
               field<&Options::style>({

--- a/tests/hyprland_workspace_backend_test.cpp
+++ b/tests/hyprland_workspace_backend_test.cpp
@@ -29,13 +29,13 @@ namespace {
   ])";
 
   std::string replyFor(std::string_view command) {
-    if (command.find("j/workspaces") != std::string_view::npos) {
+    if (command.contains("j/workspaces")) {
       return std::string(kWorkspacesJson);
     }
-    if (command.find("j/monitors") != std::string_view::npos) {
+    if (command.contains("j/monitors")) {
       return std::string(kMonitorsJson);
     }
-    if (command.find("j/status") != std::string_view::npos) {
+    if (command.contains("j/status")) {
       return R"({"configProvider": "lua"})";
     }
     return "[]";

--- a/tests/hyprland_workspace_backend_test.cpp
+++ b/tests/hyprland_workspace_backend_test.cpp
@@ -1,0 +1,157 @@
+#include "compositors/hyprland/hyprland_runtime.h"
+#include "compositors/hyprland/hyprland_workspace_backend.h"
+
+#include <atomic>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+  // Named workspaces (`workspace = name:0, ...`) get negative ids, in an order unrelated to
+  // their names. The special workspace must stay out of the listing entirely.
+  constexpr std::string_view kWorkspacesJson = R"([
+    {"id": -1338, "name": "Grave", "monitor": "WAYLAND-1"},
+    {"id": -1337, "name": "0", "monitor": "WAYLAND-1"},
+    {"id": 8, "name": "8", "monitor": "WAYLAND-1"},
+    {"id": -99, "name": "special:special", "monitor": "WAYLAND-1"}
+  ])";
+
+  constexpr std::string_view kMonitorsJson = R"([
+    {"name": "WAYLAND-1", "activeWorkspace": {"id": 8, "name": "8"}}
+  ])";
+
+  std::string replyFor(std::string_view command) {
+    if (command.find("j/workspaces") != std::string_view::npos) {
+      return std::string(kWorkspacesJson);
+    }
+    if (command.find("j/monitors") != std::string_view::npos) {
+      return std::string(kMonitorsJson);
+    }
+    if (command.find("j/status") != std::string_view::npos) {
+      return R"({"configProvider": "lua"})";
+    }
+    return "[]";
+  }
+
+  // Stands in for hyprctl's request socket: read the command until the peer half-closes,
+  // answer with JSON, close.
+  void serve(int listener, const std::atomic_bool& stop) {
+    while (!stop.load()) {
+      const int client = ::accept(listener, nullptr, nullptr);
+      if (client < 0) {
+        if (stop.load()) {
+          return;
+        }
+        continue;
+      }
+      std::string request;
+      char buffer[1024];
+      while (true) {
+        const ssize_t bytes = ::recv(client, buffer, sizeof(buffer), 0);
+        if (bytes <= 0) {
+          break;
+        }
+        request.append(buffer, buffer + bytes);
+      }
+      const std::string reply = replyFor(request);
+      (void)::send(client, reply.data(), reply.size(), MSG_NOSIGNAL);
+      ::close(client);
+    }
+  }
+
+  std::string describe(const std::vector<Workspace>& workspaces) {
+    std::string out;
+    for (const auto& workspace : workspaces) {
+      if (!out.empty()) {
+        out += ", ";
+      }
+      out += workspace.name + "(" + workspace.id + ")";
+    }
+    return out;
+  }
+
+  bool orderedById(const char* what, const std::vector<Workspace>& workspaces) {
+    static const std::vector<std::string> expected{"-1338", "-1337", "8"};
+
+    std::vector<std::string> actual;
+    actual.reserve(workspaces.size());
+    for (const auto& workspace : workspaces) {
+      actual.push_back(workspace.id);
+    }
+    if (actual == expected) {
+      return true;
+    }
+    std::cerr << "FAIL: " << what << " must be ordered by ascending hyprland id, got " << describe(workspaces) << '\n';
+    return false;
+  }
+
+} // namespace
+
+int main() {
+  const std::string runtimeDir = "/tmp/noctalia-hypr-workspace-test-" + std::to_string(::getpid());
+  const std::string signature = "test";
+  const std::string socketDir = runtimeDir + "/hypr/" + signature;
+
+  std::error_code ec;
+  std::filesystem::create_directories(socketDir, ec);
+  if (ec) {
+    std::cerr << "FAIL: cannot create " << socketDir << ": " << ec.message() << '\n';
+    return 1;
+  }
+  const std::string socketPath = socketDir + "/.socket.sock";
+
+  const int listener = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listener < 0) {
+    std::cerr << "FAIL: socket() failed\n";
+    return 1;
+  }
+
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  if (socketPath.size() >= sizeof(address.sun_path)) {
+    std::cerr << "FAIL: socket path too long\n";
+    return 1;
+  }
+  std::memcpy(address.sun_path, socketPath.c_str(), socketPath.size() + 1);
+  if (::bind(listener, reinterpret_cast<const sockaddr*>(&address), sizeof(address)) != 0) {
+    std::cerr << "FAIL: bind() failed\n";
+    return 1;
+  }
+  if (::listen(listener, 8) != 0) {
+    std::cerr << "FAIL: listen() failed\n";
+    return 1;
+  }
+
+  std::atomic_bool stop{false};
+  std::thread server([&]() { serve(listener, stop); });
+
+  // The runtime resolves its socket paths from the environment on construction.
+  ::setenv("XDG_RUNTIME_DIR", runtimeDir.c_str(), 1);
+  ::setenv("HYPRLAND_INSTANCE_SIGNATURE", signature.c_str(), 1);
+
+  bool ok = true;
+  {
+    compositors::hyprland::HyprlandRuntime runtime;
+    HyprlandWorkspaceBackend backend([](wl_output*) { return std::string("WAYLAND-1"); }, runtime);
+    backend.syncFromCompositor();
+
+    ok = orderedById("all()", backend.all()) && ok;
+    ok = orderedById("forOutput()", backend.forOutput(reinterpret_cast<wl_output*>(0x1))) && ok;
+  }
+
+  stop.store(true);
+  ::shutdown(listener, SHUT_RDWR);
+  ::close(listener);
+  server.join();
+  std::filesystem::remove_all(runtimeDir, ec);
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`HyprlandWorkspaceBackend::workspaceOrderLess()` now sorts purely by workspace id. It used to read a negative id as "this workspace is named", push those workspaces behind every numbered one, and sort them alphabetically among themselves. Hyprland orders workspaces by ascending id, negatives included, so the bar disagreed with the compositor about what the next workspace is.

The workspaces widget in `label_source = "id"` mode also falls back to the workspace name when a workspace has no numeric id, instead of falling through to its position in the bar.

## Motivation

Reported in #3871: with persistent named workspaces, the bar order does not match the order Hyprland uses for relative dispatches.

With the reporter's rules:

```
workspace = 8, monitor:<output>, persistent:true
workspace = name:0, monitor:<output>, persistent:true
workspace = name:Grave, monitor:<output>, persistent:true
```

Hyprland assigned `Grave = -1338` and `0 = -1337`. Repeatedly dispatching `workspace m+1` visits Grave, 0, 8, and `m~1` ("first workspace on the monitor") selects Grave. The bar showed 8, 0, Grave, so a next/previous keybind appeared to jump around the bar and `m~1` highlighted the rightmost pill.

The label fallback matters for the same setup: `Grave` rendered as `3` in id mode, a number that was neither its id nor its name, and that changed as soon as the ordering changed. Rendering the negative id instead would be worse than useless, since the allocation is not stable across restarts: the same two rules produced -1339/-1338 for the reporter and -1337/-1338 here.

The fallback only fires when there is no numeric identity at all, so no workspace that previously showed a number shows something else now. Backends that set `index` (niri, kwin, dwl, mango, triad) never reach it. Named sway and ext-workspace workspaces get the same improvement as Hyprland.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3871

## Testing

- `just test debug` — 80/80, including the new `tests/hyprland_workspace_backend_test.cpp`. It drives the backend against a stub hyprctl request socket serving the workspace set above plus a special workspace, and asserts ascending-id order from `all()` and `forOutput()`.
- Confirmed the new test is not vacuous by temporarily restoring the old comparator: it fails with `got: 8(8), 0(-1337), Grave(-1338)` and passes with the new one.
- `just format` — no changes (clang-format 22.1.8).
- clang-tidy with `-warnings-as-errors=*` over both modified files — clean.
- Manual: nested Hyprland instance with the rules above, running a debug build. Pills read Grave, 0, 8; stepping `workspace m+1` highlights them left to right; `m~1` selects the leftmost. Labels come out as `Grave 0 8` in id mode and `G 0 8` in name mode with `max_label_chars = 1`.

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

Hyprland coverage was a nested instance with a single output, not a full session. The unchecked boxes are untested: no layout, geometry, or scaling code is touched, so pill order and label text should be independent of bar position, density, and scale. Multi-monitor is worth a look from someone with the hardware, since `forOutput()` is one of the two call sites that changed.

## Screenshots / Videos

Bar contents in the nested instance, active workspace in brackets:

```
before, label_source = id     [8]  2   3         (pills 2 and 3 are "0" and "Grave")
after,  label_source = id      Grave  0  [8]
after,  label_source = name    G  0  [8]
```

I have PNGs of all three and can attach them on request.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

I left the documentation box unchecked deliberately. No config key, IPC name, or identifier changes, but observable behavior does change for anyone running named workspaces, and I do not know whether the docs describe workspace ordering or what id mode shows for a named workspace. Point me at the right page and I will send a note.

Two limitations worth knowing:

Order among named workspaces follows Hyprland's id allocation, not the order the rules are declared in. Above, `name:0` is declared first but `Grave` sorts first. That is inherent in matching the compositor's own traversal.

`max_label_chars` is only exposed for `label_source = "name"`, so a long workspace name is not truncated in id mode. Widening that setting's visibility to both modes is a settings-schema change I kept out of this PR. Happy to add it if you want it.
