### PR TITLE
fix(launcher): guard null config in app provider query

### DIFF
--- a/src/launcher/app_provider.cpp
+++ b/src/launcher/app_provider.cpp
@@ -289,9 +289,9 @@ std::vector<LauncherResult> AppProvider::query(std::string_view text) const {
       scored.emplace_back(s, std::make_pair(&entry, nullptr));
     }
 
-    if (!m_config->config().shell.launcher.showAppActions)
+    if (m_config == nullptr || !m_config->config().shell.launcher.showAppActions) {
       continue;
-
+    }
     for (const auto& action : entry.actions) {
       const double actionScore = scoreAction(pattern, action);
       if (FuzzyMatch::isMatch(actionScore)) {


### PR DESCRIPTION
## Summary

`AppProvider::query()` read a config setting through a pointer that can be null. When it is null, it crashed. The fix checks for null first.

## Motivation

```38/82 noctalia:desktop_entry_localization    FAIL           0.21s   killed by signal 11 SIGSEGV```

since the launcher desktop-actions toggle (#3772). Made the launcher read `show_app_actions` through 
`ConfigService*`which can be null without null check. The `desktop_entry_localization` test builds the provider
without a config, so it segfaulted. Now a missing config just falls back to the default instead of crashing. Everything else is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Testing

- Ran `just format` and `just test`, this time all the test passed

## Manual Coverage

> Not applicable

- [ ] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="727" height="261" alt="image" src="https://github.com/user-attachments/assets/f1c77c8a-462d-47c5-8224-e63f8ba7ddeb" />

> Just showing all test pass now

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed
- [x] I ran the relevant build or test commands
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
