### PR TITLE
feat(plugin-ui): expose input frame visibility

### DIFF
--- a/src/scripting/plugin_api.h
+++ b/src/scripting/plugin_api.h
@@ -26,7 +26,8 @@ namespace scripting {
   inline constexpr std::uint32_t kDirectArgvPluginApiVersion = 24;
   inline constexpr std::uint32_t kWallpaperMaskPluginApiVersion = 25;
   inline constexpr std::uint32_t kGetSettingPluginApiVersion = 26;
-  inline constexpr std::uint32_t kCurrentPluginApiVersion = kGetSettingPluginApiVersion;
+  inline constexpr std::uint32_t kInputFrameVisibilityPluginApiVersion = 27;
+  inline constexpr std::uint32_t kCurrentPluginApiVersion = kInputFrameVisibilityPluginApiVersion;
 
   static_assert(kOldestSupportedPluginApiVersion <= kCurrentPluginApiVersion);
 

--- a/src/ui/ui_tree_reconciler.cpp
+++ b/src/ui/ui_tree_reconciler.cpp
@@ -476,10 +476,11 @@ namespace ui {
       static const std::unordered_set<std::string> kGraph = {"width",   "height",    "flexGrow",   "opacity",
                                                              "visible", "values",    "values2",    "color",
                                                              "color2",  "lineWidth", "fillOpacity"};
-      static const std::unordered_set<std::string> kInput = {"width",    "height",   "flexGrow",    "opacity",
-                                                             "visible",  "value",    "placeholder", "fontSize",
-                                                             "enabled",  "password", "multiline",   "focus",
-                                                             "onChange", "onSubmit", "controlSize", "submitOnEnter"};
+      static const std::unordered_set<std::string> kInput = {"width",       "height",   "flexGrow",    "opacity",
+                                                             "visible",     "value",    "placeholder", "fontSize",
+                                                             "enabled",     "password", "multiline",   "focus",
+                                                             "onChange",    "onSubmit", "controlSize", "submitOnEnter",
+                                                             "frameVisible"};
       static const std::unordered_set<std::string> kMarkdown = {"width",   "height",  "flexGrow",
                                                                 "opacity", "visible", "text"};
       static const std::unordered_set<std::string> kSelect = {"width",       "height",   "flexGrow",      "opacity",
@@ -1573,6 +1574,9 @@ namespace ui {
       }
       if (const bool* enabled = boolProp(desired, "enabled")) {
         input->setEnabled(*enabled);
+      }
+      if (const bool* frameVisible = boolProp(desired, "frameVisible")) {
+        input->setFrameVisible(*frameVisible);
       }
       if (const std::string* onChange = strProp(desired, "onChange");
           onChange != nullptr && *onChange != slot.callbackName) {

--- a/tests/ui_tree_reconciler_test.cpp
+++ b/tests/ui_tree_reconciler_test.cpp
@@ -865,8 +865,9 @@ int main() {
     }
   }
 
-  // Multiline input: the prop applies, seeds a multi-line value, and the keyed
-  // instance survives re-renders like any other input.
+  // Multiline input: the props apply, seed a multi-line value, and the keyed
+  // instance survives re-renders like any other input. A frame-free field keeps
+  // the editor interactions while allowing its parent surface to show through.
   {
     ui::UiTreeReconciler reconciler;
     Flex host;
@@ -876,6 +877,7 @@ int main() {
     input.key = "editor";
     input.props.emplace("value", std::string("line one\nline two"));
     input.props.emplace("multiline", true);
+    input.props.emplace("frameVisible", false);
     tree.children.push_back(input);
     (void)reconciler.reconcile(host, tree, renderer);
 
@@ -883,6 +885,11 @@ int main() {
     auto* in = column != nullptr ? dynamic_cast<Input*>(column->children()[0].get()) : nullptr;
     ok =
         expect(in != nullptr && in->value() == "line one\nline two", "multiline input seeded with newline value") && ok;
+    if (in != nullptr) {
+      const auto& inputChildren = in->children();
+      ok = expect(!inputChildren.empty() && !inputChildren.front()->visible(), "frame-free input hides its chrome")
+          && ok;
+    }
     Node* inputBefore = in;
 
     (void)reconciler.reconcile(host, tree, renderer);


### PR DESCRIPTION
## Summary

- Expose the existing native input chrome toggle as the optional declarative `ui.input` property `frameVisible`.
- Keep the current framed appearance as the default; plugin authors opt out with `frameVisible = false`.
- Introduce plugin API 27 and cover frame-free multiline inputs in the reconciler test.

## Motivation

Plugin UIs sometimes place editable text directly on a custom surface, such as a sticky note or document canvas. The native `Input` control already supports hiding its background and border while retaining text editing, selection, cursor, and focus behavior, but the declarative plugin UI could not request it. Plugins therefore had to accept unrelated input chrome or replace a real editor with non-editable content.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None.

## Testing

- `meson compile -C build-debug ui_tree_reconciler_test plugin_manifest_test`
- `meson test -C build-debug ui_tree_reconciler plugin_manifest --print-errorlogs`
- `just format` with clang-format 22.1.8
- `git diff --check`

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

The locally built shell was launched on Hyprland 0.56.2 with the Clipper plugin. Both the single-line title and multiline body used `frameVisible = false`: their native gray background and border disappeared while the editable text remained visible on the parent sticky-note surface. Omitting the property continues to use the existing framed appearance.

The Clipper panel also exposed an unrelated pre-existing Luau stack-reservation bug in deeply nested declarative UI trees. The manual check used a local-only guard for that crash; the guard is intentionally excluded from this focused PR and does not affect the `frameVisible` implementation or its unit coverage.

## Screenshots / Videos

The visual result was verified with the Clipper sticky-note surface. The reconciler test additionally asserts that the native input background node becomes hidden.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

`frameVisible` maps directly to `Input::setFrameVisible`. Omitting the property preserves existing plugin behavior.

The branch was rebased onto the latest `main` after `noctalia.getSetting` claimed plugin API 26. `frameVisible` now uses the next API level, 27.
