### PR TITLE
feat(templates): add glow, shadow, and groupbar text colors to hyprland.lua

### DIFF
--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -21,8 +21,7 @@ local function apply_theme()
 				color = shadow,
 			},
 			glow = {
-				color = primary,
-				color_inactive = surface,
+				color = shadow,
 			},
 		},
         group = {

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -2,7 +2,8 @@
 
 local primary = "rgb({{colors.primary.default.hex_stripped}})"
 local surface = "rgb({{colors.surface.default.hex_stripped}})"
-local surface_variant = "rgb({{colors.surface_variant.default.hex_stripped}})"
+local on_surface = "rgb({{colors.on_surface.default.hex_stripped}})"
+local on_surface_variant = "rgb({{colors.on_surface_variant.default.hex_stripped}})"
 local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
 local shadow = "rgb({{colors.shadow.default.hex_stripped}})"
@@ -39,8 +40,8 @@ local function apply_theme()
                     locked_active = error,
                     locked_inactive = surface,
                 },
-                text_color = surface,
-                text_color_inactive = surface_variant,
+                text_color = on_surface,
+                text_color_inactive = on_surface_variant,
             },
         },
     })

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -2,8 +2,10 @@
 
 local primary = "rgb({{colors.primary.default.hex_stripped}})"
 local surface = "rgb({{colors.surface.default.hex_stripped}})"
+local surface_variant = "rgb({{colors.surface_variant.default.hex_stripped}})"
 local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
+local shadow = "rgb({{colors.shadow.default.hex_stripped}})"
 
 local function apply_theme()
     hl.config({
@@ -13,7 +15,15 @@ local function apply_theme()
                 inactive_border = surface,
             },
         },
-
+		decoration = {
+			shadow = {
+				color = shadow,
+			},
+			glow = {
+				color = primary,
+				color_inactive = surface,
+			},
+		},
         group = {
             col = {
                 border_active = secondary,
@@ -29,6 +39,8 @@ local function apply_theme()
                     locked_active = error,
                     locked_inactive = surface,
                 },
+                text_color = surface,
+                text_color_inactive = surface_variant,
             },
         },
     })
@@ -38,8 +50,10 @@ return {
     colors = {
         primary = primary,
         surface = surface,
+        surface_variant = surface_variant,
         secondary = secondary,
         error = error,
+        shadow = shadow,
     },
     apply_theme = apply_theme
 }

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -50,7 +50,8 @@ return {
     colors = {
         primary = primary,
         surface = surface,
-        surface_variant = surface_variant,
+		on_surface = on_surface,
+        on_surface_variant = on_surface_variant,
         secondary = secondary,
         error = error,
         shadow = shadow,

--- a/assets/templates/hyprland/hyprland.lua
+++ b/assets/templates/hyprland/hyprland.lua
@@ -3,9 +3,10 @@
 local primary = "rgb({{colors.primary.default.hex_stripped}})"
 local surface = "rgb({{colors.surface.default.hex_stripped}})"
 local on_surface = "rgb({{colors.on_surface.default.hex_stripped}})"
-local on_surface_variant = "rgb({{colors.on_surface_variant.default.hex_stripped}})"
 local secondary = "rgb({{colors.secondary.default.hex_stripped}})"
+local on_secondary = "rgb({{colors.on_secondary.default.hex_stripped}})"
 local error = "rgb({{colors.error.default.hex_stripped}})"
+local on_error = "rgb({{colors.on_error.default.hex_stripped}})"
 local shadow = "rgb({{colors.shadow.default.hex_stripped}})"
 
 local function apply_theme()
@@ -16,14 +17,14 @@ local function apply_theme()
                 inactive_border = surface,
             },
         },
-		decoration = {
-			shadow = {
-				color = shadow,
-			},
-			glow = {
-				color = shadow,
-			},
-		},
+        decoration = {
+            shadow = {
+                color = shadow,
+            },
+            glow = {
+                color = shadow,
+            },
+        },
         group = {
             col = {
                 border_active = secondary,
@@ -33,14 +34,17 @@ local function apply_theme()
             },
 
             groupbar = {
+                gradients = true,
                 col = {
                     active = secondary,
                     inactive = surface,
                     locked_active = error,
                     locked_inactive = surface,
                 },
-                text_color = on_surface,
-                text_color_inactive = on_surface_variant,
+                text_color = on_secondary,
+                text_color_inactive = on_surface,
+                text_color_locked_active = on_error,
+                text_color_locked_inactive = on_surface,
             },
         },
     })
@@ -50,10 +54,11 @@ return {
     colors = {
         primary = primary,
         surface = surface,
-		on_surface = on_surface,
-        on_surface_variant = on_surface_variant,
+        on_surface = on_surface,
         secondary = secondary,
+        on_secondary = on_secondary,
         error = error,
+        on_error = on_error,
         shadow = shadow,
     },
     apply_theme = apply_theme


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->


This adds the colors for Hyprland's glow, and shadow, as well as the groupbar text to the `hyprland.lua` template.

## Motivation

<!-- What problem does this solve? -->
Glow, and shadow is mostly just making it consistent with other settings/compositor templates

The groupbar text however is due to readability issues. The default setting conflicts with lighter backgrounds and dark themes, as Hyprland does not use backgrounds for it's groupbar text.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue
N/A
<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
Manually tested via a user-template in user-templates.toml using the below, there is no code changes, only template changes.
```
[theme.templates.user.hyprland]
input_path = '~/.config/noctalia/templates/hyprland.lua'
output_path = '~/.config/hypr/noctalia.lua'
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1920" height="1080" alt="screenshot_20260814_234911-region" src="https://github.com/user-attachments/assets/68673904-6a42-4f79-b59a-350e71757a74" />
<img width="1920" height="1080" alt="screenshot_20260814_234907-region" src="https://github.com/user-attachments/assets/9f926d87-817c-45cd-bbbd-3d0e2f1aca82" />
<img width="1920" height="1080" alt="screenshot_20260814_234854-region" src="https://github.com/user-attachments/assets/1132d2ed-85de-4293-bf36-7c30082cffd9" />
<img width="1920" height="1080" alt="screenshot_20260814_234833-region" src="https://github.com/user-attachments/assets/c71a583b-f937-4a93-b90f-9bdaa8c097d0" />


## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
This could be added to hyprland.conf as well, but not really recommended as [the next version will not have support for it](https://github.com/hyprwm/Hyprland/commit/a9902ea65f461af868497c4e74fed798ade0b1b0)

There is also no locked color setting for the glow effect currently, so it will look weird with borders.
