### PR TITLE
Add Keywords to .desktop file

### DIFF
--- a/assets/dev.noctalia.Noctalia.desktop
+++ b/assets/dev.noctalia.Noctalia.desktop
@@ -8,6 +8,7 @@ Terminal=false
 Categories=Settings;DesktopSettings;
 StartupNotify=false
 Actions=Settings;
+Keywords=desktop;shell;wayland;
 
 [Desktop Action Settings]
 Name=Open Settings


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Added "Keywords" field to .desktop file.
This was requested as part of the Debian packaging review.

## Motivation

Jumps over one of the Debian packaging hurdles.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141346#24

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

None.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This is a trivial addition

