### PR TITLE
Add AerynOS dependencies to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ sudo xbps-install meson ninja pkg-config git \
   polkit-devel librsvg-devel libqalculate-devel libxml2-devel jemalloc-devel
 ```
 
+### AerynOS
+
+```sh
+sudo moss install meson gcc clang just \
+  wayland-devel wayland-protocols-devel \
+  libglvnd-devel freetype-devel fontconfig-devel \
+  cairo-devel pango-devel harfbuzz-devel \
+  libxkbcommon-devel glib2-devel \
+  libsecret-devel libsodium-devel \
+  sdbus-cpp-devel pipewire-devel wireplumber-devel polkit-devel \
+  linux-pam-devel curl libwebp-devel libjxl-devel libsndfile-devel librsvg-devel \
+  libqalculate-devel libxml2-devel \
+  md4c-devel tomlplusplus-devel libical-devel \
+  nlohmann-json stb \
+  jemalloc-devel
+```
+
 Vendored dependencies, with no system package needed: `Wuffs`,
 `Luau`, `fzy`, and Material Color Utilities.
 


### PR DESCRIPTION
## Summary

Added instructions for AerynOS

## Motivation

Should someone want to install Noctalia on an AerynOS setup, they won't have to try different packages themselves.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging

## Related Issue

None.

## Testing

Used all the packages listed compiling Noctalia on my machine.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [x] Tested on another compositor: Mango
- [x] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="1920" height="1080" alt="screenshot_20260814_222840-region" src="https://github.com/user-attachments/assets/3bd6244b-5775-4453-ba10-580a9ac38858" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [ ] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

`clang` is necessary for the building, `gcc` or `gcc-devel` alone isn't enough since they don't include a linker. I haven't tested it without gcc but better be safe than sorry.