### PR TITLE
widget: fix effects profile glyphs

### DIFF
--- a/src/shell/bar/widget_definition.h
+++ b/src/shell/bar/widget_definition.h
@@ -387,6 +387,20 @@ namespace noctalia::bar {
       }
     }
 
+    template <typename T>
+    std::optional<T> configuredValueAs(
+        const WidgetConfig& config, const std::string& key, const std::vector<WidgetSettingChoice<T>>& choices,
+        const EffectiveNumericRange<T>& range, std::string_view context
+    ) {
+      if constexpr (std::is_same_v<T, WidgetSettingStringMap>) {
+        if (const auto configured = config.tables.find(key); configured != config.tables.end()) {
+          return configured->second;
+        }
+      }
+      const auto* configured = config.findSetting(key);
+      return configured != nullptr ? settingValueAs<T>(*configured, choices, range, context) : std::nullopt;
+    }
+
     inline std::string settingTranslationSegment(std::string_view key) {
       std::string segment(key);
       std::ranges::replace(segment, '_', '-');
@@ -463,11 +477,9 @@ namespace noctalia::bar {
                     effectiveRange](Options& options, const WidgetConfig* config, std::string_view context) {
           T value = defaultValue;
           if (config != nullptr) {
-            if (const auto* configured = config->findSetting(key)) {
-              const std::string fieldContext = context.empty() ? key : std::format("{}.{}", context, key);
-              if (auto decoded = detail::settingValueAs<T>(*configured, choices, effectiveRange, fieldContext)) {
-                value = std::move(*decoded);
-              }
+            const std::string fieldContext = context.empty() ? key : std::format("{}.{}", context, key);
+            if (auto configured = detail::configuredValueAs<T>(*config, key, choices, effectiveRange, fieldContext)) {
+              value = std::move(*configured);
             }
           }
           options.*Member = std::move(value);

--- a/src/shell/bar/widget_definition.h
+++ b/src/shell/bar/widget_definition.h
@@ -387,20 +387,6 @@ namespace noctalia::bar {
       }
     }
 
-    template <typename T>
-    std::optional<T> configuredValueAs(
-        const WidgetConfig& config, const std::string& key, const std::vector<WidgetSettingChoice<T>>& choices,
-        const EffectiveNumericRange<T>& range, std::string_view context
-    ) {
-      if constexpr (std::is_same_v<T, WidgetSettingStringMap>) {
-        if (const auto configured = config.tables.find(key); configured != config.tables.end()) {
-          return configured->second;
-        }
-      }
-      const auto* configured = config.findSetting(key);
-      return configured != nullptr ? settingValueAs<T>(*configured, choices, range, context) : std::nullopt;
-    }
-
     inline std::string settingTranslationSegment(std::string_view key) {
       std::string segment(key);
       std::ranges::replace(segment, '_', '-');
@@ -477,9 +463,15 @@ namespace noctalia::bar {
                     effectiveRange](Options& options, const WidgetConfig* config, std::string_view context) {
           T value = defaultValue;
           if (config != nullptr) {
-            const std::string fieldContext = context.empty() ? key : std::format("{}.{}", context, key);
-            if (auto configured = detail::configuredValueAs<T>(*config, key, choices, effectiveRange, fieldContext)) {
-              value = std::move(*configured);
+            if constexpr (std::is_same_v<T, WidgetSettingStringMap>) {
+              if (const auto configured = config->tables.find(key); configured != config->tables.end()) {
+                value = configured->second;
+              }
+            } else if (const auto* configured = config->findSetting(key)) {
+              const std::string fieldContext = context.empty() ? key : std::format("{}.{}", context, key);
+              if (auto decoded = detail::settingValueAs<T>(*configured, choices, effectiveRange, fieldContext)) {
+                value = std::move(*decoded);
+              }
             }
           }
           options.*Member = std::move(value);

--- a/tests/widget_definition_test.cpp
+++ b/tests/widget_definition_test.cpp
@@ -101,7 +101,11 @@ namespace {
       WidgetConfig config;
       config.type = std::string(type);
       for (const auto& field : schema) {
-        config.settings[field.key] = field.defaultValue;
+        if (const auto* stringMap = std::get_if<WidgetSettingStringMap>(&field.defaultValue)) {
+          config.tables[field.key] = *stringMap;
+        } else {
+          config.settings[field.key] = field.defaultValue;
+        }
       }
       if (!definition.fieldValuesEqual(
               definition.resolve(&config, type, context...), definition.resolve(nullptr, type, context...)
@@ -224,7 +228,7 @@ int main() {
   WidgetConfig inputVolume;
   inputVolume.type = "volume";
   inputVolume.settings["device"] = std::string("input");
-  inputVolume.settings["effects_profile_glyphs"] = WidgetSettingStringMap{{"Noise Canceling", "microphone"}};
+  inputVolume.tables["effects_profile_glyphs"] = WidgetSettingStringMap{{"Noise Canceling", "microphone"}};
   const auto inputOptions = volumeWidgetDefinition().resolve(&inputVolume, "volume");
   if (inputOptions.device != VolumeWidgetTarget::Input
       || inputOptions.effectsProfileGlyphs


### PR DESCRIPTION
The audio widget effect profile glyphs setting didn't do anything before this fix. The regression was introduced in commit 03071fce9.

The declarative widget resolver only looked for values in WidgetConfig::settings, while nested TOML string maps such as effects_profile_glyphs are stored in WidgetConfig::tables. Resolve string maps from tables while retaining the settings fallback for programmatic callers.