### PR TITLE
render: weight HSV hue interpolation by chroma

### DIFF
--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -137,6 +137,30 @@ Color lerpHsv(const Color& a, const Color& b, float t) {
   float h1, s1, v1;
   rgbToHsv(b, h1, s1, v1);
 
+  // Hue is undefined at negligible chroma; borrow the other endpoint's hue to avoid spurious tints.
+  constexpr float kChromaEpsilon = 1e-6F;
+  if (s0 * v0 <= kChromaEpsilon) {
+    h0 = h1;
+  }
+  if (s1 * v1 <= kChromaEpsilon) {
+    h1 = h0;
+  }
+
+  float hDelta = h1 - h0;
+  if (hDelta > 0.5F) {
+    hDelta -= 1.0F;
+  } else if (hDelta < -0.5F) {
+    hDelta += 1.0F;
+  }
+  return hsv(h0 + hDelta * t, s0 + (s1 - s0) * t, v0 + (v1 - v0) * t, a.a + (b.a - a.a) * t);
+}
+
+Color lerpHsvChromaWeighted(const Color& a, const Color& b, float t) {
+  float h0, s0, v0;
+  rgbToHsv(a, h0, s0, v0);
+  float h1, s1, v1;
+  rgbToHsv(b, h1, s1, v1);
+
   float hDelta = h1 - h0;
   if (hDelta > 0.5F) {
     hDelta -= 1.0F;

--- a/src/render/core/color.cpp
+++ b/src/render/core/color.cpp
@@ -137,22 +137,21 @@ Color lerpHsv(const Color& a, const Color& b, float t) {
   float h1, s1, v1;
   rgbToHsv(b, h1, s1, v1);
 
-  // Hue is undefined at negligible chroma; borrow the other endpoint's hue to avoid spurious tints.
-  constexpr float kChromaEpsilon = 1e-6F;
-  if (s0 * v0 <= kChromaEpsilon) {
-    h0 = h1;
-  }
-  if (s1 * v1 <= kChromaEpsilon) {
-    h1 = h0;
-  }
-
   float hDelta = h1 - h0;
   if (hDelta > 0.5F) {
     hDelta -= 1.0F;
   } else if (hDelta < -0.5F) {
     hDelta += 1.0F;
   }
-  return hsv(h0 + hDelta * t, s0 + (s1 - s0) * t, v0 + (v1 - v0) * t, a.a + (b.a - a.a) * t);
+
+  // A low-chroma color's hue is weak or undefined, so give it proportionally less influence. When both endpoints
+  // have equal chroma this reduces to the usual linear hue interpolation.
+  const float fromHueWeight = (1.0F - t) * s0 * v0;
+  const float toHueWeight = t * s1 * v1;
+  const float hueWeightSum = fromHueWeight + toHueWeight;
+  const float hueT = hueWeightSum > 0.0F ? toHueWeight / hueWeightSum : t;
+
+  return hsv(h0 + hDelta * hueT, s0 + (s1 - s0) * t, v0 + (v1 - v0) * t, a.a + (b.a - a.a) * t);
 }
 
 float relativeLuminance(const Color& color) {

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -135,7 +135,7 @@ constexpr Color lerpColor(const Color& a, const Color& b, float t) {
 [[nodiscard]] Color hsl(float h, float s, float l, float a = 1.0F);
 // Decomposes rgb into hue (turns, [0,1)), saturation, and value (each [0,1]).
 void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
-// Blends from a to b through HSV space on the shortest hue path; t in [0,1].
+// Blends from a to b through HSV space on the shortest hue path, weighting hue influence by chroma; t in [0,1].
 [[nodiscard]] Color lerpHsv(const Color& a, const Color& b, float t);
 // WCAG relative luminance of color, in [0,1].
 [[nodiscard]] float relativeLuminance(const Color& color);

--- a/src/render/core/color.h
+++ b/src/render/core/color.h
@@ -135,8 +135,10 @@ constexpr Color lerpColor(const Color& a, const Color& b, float t) {
 [[nodiscard]] Color hsl(float h, float s, float l, float a = 1.0F);
 // Decomposes rgb into hue (turns, [0,1)), saturation, and value (each [0,1]).
 void rgbToHsv(const Color& rgb, float& h, float& s, float& v);
-// Blends from a to b through HSV space on the shortest hue path, weighting hue influence by chroma; t in [0,1].
+// Blends from a to b through HSV space on the shortest hue path; t in [0,1].
 [[nodiscard]] Color lerpHsv(const Color& a, const Color& b, float t);
+// HSV blend with shortest-path hue interpolation weighted by endpoint chroma; t in [0,1].
+[[nodiscard]] Color lerpHsvChromaWeighted(const Color& a, const Color& b, float t);
 // WCAG relative luminance of color, in [0,1].
 [[nodiscard]] float relativeLuminance(const Color& color);
 // Returns opaque black or white, whichever reads better on background.

--- a/src/shell/bar/widgets/sysmon_widget.cpp
+++ b/src/shell/bar/widgets/sysmon_widget.cpp
@@ -354,7 +354,7 @@ Color SysmonWidget::currentValueColor(ColorSpec baseColor) {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpHsv(base, highlight, factor);
+  return lerpHsvChromaWeighted(base, highlight, factor);
 }
 
 void SysmonWidget::syncIcon(Renderer& renderer) {

--- a/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
+++ b/src/shell/desktop/widgets/desktop_sysmon_widget.cpp
@@ -563,7 +563,7 @@ Color DesktopSysmonWidget::currentValueColor(ColorSpec baseColor) const {
   const Color highlight = resolveColorSpec(m_highlightColor);
   const auto [activityThreshold, criticalThreshold] = currentThresholds();
   const auto factor = static_cast<float>(gradientFactor(currentGradientValue(), activityThreshold, criticalThreshold));
-  return lerpHsv(base, highlight, factor);
+  return lerpHsvChromaWeighted(base, highlight, factor);
 }
 
 std::pair<double, double> DesktopSysmonWidget::currentThresholds() const {


### PR DESCRIPTION
Give low-chroma endpoints proportionally less influence over the interpolated hue. This prevents near-achromatic colors from causing unrelated hue detours while preserving shortest-path interpolation and the existing behavior for colors with equal chroma.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/27f2f8e4-46cb-4ab7-87cf-8341c632ed46" />