### PR TITLE
fix(render): recover lock surface after resume

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -1056,6 +1056,14 @@ void Application::initSystemBusServices() {
           // Drivers may discard glyph textures while suspended without reporting a
           // full graphics reset. Re-rasterize them before the resumed surfaces paint.
           m_renderContext.invalidateGlyphTexturesNextFrame();
+          // The lock surface's Wayland frame callback can go stale across suspend
+          // (the compositor stops presenting the locked surface, so the callback
+          // registered before the stall never fires). That leaves kickFrameLoop()
+          // blocked forever and the password field never repaints. Drop the stale
+          // callback and force an immediate repaint of the lock surfaces.
+          if (m_lockScreen.isActive()) {
+            m_lockScreen.forceRepaintAfterResume();
+          }
           m_weatherService.requestRefresh();
           m_gammaService.reevaluateSchedule();
           // Auto theme mode schedules with steady_clock timers, which do not advance while

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -232,6 +232,15 @@ void LockScreen::requestUpdate() {
   }
 }
 
+void LockScreen::forceRepaintAfterResume() {
+  for (auto& inst : m_instances) {
+    if (inst.surface != nullptr) {
+      inst.surface->discardPendingFrameCallback();
+      inst.surface->requestRedraw();
+    }
+  }
+}
+
 void LockScreen::onOutputChange() {
   if (m_lockDeferred) {
     if (m_wayland != nullptr && !m_wayland->outputs().empty()) {

--- a/src/shell/lockscreen/lock_screen.h
+++ b/src/shell/lockscreen/lock_screen.h
@@ -64,6 +64,9 @@ public:
   void onKeyboardLayoutChanged();
   void requestLayout();
   void requestUpdate();
+  /// After suspend/resume, discard pending callbacks on active lock surfaces
+  /// while preserving queued work, then request an immediate redraw.
+  void forceRepaintAfterResume();
   void onPointerEvent(const PointerEvent& event);
   void onKeyboardEvent(const KeyboardEvent& event);
   [[nodiscard]] bool isActive() const noexcept;

--- a/src/wayland/surface.cpp
+++ b/src/wayland/surface.cpp
@@ -1122,6 +1122,19 @@ void Surface::requestUpdate() {
   kickFrameLoop();
 }
 
+void Surface::discardPendingFrameCallback() {
+  if (m_frameCallback == nullptr) {
+    return;
+  }
+
+  // Carry the in-flight callback's tick intent to the replacement callback.
+  // Queued frame work and pending update/layout/redraw state remain untouched.
+  m_nextFrameCallbackShouldTick = m_nextFrameCallbackShouldTick || m_frameCallbackShouldTick;
+  m_frameCallbackShouldTick = false;
+  wl_callback_destroy(m_frameCallback);
+  m_frameCallback = nullptr;
+}
+
 void Surface::requestUpdateOnly() {
   recordSurfaceProfileEvent(*this, SurfaceProfileEvent::RequestUpdateOnly);
   m_updateRequested = true;

--- a/src/wayland/surface.h
+++ b/src/wayland/surface.h
@@ -117,6 +117,9 @@ public:
   void requestRedraw();
   void requestFrameTick();
   void renderNow();
+  /// Discards an in-flight Wayland frame callback without losing queued work
+  /// or the tick intent attached to that callback.
+  void discardPendingFrameCallback();
   void setAnimationManager(AnimationManager* manager) noexcept { m_animationManager = manager; }
   void setSceneRoot(Node* root);
   void setRenderContext(RenderContext* ctx);


### PR DESCRIPTION
<!-- This PR is ready for review. -->

## Summary

After suspend/resume, the compositor can stop presenting the lock surface: the `wl_surface.frame` callback registered before the stall never fires, and `Surface::kickFrameLoop()` keeps waiting for it. The lock screen then stops repainting, so password mask glyphs remain invisible even though input and authentication continue to work.

This PR keeps recovery scoped to the reproduced path:

- `Surface::discardPendingFrameCallback()` destroys only the in-flight callback and transfers its tick intent to the replacement callback, without clearing queued frame work or update/layout/redraw state.
- After resume, active lock surfaces discard their pending callback and request an immediate redraw.
- The normal frame loop is unchanged: there is no timestamp or generic timeout policy.

## Motivation

Closes #3916. On the affected host (RTX 5070 Ti / CachyOS / Hyprland), the previous fix `4dd6f29d` re-rasterized glyph textures but remained blocked because no frame was rendered after resume.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3916

## Testing

Targeted instrumented build on the affected host, with the generic timeout removed:

| cycle | replacement callback completed | prompt updates after resume | result |
|---|---:|---:|---|
| 1 | 582 ms | 16 | mask visible, unlock OK |
| 2 | 616 ms | 16 | mask visible, unlock OK |
| 3 | 574 ms | 17 | mask visible, unlock OK |

Each cycle recorded exactly one callback discard, followed by a replacement callback and continued prompt updates. There were zero errors and zero global stale-callback resets.

Clean candidate rebased onto `d911d37e` (`main` at test time):

- structural recovery check: PASS;
- release build: PASS;
- Meson suite with `-Dtests=enabled`: **85/85 PASS**;
- `just format` with clang-format 22.1.8: no changes;
- clean binary contains neither diagnostic logging nor the removed timeout policy;
- clean build physical verification: **1/1 suspend/resume cycle passed** (mask visible and updating, unlock normal, zero errors).

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A (fix restores expected rendering; no UI change).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

- Updated following Ly-sec's review: recovery is limited to active lock surfaces after resume, preserves queued work and tick intent, and does not impose a global callback deadline.
- No diagnostic instrumentation is included in the PR.
- Final diff: 5 files, 36 insertions.
