### PR TITLE
feat(wallpaper): support randomization without replacement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -728,6 +728,7 @@ _noctalia_sources = files(
   'src/system/app_identity.cpp',
   'src/shell/wallpaper/wallpaper_paths.cpp',
   'src/shell/wallpaper/wallpaper_geometry.cpp',
+  'src/shell/wallpaper/wallpaper_shuffle_state.cpp',
   'src/shell/wallpaper/wallpaper.cpp',
   'src/shell/wallpaper/panel/wallpaper_panel.cpp',
   'src/shell/wallpaper/panel/wallpaper_scanner.cpp',
@@ -1193,6 +1194,7 @@ if build_tests
     'wayland_toplevels_identity',
     'widget_action',
     'widget_definition',
+    'wallpaper_shuffle_state',
     'workspace_alert_service',
   ]
 

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -886,18 +886,19 @@ ThemeMode Wallpaper::directoryThemeMode() const noexcept {
 }
 
 std::string Wallpaper::pickRandomWallpaperPath(
-    const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope
+    const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope,
+    std::string_view source
 ) {
-  return m_shuffleState.pick(scope, candidates, currentPath, randomFloat(0.0F, 1.0F));
+  return m_shuffleState.pick(scope, source, candidates, currentPath, randomFloat(0.0F, 1.0F));
 }
 
 std::string Wallpaper::pickAutomationWallpaperPath(
     const WallpaperAutomationConfig& automation, std::vector<std::string> candidates, const std::string& currentPath,
-    std::string_view scope
+    std::string_view scope, std::string_view source
 ) {
   return automation.order == WallpaperAutomationConfig::Order::Alphabetical
       ? pickAlphabeticalWallpaperPath(std::move(candidates), currentPath)
-      : pickRandomWallpaperPath(candidates, currentPath, scope);
+      : pickRandomWallpaperPath(candidates, currentPath, scope, source);
 }
 
 void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
@@ -923,17 +924,16 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
       }
 
       attempted = true;
+      const std::string dir = wallpaper::resolveWallpaperDirectory(wallpaper, output, mode);
       std::vector<std::string> candidates;
-      collectWallpaperCandidates(
-          wallpaper::resolveWallpaperDirectory(wallpaper, output, mode), automation.recursive, candidates
-      );
+      collectWallpaperCandidates(dir, automation.recursive, candidates);
       if (candidates.empty()) {
         continue;
       }
 
       const std::string currentPath = m_config->getWallpaperPath(output.connectorName);
       const std::string picked = pickAutomationWallpaperPath(
-          automation, std::move(candidates), currentPath, outputShuffleScope(output.connectorName)
+          automation, std::move(candidates), currentPath, outputShuffleScope(output.connectorName), dir
       );
       if (picked.empty() || picked == currentPath) {
         continue;
@@ -958,14 +958,13 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
     }
 
     if (attempted) {
+      const std::string dir = wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode);
       std::vector<std::string> candidates;
-      collectWallpaperCandidates(
-          wallpaper::resolveGlobalWallpaperDirectory(wallpaper, mode), automation.recursive, candidates
-      );
+      collectWallpaperCandidates(dir, automation.recursive, candidates);
       if (!candidates.empty()) {
         const std::string currentDefault = m_config->getDefaultWallpaperPath();
         const std::string picked =
-            pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope);
+            pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope, dir);
         if (!picked.empty()) {
           if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(picked); favorite != nullptr) {
             std::vector<std::string> connectors;
@@ -1040,7 +1039,7 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
       }
       const std::string currentPath = m_config->getWallpaperPath(inst->connectorName);
       const std::string picked = pickAutomationWallpaperPath(
-          automation, std::move(candidates), currentPath, outputShuffleScope(inst->connectorName)
+          automation, std::move(candidates), currentPath, outputShuffleScope(inst->connectorName), dir
       );
       if (picked.empty() || picked == currentPath) {
         continue;
@@ -1059,7 +1058,7 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
     if (!candidates.empty()) {
       const std::string currentDefault = m_config->getDefaultWallpaperPath();
       const std::string picked =
-          pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope);
+          pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope, dir);
       if (!picked.empty()) {
         if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(picked); favorite != nullptr) {
           std::vector<std::string> connectors;
@@ -1094,11 +1093,12 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
   const ThemeMode mode = directoryThemeMode();
 
   const auto pick = [this, action](
-                        std::vector<std::string> candidates, const std::string& currentPath, std::string_view scope
+                        std::vector<std::string> candidates, const std::string& currentPath, std::string_view scope,
+                        std::string_view source
                     ) -> std::string {
     switch (action) {
     case PickWallpaper::Random:
-      return pickRandomWallpaperPath(candidates, currentPath, scope);
+      return pickRandomWallpaperPath(candidates, currentPath, scope, source);
     case PickWallpaper::Next:
       return pickAlphabeticalWallpaperPath(std::move(candidates), currentPath, 1);
     case PickWallpaper::Previous:
@@ -1146,7 +1146,8 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
       return SwitchOutcome::Unavailable;
     }
     const std::string currentPath = m_config->getWallpaperPath(std::string(*connector));
-    const std::string picked = pick(std::move(candidates), currentPath, outputShuffleScope(std::string(*connector)));
+    const std::string picked =
+        pick(std::move(candidates), currentPath, outputShuffleScope(std::string(*connector)), dir);
     if (picked.empty() || picked == currentPath) {
       return SwitchOutcome::NoChange;
     }
@@ -1182,7 +1183,7 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
       }
       sawCandidates = true;
       const std::string currentPath = m_config->getWallpaperPath(inst->connectorName);
-      const std::string picked = pick(std::move(candidates), currentPath, outputShuffleScope(inst->connectorName));
+      const std::string picked = pick(std::move(candidates), currentPath, outputShuffleScope(inst->connectorName), dir);
       if (picked.empty() || picked == currentPath) {
         continue;
       }
@@ -1197,7 +1198,7 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
     if (!candidates.empty()) {
       sawCandidates = true;
       const std::string currentDefault = m_config->getDefaultWallpaperPath();
-      const std::string picked = pick(std::move(candidates), currentDefault, kGlobalShuffleScope);
+      const std::string picked = pick(std::move(candidates), currentDefault, kGlobalShuffleScope, dir);
       if (!picked.empty() && picked != currentDefault) {
         for (const auto& inst : m_instances) {
           if (!inst->connectorName.empty()) {

--- a/src/shell/wallpaper/wallpaper.cpp
+++ b/src/shell/wallpaper/wallpaper.cpp
@@ -16,6 +16,7 @@
 #include "shell/wallpaper/wallpaper_geometry.h"
 #include "shell/wallpaper/wallpaper_instance.h"
 #include "shell/wallpaper/wallpaper_paths.h"
+#include "shell/wallpaper/wallpaper_shuffle_state.h"
 #include "theme/theme_service.h"
 #include "ui/builders.h"
 #include "ui/controls/box.h"
@@ -41,6 +42,11 @@ using Random::randomFloat;
 namespace {
 
   constexpr Easing kWallpaperTransitionEasing = Easing::EaseInOutCubic;
+  constexpr std::string_view kGlobalShuffleScope = "global";
+
+  [[nodiscard]] std::string outputShuffleScope(std::string_view connector) {
+    return std::string("output:").append(connector);
+  }
 
   [[nodiscard]] Color defaultWallpaperColor() { return rgba(0.0F, 0.0F, 0.0F, 1.0F); }
 
@@ -188,27 +194,6 @@ namespace {
     }
   }
 
-  std::string pickRandomWallpaperPath(const std::vector<std::string>& candidates, const std::string& currentPath) {
-    if (candidates.empty()) {
-      return {};
-    }
-    if (candidates.size() == 1) {
-      return candidates.front();
-    }
-
-    const std::size_t start = std::min<std::size_t>(
-        static_cast<std::size_t>(std::floor(randomFloat(0.0F, static_cast<float>(candidates.size())))),
-        candidates.size() - 1
-    );
-    for (std::size_t i = 0; i < candidates.size(); ++i) {
-      const std::string& candidate = candidates[(start + i) % candidates.size()];
-      if (candidate != currentPath) {
-        return candidate;
-      }
-    }
-    return candidates.front();
-  }
-
   bool lessCaseInsensitive(std::string_view a, std::string_view b) {
     return StringUtils::naturalCaseInsensitiveLess(a, b);
   }
@@ -232,14 +217,6 @@ namespace {
     const auto idx = static_cast<std::size_t>(std::distance(candidates.begin(), it));
     const std::size_t step = (direction < 0) ? n - 1 : 1;
     return candidates[(idx + step) % n];
-  }
-
-  std::string pickAutomationWallpaperPath(
-      const WallpaperAutomationConfig& automation, std::vector<std::string> candidates, const std::string& currentPath
-  ) {
-    return automation.order == WallpaperAutomationConfig::Order::Alphabetical
-        ? pickAlphabeticalWallpaperPath(std::move(candidates), currentPath)
-        : pickRandomWallpaperPath(candidates, currentPath);
   }
 
   bool wallpaperOutputEnabled(const WallpaperConfig& config, const WaylandOutput& output) {
@@ -328,7 +305,12 @@ namespace {
 
 } // namespace
 
-Wallpaper::Wallpaper() = default;
+Wallpaper::Wallpaper() {
+  const std::string stateDir = FileUtils::stateDir();
+  if (!stateDir.empty()) {
+    m_shuffleState.setStatePath(std::filesystem::path(stateDir) / "wallpaper_shuffle.json");
+  }
+}
 
 Wallpaper::~Wallpaper() {
   for (auto& inst : m_instances) {
@@ -903,6 +885,21 @@ ThemeMode Wallpaper::directoryThemeMode() const noexcept {
   return wallpaper::effectiveThemeMode(configured, isLight);
 }
 
+std::string Wallpaper::pickRandomWallpaperPath(
+    const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope
+) {
+  return m_shuffleState.pick(scope, candidates, currentPath, randomFloat(0.0F, 1.0F));
+}
+
+std::string Wallpaper::pickAutomationWallpaperPath(
+    const WallpaperAutomationConfig& automation, std::vector<std::string> candidates, const std::string& currentPath,
+    std::string_view scope
+) {
+  return automation.order == WallpaperAutomationConfig::Order::Alphabetical
+      ? pickAlphabeticalWallpaperPath(std::move(candidates), currentPath)
+      : pickRandomWallpaperPath(candidates, currentPath, scope);
+}
+
 void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
   const auto& wallpaper = m_config->config().wallpaper;
   const auto& automation = wallpaper.automation;
@@ -935,7 +932,9 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
       }
 
       const std::string currentPath = m_config->getWallpaperPath(output.connectorName);
-      const std::string picked = pickAutomationWallpaperPath(automation, std::move(candidates), currentPath);
+      const std::string picked = pickAutomationWallpaperPath(
+          automation, std::move(candidates), currentPath, outputShuffleScope(output.connectorName)
+      );
       if (picked.empty() || picked == currentPath) {
         continue;
       }
@@ -965,7 +964,8 @@ void Wallpaper::applyStartupAutomation(std::int64_t secondStamp) {
       );
       if (!candidates.empty()) {
         const std::string currentDefault = m_config->getDefaultWallpaperPath();
-        const std::string picked = pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault);
+        const std::string picked =
+            pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope);
         if (!picked.empty()) {
           if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(picked); favorite != nullptr) {
             std::vector<std::string> connectors;
@@ -1039,7 +1039,9 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
         continue;
       }
       const std::string currentPath = m_config->getWallpaperPath(inst->connectorName);
-      const std::string picked = pickAutomationWallpaperPath(automation, std::move(candidates), currentPath);
+      const std::string picked = pickAutomationWallpaperPath(
+          automation, std::move(candidates), currentPath, outputShuffleScope(inst->connectorName)
+      );
       if (picked.empty() || picked == currentPath) {
         continue;
       }
@@ -1056,7 +1058,8 @@ void Wallpaper::runAutomation(std::int64_t secondStamp) {
     collectWallpaperCandidates(dir, automation.recursive, candidates);
     if (!candidates.empty()) {
       const std::string currentDefault = m_config->getDefaultWallpaperPath();
-      const std::string picked = pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault);
+      const std::string picked =
+          pickAutomationWallpaperPath(automation, std::move(candidates), currentDefault, kGlobalShuffleScope);
       if (!picked.empty()) {
         if (const WallpaperFavorite* favorite = m_config->wallpaperFavorite(picked); favorite != nullptr) {
           std::vector<std::string> connectors;
@@ -1090,10 +1093,12 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
   const auto& wallpaper = m_config->config().wallpaper;
   const ThemeMode mode = directoryThemeMode();
 
-  const auto pick = [action](std::vector<std::string> candidates, const std::string& currentPath) -> std::string {
+  const auto pick = [this, action](
+                        std::vector<std::string> candidates, const std::string& currentPath, std::string_view scope
+                    ) -> std::string {
     switch (action) {
     case PickWallpaper::Random:
-      return pickRandomWallpaperPath(candidates, currentPath);
+      return pickRandomWallpaperPath(candidates, currentPath, scope);
     case PickWallpaper::Next:
       return pickAlphabeticalWallpaperPath(std::move(candidates), currentPath, 1);
     case PickWallpaper::Previous:
@@ -1141,7 +1146,7 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
       return SwitchOutcome::Unavailable;
     }
     const std::string currentPath = m_config->getWallpaperPath(std::string(*connector));
-    const std::string picked = pick(std::move(candidates), currentPath);
+    const std::string picked = pick(std::move(candidates), currentPath, outputShuffleScope(std::string(*connector)));
     if (picked.empty() || picked == currentPath) {
       return SwitchOutcome::NoChange;
     }
@@ -1177,7 +1182,7 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
       }
       sawCandidates = true;
       const std::string currentPath = m_config->getWallpaperPath(inst->connectorName);
-      const std::string picked = pick(std::move(candidates), currentPath);
+      const std::string picked = pick(std::move(candidates), currentPath, outputShuffleScope(inst->connectorName));
       if (picked.empty() || picked == currentPath) {
         continue;
       }
@@ -1192,7 +1197,7 @@ Wallpaper::SwitchOutcome Wallpaper::switchWallpaperTo(PickWallpaper action, std:
     if (!candidates.empty()) {
       sawCandidates = true;
       const std::string currentDefault = m_config->getDefaultWallpaperPath();
-      const std::string picked = pick(std::move(candidates), currentDefault);
+      const std::string picked = pick(std::move(candidates), currentDefault, kGlobalShuffleScope);
       if (!picked.empty() && picked != currentDefault) {
         for (const auto& inst : m_instances) {
           if (!inst->connectorName.empty()) {

--- a/src/shell/wallpaper/wallpaper.h
+++ b/src/shell/wallpaper/wallpaper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/config_types.h"
+#include "shell/wallpaper/wallpaper_shuffle_state.h"
 #include "ui/signal.h"
 
 #include <cstdint>
@@ -98,6 +99,13 @@ private:
   [[nodiscard]] SwitchOutcome
   switchWallpaperTo(PickWallpaper action, std::optional<std::string_view> connector = std::nullopt);
   [[nodiscard]] ThemeMode directoryThemeMode() const noexcept;
+  [[nodiscard]] std::string pickRandomWallpaperPath(
+      const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope
+  );
+  [[nodiscard]] std::string pickAutomationWallpaperPath(
+      const WallpaperAutomationConfig& automation, std::vector<std::string> candidates, const std::string& currentPath,
+      std::string_view scope
+  );
   void createInstance(const WaylandOutput& output);
   [[nodiscard]] TextureHandle acquireTexture(const std::string& path);
   void releaseTexture(TextureHandle& handle, const std::string& path);
@@ -122,6 +130,7 @@ private:
   std::int64_t m_lastAutomationSecondStamp = -1;
   std::int64_t m_lastAutomationSwitchSecond = -1;
   std::function<bool()> m_automationGate;
+  wallpaper::ShuffleState m_shuffleState;
   Signal<>::ScopedConnection m_paletteConn;
   Signal<> m_changed;
   std::vector<std::unique_ptr<WallpaperInstance>> m_instances;

--- a/src/shell/wallpaper/wallpaper.h
+++ b/src/shell/wallpaper/wallpaper.h
@@ -100,11 +100,12 @@ private:
   switchWallpaperTo(PickWallpaper action, std::optional<std::string_view> connector = std::nullopt);
   [[nodiscard]] ThemeMode directoryThemeMode() const noexcept;
   [[nodiscard]] std::string pickRandomWallpaperPath(
-      const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope
+      const std::vector<std::string>& candidates, const std::string& currentPath, std::string_view scope,
+      std::string_view source
   );
   [[nodiscard]] std::string pickAutomationWallpaperPath(
       const WallpaperAutomationConfig& automation, std::vector<std::string> candidates, const std::string& currentPath,
-      std::string_view scope
+      std::string_view scope, std::string_view source
   );
   void createInstance(const WaylandOutput& output);
   [[nodiscard]] TextureHandle acquireTexture(const std::string& path);

--- a/src/shell/wallpaper/wallpaper_shuffle_state.cpp
+++ b/src/shell/wallpaper/wallpaper_shuffle_state.cpp
@@ -1,0 +1,134 @@
+#include "shell/wallpaper/wallpaper_shuffle_state.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <system_error>
+
+namespace wallpaper {
+
+  void ShuffleState::setStatePath(std::filesystem::path path) {
+    m_statePath = std::move(path);
+    m_seenByScope.clear();
+    load();
+  }
+
+  std::string ShuffleState::pick(
+      std::string_view scope, const std::vector<std::string>& candidates, std::string_view currentPath, float randomUnit
+  ) {
+    if (candidates.empty()) {
+      return {};
+    }
+
+    auto& seen = m_seenByScope[std::string(scope)];
+    std::unordered_set<std::string_view> candidateSet;
+    candidateSet.reserve(candidates.size());
+    for (const std::string& candidate : candidates) {
+      candidateSet.insert(candidate);
+    }
+
+    std::erase_if(seen, [&](const std::string& path) { return !candidateSet.contains(path); });
+    if (candidateSet.contains(currentPath)) {
+      seen.emplace(currentPath);
+    }
+
+    std::vector<const std::string*> available;
+    available.reserve(candidates.size());
+    const auto collectAvailable = [&] {
+      available.clear();
+      for (const std::string& candidate : candidates) {
+        if (candidate != currentPath && !seen.contains(candidate)) {
+          available.push_back(&candidate);
+        }
+      }
+    };
+    collectAvailable();
+
+    if (available.empty()) {
+      seen.clear();
+      if (candidateSet.contains(currentPath)) {
+        seen.emplace(currentPath);
+      }
+      collectAvailable();
+    }
+
+    if (available.empty()) {
+      save();
+      return candidates.front();
+    }
+
+    if (!std::isfinite(randomUnit)) {
+      randomUnit = 0.0F;
+    }
+    randomUnit = std::clamp(randomUnit, 0.0F, 1.0F);
+    const std::size_t index =
+        std::min(static_cast<std::size_t>(randomUnit * static_cast<float>(available.size())), available.size() - 1);
+    const std::string picked = *available[index];
+    seen.insert(picked);
+    save();
+    return picked;
+  }
+
+  void ShuffleState::load() {
+    if (m_statePath.empty()) {
+      return;
+    }
+
+    std::ifstream file(m_statePath);
+    if (!file.is_open()) {
+      return;
+    }
+
+    try {
+      const nlohmann::json root = nlohmann::json::parse(file);
+      if (root.value("version", 0) != 1) {
+        return;
+      }
+      const auto scopes = root.find("scopes");
+      if (scopes == root.end() || !scopes->is_object()) {
+        return;
+      }
+      for (const auto& [scope, paths] : scopes->items()) {
+        if (!paths.is_array()) {
+          continue;
+        }
+        auto& seen = m_seenByScope[scope];
+        for (const auto& path : paths) {
+          if (path.is_string()) {
+            seen.insert(path.get<std::string>());
+          }
+        }
+      }
+    } catch (const nlohmann::json::exception&) {
+      m_seenByScope.clear();
+    }
+  }
+
+  void ShuffleState::save() const {
+    if (m_statePath.empty()) {
+      return;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(m_statePath.parent_path(), ec);
+    if (ec) {
+      return;
+    }
+
+    try {
+      nlohmann::json scopes = nlohmann::json::object();
+      for (const auto& [scope, seen] : m_seenByScope) {
+        scopes[scope] = seen;
+      }
+      const nlohmann::json root{{"version", 1}, {"scopes", std::move(scopes)}};
+      std::ofstream file(m_statePath, std::ios::trunc);
+      if (file.is_open()) {
+        file << root.dump(2) << '\n';
+      }
+    } catch (const nlohmann::json::exception&) {
+      // A non-UTF-8 filesystem path cannot be represented in JSON. Runtime state still works.
+    }
+  }
+
+} // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_shuffle_state.cpp
+++ b/src/shell/wallpaper/wallpaper_shuffle_state.cpp
@@ -15,13 +15,14 @@ namespace wallpaper {
   }
 
   std::string ShuffleState::pick(
-      std::string_view scope, const std::vector<std::string>& candidates, std::string_view currentPath, float randomUnit
+      std::string_view scope, std::string_view source, const std::vector<std::string>& candidates,
+      std::string_view currentPath, float randomUnit
   ) {
     if (candidates.empty()) {
       return {};
     }
 
-    auto& seen = m_seenByScope[std::string(scope)];
+    auto& seen = m_seenByScope[std::string(scope)][std::string(source)];
     std::unordered_set<std::string_view> candidateSet;
     candidateSet.reserve(candidates.size());
     for (const std::string& candidate : candidates) {
@@ -82,21 +83,27 @@ namespace wallpaper {
 
     try {
       const nlohmann::json root = nlohmann::json::parse(file);
-      if (root.value("version", 0) != 1) {
+      if (root.value("version", 0) != 2) {
         return;
       }
       const auto scopes = root.find("scopes");
       if (scopes == root.end() || !scopes->is_object()) {
         return;
       }
-      for (const auto& [scope, paths] : scopes->items()) {
-        if (!paths.is_array()) {
+      for (const auto& [scope, sources] : scopes->items()) {
+        if (!sources.is_object()) {
           continue;
         }
-        auto& seen = m_seenByScope[scope];
-        for (const auto& path : paths) {
-          if (path.is_string()) {
-            seen.insert(path.get<std::string>());
+        auto& seenBySource = m_seenByScope[scope];
+        for (const auto& [source, paths] : sources.items()) {
+          if (!paths.is_array()) {
+            continue;
+          }
+          auto& seen = seenBySource[source];
+          for (const auto& path : paths) {
+            if (path.is_string()) {
+              seen.insert(path.get<std::string>());
+            }
           }
         }
       }
@@ -118,10 +125,14 @@ namespace wallpaper {
 
     try {
       nlohmann::json scopes = nlohmann::json::object();
-      for (const auto& [scope, seen] : m_seenByScope) {
-        scopes[scope] = seen;
+      for (const auto& [scope, seenBySource] : m_seenByScope) {
+        nlohmann::json sources = nlohmann::json::object();
+        for (const auto& [source, seen] : seenBySource) {
+          sources[source] = seen;
+        }
+        scopes[scope] = std::move(sources);
       }
-      const nlohmann::json root{{"version", 1}, {"scopes", std::move(scopes)}};
+      const nlohmann::json root{{"version", 2}, {"scopes", std::move(scopes)}};
       std::ofstream file(m_statePath, std::ios::trunc);
       if (file.is_open()) {
         file << root.dump(2) << '\n';

--- a/src/shell/wallpaper/wallpaper_shuffle_state.h
+++ b/src/shell/wallpaper/wallpaper_shuffle_state.h
@@ -14,8 +14,8 @@ namespace wallpaper {
     void setStatePath(std::filesystem::path path);
 
     [[nodiscard]] std::string pick(
-        std::string_view scope, const std::vector<std::string>& candidates, std::string_view currentPath,
-        float randomUnit
+        std::string_view scope, std::string_view source, const std::vector<std::string>& candidates,
+        std::string_view currentPath, float randomUnit
     );
 
   private:
@@ -23,7 +23,7 @@ namespace wallpaper {
     void save() const;
 
     std::filesystem::path m_statePath;
-    std::unordered_map<std::string, std::unordered_set<std::string>> m_seenByScope;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_set<std::string>>> m_seenByScope;
   };
 
 } // namespace wallpaper

--- a/src/shell/wallpaper/wallpaper_shuffle_state.h
+++ b/src/shell/wallpaper/wallpaper_shuffle_state.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace wallpaper {
+
+  class ShuffleState {
+  public:
+    void setStatePath(std::filesystem::path path);
+
+    [[nodiscard]] std::string pick(
+        std::string_view scope, const std::vector<std::string>& candidates, std::string_view currentPath,
+        float randomUnit
+    );
+
+  private:
+    void load();
+    void save() const;
+
+    std::filesystem::path m_statePath;
+    std::unordered_map<std::string, std::unordered_set<std::string>> m_seenByScope;
+  };
+
+} // namespace wallpaper

--- a/tests/wallpaper_shuffle_state_test.cpp
+++ b/tests/wallpaper_shuffle_state_test.cpp
@@ -1,0 +1,85 @@
+#include "shell/wallpaper/wallpaper_shuffle_state.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::fprintf(stderr, "wallpaper_shuffle_state_test: %s\n", message);
+      return false;
+    }
+    return true;
+  }
+
+} // namespace
+
+int main() {
+  namespace fs = std::filesystem;
+
+  const fs::path tempDir = fs::temp_directory_path()
+      / ("noctalia-wallpaper-shuffle-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const fs::path statePath = tempDir / "wallpaper_shuffle.json";
+  const std::vector<std::string> candidates{"a.jpg", "b.jpg", "c.jpg"};
+
+  bool ok = true;
+  {
+    wallpaper::ShuffleState state;
+    state.setStatePath(statePath);
+    ok = expect(state.pick("global", candidates, "a.jpg", 0.0F) == "b.jpg", "first pick excludes current") && ok;
+  }
+  {
+    wallpaper::ShuffleState state;
+    state.setStatePath(statePath);
+    ok = expect(
+             state.pick("global", candidates, "b.jpg", 0.0F) == "c.jpg",
+             "persisted cycle does not replace a previously shown wallpaper"
+         )
+        && ok;
+  }
+  {
+    wallpaper::ShuffleState state;
+    state.setStatePath(statePath);
+    ok = expect(state.pick("global", candidates, "c.jpg", 0.0F) == "a.jpg", "new cycle starts after exhaustion") && ok;
+    ok = expect(
+             state.pick("output:DP-1", candidates, "a.jpg", 1.0F) == "c.jpg",
+             "output scopes keep independent shuffle cycles"
+         )
+        && ok;
+  }
+  {
+    wallpaper::ShuffleState state;
+    const std::vector<std::string> changedCandidates{"b.jpg", "c.jpg", "d.jpg"};
+    state.setStatePath(statePath);
+    ok = expect(
+             state.pick("global", changedCandidates, "a.jpg", 1.0F) == "d.jpg",
+             "removed and newly added candidates reconcile with persisted state"
+         )
+        && ok;
+    ok = expect(
+             state.pick("global", changedCandidates, "d.jpg", 0.0F) == "b.jpg",
+             "remaining changed candidates are used before replacement"
+         )
+        && ok;
+  }
+  {
+    std::ofstream malformed(statePath, std::ios::trunc);
+    malformed << "not json\n";
+    malformed.close();
+
+    wallpaper::ShuffleState state;
+    state.setStatePath(statePath);
+    ok = expect(state.pick("global", candidates, "a.jpg", 0.0F) == "b.jpg", "malformed state starts a fresh cycle")
+        && ok;
+    ok = expect(state.pick("global", {"only.jpg"}, "only.jpg", 0.0F) == "only.jpg", "single candidate is stable") && ok;
+  }
+
+  std::error_code ec;
+  fs::remove_all(tempDir, ec);
+  return ok ? 0 : 1;
+}

--- a/tests/wallpaper_shuffle_state_test.cpp
+++ b/tests/wallpaper_shuffle_state_test.cpp
@@ -31,13 +31,14 @@ int main() {
   {
     wallpaper::ShuffleState state;
     state.setStatePath(statePath);
-    ok = expect(state.pick("global", candidates, "a.jpg", 0.0F) == "b.jpg", "first pick excludes current") && ok;
+    ok = expect(state.pick("global", "default", candidates, "a.jpg", 0.0F) == "b.jpg", "first pick excludes current")
+        && ok;
   }
   {
     wallpaper::ShuffleState state;
     state.setStatePath(statePath);
     ok = expect(
-             state.pick("global", candidates, "b.jpg", 0.0F) == "c.jpg",
+             state.pick("global", "default", candidates, "b.jpg", 0.0F) == "c.jpg",
              "persisted cycle does not replace a previously shown wallpaper"
          )
         && ok;
@@ -45,9 +46,12 @@ int main() {
   {
     wallpaper::ShuffleState state;
     state.setStatePath(statePath);
-    ok = expect(state.pick("global", candidates, "c.jpg", 0.0F) == "a.jpg", "new cycle starts after exhaustion") && ok;
     ok = expect(
-             state.pick("output:DP-1", candidates, "a.jpg", 1.0F) == "c.jpg",
+             state.pick("global", "default", candidates, "c.jpg", 0.0F) == "a.jpg", "new cycle starts after exhaustion"
+         )
+        && ok;
+    ok = expect(
+             state.pick("output:DP-1", "default", candidates, "a.jpg", 1.0F) == "c.jpg",
              "output scopes keep independent shuffle cycles"
          )
         && ok;
@@ -57,13 +61,39 @@ int main() {
     const std::vector<std::string> changedCandidates{"b.jpg", "c.jpg", "d.jpg"};
     state.setStatePath(statePath);
     ok = expect(
-             state.pick("global", changedCandidates, "a.jpg", 1.0F) == "d.jpg",
+             state.pick("global", "default", changedCandidates, "a.jpg", 1.0F) == "d.jpg",
              "removed and newly added candidates reconcile with persisted state"
          )
         && ok;
     ok = expect(
-             state.pick("global", changedCandidates, "d.jpg", 0.0F) == "b.jpg",
+             state.pick("global", "default", changedCandidates, "d.jpg", 0.0F) == "b.jpg",
              "remaining changed candidates are used before replacement"
+         )
+        && ok;
+  }
+  {
+    wallpaper::ShuffleState state;
+    const std::vector<std::string> darkCandidates{"dark-a.jpg", "dark-b.jpg", "dark-c.jpg"};
+    const std::vector<std::string> lightCandidates{"light-a.jpg", "light-b.jpg", "light-c.jpg"};
+    state.setStatePath(statePath);
+    ok = expect(
+             state.pick("theme", "dark", darkCandidates, "dark-a.jpg", 0.0F) == "dark-b.jpg",
+             "dark cycle starts without replacing the current wallpaper"
+         )
+        && ok;
+    ok = expect(
+             state.pick("theme", "light", lightCandidates, "dark-b.jpg", 0.0F) == "light-a.jpg",
+             "light source keeps an independent cycle"
+         )
+        && ok;
+  }
+  {
+    wallpaper::ShuffleState state;
+    const std::vector<std::string> darkCandidates{"dark-a.jpg", "dark-b.jpg", "dark-c.jpg"};
+    state.setStatePath(statePath);
+    ok = expect(
+             state.pick("theme", "dark", darkCandidates, "light-a.jpg", 0.0F) == "dark-c.jpg",
+             "returning to a source preserves its persisted unexhausted cycle"
          )
         && ok;
   }
@@ -74,9 +104,15 @@ int main() {
 
     wallpaper::ShuffleState state;
     state.setStatePath(statePath);
-    ok = expect(state.pick("global", candidates, "a.jpg", 0.0F) == "b.jpg", "malformed state starts a fresh cycle")
+    ok = expect(
+             state.pick("global", "default", candidates, "a.jpg", 0.0F) == "b.jpg",
+             "malformed state starts a fresh cycle"
+         )
         && ok;
-    ok = expect(state.pick("global", {"only.jpg"}, "only.jpg", 0.0F) == "only.jpg", "single candidate is stable") && ok;
+    ok = expect(
+             state.pick("global", "default", {"only.jpg"}, "only.jpg", 0.0F) == "only.jpg", "single candidate is stable"
+         )
+        && ok;
   }
 
   std::error_code ec;


### PR DESCRIPTION
## Summary
This PR adds the ability to track used wallpapers to the wallpaper automation feature.

## Motivation
The wallpaper randomizer would show some of the same wallpapers repeatedly. This annoyed me, so I added an option to track used wallpapers in order to prevent repeats.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue
N/A

## Testing
Tested this on Hyprland and Niri on different machines.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes
N/A
