### PR TITLE
fix(network): support WPA3 SAE connections

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1165,6 +1165,7 @@ if build_tests
     'location_service',
     'math_provider',
     'monitor_selector',
+    'network_manager_security',
     'notification_dnd',
     'notification_filter',
     'notification_history_utf8',

--- a/src/dbus/network/network_manager_security.h
+++ b/src/dbus/network/network_manager_security.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace network_manager_security {
+
+  inline constexpr std::uint32_t kNm80211ApSecKeyMgmtSae = 0x00000400U;
+
+  [[nodiscard]] constexpr bool supportsSae(std::uint32_t rsnFlags) noexcept {
+    return (rsnFlags & kNm80211ApSecKeyMgmtSae) != 0U;
+  }
+
+  [[nodiscard]] constexpr std::string_view keyManagement(bool supportsSae) noexcept {
+    return supportsSae ? "sae" : "wpa-psk";
+  }
+
+} // namespace network_manager_security

--- a/src/dbus/network/network_manager_service.cpp
+++ b/src/dbus/network/network_manager_service.cpp
@@ -1,6 +1,7 @@
 #include "dbus/network/network_manager_service.h"
 
 #include "core/log.h"
+#include "dbus/network/network_manager_security.h"
 #include "dbus/system_bus.h"
 #include "system/rfkill_helper.h"
 
@@ -389,7 +390,8 @@ bool NetworkManagerService::addAndActivateAccessPoint(
   ConnectionSettings settings;
   if (ap.secured) {
     // Minimal secured-wifi settings — NM fills in ssid from the specific_object.
-    settings["802-11-wireless-security"]["key-mgmt"] = sdbus::Variant{std::string("wpa-psk")};
+    settings["802-11-wireless-security"]["key-mgmt"] =
+        sdbus::Variant{std::string(network_manager_security::keyManagement(ap.supportsSae))};
     if (psk.has_value()) {
       settings["802-11-wireless-security"]["psk"] = sdbus::Variant{*psk};
     }
@@ -1693,6 +1695,7 @@ void NetworkManagerService::refreshAccessPoints(std::function<void()> onComplete
                                           }();
                                           info.secured =
                                               (wpaFlags != k_nm80211ApSecNone) || (rsnFlags != k_nm80211ApSecNone);
+                                          info.supportsSae = network_manager_security::supportsSae(rsnFlags);
                                           if (!info.ssid.empty()) {
                                             apState->aps.push_back(std::move(info));
                                           }
@@ -1774,6 +1777,7 @@ void NetworkManagerService::finishRefreshAccessPoints(
       it->path = ap.path;
       it->devicePath = ap.devicePath;
       it->secured = ap.secured;
+      it->supportsSae = ap.supportsSae;
     }
   }
   std::ranges::sort(deduped, [](const AccessPointInfo& a, const AccessPointInfo& b) {
@@ -2246,13 +2250,11 @@ void NetworkManagerService::readStateAsync(std::function<void(NetworkState)> onC
 
               if (deviceType == kNmDeviceTypeWifi) {
                 next->kind = NetworkConnectivity::Wireless;
-              } else if (
-                  deviceType == kNmDeviceTypeEthernet
-                  || deviceType == kNmDeviceTypeBridge
-                  || deviceType == kNmDeviceTypeBond
-                  || deviceType == kNmDeviceTypeTeam
-                  || deviceType == kNmDeviceTypeVlan
-              ) {
+              } else if (deviceType == kNmDeviceTypeEthernet
+                         || deviceType == kNmDeviceTypeBridge
+                         || deviceType == kNmDeviceTypeBond
+                         || deviceType == kNmDeviceTypeTeam
+                         || deviceType == kNmDeviceTypeVlan) {
                 next->kind = NetworkConnectivity::Wired;
               }
               // Remaining device types (wireguard, tun, …) are VPN/overlay virtual

--- a/src/dbus/network/network_types.h
+++ b/src/dbus/network/network_types.h
@@ -9,6 +9,7 @@ struct AccessPointInfo {
   std::string ssid;
   std::uint8_t strength = 0; // 0..100
   bool secured = false;
+  bool supportsSae = false;
   bool active = false;
 
   bool operator==(const AccessPointInfo&) const = default;

--- a/src/shell/control_center/tabs/network_tab.cpp
+++ b/src/shell/control_center/tabs/network_tab.cpp
@@ -809,10 +809,10 @@ void NetworkTab::handleWirelessEnabledCompletion(std::uint64_t generation, bool 
   PanelManager::instance().requestRedraw();
 }
 
-// Identity of the built list: which rows exist, in which order, and which controls
-// each carries. The signal strength is absent by design — it refreshes in place
-// through syncApRows(), so a scan update no longer tears the list down. Access points
-// arrive sorted, so a change in row order changes the key.
+// Identity of the built list: which rows exist, in which order, which controls
+// each carries, and how each activates. The signal strength is absent by design —
+// it refreshes in place through syncApRows(), so a scan update no longer tears the
+// list down. Access points arrive sorted, so a change in row order changes the key.
 std::string
 NetworkTab::structureKey(const std::vector<AccessPointInfo>& aps, const std::vector<VpnConnectionInfo>& vpns) const {
   std::string key;
@@ -820,6 +820,8 @@ NetworkTab::structureKey(const std::vector<AccessPointInfo>& aps, const std::vec
     key += ap.ssid;
     key.push_back(':');
     key += ap.secured ? '1' : '0';
+    key.push_back(':');
+    key += ap.supportsSae ? '1' : '0';
     key.push_back(':');
     key += ap.active ? '1' : '0';
     key.push_back(':');

--- a/tests/network_manager_security_test.cpp
+++ b/tests/network_manager_security_test.cpp
@@ -1,0 +1,18 @@
+#include "dbus/network/network_manager_security.h"
+#include "dbus/network/network_types.h"
+#include "tests/test_check.h"
+
+int main() {
+  TEST_CHECK(!network_manager_security::supportsSae(0U));
+  TEST_CHECK(!network_manager_security::supportsSae(0x00000100U));
+  TEST_CHECK(network_manager_security::supportsSae(0x00000400U));
+  TEST_CHECK(network_manager_security::supportsSae(0x00000500U));
+
+  TEST_CHECK(network_manager_security::keyManagement(false) == "wpa-psk");
+  TEST_CHECK(network_manager_security::keyManagement(true) == "sae");
+
+  const AccessPointInfo accessPoint;
+  TEST_CHECK(!accessPoint.supportsSae);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Preserve NetworkManager's SAE capability from access-point discovery through activation.
- Select `sae` for SAE-capable access points and retain `wpa-psk` for WPA2-Personal access points.
- Prefer SAE for WPA2/WPA3 transition-mode access points.
- Preserve the selected BSSID's SAE capability during SSID deduplication.
- Refresh cached control-center network rows when the advertised SAE capability changes.

## Motivation

First-time connections to WPA3-Personal/SAE-only access points failed because Noctalia reduced NetworkManager's WPA/RSN capability flags to a generic `secured` value and always created secured connections with:

```text
802-11-wireless-security.key-mgmt = wpa-psk
 ```

 SAE-only access points require:

 ```text
802-11-wireless-security.key-mgmt = sae
 ```
This change preserves the SAE capability of the selected NetworkManager access-point object through discovery, deduplication, password prompting, and activation. WPA2 access points continue to use WPA-PSK.

 The network panel's cached row identity now also includes SAE capability. If an existing SSID's advertised capability changes while the panel remains open, the row is rebuilt with the current AccessPointInfo instead of activating with stale key management.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

 Fixes #3841

## Testing

Ran the focused regression in the Nix development environment:

 ```sh
nix develop --command just test debug network_manager_security --print-errorlogs
 ```

 Result:

 ```text
network_manager_security: 1/1 passed
 ```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The NetworkManager SAE bit and key-management mapping are kept together in a small allocation-free helper. This gives production code and regression tests one source of truth without requiring D-Bus or a running NetworkManager instance in the focused test.
Other network backends retain their existing behavior because AccessPointInfo::supportsSae defaults to false.
When multiple BSSIDs advertise the same SSID, Noctalia retains the SAE capability of the selected representative access-point object rather than combining capabilities across BSSIDs. This matches the access-point object passed to AddAndActivateConnection2.
