### PR TITLE
feat(cli): implement dynamic runtime completions for plugins

### DIFF
--- a/src/cli/completions.cpp
+++ b/src/cli/completions.cpp
@@ -3,6 +3,7 @@
 #include "cli/parse.h"
 #include "cli/schema_root.h"
 
+#include <algorithm>
 #include <print>
 #include <span>
 #include <string_view>
@@ -218,6 +219,11 @@ namespace noctalia::cli {
         "  local words=\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"disabled\" {print $1}')\"\n"
         "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
         "}\n\n"
+        "_noctalia_plugin_prefix() {\n"
+        "  local words=\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1\":\"}')\"\n"
+        "  compopt -o nospace 2>/dev/null\n"
+        "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
+        "}\n\n"
         "_noctalia_completions() {\n"
         "  local cur=\"${COMP_WORDS[COMP_CWORD]}\"\n"
         "  local path=noctalia\n"
@@ -373,6 +379,15 @@ namespace noctalia::cli {
         "  else\n"
         "    _message 'no disabled plugins found'\n"
         "  fi\n"
+        "}\n\n"
+        "_noctalia_plugin_prefix() {\n"
+        "  local -a plugins\n"
+        "  plugins=(${(f)\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1\":\"}')\"})\n"
+        "  if [[ ${#plugins[@]} -gt 0 ]]; then\n"
+        "    compadd -S '' -a plugins\n"
+        "  else\n"
+        "    _message 'no enabled plugins found'\n"
+        "  fi\n"
         "}\n\n";
 
     for (const CommandState& state : states) {
@@ -419,7 +434,7 @@ namespace noctalia::cli {
           std::string spec = positional.variadic ? "*" : std::to_string(i + 1);
           spec.push_back(':');
           std::string safeName{positional.name};
-          std::replace(safeName.begin(), safeName.end(), ':', '-');
+          std::ranges::replace(safeName, ':', '-');
           spec.append(safeName);
           spec.push_back(':');
 
@@ -504,6 +519,9 @@ namespace noctalia::cli {
                          "end\n\n"
                          "function __noctalia_plugins_disabled\n"
                          "    noctalia msg plugins list 2>/dev/null | awk '$4 == \"disabled\" {print $1}'\n"
+                         "end\n\n"
+                         "function __noctalia_plugin_prefix\n"
+                         "    noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1\":\"}'\n"
                          "end\n\n";
 
     for (const CommandState& state : states) {

--- a/src/cli/completions.cpp
+++ b/src/cli/completions.cpp
@@ -203,20 +203,29 @@ namespace noctalia::cli {
 
   std::string generateBash(const Command& root) {
     const auto states = collectStates(root);
-    std::string output = "# bash completion for noctalia; generated from the live CLI schema\n"
-                         "_noctalia_complete_words() {\n"
-                         "  local words=\"$1\"\n"
-                         "  local IFS=$'\\n'\n"
-                         "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
-                         "}\n\n"
-                         "_noctalia_completions() {\n"
-                         "  local cur=\"${COMP_WORDS[COMP_CWORD]}\"\n"
-                         "  local path=noctalia\n"
-                         "  local depth=1\n"
-                         "  local i token\n"
-                         "  for ((i=1; i<COMP_CWORD; ++i)); do\n"
-                         "    token=\"${COMP_WORDS[i]}\"\n"
-                         "    case \"$path:$token\" in\n";
+    std::string output =
+        "# bash completion for noctalia; generated from the live CLI schema\n"
+        "_noctalia_complete_words() {\n"
+        "  local words=\"$1\"\n"
+        "  local IFS=$'\\n'\n"
+        "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
+        "}\n\n"
+        "_noctalia_plugins_enabled() {\n"
+        "  local words=\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1}')\"\n"
+        "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
+        "}\n\n"
+        "_noctalia_plugins_disabled() {\n"
+        "  local words=\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"disabled\" {print $1}')\"\n"
+        "  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n"
+        "}\n\n"
+        "_noctalia_completions() {\n"
+        "  local cur=\"${COMP_WORDS[COMP_CWORD]}\"\n"
+        "  local path=noctalia\n"
+        "  local depth=1\n"
+        "  local i token\n"
+        "  for ((i=1; i<COMP_CWORD; ++i)); do\n"
+        "    token=\"${COMP_WORDS[i]}\"\n"
+        "    case \"$path:$token\" in\n";
 
     for (const CommandState& state : states) {
       for (const Command& child : state.command->subcommands) {
@@ -309,10 +318,16 @@ namespace noctalia::cli {
         output.append("        ");
         output.append(std::to_string(i));
         output.append(")\n");
-        if (positional.choices.empty())
+        if (!positional.runtimeProvider.empty()) {
+          output.append(10, ' ');
+          output.append("_noctalia_");
+          output.append(positional.runtimeProvider);
+          output.append("\n");
+        } else if (positional.choices.empty()) {
           appendBashFiles(output, 10);
-        else
+        } else {
           appendBashCompletion(output, positional.choices, 10);
+        }
         output.append("          ;;\n");
         if (positional.variadic)
           break;
@@ -320,10 +335,16 @@ namespace noctalia::cli {
       output.append("        *)\n");
       if (!command.positionals.empty() && command.positionals.back().variadic) {
         const Positional& positional = command.positionals.back();
-        if (positional.choices.empty())
+        if (!positional.runtimeProvider.empty()) {
+          output.append(10, ' ');
+          output.append("_noctalia_");
+          output.append(positional.runtimeProvider);
+          output.append("\n");
+        } else if (positional.choices.empty()) {
           appendBashFiles(output, 10);
-        else
+        } else {
           appendBashCompletion(output, positional.choices, 10);
+        }
       }
       output.append("          ;;\n      esac\n      ;;\n");
     }
@@ -333,7 +354,26 @@ namespace noctalia::cli {
 
   std::string generateZsh(const Command& root) {
     const auto states = collectStates(root);
-    std::string output = "#compdef noctalia\n# generated from the live CLI schema\n\n";
+    std::string output =
+        "#compdef noctalia\n# generated from the live CLI schema\n\n"
+        "_noctalia_plugins_enabled() {\n"
+        "  local -a plugins\n"
+        "  plugins=(${(f)\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1}')\"})\n"
+        "  if [[ ${#plugins[@]} -gt 0 ]]; then\n"
+        "    _values 'enabled plugin' $plugins\n"
+        "  else\n"
+        "    _message 'no enabled plugins found'\n"
+        "  fi\n"
+        "}\n\n"
+        "_noctalia_plugins_disabled() {\n"
+        "  local -a plugins\n"
+        "  plugins=(${(f)\"$(noctalia msg plugins list 2>/dev/null | awk '$4 == \"disabled\" {print $1}')\"})\n"
+        "  if [[ ${#plugins[@]} -gt 0 ]]; then\n"
+        "    _values 'disabled plugin' $plugins\n"
+        "  else\n"
+        "    _message 'no disabled plugins found'\n"
+        "  fi\n"
+        "}\n\n";
 
     for (const CommandState& state : states) {
       const Command& command = *state.command;
@@ -378,9 +418,18 @@ namespace noctalia::cli {
           const Positional& positional = command.positionals[i];
           std::string spec = positional.variadic ? "*" : std::to_string(i + 1);
           spec.push_back(':');
-          spec.append(positional.name);
+          std::string safeName{positional.name};
+          std::replace(safeName.begin(), safeName.end(), ':', '-');
+          spec.append(safeName);
           spec.push_back(':');
-          spec.append(positional.choices.empty() ? "_files" : zshChoiceList(positional.choices));
+
+          if (!positional.runtimeProvider.empty())
+            spec.append("_noctalia_").append(positional.runtimeProvider);
+          else if (positional.choices.empty())
+            spec.append("_files");
+          else
+            spec.append(zshChoiceList(positional.choices));
+
           output.append("    ");
           output.append(shellSingleQuote(spec));
           output.append(i + 1 == command.positionals.size() ? "\n" : " \\\n");
@@ -449,6 +498,12 @@ namespace noctalia::cli {
                          "        end\n"
                          "    end\n"
                          "    test $seen -eq $wanted\n"
+                         "end\n\n"
+                         "function __noctalia_plugins_enabled\n"
+                         "    noctalia msg plugins list 2>/dev/null | awk '$4 == \"enabled\" {print $1}'\n"
+                         "end\n\n"
+                         "function __noctalia_plugins_disabled\n"
+                         "    noctalia msg plugins list 2>/dev/null | awk '$4 == \"disabled\" {print $1}'\n"
                          "end\n\n";
 
     for (const CommandState& state : states) {
@@ -503,8 +558,9 @@ namespace noctalia::cli {
 
       for (std::size_t i = 0; i < command.positionals.size(); ++i) {
         const Positional& positional = command.positionals[i];
-        if (positional.choices.empty())
+        if (positional.choices.empty() && positional.runtimeProvider.empty())
           continue;
+
         std::string condition = "__noctalia_at_pos " + std::to_string(i);
         if (!path.empty()) {
           condition.push_back(' ');
@@ -513,7 +569,14 @@ namespace noctalia::cli {
         output.append("complete -c noctalia -n ");
         output.append(shellSingleQuote(condition));
         output.append(" -f -a ");
-        output.append(shellSingleQuote(fishChoiceList(positional.choices)));
+
+        if (!positional.runtimeProvider.empty()) {
+          std::string call = "(__noctalia_" + std::string(positional.runtimeProvider) + ")";
+          output.append(shellSingleQuote(call));
+        } else {
+          output.append(shellSingleQuote(fishChoiceList(positional.choices)));
+        }
+
         if (!positional.description.empty()) {
           output.append(" -d ");
           output.append(shellSingleQuote(positional.description));

--- a/src/cli/schema.h
+++ b/src/cli/schema.h
@@ -23,6 +23,7 @@ namespace noctalia::cli {
     bool required = false;
     bool variadic = false;
     bool joinRemaining = false;
+    std::string_view runtimeProvider;
   };
 
   struct Command {

--- a/src/cli/schema_msg.h
+++ b/src/cli/schema_msg.h
@@ -33,8 +33,11 @@ namespace noctalia::cli {
       Command{"custom", "Use a custom palette", {}, {}, {}, kMsgColorSchemeSetCustomPositionals, {}, false},
   };
 
-  inline constexpr std::array kMsgPluginsPluginPositionals{
-      Positional{"author/plugin", {}, {}, true, false, false},
+  inline constexpr std::array kMsgPluginsEnablePositionals{
+      Positional{"author/plugin", {}, {}, true, false, false, "plugins_disabled"},
+  };
+  inline constexpr std::array kMsgPluginsDisablePositionals{
+      Positional{"author/plugin", {}, {}, true, false, false, "plugins_enabled"},
   };
   inline constexpr std::array kMsgPluginsUpdatePositionals{
       Positional{"source-name", {}, {}, true, false, false},
@@ -55,8 +58,8 @@ namespace noctalia::cli {
   };
   inline constexpr std::array kMsgPluginsSubcommands{
       Command{"list", "List installed plugins", {}, {}, {}, {}, {}, false},
-      Command{"enable", "Enable a plugin", {}, {}, {}, kMsgPluginsPluginPositionals, {}, false},
-      Command{"disable", "Disable a plugin", {}, {}, {}, kMsgPluginsPluginPositionals, {}, false},
+      Command{"enable", "Enable a plugin", {}, {}, {}, kMsgPluginsEnablePositionals, {}, false},
+      Command{"disable", "Disable a plugin", {}, {}, {}, kMsgPluginsDisablePositionals, {}, false},
       Command{"update", "Update a plugin source", {}, {}, {}, kMsgPluginsUpdatePositionals, {}, false},
       Command{"source", "Manage plugin sources", {}, {}, {}, {}, kMsgPluginsSourceSubcommands, false},
   };
@@ -170,7 +173,7 @@ namespace noctalia::cli {
       Positional{"context", {}, {}, false, false, false},
   };
   inline constexpr std::array kMsgPluginPositionals{
-      Positional{"author/plugin:entry", {}, {}, true, false, false},
+      Positional{"author/plugin:entry", {}, {}, true, false, false, "plugins_enabled"},
       Positional{"target[:bar-name]", {}, {}, true, false, false},
       Positional{"event", {}, {}, true, false, false},
       Positional{"payload", {}, {}, false, false, false},

--- a/src/cli/schema_msg.h
+++ b/src/cli/schema_msg.h
@@ -173,7 +173,7 @@ namespace noctalia::cli {
       Positional{"context", {}, {}, false, false, false},
   };
   inline constexpr std::array kMsgPluginPositionals{
-      Positional{"author/plugin:entry", {}, {}, true, false, false, "plugins_enabled"},
+      Positional{"author/plugin:entry", {}, {}, true, false, false, "plugin_prefix"},
       Positional{"target[:bar-name]", {}, {}, true, false, false},
       Positional{"event", {}, {}, true, false, false},
       Positional{"payload", {}, {}, false, false, false},


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Added a `runtimeProvider` field to the `Positional` schema. This allows the completion generators (bash, zsh, fish) to inject shell functions that fetch choices dynamically at runtime. 

Implemented this specifically for plugins by adding `plugins_enabled` and `plugins_disabled` providers, hooking them into `msg plugins enable`, `msg plugins disable`, and `msg plugin <entry>`.

## Motivation

<!-- What problem does this solve? -->
Typing out long `author/plugin` names by hand is tedious, and it's hard to remember all the exact names off the top of your head. Initially, I just wanted to implement this for the `msg plugin` command so that hitting `<TAB>` would only suggest currently enabled plugins. However, I realized the other commands could easily make use of this too, like `msg plugins disable` (shows only enabled plugins) and `msg plugins enable` (shows only disabled plugins).

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
None 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Generated and sourced completions for `bash`, `zsh`, and `fish`.
- Tested `noctalia msg plugins disable <TAB>` and verified it only lists enabled plugins.
- Tested `noctalia msg plugins enable <TAB>` and verified it only lists disabled plugins.
- Tested `noctalia msg plugin <TAB>` to ensure the runtime provider triggers correctly on subcommands.
- ran `just format` and `just test`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="386" height="172" alt="image" src="https://github.com/user-attachments/assets/405e534a-649c-459f-a8cd-416a21419578" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [ ] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
The `runtimeProvider` is can be extensible. If we ever want to add dynamic completions other type of commands in the future, we just need to drop a new provider tag in the schema and add a quick shell function in `completions.cpp`.