### PR TITLE
feat(sysmon): add a gpu_vram_used stat

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -547,6 +547,7 @@
         "stat-gpu-temp": "GPU Temp",
         "stat-gpu-usage": "GPU Usage",
         "stat-gpu-vram": "GPU VRAM",
+        "stat-gpu-vram-used": "GPU VRAM Used",
         "stat-net-rx": "Net Rx",
         "stat-net-tx": "Net Tx",
         "stat-none": "None",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -3236,6 +3236,7 @@
         "gpu-temp": "GPU Temperature",
         "gpu-usage": "GPU Usage",
         "gpu-vram": "GPU VRAM",
+        "gpu-vram-used": "GPU VRAM Used",
         "graph": "Graph",
         "graphic": "Graphic",
         "hidden": "Hidden",

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -104,7 +104,7 @@ namespace {
   bool needsCpuTemp(SysmonStat stat) { return stat == SysmonStat::CpuTemp; }
   bool needsGpuTemp(SysmonStat stat) { return stat == SysmonStat::GpuTemp; }
   bool needsGpuUsage(SysmonStat stat) { return stat == SysmonStat::GpuUsage; }
-  bool needsGpuVram(SysmonStat stat) { return stat == SysmonStat::GpuVram; }
+  bool needsGpuVram(SysmonStat stat) { return stat == SysmonStat::GpuVram || stat == SysmonStat::GpuVramUsed; }
 
   bool isDiskStat(SysmonStat stat) {
     return stat == SysmonStat::DiskUsedPct
@@ -113,10 +113,11 @@ namespace {
         || stat == SysmonStat::DiskFree;
   }
 
-  constexpr std::array<SysmonStat, 15> kTooltipStats{
-      SysmonStat::CpuUsage, SysmonStat::CpuTemp,     SysmonStat::CpuFreq,  SysmonStat::GpuTemp, SysmonStat::GpuUsage,
-      SysmonStat::GpuVram,  SysmonStat::RamUsed,     SysmonStat::RamPct,   SysmonStat::SwapPct, SysmonStat::DiskUsedPct,
-      SysmonStat::DiskUsed, SysmonStat::DiskFreePct, SysmonStat::DiskFree, SysmonStat::NetRx,   SysmonStat::NetTx,
+  constexpr std::array<SysmonStat, 16> kTooltipStats{
+      SysmonStat::CpuUsage,    SysmonStat::CpuTemp,  SysmonStat::CpuFreq,     SysmonStat::GpuTemp,
+      SysmonStat::GpuUsage,    SysmonStat::GpuVram,  SysmonStat::GpuVramUsed, SysmonStat::RamUsed,
+      SysmonStat::RamPct,      SysmonStat::SwapPct,  SysmonStat::DiskUsedPct, SysmonStat::DiskUsed,
+      SysmonStat::DiskFreePct, SysmonStat::DiskFree, SysmonStat::NetRx,       SysmonStat::NetTx,
   };
 
   [[nodiscard]] double netRxFromStats(const SystemStats& stats, std::string_view interfaceName) {
@@ -154,6 +155,7 @@ namespace {
     case SysmonStat::GpuUsage:
       return i18n::tr("bar.widgets.sysmon.gpu-usage");
     case SysmonStat::GpuVram:
+    case SysmonStat::GpuVramUsed:
       return i18n::tr("bar.widgets.sysmon.gpu-vram");
     case SysmonStat::RamUsed:
     case SysmonStat::RamPct:
@@ -408,6 +410,7 @@ std::pair<double, double> SysmonWidget::currentThresholds() const {
   case SysmonStat::GpuUsage:
     return {monitorConfig.gpuUsageActivityThreshold, monitorConfig.gpuUsageCriticalThreshold};
   case SysmonStat::GpuVram:
+  case SysmonStat::GpuVramUsed:
     return {monitorConfig.gpuVramActivityThreshold, monitorConfig.gpuVramCriticalThreshold};
   case SysmonStat::RamUsed:
   case SysmonStat::RamPct:
@@ -455,6 +458,7 @@ double SysmonWidget::currentGradientValue() {
   case SysmonStat::GpuUsage:
     return stats.gpuUsagePercent.value_or(0.0);
   case SysmonStat::GpuVram:
+  case SysmonStat::GpuVramUsed:
     if (stats.gpuVramUsedBytes.has_value() && stats.gpuVramTotalBytes.has_value() && *stats.gpuVramTotalBytes > 0) {
       return 100.0 * static_cast<double>(*stats.gpuVramUsedBytes) / static_cast<double>(*stats.gpuVramTotalBytes);
     }
@@ -832,6 +836,7 @@ double SysmonWidget::normalizedFromStats(
     return 0.0;
 
   case SysmonStat::GpuVram:
+  case SysmonStat::GpuVramUsed:
     if (stats.gpuVramUsedBytes.has_value() && stats.gpuVramTotalBytes.has_value() && *stats.gpuVramTotalBytes > 0) {
       return static_cast<double>(*stats.gpuVramUsedBytes) / static_cast<double>(*stats.gpuVramTotalBytes);
     }
@@ -970,6 +975,12 @@ std::optional<std::string> SysmonWidget::formatValueFor(SysmonStat stat, const S
     }
     return std::nullopt;
 
+  case SysmonStat::GpuVramUsed:
+    if (stats.gpuVramUsedBytes.has_value()) {
+      return FormatUnits::formatBinaryBytesAsGib(*stats.gpuVramUsedBytes);
+    }
+    return std::nullopt;
+
   case SysmonStat::RamUsed:
     return FormatUnits::formatBinaryMib(stats.ramUsedMb);
 
@@ -1020,6 +1031,7 @@ bool SysmonWidget::statAvailableForTooltip(SysmonStat stat, const SystemStats& s
   case SysmonStat::GpuUsage:
     return monitorConfig.gpuPollSeconds > 0.0F && stats.gpuUsagePercent.has_value();
   case SysmonStat::GpuVram:
+  case SysmonStat::GpuVramUsed:
     return monitorConfig.gpuPollSeconds > 0.0F
         && stats.gpuVramUsedBytes.has_value()
         && stats.gpuVramTotalBytes.has_value()
@@ -1084,6 +1096,7 @@ const char* SysmonWidget::glyphName(SysmonStat stat) {
   case SysmonStat::GpuUsage:
     return "gpu-usage";
   case SysmonStat::GpuVram:
+  case SysmonStat::GpuVramUsed:
     return "memory";
   case SysmonStat::RamUsed:
   case SysmonStat::RamPct:

--- a/src/shell/bar/widgets/sysmon_widget.h
+++ b/src/shell/bar/widgets/sysmon_widget.h
@@ -34,6 +34,7 @@ enum class SysmonStat {
   GpuTemp,
   GpuUsage,
   GpuVram,
+  GpuVramUsed,
   RamUsed,
   RamPct,
   SwapPct,

--- a/src/shell/bar/widgets/sysmon_widget_definition.cpp
+++ b/src/shell/bar/widgets/sysmon_widget_definition.cpp
@@ -58,6 +58,11 @@ const noctalia::bar::WidgetDefinition<SysmonWidget::Options, SysmonWidgetDefinit
                           .labelKey = "settings.widgets.options.gpu-vram",
                       },
                       {
+                          .value = SysmonStat::GpuVramUsed,
+                          .configValue = "gpu_vram_used",
+                          .labelKey = "settings.widgets.options.gpu-vram-used",
+                      },
+                      {
                           .value = SysmonStat::RamUsed,
                           .configValue = "ram_used",
                           .labelKey = "settings.widgets.options.ram-used",

--- a/src/shell/desktop/desktop_widget_factory.cpp
+++ b/src/shell/desktop/desktop_widget_factory.cpp
@@ -363,6 +363,8 @@ std::unique_ptr<DesktopWidget> DesktopWidgetFactory::create(
         return DesktopSysmonStat::GpuUsage;
       if (s == "gpu_vram")
         return DesktopSysmonStat::GpuVram;
+      if (s == "gpu_vram_used")
+        return DesktopSysmonStat::GpuVramUsed;
       if (s == "ram_pct")
         return DesktopSysmonStat::RamPct;
       if (s == "swap_pct")

--- a/src/shell/desktop/desktop_widget_settings_registry.cpp
+++ b/src/shell/desktop/desktop_widget_settings_registry.cpp
@@ -222,6 +222,7 @@ namespace desktop_settings {
         {"gpu_temp", "desktop-widgets.editor.settings.stat-gpu-temp"},
         {"gpu_usage", "desktop-widgets.editor.settings.stat-gpu-usage"},
         {"gpu_vram", "desktop-widgets.editor.settings.stat-gpu-vram"},
+        {"gpu_vram_used", "desktop-widgets.editor.settings.stat-gpu-vram-used"},
         {"ram_pct", "desktop-widgets.editor.settings.stat-ram-pct"},
         {"swap_pct", "desktop-widgets.editor.settings.stat-swap-pct"},
         {"net_rx", "desktop-widgets.editor.settings.stat-net-rx"},

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -53,7 +53,9 @@ namespace {
   bool needsCpuTemp(DesktopSysmonStat stat) { return stat == DesktopSysmonStat::CpuTemp; }
   bool needsGpuTemp(DesktopSysmonStat stat) { return stat == DesktopSysmonStat::GpuTemp; }
   bool needsGpuUsage(DesktopSysmonStat stat) { return stat == DesktopSysmonStat::GpuUsage; }
-  bool needsGpuVram(DesktopSysmonStat stat) { return stat == DesktopSysmonStat::GpuVram; }
+  bool needsGpuVram(DesktopSysmonStat stat) {
+    return stat == DesktopSysmonStat::GpuVram || stat == DesktopSysmonStat::GpuVramUsed;
+  }
 
   struct GlyphInkBounds {
     float left = 0.0F;
@@ -583,6 +585,7 @@ std::pair<double, double> DesktopSysmonWidget::currentThresholds() const {
   case DesktopSysmonStat::GpuUsage:
     return {monitorConfig.gpuUsageActivityThreshold, monitorConfig.gpuUsageCriticalThreshold};
   case DesktopSysmonStat::GpuVram:
+  case DesktopSysmonStat::GpuVramUsed:
     return {monitorConfig.gpuVramActivityThreshold, monitorConfig.gpuVramCriticalThreshold};
   case DesktopSysmonStat::RamPct:
     return {monitorConfig.ramPctActivityThreshold, monitorConfig.ramPctCriticalThreshold};
@@ -614,6 +617,7 @@ double DesktopSysmonWidget::currentGradientValue() const {
   case DesktopSysmonStat::GpuUsage:
     return stats.gpuUsagePercent.value_or(0.0);
   case DesktopSysmonStat::GpuVram:
+  case DesktopSysmonStat::GpuVramUsed:
     if (stats.gpuVramUsedBytes.has_value() && stats.gpuVramTotalBytes.has_value() && *stats.gpuVramTotalBytes > 0) {
       return 100.0 * static_cast<double>(*stats.gpuVramUsedBytes) / static_cast<double>(*stats.gpuVramTotalBytes);
     }
@@ -710,6 +714,7 @@ double DesktopSysmonWidget::normalizedFromStats(
     return 0.0;
 
   case DesktopSysmonStat::GpuVram:
+  case DesktopSysmonStat::GpuVramUsed:
     if (stats.gpuVramUsedBytes.has_value() && stats.gpuVramTotalBytes.has_value() && *stats.gpuVramTotalBytes > 0) {
       return static_cast<double>(*stats.gpuVramUsedBytes) / static_cast<double>(*stats.gpuVramTotalBytes);
     }
@@ -793,6 +798,12 @@ std::string DesktopSysmonWidget::formatValueFor(DesktopSysmonStat stat) const {
           "{:.0F}%",
           100.0 * static_cast<double>(*stats.gpuVramUsedBytes) / static_cast<double>(*stats.gpuVramTotalBytes)
       );
+    }
+    return "--";
+
+  case DesktopSysmonStat::GpuVramUsed:
+    if (stats.gpuVramUsedBytes.has_value()) {
+      return FormatUnits::formatBinaryBytesAsGib(*stats.gpuVramUsedBytes);
     }
     return "--";
 
@@ -906,6 +917,7 @@ const char* DesktopSysmonWidget::glyphName(DesktopSysmonStat stat) {
   case DesktopSysmonStat::GpuUsage:
     return "gpu-usage";
   case DesktopSysmonStat::GpuVram:
+  case DesktopSysmonStat::GpuVramUsed:
     return "memory";
   case DesktopSysmonStat::RamPct:
     return "memory";

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.h
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.h
@@ -27,6 +27,7 @@ enum class DesktopSysmonStat : std::uint8_t {
   GpuTemp,
   GpuUsage,
   GpuVram,
+  GpuVramUsed,
   RamPct,
   SwapPct,
   NetRx,

--- a/tests/config_validate/generated-config
+++ b/tests/config_validate/generated-config
@@ -21,6 +21,12 @@ type = "calendar"
 show_events = true
 show_week_numbers = true
 
+[desktop_widgets.widget.gpu_vram]
+type = "sysmon"
+
+[desktop_widgets.widget.gpu_vram.settings]
+stat = "gpu_vram_used"
+
 [plugins]
 enabled = ["noctalia/wallhaven"]
 


### PR DESCRIPTION
## Summary

Add a gpu_vram_used stat.

## Motivation

Allows to see VRAM usage in absolute number, mirroring RAM stat.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

No related issue.

## Testing

- `clang-format --dry-run -Werror` over `src` with v22.1.8: clean.
- Built from source: clean, no new warnings.
- `noctalia config validate` on a config using both `gpu_vram_used` and `gpu_vram`: valid, no warnings. The same config on an unpatched build warns`"gpu_vram_used" is not one of the allowed values`.
- Did not run the meson test suite; no test references `SysmonStat`.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Closeup as used in my config:

<img width="101" height="187" alt="Screenshot from 2026-08-11 23-27-00" src="https://github.com/user-attachments/assets/c4fc3f0d-1866-4840-8f10-cb065ff8abb0" />

with the following settings:

```toml
[widget.vram]
type = "sysmon"
stat = "gpu_vram_used"
glyph = "device-desktop"
label_show_units = false
```

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

RAM has `ram_used` and `ram_pct`. To mirror that without renaming existing `gpu-vram`, named it `gpu-vram-used`.

VRAM usage in the control center is already displayed in absolute number, now there is a matching option.

Development was assisted by AI.