### PR TITLE
fix(screen-time):pause tracking while session is locked

### DIFF
--- a/src/app/application.h
+++ b/src/app/application.h
@@ -251,6 +251,8 @@ private:
   bool m_releaseSleepDelayWhenLocked = false;
   // Set before Noctalia-initiated suspend so PrepareForSleep skips lock-before-sleep.
   bool m_skipLockOnNextSleep = false;
+  // Prevents the unlock hook from resuming tracking during suspend.
+  bool m_preparingForSleep = false;
   std::unique_ptr<AccountsService> m_accountsService;
   std::unique_ptr<ScreenSaverService> m_screenSaverService;
   std::unique_ptr<ScreenSaverPollSource> m_screenSaverPollSource;

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -965,6 +965,7 @@ void Application::initSystemBusServices() {
           m_idleGraceOverlay.hide();
           if (sleeping) {
             // Screen time must not accumulate across suspend even when lock-before-suspend is off.
+            m_preparingForSleep = true;
             m_screenTimeService.setTrackingPaused(true);
             // Delay inhibit (when lock_before_suspend is on) holds sleep until we lock.
             // Do not use runAfterSessionLocked here — that slot belongs to lock-and-suspend.
@@ -1013,8 +1014,10 @@ void Application::initSystemBusServices() {
           }
           m_skipLockOnNextSleep = false;
           m_releaseSleepDelayWhenLocked = false;
+          m_preparingForSleep = false;
           if (!m_lockScreen.isSessionLocked()) {
-            // Still locked after wake; the unlock hook resumes tracking.
+            // After wake, resume tracking if the session is already unlocked.
+            // Otherwise, keep it paused until the session unlocks.
             m_screenTimeService.setTrackingPaused(false);
           }
           if (m_configService.shouldLockBeforeSuspend() && m_logindService != nullptr) {

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -964,6 +964,8 @@ void Application::initSystemBusServices() {
           // fade-complete cleanup races with process freeze.
           m_idleGraceOverlay.hide();
           if (sleeping) {
+            // Screen time must not accumulate across suspend even when lock-before-suspend is off.
+            m_screenTimeService.setTrackingPaused(true);
             // Delay inhibit (when lock_before_suspend is on) holds sleep until we lock.
             // Do not use runAfterSessionLocked here — that slot belongs to lock-and-suspend.
             if (m_skipLockOnNextSleep) {
@@ -1011,6 +1013,10 @@ void Application::initSystemBusServices() {
           }
           m_skipLockOnNextSleep = false;
           m_releaseSleepDelayWhenLocked = false;
+          if (!m_lockScreen.isSessionLocked()) {
+            // Still locked after wake; the unlock hook resumes tracking.
+            m_screenTimeService.setTrackingPaused(false);
+          }
           if (m_configService.shouldLockBeforeSuspend() && m_logindService != nullptr) {
             (void)m_logindService->acquireSleepDelayInhibit();
           }

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -327,7 +327,7 @@ void Application::initLockScreenAndSession() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
         m_idleManager.setSessionLocked(true);
-        m_screenTimeService.setSessionLocked(true);
+        m_screenTimeService.setTrackingPaused(true);
         m_hookManager.fire(HookKind::SessionLocked);
         releaseSleepDelayInhibitIfPending();
       },
@@ -335,7 +335,7 @@ void Application::initLockScreenAndSession() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
         m_idleManager.setSessionLocked(false);
-        m_screenTimeService.setSessionLocked(false);
+        m_screenTimeService.setTrackingPaused(false);
         m_hookManager.fire(HookKind::SessionUnlocked);
         // Lock aborted before engage (e.g. compositor finished the lock object) — still release
         // so PrepareForSleep is not stuck on the delay inhibit.

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -335,7 +335,9 @@ void Application::initLockScreenAndSession() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
         m_idleManager.setSessionLocked(false);
-        m_screenTimeService.setTrackingPaused(false);
+        if (!m_preparingForSleep) {
+          m_screenTimeService.setTrackingPaused(false);
+        }
         m_hookManager.fire(HookKind::SessionUnlocked);
         // Lock aborted before engage (e.g. compositor finished the lock object) — still release
         // so PrepareForSleep is not stuck on the delay inhibit.

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -327,6 +327,7 @@ void Application::initLockScreenAndSession() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
         m_idleManager.setSessionLocked(true);
+        m_screenTimeService.setSessionLocked(true);
         m_hookManager.fire(HookKind::SessionLocked);
         releaseSleepDelayInhibitIfPending();
       },
@@ -334,6 +335,7 @@ void Application::initLockScreenAndSession() {
         m_idleGraceOverlay.hide();
         m_lockscreenWidgetsController.onLockStateChanged();
         m_idleManager.setSessionLocked(false);
+        m_screenTimeService.setSessionLocked(false);
         m_hookManager.fire(HookKind::SessionUnlocked);
         // Lock aborted before engage (e.g. compositor finished the lock object) — still release
         // so PrepareForSleep is not stuck on the delay inhibit.

--- a/src/system/screen_time_service.cpp
+++ b/src/system/screen_time_service.cpp
@@ -321,25 +321,31 @@ void ScreenTimeService::setEnabled(bool enabled) {
 }
 
 void ScreenTimeService::restartTicking() {
+  if (m_trackingPaused) {
+    return;
+  }
   onFocusChange();
   if (!m_tickTimer.active()) {
     m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
   }
 }
 
-void ScreenTimeService::setSessionLocked(bool locked) {
-  if (m_sessionLocked == locked) {
+void ScreenTimeService::setTrackingPaused(bool paused) {
+  if (m_trackingPaused == paused) {
     return;
   }
-  m_sessionLocked = locked;
-  if (locked) {
-    // Locks session then stop counting.
+  m_trackingPaused = paused;
+  if (paused) {
+    // Pause counts (session lock or suspend) and stop counting.
     flushActiveSession(std::chrono::steady_clock::now());
     m_activeAppKey.clear();
     m_activeSince = {};
+    if (m_dirty) {
+      save();
+    }
     m_tickTimer.stop();
   } else {
-    // Resumes on login again, resume the tick timer and credit the current app.
+    // Resume on unlock/login, resume the tick timer and credit the current app.
     if (m_enabled) {
       restartTicking();
     }
@@ -347,7 +353,7 @@ void ScreenTimeService::setSessionLocked(bool locked) {
 }
 
 void ScreenTimeService::onFocusChange() {
-  if (!m_enabled || m_sessionLocked) {
+  if (!m_enabled || m_trackingPaused) {
     return;
   }
   const std::string candidate = appKeyForActive();

--- a/src/system/screen_time_service.cpp
+++ b/src/system/screen_time_service.cpp
@@ -313,18 +313,41 @@ void ScreenTimeService::setEnabled(bool enabled) {
     }
     m_tickTimer.stop();
   } else {
-    onFocusChange();
-    if (!m_tickTimer.active()) {
-      m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
-    }
+    restartTicking();
   }
   if (m_changeCallback) {
     m_changeCallback();
   }
 }
 
+void ScreenTimeService::restartTicking() {
+  onFocusChange();
+  if (!m_tickTimer.active()) {
+    m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
+  }
+}
+
+void ScreenTimeService::setSessionLocked(bool locked) {
+  if (m_sessionLocked == locked) {
+    return;
+  }
+  m_sessionLocked = locked;
+  if (locked) {
+    // Locks session then stop counting.
+    flushActiveSession(std::chrono::steady_clock::now());
+    m_activeAppKey.clear();
+    m_activeSince = {};
+    m_tickTimer.stop();
+  } else {
+    // Resumes on login again, resume the tick timer and credit the current app.
+    if (m_enabled) {
+      restartTicking();
+    }
+  }
+}
+
 void ScreenTimeService::onFocusChange() {
-  if (!m_enabled) {
+  if (!m_enabled || m_sessionLocked) {
     return;
   }
   const std::string candidate = appKeyForActive();

--- a/src/system/screen_time_service.h
+++ b/src/system/screen_time_service.h
@@ -48,7 +48,7 @@ public:
   void onFocusChange();
   void setChangeCallback(std::function<void()> callback);
   void setEnabled(bool enabled);
-  void setSessionLocked(bool locked);
+  void setTrackingPaused(bool paused);
   [[nodiscard]] bool enabled() const noexcept { return m_enabled; }
 
   [[nodiscard]] ScreenTimeSnapshot snapshot(int rangeDays = 1);
@@ -98,5 +98,5 @@ private:
   std::chrono::steady_clock::time_point m_activeSince;
   bool m_dirty = false;
   bool m_enabled = false;
-  bool m_sessionLocked = false;
+  bool m_trackingPaused = false;
 };

--- a/src/system/screen_time_service.h
+++ b/src/system/screen_time_service.h
@@ -48,6 +48,7 @@ public:
   void onFocusChange();
   void setChangeCallback(std::function<void()> callback);
   void setEnabled(bool enabled);
+  void setSessionLocked(bool locked);
   [[nodiscard]] bool enabled() const noexcept { return m_enabled; }
 
   [[nodiscard]] ScreenTimeSnapshot snapshot(int rangeDays = 1);
@@ -65,6 +66,7 @@ private:
   };
 
   void tick();
+  void restartTicking();
   void flushActiveSession(std::chrono::steady_clock::time_point now);
   void ensureCurrentDayLocked(std::chrono::system_clock::time_point now);
   void load();
@@ -96,4 +98,5 @@ private:
   std::chrono::steady_clock::time_point m_activeSince;
   bool m_dirty = false;
   bool m_enabled = false;
+  bool m_sessionLocked = false;
 };


### PR DESCRIPTION
## Summary

This PR fixes the screen time accumulating usage while the session is locked.

## Motivation

Just to keep screen time not counting usage when session is locked or suspended.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3882 

## Testing

- Ran `just format`, `just build`, `just test` all were clean and passed.
- Then killed noctalia `pkill noctalia` then started build debug `./build-debug/noctalia`
- I already had screen time setting on, for testing i opened VLC played a video then stop after 2 mins, then lock and suspend. After 5 mins login, then screen time of vlc was still 2 min, didn't increase on suspend.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
