### PR TITLE
fix(dock): search pinned entries for a match before the full list

### DIFF
--- a/src/shell/dock/dock_model.cpp
+++ b/src/shell/dock/dock_model.cpp
@@ -95,7 +95,7 @@ namespace shell::dock {
 
     const auto runningIds =
         deps.config.showRunning ? deps.platform.runningAppIds(snapshot.filterOutput) : std::vector<std::string>{};
-    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries());
+    const auto resolvedRunning = app_identity::resolveRunningApps(runningIds, desktopEntries(), deps.pinnedEntries);
 
     std::unordered_map<std::string, std::string> compositorIdByEntryId;
     compositorIdByEntryId.reserve(resolvedRunning.size());

--- a/src/system/app_identity.cpp
+++ b/src/system/app_identity.cpp
@@ -41,7 +41,7 @@ namespace app_identity {
     }
 
     std::optional<DesktopEntry>
-    findDesktopEntryByIdTail(std::string_view appKey, const std::vector<DesktopEntry>& allEntries) {
+    findDesktopEntryByIdTail(std::string_view appKey, std::span<const DesktopEntry> allEntries) {
       const std::string appLower = StringUtils::toLower(std::string(appKey));
       const std::string tailLower = StringUtils::toLower(std::string(appIdTail(appKey)));
       if (tailLower.empty() || tailLower == appLower) {
@@ -82,9 +82,11 @@ namespace app_identity {
       bool matchedDesktopEntry = false;
     };
 
-    DesktopEntryResolution
-    resolveRunningDesktopEntryWithStatus(std::string_view runningAppId, const std::vector<DesktopEntry>& allEntries) {
-      if (auto matched = findDesktopEntry(runningAppId, allEntries)) {
+    DesktopEntryResolution resolveRunningDesktopEntryWithStatus(
+        std::string_view runningAppId, std::span<const DesktopEntry> allEntries,
+        std::span<const DesktopEntry> priorityEntries = {}
+    ) {
+      if (auto matched = findDesktopEntry(runningAppId, allEntries, priorityEntries)) {
         if (runningAppId.starts_with("steam_app_") && matched->startupWmClass.empty()) {
           matched->startupWmClass = std::string(runningAppId);
         }
@@ -129,12 +131,19 @@ namespace app_identity {
     );
   }
 
-  std::optional<DesktopEntry> findDesktopEntry(std::string_view appKey, const std::vector<DesktopEntry>& allEntries) {
+  std::optional<DesktopEntry> findDesktopEntry(
+      std::string_view appKey, std::span<const DesktopEntry> allEntries, std::span<const DesktopEntry> priorityEntries
+  ) {
     if (appKey.empty()) {
       return std::nullopt;
     }
 
     const std::string appLower = StringUtils::toLower(std::string(appKey));
+    for (const auto& entry : priorityEntries) {
+      if (desktopEntryMatchesLower(entry, appLower)) {
+        return entry;
+      }
+    }
     for (const auto& entry : allEntries) {
       if (desktopEntryMatchesLower(entry, appLower)) {
         return entry;
@@ -167,12 +176,14 @@ namespace app_identity {
     return std::nullopt;
   }
 
-  DesktopEntry resolveRunningDesktopEntry(std::string_view runningAppId, const std::vector<DesktopEntry>& allEntries) {
+  DesktopEntry resolveRunningDesktopEntry(std::string_view runningAppId, std::span<const DesktopEntry> allEntries) {
     return resolveRunningDesktopEntryWithStatus(runningAppId, allEntries).entry;
   }
 
-  std::vector<ResolvedRunningApp>
-  resolveRunningApps(const std::vector<std::string>& runningAppIds, const std::vector<DesktopEntry>& allEntries) {
+  std::vector<ResolvedRunningApp> resolveRunningApps(
+      std::span<const std::string> runningAppIds, std::span<const DesktopEntry> allEntries,
+      std::span<const DesktopEntry> priorityEntries
+  ) {
     std::vector<ResolvedRunningApp> resolved;
     resolved.reserve(runningAppIds.size());
 
@@ -181,7 +192,7 @@ namespace app_identity {
 
     for (const auto& runningAppId : runningAppIds) {
       const std::string runningLower = StringUtils::toLower(runningAppId);
-      const auto resolution = resolveRunningDesktopEntryWithStatus(runningAppId, allEntries);
+      const auto resolution = resolveRunningDesktopEntryWithStatus(runningAppId, allEntries, priorityEntries);
       std::string dedupeKey = resolution.matchedDesktopEntry ? StringUtils::toLower(resolution.entry.id) : runningLower;
       if (dedupeKey.empty()) {
         dedupeKey = runningLower;

--- a/src/system/app_identity.h
+++ b/src/system/app_identity.h
@@ -3,6 +3,7 @@
 #include "system/desktop_entry.h"
 
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -24,13 +25,17 @@ namespace app_identity {
 
   // Best-effort lookup by app id / StartupWMClass. Operates on the parsed desktop-entry list,
   // which already excludes hidden/NoDisplay/wrong-desktop entries.
-  [[nodiscard]] std::optional<DesktopEntry>
-  findDesktopEntry(std::string_view appKey, const std::vector<DesktopEntry>& allEntries);
+  [[nodiscard]] std::optional<DesktopEntry> findDesktopEntry(
+      std::string_view appKey, std::span<const DesktopEntry> allEntries,
+      std::span<const DesktopEntry> priorityEntries = {}
+  );
 
   [[nodiscard]] DesktopEntry
-  resolveRunningDesktopEntry(std::string_view runningAppId, const std::vector<DesktopEntry>& allEntries);
+  resolveRunningDesktopEntry(std::string_view runningAppId, std::span<const DesktopEntry> allEntries);
 
-  [[nodiscard]] std::vector<ResolvedRunningApp>
-  resolveRunningApps(const std::vector<std::string>& runningAppIds, const std::vector<DesktopEntry>& allEntries);
+  [[nodiscard]] std::vector<ResolvedRunningApp> resolveRunningApps(
+      std::span<const std::string> runningAppIds, std::span<const DesktopEntry> allEntries,
+      std::span<const DesktopEntry> priorityEntries = {}
+  );
 
 } // namespace app_identity

--- a/tests/app_identity_test.cpp
+++ b/tests/app_identity_test.cpp
@@ -123,26 +123,26 @@ int main() {
   // production and does not re-filter them. If one is present it resolves like any other entry.
   DesktopEntry hidden = sampleChatEntry();
   hidden.hidden = true;
-  TEST_CHECK(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", {hidden}).id == "sample-chat-desktop");
+  TEST_CHECK(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", std::array<DesktopEntry, 1>{hidden}).id == "sample-chat-desktop");
 
   DesktopEntry noDisplay = sampleChatEntry();
   noDisplay.noDisplay = true;
-  TEST_CHECK(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", {noDisplay}).id == "sample-chat-desktop");
+  TEST_CHECK(app_identity::resolveRunningDesktopEntry("Sample.ChatDesktop", std::array<DesktopEntry, 1>{noDisplay}).id == "sample-chat-desktop");
 
   const std::vector<DesktopEntry> multipleEntries = {sampleChatEntry(), sampleMailEntry()};
   const auto resolvedApps =
-      app_identity::resolveRunningApps({"Sample.ChatDesktop", "sample-chat-desktop", "SampleMail"}, multipleEntries);
+    app_identity::resolveRunningApps(std::array<std::string, 3>{"Sample.ChatDesktop", "sample-chat-desktop", "SampleMail"}, multipleEntries);
   TEST_CHECK(resolvedApps.size() == 2);
   TEST_CHECK(resolvedApps[0].entry.id == "sample-chat-desktop");
   TEST_CHECK(resolvedApps[1].entry.id == "sample-mail");
 
-  const auto unknownApps = app_identity::resolveRunningApps({"Unknown.App", "unknown-app"}, multipleEntries);
+  const auto unknownApps = app_identity::resolveRunningApps(std::array<std::string, 2>{"Unknown.App", "unknown-app"}, multipleEntries);
   TEST_CHECK(unknownApps.size() == 2);
   TEST_CHECK(unknownApps[0].entry.id == "Unknown.App");
   TEST_CHECK(unknownApps[1].entry.id == "unknown-app");
 
   const DesktopEntry easyEffects = easyEffectsEntry();
-  const DesktopEntry kdeResolved = app_identity::resolveRunningDesktopEntry("org.kde.easyeffects", {easyEffects});
+  const DesktopEntry kdeResolved = app_identity::resolveRunningDesktopEntry("org.kde.easyeffects", std::array<DesktopEntry, 1>{easyEffects});
   TEST_CHECK(kdeResolved.id == "com.github.wwmm.easyeffects");
   TEST_CHECK(kdeResolved.name == "Easy Effects");
   TEST_CHECK(kdeResolved.icon == "easyeffects");


### PR DESCRIPTION
emacsclient.desktop and emacs.desktop have the same StartupWMClass, so having emacsclient.desktop pinned and launching it would create another icon in the dock because emacs.desktop would be picked first when matching.

This also changes a few signatures to use span instead of vector because an empty span for a default value is a better conceptual match for an empty list than an empty vector, and also read-only functions should operate on span anyway (just like how read-only string functions should operate on string_view)

<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

`app_identity::{findDesktopEntry, resolveRunningApps}` now take an optional parameter `priorityEntries` which is searched first. The dock supplies the pinned entries as this argument

## Motivation

emacsclient.desktop and emacs.desktop have the same StartupWMClass, so having emacsclient.desktop pinned and launching it would create another icon in the dock because emacs.desktop would be picked first when matching.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

I reported this on Discord: https://discord.com/channels/1401598189823590460/1537045696874684416

## Testing
Tested manually, see videos.


## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/c69c6460-3f18-4dc0-a790-6b4710f1d879

After:

https://github.com/user-attachments/assets/51c494dc-4924-4543-9e3a-cc74c1bc786b

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
