### PR TITLE
feat(nix): bundle shell completions to be picked up by nixos/hm

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -69,6 +69,10 @@ lib.warnIf cudaSupport
   postFixup = ''
     wrapProgram $out/bin/noctalia \
       --prefix PATH : ${lib.makeBinPath [ git ]}
+
+    $out/bin/noctalia completions bash | install -D /dev/stdin $out/share/bash-completion/completions/noctalia
+    $out/bin/noctalia completions zsh  | install -D /dev/stdin $out/share/zsh/site-functions/_noctalia
+    $out/bin/noctalia completions fish | install -D /dev/stdin $out/share/fish/vendor_completions.d/noctalia.fish
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary
Generate and include shell completions in the nix package, allowing nixos/hm to pick them up as needed (handled by the respective `programs.<shell>` configuration).

## Motivation
Nix(OS) users can now get shell completions automatically when installing if the corresponding shell's enable auto completion setting is set, improving CLI usability

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue
N/A

## Testing
Ensured completions worked in bash/fish, did not test on zsh as I do not have it installed, but it _should_ work

## Manual Coverage
- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos
https://github.com/user-attachments/assets/fae4066a-7802-4412-9bcc-3d6b03f2fd9f

## Checklist

- [x] This PR is ready for review,
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] this PR has no code changes.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] this PR does not change user-facing configuration or behavior.
- [x] this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
N/A