### PR TITLE
widgets/sysmon: show highlight color setting even without visualization

### DIFF
--- a/src/shell/bar/widgets/sysmon_widget_definition.cpp
+++ b/src/shell/bar/widgets/sysmon_widget_definition.cpp
@@ -262,7 +262,6 @@ const noctalia::bar::WidgetDefinition<SysmonWidget::Options, SysmonWidgetDefinit
               .presentation =
                   settings::WidgetSettingPresentation{
                       .group = "presentation",
-                      .visibleWhen = hasVisualization,
                   },
           }),
       },


### PR DESCRIPTION
Show the highlight color setting when visualization is None, since glyph and value are still colorized.