### PR TITLE
feat(input): add readline-style shorcuts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1154,6 +1154,7 @@ if build_tests
     'image_source_log',
     'input_area',
     'input_dispatcher',
+    'input_readline_shortcuts',
     'input_password_mode',
     'inotify',
     'ipc_service',

--- a/src/shell/launcher/launcher_panel.cpp
+++ b/src/shell/launcher/launcher_panel.cpp
@@ -1070,6 +1070,7 @@ void LauncherPanel::create() {
           .controlHeight = Style::controlHeight * scale,
           .horizontalPadding = Style::spaceMd * scale,
           .clearButtonEnabled = true,
+          .lineEditing = true,
           .surfaceOpacity = panelCardOpacity(),
           .onChange =
               [this](const std::string& text) {

--- a/src/ui/builders.cpp
+++ b/src/ui/builders.cpp
@@ -243,6 +243,9 @@ namespace ui {
     if (props.passwordMode.has_value()) {
       control->setPasswordMode(*props.passwordMode);
     }
+    if (props.lineEditing.has_value()) {
+      control->setLineEditingEnabled(*props.lineEditing);
+    }
     if (props.invalid.has_value()) {
       control->setInvalid(*props.invalid);
     }

--- a/src/ui/builders.h
+++ b/src/ui/builders.h
@@ -146,6 +146,7 @@ namespace ui {
     std::optional<float> horizontalPadding = std::nullopt;
     std::optional<bool> clearButtonEnabled = std::nullopt;
     std::optional<bool> passwordMode = std::nullopt;
+    std::optional<bool> lineEditing = std::nullopt;
     std::optional<bool> invalid = std::nullopt;
     std::optional<bool> frameVisible = std::nullopt;
     std::optional<bool> embeddedOnSolidPrimary = std::nullopt;

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -1185,12 +1185,22 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
   }
   if (clearShortcut) {
     resetUndoCoalescing();
-    if (!m_value.empty() || hasSelection()) {
-      pushUndoSnapshot(EditCoalesceKind::Discrete);
-      m_value.clear();
-      m_cursorPos = 0;
-      m_selectionAnchor = 0;
-      changed = true;
+    if (m_lineEditing) {
+      if (m_cursorPos > 0) {
+        pushUndoSnapshot(EditCoalesceKind::Discrete);
+        m_value.erase(0, m_cursorPos);
+        m_cursorPos = 0;
+        m_selectionAnchor = 0;
+        changed = true;
+      }
+    } else {
+      if (!m_value.empty() || hasSelection()) {
+        pushUndoSnapshot(EditCoalesceKind::Discrete);
+        m_value.clear();
+        m_cursorPos = 0;
+        m_selectionAnchor = 0;
+        changed = true;
+      }
     }
   } else if (ctrl && (sym == 'a' || sym == 'A')) {
     resetUndoCoalescing();
@@ -1227,7 +1237,7 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
     m_selectionAnchor = m_cursorPos;
   } else if (lineEditWordForward) {
     resetUndoCoalescing();
-    m_cursorPos = nextWordStartForByteOffset(m_cursorPos);
+    m_cursorPos = nextWordEndForByteOffset(m_cursorPos);
     m_selectionAnchor = m_cursorPos;
   } else if (lineEditDeleteWordBack) {
     if (hasSelection()) {

--- a/src/ui/controls/input.cpp
+++ b/src/ui/controls/input.cpp
@@ -649,6 +649,8 @@ void Input::moveCaretRight(bool shift) {
   notifyTextInputStateChanged(TextInputChangeCause::Other);
 }
 
+void Input::setLineEditingEnabled(bool enabled) { m_lineEditing = enabled; }
+
 void Input::clearSelection() {
   resetUndoCoalescing();
   m_selectionAnchor = m_cursorPos;
@@ -1095,8 +1097,28 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
   const bool undoShortcut = ctrl && !shift && (sym == 'z' || sym == 'Z');
   const bool redoShortcut = (ctrl && (sym == 'y' || sym == 'Y')) || (ctrl && shift && (sym == 'z' || sym == 'Z'));
   const bool clearShortcut = ctrl && !shift && (sym == 'u' || sym == 'U');
+
+  const bool alt = (modifiers & KeyMod::Alt) != 0;
+  const bool lineEditCaretToEnd = m_lineEditing && ctrl && !shift && (sym == 'e' || sym == 'E');
+  const bool lineEditCaretBack = m_lineEditing && ctrl && !shift && (sym == 'b' || sym == 'B');
+  const bool lineEditCaretForward = m_lineEditing && ctrl && !shift && (sym == 'f' || sym == 'F');
+  const bool lineEditWordBack = m_lineEditing && alt && (sym == 'b' || sym == 'B');
+  const bool lineEditWordForward = m_lineEditing && alt && (sym == 'f' || sym == 'F');
+  const bool lineEditDeleteWordBack = m_lineEditing && ctrl && (sym == 'w' || sym == 'W');
+  const bool lineEditDeleteToEnd = m_lineEditing && ctrl && !shift && (sym == 'k' || sym == 'K');
+  const bool lineEditDeleteWordForward = m_lineEditing && alt && (sym == 'd' || sym == 'D');
+  const bool lineEditShortcut = lineEditCaretToEnd
+      || lineEditCaretBack
+      || lineEditCaretForward
+      || lineEditWordBack
+      || lineEditWordForward
+      || lineEditDeleteWordBack
+      || lineEditDeleteToEnd
+      || lineEditDeleteWordForward;
+
   const bool verticalNav = m_multiline
       && (KeySymbol::isUp(sym) || KeySymbol::isDown(sym) || KeySymbol::isPageUp(sym) || KeySymbol::isPageDown(sym));
+
   // Any non-vertical key breaks an Up/Down run's sticky column.
   if (!verticalNav) {
     m_goalCaretX = -1.0F;
@@ -1114,7 +1136,8 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
         || verticalNav
         || undoShortcut
         || redoShortcut
-        || clearShortcut;
+        || clearShortcut
+        || lineEditShortcut;
     if (!navigationOrEdit && !validateMatch) {
       return;
     }
@@ -1170,10 +1193,72 @@ void Input::handleKey(std::uint32_t sym, std::uint32_t utf32, std::uint32_t modi
       changed = true;
     }
   } else if (ctrl && (sym == 'a' || sym == 'A')) {
-    // Select all
     resetUndoCoalescing();
-    m_selectionAnchor = 0;
+    if (m_lineEditing) {
+      m_cursorPos = 0;
+      m_selectionAnchor = 0;
+    } else {
+      m_selectionAnchor = 0;
+      m_cursorPos = m_value.size();
+    }
+  } else if (lineEditCaretToEnd) {
+    resetUndoCoalescing();
     m_cursorPos = m_value.size();
+    m_selectionAnchor = m_cursorPos;
+  } else if (lineEditCaretBack) {
+    resetUndoCoalescing();
+    if (hasSelection()) {
+      m_cursorPos = selectionStart();
+    } else {
+      m_cursorPos = prevCharPos(m_value, m_cursorPos);
+    }
+    m_selectionAnchor = m_cursorPos;
+  } else if (lineEditCaretForward) {
+    resetUndoCoalescing();
+    if (hasSelection()) {
+      m_cursorPos = selectionEnd();
+    } else {
+      m_cursorPos = nextCharPos(m_value, m_cursorPos);
+    }
+    m_selectionAnchor = m_cursorPos;
+  } else if (lineEditWordBack) {
+    resetUndoCoalescing();
+    m_cursorPos = previousWordStartForByteOffset(m_cursorPos);
+    m_selectionAnchor = m_cursorPos;
+  } else if (lineEditWordForward) {
+    resetUndoCoalescing();
+    m_cursorPos = nextWordStartForByteOffset(m_cursorPos);
+    m_selectionAnchor = m_cursorPos;
+  } else if (lineEditDeleteWordBack) {
+    if (hasSelection()) {
+      pushUndoSnapshot(EditCoalesceKind::Discrete);
+      deleteSelection();
+      changed = true;
+    } else {
+      const std::size_t prev = previousWordStartForByteOffset(m_cursorPos);
+      if (prev != m_cursorPos) {
+        pushUndoSnapshot(EditCoalesceKind::Discrete);
+        m_value.erase(prev, m_cursorPos - prev);
+        m_cursorPos = prev;
+        m_selectionAnchor = prev;
+        changed = true;
+      }
+    }
+  } else if (lineEditDeleteToEnd) {
+    if (m_cursorPos < m_value.size()) {
+      pushUndoSnapshot(EditCoalesceKind::Discrete);
+      m_value.erase(m_cursorPos);
+      m_selectionAnchor = m_cursorPos;
+      changed = true;
+    }
+  } else if (lineEditDeleteWordForward) {
+    const std::size_t end = nextWordEndForByteOffset(m_cursorPos);
+    if (end != m_cursorPos) {
+      pushUndoSnapshot(EditCoalesceKind::Discrete);
+      m_value.erase(m_cursorPos, end - m_cursorPos);
+      m_selectionAnchor = m_cursorPos;
+      changed = true;
+    }
   } else if (copyShortcut) {
     if (g_clipboard != nullptr && hasSelection() && !m_passwordMode) {
       g_clipboard->setClipboardText(m_value.substr(selectionStart(), selectionEnd() - selectionStart()));

--- a/src/ui/controls/input.h
+++ b/src/ui/controls/input.h
@@ -39,6 +39,8 @@ public:
   void setHorizontalPadding(float padding);
   void setClearButtonEnabled(bool enabled);
   void setPasswordMode(bool enabled);
+  /// Apply readline-style line editing shortcuts.
+  void setLineEditingEnabled(bool enabled);
   /// Multi-line editing: Enter inserts '\n' (Ctrl+Enter submits), the text wraps
   /// at the viewport width and scrolls vertically. The control keeps whatever
   /// height layout assigns (explicit height or flex-grown) instead of forcing
@@ -230,6 +232,7 @@ private:
   bool m_clearButtonEnabled = false;
   bool m_passwordMode = false;
   bool m_multiline = false;
+  bool m_lineEditing = false;
   bool m_invalid = false;
   bool m_frameVisible = true;
   bool m_embeddedOnSolidPrimary = false;

--- a/tests/input_readline_shortcuts_test.cpp
+++ b/tests/input_readline_shortcuts_test.cpp
@@ -94,7 +94,7 @@ int main() {
     ctrlA(input);
     altF(input);
     type(input, 'x');
-    ok = expect(input.value() == "foo xbar", "Alt+F moves the caret forward one word") && ok;
+    ok = expect(input.value() == "foox bar", "Alt+F moves the caret forward one word") && ok;
   }
 
   // Ctrl+W: delete the word before the caret.
@@ -111,6 +111,16 @@ int main() {
     setup(input, "foo bar", true);
     ctrlU(input);
     ok = expect(input.value().empty(), "Ctrl+U clears the whole field") && ok;
+  }
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlA(input);
+    ctrlF(input);
+    ctrlF(input);
+    ctrlF(input);
+    ctrlU(input);
+    ok = expect(input.value() == " bar", "Ctrl+U in the middle kills backward to start") && ok;
   }
 
   // Ctrl+K: delete from the caret to the end of the field.

--- a/tests/input_readline_shortcuts_test.cpp
+++ b/tests/input_readline_shortcuts_test.cpp
@@ -1,0 +1,153 @@
+#include "core/input/key_modifiers.h"
+#include "render/scene/input_area.h"
+#include "ui/controls/input.h"
+
+#include <print>
+#include <string>
+#include <string_view>
+
+namespace {
+  bool expect(bool condition, const char* message) {
+    if (!condition) {
+      std::println(stderr, "input_edit_shortcuts_test: {}", message);
+    }
+    return condition;
+  }
+
+  void sendKey(Input& input, std::uint32_t sym, std::uint32_t utf32, std::uint32_t modifiers) {
+    input.inputArea()->dispatchKey(sym, utf32, modifiers, true);
+  }
+
+  void ctrlA(Input& input) { sendKey(input, 'a', 0, KeyMod::Ctrl); }
+  void ctrlE(Input& input) { sendKey(input, 'e', 0, KeyMod::Ctrl); }
+  void ctrlB(Input& input) { sendKey(input, 'b', 0, KeyMod::Ctrl); }
+  void ctrlF(Input& input) { sendKey(input, 'f', 0, KeyMod::Ctrl); }
+  void ctrlW(Input& input) { sendKey(input, 'w', 0, KeyMod::Ctrl); }
+  void ctrlU(Input& input) { sendKey(input, 'u', 0, KeyMod::Ctrl); }
+  void ctrlK(Input& input) { sendKey(input, 'k', 0, KeyMod::Ctrl); }
+  void altB(Input& input) { sendKey(input, 'b', 0, KeyMod::Alt); }
+  void altF(Input& input) { sendKey(input, 'f', 0, KeyMod::Alt); }
+  void altD(Input& input) { sendKey(input, 'd', 0, KeyMod::Alt); }
+  void type(Input& input, char c) { sendKey(input, c, c, 0); }
+
+  void setup(Input& input, std::string_view value, bool lineEditing) {
+    if (lineEditing) {
+      input.setLineEditingEnabled(true);
+    }
+    input.setValue(value);
+  }
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  // Ctrl+A: move the caret to the start of the field.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlA(input);
+    type(input, 'x');
+    ok = expect(input.value() == "xfoo bar", "Ctrl+A puts the caret at the start") && ok;
+  }
+
+  // Ctrl+E: move the caret to the end of the field.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlE(input);
+    type(input, 'x');
+    ok = expect(input.value() == "foo barx", "Ctrl+E puts the caret at the end") && ok;
+  }
+
+  // Ctrl+B: move the caret back one character.
+  {
+    Input input;
+    setup(input, "abc", true);
+    ctrlB(input);
+    type(input, 'x');
+    ok = expect(input.value() == "abxc", "Ctrl+B moves the caret back one character") && ok;
+  }
+
+  // Ctrl+F: move the caret forward one character.
+  {
+    Input input;
+    setup(input, "abc", true);
+    ctrlA(input);
+    ctrlF(input);
+    type(input, 'x');
+    ok = expect(input.value() == "axbc", "Ctrl+F moves the caret forward one character") && ok;
+  }
+
+  // Alt+B: move the caret back one word.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    altB(input);
+    type(input, 'x');
+    ok = expect(input.value() == "foo xbar", "Alt+B moves the caret back one word") && ok;
+  }
+
+  // Alt+F: move the caret forward one word.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlA(input);
+    altF(input);
+    type(input, 'x');
+    ok = expect(input.value() == "foo xbar", "Alt+F moves the caret forward one word") && ok;
+  }
+
+  // Ctrl+W: delete the word before the caret.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlW(input);
+    ok = expect(input.value() == "foo ", "Ctrl+W deletes the previous word") && ok;
+  }
+
+  // Ctrl+U: clear the whole field.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlU(input);
+    ok = expect(input.value().empty(), "Ctrl+U clears the whole field") && ok;
+  }
+
+  // Ctrl+K: delete from the caret to the end of the field.
+  {
+    Input input;
+    setup(input, "foo bar", true);
+    ctrlA(input);
+    ctrlF(input);
+    ctrlK(input);
+    ok = expect(input.value() == "f", "Ctrl+K deletes the text after the caret") && ok;
+  }
+
+  // Alt+D: delete the word after the caret.
+  {
+    Input input;
+    setup(input, "foo bar baz", true);
+    ctrlA(input);
+    altD(input);
+    ok = expect(input.value() == " bar baz", "Alt+D deletes the next word") && ok;
+  }
+
+  // With line editing off, Ctrl+A selects all.
+  {
+    Input input;
+    setup(input, "foo bar", false);
+    ctrlA(input);
+    type(input, 'x');
+    ok = expect(input.value() == "x", "without line editing Ctrl+A stays \"select all\"") && ok;
+  }
+
+  // With line editing off, Ctrl+W does not delete words.
+  {
+    Input input;
+    setup(input, "foo bar", false);
+    ctrlW(input);
+    ok = expect(input.value() == "foo bar", "without line editing Ctrl+W does nothing") && ok;
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Added a subset of [readline-style](https://en.wikipedia.org/wiki/GNU_Readline#Emacs_keyboard_shortcuts) shortcuts to inputs (e.g. Ctrl+W to delete a word, Ctrl+A to move caret to start) and made app launcher use them.

## Motivation

<!-- What problem does this solve? -->
When you make a typo in app launcher, it's usually faster to delete the whole word (or line) and rewrite it rather than moving the caret.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
None

## Testing

- Added [tests](https://github.com/xirzo/noctalia/blob/210007d0528649e32c8076ef2b88757a76f2af0b/tests/input_readline_shortcuts_test.cpp) for new shortcuts;
- Manually went through each keybinding in app launcher.

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<p align="center">
<img width="640" height="200" alt="showcase" src="https://github.com/user-attachments/assets/dc6e34be-f1b3-4bf4-92f6-be2f12a134c6" />
</p>

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

Docs updated:  noctalia-dev/noctalia-docs#224

All new shortcuts:

| Shortcut | Action |
|---|---|
| `Ctrl+A` | Move caret to start of line |
| `Ctrl+E` | Move caret to end of line |
| `Ctrl+B` / `Ctrl+F` | Move caret back / forward one character |
| `Alt+B` / `Alt+F` | Move caret back / forward one word |
| `Ctrl+W` | Delete previous word |
| `Ctrl+U` | Clear the entire line |
| `Ctrl+K` | Delete from caret to end of line |
| `Alt+D` | Delete next word |

<!-- Add follow-up notes, reviewer context, or known limitations. -->
