### PR TITLE
feat(control-center): close notification tab on clear-all when sidebar hidden

### DIFF
--- a/src/shell/control_center/control_center_panel.h
+++ b/src/shell/control_center/control_center_panel.h
@@ -90,6 +90,7 @@ public:
   [[nodiscard]] float preferredWidth() const override;
   [[nodiscard]] float preferredHeight() const override { return scaled(520.0F); }
   [[nodiscard]] PanelPlacement panelPlacement() const noexcept override;
+  [[nodiscard]] bool showsSidebar() const noexcept { return m_showSidebar; }
 
 private:
   void onPanelCardOpacityChanged(float opacity) override;

--- a/src/shell/control_center/tabs/notifications_tab.cpp
+++ b/src/shell/control_center/tabs/notifications_tab.cpp
@@ -9,6 +9,7 @@
 #include "render/animation/animation.h"
 #include "render/core/renderer.h"
 #include "render/core/texture_manager.h"
+#include "shell/control_center/control_center_panel.h"
 #include "shell/panel/panel_button_style.h"
 #include "shell/panel/panel_manager.h"
 #include "time/time_format.h"
@@ -948,7 +949,12 @@ void NotificationsTab::clearAllNotifications() {
   if (m_list != nullptr) {
     m_list->notifyDataChanged();
   }
-  PanelManager::instance().refresh();
+  auto* panel = dynamic_cast<ControlCenterPanel*>(PanelManager::instance().activePanel());
+  if (panel != nullptr && !panel->showsSidebar()) {
+    PanelManager::instance().close();
+  } else {
+    PanelManager::instance().refresh();
+  }
 }
 
 void NotificationsTab::toggleDoNotDisturb() {

--- a/src/shell/panel/panel_manager.h
+++ b/src/shell/panel/panel_manager.h
@@ -115,6 +115,7 @@ public:
   // Bar that opened the active panel; empty when none was recorded.
   [[nodiscard]] std::string_view attachedSourceBarName() const noexcept;
   [[nodiscard]] const std::string& activePanelId() const noexcept;
+  [[nodiscard]] Panel* activePanel() const noexcept { return m_activePanel; }
   // True when a panel is open and it reports the given context as active (e.g. control-center tab).
   [[nodiscard]] bool isActivePanelContext(std::string_view context) const noexcept;
   [[nodiscard]] std::optional<LayerPopupParentContext> popupParentContextForSurface(wl_surface* surface) const noexcept;


### PR DESCRIPTION
## Summary

This PR Auto-closes the notification tab of the control center when the user clears all notifications **only** when sidebar is hidden (none).
`control_center.sidebar = "none"` / `sidebar_section = "none"`

Full and compact mode is unchanged.

## Motivation

After clearing all notifications, the panel shows an empty list, so closing it manually is an extra click. Feedback and changed suggested by Lemmy in #3819 said it is only good when there is no sidebar

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

References #3819. 

## Testing

- Ran `just format`, `just build debug`,  no issues.
- Ran `just test` and `just lint`, all tests passed, lint clean.
- Then manual:- `pkill noctalia`, launched `./build-debug/noctalia`, `notify-send` for notification testing
  - No sidebar, panel closes after clearing all notification.
  - Full/compact, panel stay open after clearing all notification.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/1180ea79-4a2c-4e19-988f-891eeed46008


## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
