### PR TITLE
fix(theme): scale container saturation offset by headroom

### DIFF
--- a/src/theme/custom_schemes.cpp
+++ b/src/theme/custom_schemes.cpp
@@ -621,7 +621,10 @@ namespace noctalia::theme {
 
       auto makeContainerDark = [](const Color& base) {
         auto [h, s, l] = base.toHsl();
-        return fromHsl(h, std::min(s + 0.15, 1.0), std::max(l - 0.35, 0.15));
+        // Scale the saturation step by the remaining headroom instead of adding a
+        // constant: a flat +0.15 clamps at S = 1.0 for already-saturated accents,
+        // producing a maximally saturated "container" instead of a muted one.
+        return fromHsl(h, s + 0.15 * (1.0 - s), std::max(l - 0.35, 0.15));
       };
       const Color primary_container = makeContainerDark(primary_adjusted);
       const Color secondary_container = makeContainerDark(secondary_adjusted);

--- a/src/theme/fixed_palette.cpp
+++ b/src/theme/fixed_palette.cpp
@@ -231,7 +231,11 @@ namespace noctalia::theme {
 
     auto makeContainerDark = [](const Color& base) {
       auto [h, s, l] = base.toHsl();
-      return Color::fromHsl(h, std::min(s + 0.15, 1.0), std::max(l - 0.35, 0.15));
+      // Scale the saturation step by the remaining headroom instead of adding a
+      // constant: on already-saturated accents (e.g. pastel palettes with S near
+      // 1.0) a flat +0.15 clamps at the gamut wall while L still drops into the
+      // midtones, producing a neon "container" instead of a muted one.
+      return Color::fromHsl(h, s + 0.15 * (1.0 - s), std::max(l - 0.35, 0.15));
     };
     auto makeContainerLight = [](const Color& base) {
       auto [h, s, l] = base.toHsl();

--- a/tests/scheme_test.cpp
+++ b/tests/scheme_test.cpp
@@ -1,3 +1,4 @@
+#include "theme/builtin_palettes.h"
 #include "theme/color.h"
 #include "theme/contrast.h"
 #include "theme/palette_generator.h"
@@ -104,6 +105,30 @@ namespace {
     ok = expect(
              mutedSurface < softSurface && softSurface < faithfulSurface,
              "soft surface saturation sits between muted and faithful"
+         )
+        && ok;
+
+    return ok;
+  }
+
+  bool checkContainerSaturationHeadroom() {
+    bool ok = true;
+
+    const auto* catppuccin = noctalia::theme::findBuiltinPalette("Catppuccin");
+    if (!expect(catppuccin != nullptr, "finds Catppuccin builtin palette"))
+      return false;
+
+    const auto fixed = noctalia::theme::expandBuiltinPalette(*catppuccin);
+    const auto fixedContainer = noctalia::theme::Color::fromArgb(token(fixed, "primary_container"));
+    ok = expect(fixedContainer.toHex() == "#6d10da", "fixed palette container saturation scales by remaining headroom")
+        && ok;
+
+    const auto custom = noctalia::theme::generateCustom(makeColorfulBuffer(), noctalia::theme::Scheme::Faithful);
+    const double customPrimarySaturation = saturation(token(custom, "primary"));
+    const double customContainerSaturation = saturation(token(custom, "primary_container"));
+    ok = expect(
+             customContainerSaturation < customPrimarySaturation + 0.10,
+             "custom palette container saturation scales by remaining headroom"
          )
         && ok;
 
@@ -243,6 +268,7 @@ int main() {
   bool ok = true;
   ok = checkSchemeStrings() && ok;
   ok = checkSoftGeneration() && ok;
+  ok = checkContainerSaturationHeadroom() && ok;
   ok = checkPerceptualContrastAdjustment() && ok;
   ok = checkTerminalContrast() && ok;
   return ok ? 0 : 1;


### PR DESCRIPTION
## What

`makeContainerDark()` derives `*_container` colour roles from their base role with a fixed HSL offset of `S +0.15, L -0.35`, applied with no headroom check. On palettes whose accents already sit high on the saturation scale, the `+0.15` clamps at `S = 1.0` while `L` still drops into the midtones, turning a muted container tint into a fully saturated, near-neon colour on the sRGB gamut wall (e.g. built-in Catppuccin's `primary` `#cba6f7` becomes `primary_container` `#6b02e9`).

This fixes both places that use the pattern:
- `fixed_palette.cpp` (builtin + community palette derivation)
- `custom_schemes.cpp` (custom-scheme derivation)

## Fix

Scale the saturation step by the remaining headroom instead of adding a constant, as suggested in the issue:

```cpp
S' = S + 0.15 * (1 - S)
```

## Verification

I re-derived the issue's numbers from source to confirm both the bug and the fix, rather than taking the formula on faith:

- **Reproduced the bug**: recomputing `S +0.15 / L -0.35` from Catppuccin's actual HSL values lines up with the hex values reported in the issue (`primary` becomes `#6b02e9`, `secondary` clamps at `S=1.00`, etc.), confirming this is the right code path.
- **Confirmed the fix moves saturation the right way on the reported case**: Catppuccin's derived saturations drop meaningfully off the gamut wall. `primary` goes 0.99 to 0.86, `secondary` 1.00 to 0.93, `tertiary` 0.72 to 0.64, instead of pinning at 1.0.
- **Checked the low-saturation control isn't broken**: on Nord (S 0.25 to 0.43, the case the issue says is "fine" today), the new formula shifts saturation by only about 0.04 to 0.065. That's a small, real change, not a no-op, but nowhere near enough to be visually significant. Flagging this precisely rather than claiming byte-identical output.

`source = "wallpaper"` is unaffected either way; it goes through Material Color Utilities / HCT gamut mapping rather than this HSL offset.

Compiles clean in isolation; couldn't do a full `meson` build (missing `wayland-protocols` on my machine). Formatted with `clang-format` per `just format`.

Fixes #3924