### PR TITLE
fix(fingerprint): leave the device alone while suspending

### DIFF
--- a/src/auth/fingerprint_authenticator.cpp
+++ b/src/auth/fingerprint_authenticator.cpp
@@ -67,11 +67,17 @@ namespace {
 FingerprintAuthenticator::FingerprintAuthenticator(SystemBus& bus) : m_bus(bus) {
   try {
     m_loginManager = sdbus::createProxy(m_bus.connection(), kLoginBusName, kLoginPath);
-    // on sleep, stop verification; on resume, restart if active and not aborted
+    // on sleep, leave the device to fprintd; on resume, re-arm if still active
     m_loginManager->uponSignal("PrepareForSleep").onInterface(kLoginManagerInterface).call([this](bool sleeping) {
       m_sleeping = sleeping;
       if (sleeping) {
-        stopVerify();
+        // Do not call into fprintd here. It handles PrepareForSleep itself and has
+        // already powered the sensor down; a call arriving after that never gets a
+        // reply and blocks until logind freezes the session mid-transfer, leaving
+        // the sensor with a stalled endpoint on resume. startVerify() already
+        // refuses to run while m_sleeping, so only the re-arm state needs clearing.
+        m_retryTimer.stop();
+        m_verifying = false;
       } else if (m_active && !m_abort) {
         startVerify(false);
       }


### PR DESCRIPTION
## Summary

`FingerprintAuthenticator`'s `PrepareForSleep` handler called `stopVerify()`. fprintd already handles suspend itself: it holds a logind delay inhibitor, cancels the in-flight transfer, powers the sensor down and releases the inhibitor, all in well under a millisecond. Noctalia's call lands inside that window and is executed against a sensor that has just been powered down. fprintd accepts it, submits a USB transfer that can never complete, and never replies.

The synchronous D-Bus call then blocks until logind stops waiting for the delay inhibitor (`InhibitDelayMaxSec`, 5s by default) and freezes the session, so the machine suspends with a transfer still in flight. The sensor resumes with a stalled endpoint, and fprintd answers every `VerifyStart` with

```
Device reported an error during verify: endpoint stalled or request not supported
```

in under 3ms. Because `verify-unknown-error` is treated as a spent attempt and the re-arm delay is 250ms, the entire retry budget is consumed about a second after resume and the user is dropped to the password field without the sensor ever having read a finger. Only a USB port reset, or restarting fprintd, clears it.

Measured with `G_MESSAGES_DEBUG=all` and `FP_DEBUG_TRANSFER=1` on Synaptics 06cb:00f9:

```
T+0.000ms  fprintd: got suspend request
T+0.174ms  fprintd: Device reported suspend completion (error: none)
T+0.612ms  fprintd: Released delay inhibitor for sleep.
T+1.139ms  fprintd: Release accepted from Noctalia
T+1.594ms  fprintd: Transfer submitted, endpoint 0x1
           ... 39s of silence ...
T+5.14s    logind: Delay lock is active but inhibitor timeout is reached
           user.slice frozen, machine suspends mid-transfer
```

The same applies to any device call made from this handler. `VerifyStop` and `Release` are equally affected, since the problem is the timing rather than the method. The fix is to make no call at all and let fprintd do its job: keep the bookkeeping that prevents re-arming, drop the D-Bus traffic. `startVerify()` already refuses to run while `m_sleeping` is set, and the resume branch re-acquires as before.

## Motivation

Fingerprint unlock is unusable after the first suspend taken with the lock screen armed, which is the common case: lock, close the lid, reopen. The sensor stays broken until fprintd is restarted, so it does not recover on its own for the rest of the session.

**Side benefit: suspend is no longer delayed.** Because the handler blocks, Noctalia holds its delay inhibitor until logind gives up on it and force-freezes the session:

```
logind: Delay lock is active (UID 1000, PID .../noctalia) but inhibitor timeout is reached.
```

Every suspend taken with the lock screen armed pays that full delay. With no call to block on, the inhibitor is released immediately and the suspend proceeds. That warning no longer appears.

The blocked call itself outlives the suspend: it ends either when fprintd finally replies after resume, having failed the transfer against the now-stalled endpoint, or at sd-bus's default 25s method timeout. Both were observed. That determines which error surfaces, not how long the suspend waits.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

None filed.

## Testing

`meson compile` clean, `clang-format` v22 reports no replacements.

Two lock -> suspend -> resume cycles, including one with the device claimed and armed for 53 minutes across the suspend. In both, the sensor read normally on resume (`verify-match` after a ~1.6s scan) and released cleanly. No stalled endpoint, no `verify-unknown-error`, no exhausted retry budget, and no `single event dispatch took ...ms` warnings. The same reproducer failed every time before the change.

## Manual Coverage

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

This is lock screen and fprintd interaction and is independent of the compositor, so the compositor boxes are left unticked rather than implying coverage that was not exercised. Developed and tested on Niri.

## Screenshots / Videos

Not applicable, no visual change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Reported for Synaptics 06cb:00f9, but nothing here is vendor specific: it is a race against fprintd's own suspend handling, and several readers are documented as not resuming when left active over a suspend.

Separately, `verify-unknown-error` being counted as a spent attempt is what turns the stall into an immediate fallback to the password field. `MatchResult::Disconnected` is already handled differently (`m_abort = true`), and a device error arguably belongs in that category rather than costing the user an attempt. Not addressed here, since with this fix the stall no longer occurs.
