### PR TITLE
fix(screen-time): pause tracking while suspended

### DIFF
--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -999,6 +999,8 @@ void Application::initSystemBusServices() {
           // fade-complete cleanup races with process freeze.
           m_idleGraceOverlay.hide();
           if (sleeping) {
+            // Screen time must not accumulate across suspend even when lock-before-suspend is off.
+            m_screenTimeService.setSuspendPaused(true);
             // Delay inhibit (when lock_before_suspend is on) holds sleep until we lock.
             // Do not use runAfterSessionLocked here — that slot belongs to lock-and-suspend.
             if (m_skipLockOnNextSleep) {
@@ -1046,6 +1048,7 @@ void Application::initSystemBusServices() {
           }
           m_skipLockOnNextSleep = false;
           m_releaseSleepDelayWhenLocked = false;
+          m_screenTimeService.setSuspendPaused(false);
           if (m_configService.shouldLockBeforeSuspend() && m_logindService != nullptr) {
             (void)m_logindService->acquireSleepDelayInhibit();
           }

--- a/src/system/screen_time_service.cpp
+++ b/src/system/screen_time_service.cpp
@@ -313,10 +313,7 @@ void ScreenTimeService::setEnabled(bool enabled) {
     }
     m_tickTimer.stop();
   } else {
-    if (!m_sessionLocked) {
-      onFocusChange();
-      m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
-    }
+    resumeTracking();
   }
   if (m_changeCallback) {
     m_changeCallback();
@@ -327,29 +324,48 @@ void ScreenTimeService::setSessionLocked(bool locked) {
   if (m_sessionLocked == locked) {
     return;
   }
-
   m_sessionLocked = locked;
   if (locked) {
-    if (m_enabled) {
-      flushActiveSession(std::chrono::steady_clock::now());
-      if (m_dirty) {
-        save();
-      }
-    }
-    m_activeAppKey.clear();
-    m_activeSince = {};
-    m_tickTimer.stop();
+    pauseTracking();
     return;
   }
+  resumeTracking();
+}
 
-  if (m_enabled) {
-    onFocusChange();
-    m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
+void ScreenTimeService::setSuspendPaused(bool paused) {
+  if (m_suspendPaused == paused) {
+    return;
   }
+  m_suspendPaused = paused;
+  if (paused) {
+    pauseTracking();
+    return;
+  }
+  resumeTracking();
+}
+
+void ScreenTimeService::pauseTracking() {
+  if (m_enabled) {
+    flushActiveSession(std::chrono::steady_clock::now());
+    if (m_dirty) {
+      save();
+    }
+  }
+  m_activeAppKey.clear();
+  m_activeSince = {};
+  m_tickTimer.stop();
+}
+
+void ScreenTimeService::resumeTracking() {
+  if (!m_enabled || m_sessionLocked || m_suspendPaused) {
+    return;
+  }
+  onFocusChange();
+  m_tickTimer.startRepeating(kTickInterval, [this]() { tick(); });
 }
 
 void ScreenTimeService::onFocusChange() {
-  if (!m_enabled || m_sessionLocked) {
+  if (!m_enabled || m_sessionLocked || m_suspendPaused) {
     return;
   }
   const std::string candidate = appKeyForActive();
@@ -372,7 +388,7 @@ void ScreenTimeService::onFocusChange() {
 }
 
 void ScreenTimeService::tick() {
-  if (!m_enabled || m_sessionLocked) {
+  if (!m_enabled || m_sessionLocked || m_suspendPaused) {
     return;
   }
   const bool wasDirty = m_dirty;

--- a/src/system/screen_time_service.h
+++ b/src/system/screen_time_service.h
@@ -49,6 +49,7 @@ public:
   void setChangeCallback(std::function<void()> callback);
   void setEnabled(bool enabled);
   void setSessionLocked(bool locked);
+  void setSuspendPaused(bool paused);
   [[nodiscard]] bool enabled() const noexcept { return m_enabled; }
 
   [[nodiscard]] ScreenTimeSnapshot snapshot(int rangeDays = 1);
@@ -64,7 +65,8 @@ private:
     std::unordered_map<std::string, std::array<std::chrono::seconds, 24>> appHourly;
     std::array<std::chrono::seconds, 24> hourly{};
   };
-
+  void pauseTracking();
+  void resumeTracking();
   void tick();
   void flushActiveSession(std::chrono::steady_clock::time_point now);
   void ensureCurrentDayLocked(std::chrono::system_clock::time_point now);
@@ -98,4 +100,5 @@ private:
   bool m_dirty = false;
   bool m_enabled = false;
   bool m_sessionLocked = false;
+  bool m_suspendPaused = false;
 };


### PR DESCRIPTION
## Summary

This PR fix the screen time tracking across system suspend. Builds on the commit lock-pause fix (`3f66cfafb`) and adds the suspend coverage that was missing from it.

## Motivation

Just adds the fix for the missing suspend part which didn't merged from this PR #3897.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Related to #3882 (already closed by the commit `3f66cfafb`), this PR adds the suspend half of that fix.

## Testing

- Ran `just format`, `just build`, `just test` all clean and test passed.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [ ] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
