### PR TITLE
feat(clipboard):auto-close panel when clearing history with no pinned entries

### DIFF
--- a/src/shell/clipboard/clipboard_panel.cpp
+++ b/src/shell/clipboard/clipboard_panel.cpp
@@ -1547,7 +1547,11 @@ void ClipboardPanel::performClearUnpinnedHistory() {
   }
   schedulePreviewPayloadRefresh(false);
   m_pendingScrollToSelected = true;
-  PanelManager::instance().refresh();
+  if (m_clipboard->history().empty()) {
+    PanelManager::instance().close();
+  } else {
+    PanelManager::instance().refresh();
+  }
 }
 
 void ClipboardPanel::performClearAllHistory() {
@@ -1566,7 +1570,11 @@ void ClipboardPanel::performClearAllHistory() {
   }
   schedulePreviewPayloadRefresh(false);
   m_pendingScrollToSelected = false;
-  PanelManager::instance().refresh();
+  if (m_clipboard->history().empty()) {
+    PanelManager::instance().close();
+  } else {
+    PanelManager::instance().refresh();
+  }
 }
 
 void ClipboardPanel::clearUnpinnedHistory() {


### PR DESCRIPTION
## Summary

This PR Auto-closes the clipboard panel when its history is emptied and nothing remains pinned. Lemmy's approved design from the #3826 discussion.

## Motivation

After "Clear all", the panel is left showing empty history, so the user has to close it manually. I see no point of it staying open when there nothing left.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

- Ran `just format`, `just build`, `just test` (all passed), `just lint` clean.
- Killed the running noctalia `pkill noctalia` then start the build debug `./build-debug/noctalia`
- Then Tested manually:-
  - Panel closes automatically on "Clear all".
  - Panel stays open with pinned entries on "Keep pinned".
  - Clear-all with pinned entries present:- Panel closes automatically. 
  - Single-entry delete / pin toggle / new copies while open:- Panel stays open.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/3fdef3a0-0695-4f92-877b-9a2dd868d6da


## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
