### PR TITLE
feat(plugin): add back to plugin catalog button in plugin store

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1524,6 +1524,7 @@
       },
       "store": {
         "add": "Add to Noctalia",
+        "back-to-catalog": "Back to the plugin catalog",
         "categories": "Categories",
         "category-all": "All",
         "empty": "No plugins found",

--- a/src/shell/settings/settings_sheet.cpp
+++ b/src/shell/settings/settings_sheet.cpp
@@ -24,6 +24,7 @@ namespace settings {
     m_preDispatchKeyboard = std::move(request.preDispatchKeyboard);
     m_title = std::move(request.sheetTitle);
     m_removeAction = std::move(request.removeAction);
+    m_createLeadingAction = std::move(request.createLeadingAction);
     m_createHeaderAction = std::move(request.createHeaderAction);
     m_populateBody = std::move(request.populateSheetBody);
     clearNodePointers();
@@ -49,6 +50,11 @@ namespace settings {
         .align = FlexAlign::Center,
         .gap = Style::spaceSm * m_scale,
     });
+    if (m_createLeadingAction) {
+      if (auto action = m_createLeadingAction()) {
+        header->addChild(std::move(action));
+      }
+    }
     header->addChild(
         ui::label({
             .out = &m_titleLabel,
@@ -158,6 +164,7 @@ namespace settings {
     m_statusMessage.clear();
     m_statusIsError = false;
     m_removeAction = nullptr;
+    m_createLeadingAction = nullptr;
     m_createHeaderAction = nullptr;
     m_populateBody = nullptr;
     m_onCloseRequested = nullptr;

--- a/src/shell/settings/settings_sheet.h
+++ b/src/shell/settings/settings_sheet.h
@@ -18,6 +18,7 @@ namespace settings {
   struct SettingsSheetRequest {
     std::string sheetTitle;
     std::function<void()> removeAction;
+    std::function<std::unique_ptr<Node>()> createLeadingAction;
     std::function<std::unique_ptr<Node>()> createHeaderAction;
     std::function<void(Flex& sheetBody)> populateSheetBody;
     float scale = 1.0F;
@@ -77,6 +78,7 @@ namespace settings {
     Flex* m_statusBanner = nullptr;
     Label* m_statusLabel = nullptr;
     std::function<void()> m_removeAction;
+    std::function<std::unique_ptr<Node>()> m_createLeadingAction;
     std::function<std::unique_ptr<Node>()> m_createHeaderAction;
     std::function<void(Flex&)> m_populateBody;
     std::function<void()> m_closeAction;

--- a/src/shell/settings/settings_window_popups.cpp
+++ b/src/shell/settings/settings_window_popups.cpp
@@ -2090,6 +2090,22 @@ void SettingsWindow::openPluginStore() {
           settings::SettingsSheetRequest{
               .sheetTitle = i18n::tr("settings.plugins.store.title"),
               .removeAction = nullptr,
+              .createLeadingAction = [storeContent, scale]() -> std::unique_ptr<Node> {
+                if (!storeContent->isDetailView()) {
+                  return nullptr;
+                }
+                return ui::button({
+                    .glyph = "chevron-left",
+                    .glyphSize = Style::fontSizeBody * scale,
+                    .variant = ButtonVariant::Ghost,
+                    .tooltip = i18n::tr("settings.plugins.store.back-to-catalog"),
+                    .minWidth = Style::controlHeightSm * scale,
+                    .minHeight = Style::controlHeightSm * scale,
+                    .padding = Style::spaceXs * scale,
+                    .radius = Style::scaledRadiusMd(scale),
+                    .onClick = [storeContent]() { storeContent->closeDetail(); },
+                });
+              },
               .createHeaderAction = [storeContent, scale]() -> std::unique_ptr<Node> {
                 const auto pageUrl = storeContent->detailPageUrl();
                 const auto sourceUrl = storeContent->detailSourceUrl();


### PR DESCRIPTION
## Summary

This PR adds back button in plugin detail to go back to plugin store catalog. Reused `chevron-left` button from calendar.

## Motivation

Only ESC key was option to go back to plugin catalog and close plugin store. This is an extra feature, just adds back button to go back to catalog for easy navigation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

- Ran `just format`, `just build`, `just test` (all passed), `just lint` clean.
- Killed the running noctalia `pkill noctalia` then start the build debug `./build-debug/noctalia`
- Then Tested manually:-
  - Open Plugin store then one of the plugin detail
  - A back button appears on left top corner
  - Back button let us go back to plugin catalog

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/e8774466-108c-448a-a5f4-f047df5956e6


## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
