### PR TITLE
fix(tray): detect an existing StatusNotifierWatcher instead of assuming none

### DIFF
--- a/src/dbus/tray/tray_service.cpp
+++ b/src/dbus/tray/tray_service.cpp
@@ -1,6 +1,5 @@
 #include "dbus/tray/tray_service.h"
 
-#include "compositors/compositor_detect.h"
 #include "core/deferred_call.h"
 #include "core/log.h"
 #include "core/timer_manager.h"
@@ -563,82 +562,14 @@ void TrayService::start() {
     return;
   }
 
-  if (compositors::isKde()) {
-    startKde();
-  } else {
-    startLegacyOwner();
-  }
+  // Another watcher may already own the name on any desktop, not just KDE: kded6 is
+  // commonly run outside a Plasma session. Become its client if so, own it otherwise.
+  startWithWatcherDetection();
 
   m_started = true;
 }
 
-void TrayService::startLegacyOwner() {
-  m_watcherRole = WatcherRole::Owner;
-
-  m_watcherObject = sdbus::createObject(m_bus.connection(), kWatcherObjectPath);
-
-  auto regItem = sdbus::registerMethod("RegisterStatusNotifierItem").withInputParamNames("service");
-  regItem.inputSignature = "s";
-  regItem.callbackHandler = [this](sdbus::MethodCall msg) {
-    std::string serviceOrPath;
-    msg >> serviceOrPath;
-    const char* sender = msg.getSender();
-    msg.createReply().send();
-    DeferredCall::callLater([this, serviceOrPath = std::move(serviceOrPath),
-                             senderBusName = std::string(sender != nullptr ? sender : "")]() {
-      onRegisterStatusNotifierItem(serviceOrPath, senderBusName);
-    });
-  };
-
-  m_watcherObject
-      ->addVTable(
-          std::move(regItem),
-
-          sdbus::registerMethod("RegisterStatusNotifierHost")
-              .withInputParamNames("service")
-              .implementedAs([this](const std::string& host) { onRegisterStatusNotifierHost(host); }),
-
-          sdbus::registerMethod("GetRegisteredItems").withOutputParamNames("items").implementedAs([this]() {
-            return registeredItems();
-          }),
-
-          sdbus::registerProperty("RegisteredStatusNotifierItems").withGetter([this]() { return registeredItems(); }),
-          sdbus::registerProperty("IsStatusNotifierHostRegistered").withGetter([this]() { return m_hostRegistered; }),
-          sdbus::registerProperty("ProtocolVersion").withGetter([]() { return static_cast<std::int32_t>(0); }),
-
-          sdbus::registerSignal("StatusNotifierItemRegistered").withParameters<std::string>("service"),
-          sdbus::registerSignal("StatusNotifierItemUnregistered").withParameters<std::string>("service"),
-          sdbus::registerSignal("StatusNotifierHostRegistered").withParameters<>()
-      )
-      .forInterface(kWatcherInterface);
-
-  try {
-    m_bus.connection().requestName(kWatcherBusName);
-  } catch (const sdbus::Error& e) {
-    kLog.warn("tray failed to claim {}: {}", std::string{kWatcherBusName}, e.what());
-    throw;
-  }
-
-  m_dbusProxy = sdbus::createProxy(m_bus.connection(), kDbusName, kDbusPath);
-  m_dbusProxy->uponSignal("NameOwnerChanged")
-      .onInterface(kDbusInterface)
-      .call([this](const std::string& name, const std::string& old_owner, const std::string& new_owner) {
-        if (old_owner.empty() && !new_owner.empty() && isStatusNotifierItemBusName(name)) {
-          DeferredCall::callLater([this, name]() { tryRegisterItemForBusName(name); });
-        }
-        if (!old_owner.empty() && new_owner.empty()) {
-          removeItemsForBusName(name);
-        }
-      });
-
-  kLog.debug("tray watcher active on {}", std::string{kWatcherBusName});
-
-  m_watcherObject->emitSignal("StatusNotifierHostRegistered").onInterface(kWatcherInterface);
-  DeferredCall::callLater([this]() { discoverExistingItems(); });
-  DeferredCall::callLater([this]() { discoverExistingItems(); });
-}
-
-void TrayService::startKde() {
+void TrayService::startWithWatcherDetection() {
   m_dbusProxy = sdbus::createProxy(m_bus.connection(), kDbusName, kDbusPath);
   m_dbusProxy->uponSignal("NameOwnerChanged")
       .onInterface(kDbusInterface)

--- a/src/dbus/tray/tray_service.h
+++ b/src/dbus/tray/tray_service.h
@@ -108,8 +108,7 @@ private:
 
   void onRegisterStatusNotifierItem(const std::string& serviceOrPath, const std::string& senderBusName);
   void onRegisterStatusNotifierHost(const std::string& host);
-  void startLegacyOwner();
-  void startKde();
+  void startWithWatcherDetection();
   void startAsWatcherOwner();
   void startAsWatcherClient();
   void connectToExternalWatcher();


### PR DESCRIPTION
## Summary

`TrayService::start()` branched on `compositors::isKde()`. Only under Plasma did it check whether `org.kde.StatusNotifierWatcher` already had an owner and become a client of it. Every other session took `startLegacyOwner()`, which claims the name unconditionally and rethrows when the claim fails, leaving the tray with no watcher and no items at all.

Whether another watcher already exists is a runtime fact, not a property of the desktop. This always runs the detecting path (renamed from `startKde()`, since it no longer describes a desktop) and removes `startLegacyOwner()`, which duplicated `startAsWatcherOwner()` apart from creating the bus proxy, and differed only in skipping the detection and in not watching `NameOwnerChanged` for the watcher name, so a client could never recover if the external watcher restarted.

## Motivation

`kded6` from plasma-workspace provides a StatusNotifierWatcher and is commonly run outside a Plasma session, because `plasma-nm`, `plasma-pa` and `powerdevil` are useful on their own. On such a session Noctalia logs:

```
[WRN] [tray] tray failed to claim org.kde.StatusNotifierWatcher: [org.freedesktop.DBus.Error.FileExists] Failed to request bus name
[WRN] [app] tray watcher disabled: [org.freedesktop.DBus.Error.FileExists] Failed to request bus name
```

and the tray stays empty. It is not specific to kded6 either, any other owner of the name produces it.

The documented workaround is `pkill kded6` (FAQ: "Why are my tray icons missing after (re)starting Noctalia?"). That is not always available: kded6 also provides plasma-nm's NetworkManager secret agent, so killing it costs Wi-Fi credentials at login on systems that rely on it.

Worth noting this is not new behaviour being requested. The same binary already does exactly this under KDE via `startKde()`; the change only stops making it conditional on the desktop.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

Related: #3856

## Testing

`meson compile` clean, `clang-format` v22 reports no replacements.

Before, on Niri with kded6 running:

```
[WRN] [tray] tray failed to claim org.kde.StatusNotifierWatcher: FileExists
```

with an empty tray. After:

```
[DBG] [tray] tray using external StatusNotifierWatcher
[DBG] [tray] tray item registered id=:1.51/StatusNotifierItem bus=':1.51' path='/StatusNotifierItem'
[DBG] [tray] tray connected to external watcher (4 items)
```

All items present, including ones registered under unique bus names rather than well-known `org.kde.StatusNotifierItem-*` names.

## Manual Coverage

- [x] Tested on Niri
- [x] Tested on Hyprland
- [x] Tested on Sway
- [x] Tested on another compositor: KDE Plasma, to confirm no regression on the path that already worked
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

Not applicable, no visual change beyond tray items appearing.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The FAQ entry could be dropped if this lands, since the workaround it describes would no longer be needed.
