### PR TITLE
refactor(bar): detach group hover pills and fix hit-box bounds

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -484,6 +484,91 @@ namespace {
     }
   }
 
+  struct CapsuleMemberGeometry {
+    std::size_t widgetIndex = 0;
+    float x = 0.0F;
+    float y = 0.0F;
+    float width = 0.0F;
+    float height = 0.0F;
+    float sliceStart = 0.0F;
+    float sliceEnd = 0.0F;
+
+    [[nodiscard]] float mainStart(bool isVertical) const noexcept { return isVertical ? y : x; }
+    [[nodiscard]] float mainEnd(bool isVertical) const noexcept {
+      return mainStart(isVertical) + (isVertical ? height : width);
+    }
+  };
+
+  [[nodiscard]] std::vector<CapsuleMemberGeometry>
+  capsuleMemberSlices(const BarCapsuleRun& run, bool isVertical, float widgetHoverPadding) {
+    std::vector<CapsuleMemberGeometry> members;
+    if (run.shell == nullptr) {
+      return members;
+    }
+    members.reserve(run.widgets.size());
+
+    float shellX = 0.0F;
+    float shellY = 0.0F;
+    Node::absolutePosition(run.shell, shellX, shellY);
+    for (std::size_t i = 0; i < run.widgets.size(); ++i) {
+      Widget* widget = run.widgets[i];
+      Node* root = widget != nullptr ? widget->outerNode() : nullptr;
+      if (root == nullptr || !root->visible() || !root->participatesInLayout() || !root->hitTestVisible()) {
+        continue;
+      }
+
+      float rootX = 0.0F;
+      float rootY = 0.0F;
+      Node::absolutePosition(root, rootX, rootY);
+      members.push_back(
+          CapsuleMemberGeometry{
+              .widgetIndex = i,
+              .x = rootX - shellX,
+              .y = rootY - shellY,
+              .width = root->width(),
+              .height = root->height(),
+          }
+      );
+    }
+
+    const float shellMain = isVertical ? run.shell->height() : run.shell->width();
+    for (std::size_t i = 0; i < members.size(); ++i) {
+      auto& member = members[i];
+      const float memberStart = member.mainStart(isVertical);
+      const float memberEnd = member.mainEnd(isVertical);
+      const float pad = widgetHoverPadding * run.widgets[member.widgetIndex]->contentScale();
+      float before = pad;
+      float after = pad;
+
+      if (i > 0) {
+        before = std::min(before, std::max(0.0F, (memberStart - members[i - 1].mainEnd(isVertical)) * 0.5F));
+      }
+      if (i + 1 < members.size()) {
+        after = std::min(after, std::max(0.0F, (members[i + 1].mainStart(isVertical) - memberEnd) * 0.5F));
+      }
+
+      if (members.size() > 1) {
+        if (i == 0) {
+          before = after;
+        }
+        if (i + 1 == members.size()) {
+          after = before;
+        }
+      }
+      if (run.hasPaintedCapsuleBackground) {
+        if (i == 0) {
+          before = std::min(before, std::max(0.0F, memberStart));
+        }
+        if (i + 1 == members.size()) {
+          after = std::min(after, std::max(0.0F, shellMain - memberEnd));
+        }
+      }
+      member.sliceStart = memberStart - before;
+      member.sliceEnd = memberEnd + after;
+    }
+    return members;
+  }
+
   // Extends each member's hit target across the capsule padding and half the gap to its
   // neighbors, so hover/click coverage matches the capsule ink instead of stopping at the
   // content edge. Runs after applyBarWidgetHitTargets (which replaces outsets each layout).
@@ -519,56 +604,23 @@ namespace {
 
       // Tile only laid-out members; hidden ones keep stale geometry, and members clipped out of a
       // collapsed accordion are input-suppressed so their slice belongs to the visible member.
-      std::vector<std::size_t> laidOut;
-      laidOut.reserve(run.widgets.size());
-      for (std::size_t i = 0; i < run.widgets.size(); ++i) {
-        Widget* widget = run.widgets[i];
-        auto* root = widget != nullptr ? widget->outerNode() : nullptr;
-        if (root == nullptr || !root->visible() || !root->participatesInLayout() || !root->hitTestVisible()) {
-          continue;
-        }
-        laidOut.push_back(i);
-      }
-
+      const auto laidOut = capsuleMemberSlices(run, isVertical, widgetHoverPadding);
       const float shellMain = isVertical ? run.shell->height() : run.shell->width();
-      const float containerMain = isVertical ? run.container->y() : run.container->x();
-      auto memberStart = [&](std::size_t i) {
-        const Node* node = run.widgets[i]->outerNode();
-        return containerMain + (isVertical ? node->y() : node->x());
-      };
-      auto memberEnd = [&](std::size_t i) {
-        const Node* node = run.widgets[i]->outerNode();
-        return memberStart(i) + (isVertical ? node->height() : node->width());
-      };
-      for (std::size_t vi = 0; vi < laidOut.size(); ++vi) {
-        const std::size_t i = laidOut[vi];
+      float minSliceStart = 0.0F;
+      float maxSliceEnd = shellMain;
+      for (const auto& member : laidOut) {
+        const std::size_t i = member.widgetIndex;
         Node* area = run.widgets[i]->outerNode();
-
-        const float pad = widgetHoverPadding * run.widgets[i]->contentScale();
-
-        float sliceStart = memberStart(i) - pad;
-        if (vi == 0) {
-          if (run.hasVisibleInk) {
-            sliceStart = std::max(0.0F, sliceStart);
-          }
-        } else {
-          const float mid = (memberEnd(laidOut[vi - 1]) + memberStart(i)) * 0.5F;
-          sliceStart = std::max(sliceStart, mid);
-        }
-
-        float sliceEnd = memberEnd(i) + pad;
-        if (vi + 1 == laidOut.size()) {
-          if (run.hasVisibleInk) {
-            sliceEnd = std::min(shellMain, sliceEnd);
-          }
-        } else {
-          const float mid = (memberEnd(i) + memberStart(laidOut[vi + 1])) * 0.5F;
-          sliceEnd = std::min(sliceEnd, mid);
-        }
+        const float memberStart = member.mainStart(isVertical);
+        const float memberEnd = member.mainEnd(isVertical);
+        const float sliceStart = member.sliceStart;
+        const float sliceEnd = member.sliceEnd;
+        minSliceStart = std::min(minSliceStart, sliceStart);
+        maxSliceEnd = std::max(maxSliceEnd, sliceEnd);
 
         auto outset = area->hitTestOutset();
-        const float before = std::max(0.0F, memberStart(i) - sliceStart);
-        const float after = std::max(0.0F, sliceEnd - memberEnd(i));
+        const float before = std::max(0.0F, memberStart - sliceStart);
+        const float after = std::max(0.0F, sliceEnd - memberEnd);
         if (isVertical) {
           outset.top += before;
           outset.bottom += after;
@@ -578,6 +630,15 @@ namespace {
         }
         area->setHitTestOutset(outset);
       }
+      auto shellOutset = run.shell->hitTestOutset();
+      if (isVertical) {
+        shellOutset.top += std::max(0.0F, -minSliceStart);
+        shellOutset.bottom += std::max(0.0F, maxSliceEnd - shellMain);
+      } else {
+        shellOutset.left += std::max(0.0F, -minSliceStart);
+        shellOutset.right += std::max(0.0F, maxSliceEnd - shellMain);
+      }
+      run.shell->setHitTestOutset(shellOutset);
     }
   }
 
@@ -936,15 +997,17 @@ namespace {
         }
 
         bool hasVisibleContent = false;
-        bool hasVisibleInk = false;
+        bool hasCapsuleContent = false;
         for (Widget* widget : run.widgets) {
           if (widget == nullptr || widget->root() == nullptr) {
             continue;
           }
           hasVisibleContent = hasVisibleContent || widget->root()->visible();
-          hasVisibleInk = hasVisibleInk || widget->shouldShowBarCapsule();
+          hasCapsuleContent = hasCapsuleContent || widget->shouldShowBarCapsule();
         }
-        run.hasVisibleInk = hasVisibleInk;
+        const bool hasPaintedFill = resolveColorSpec(withOpacity(run.spec.fill, run.spec.opacity)).a > 0.0F;
+        const bool hasPaintedBorder = run.spec.border.has_value() && resolveColorSpec(*run.spec.border).a > 0.0F;
+        run.hasPaintedCapsuleBackground = hasCapsuleContent && (hasPaintedFill || hasPaintedBorder);
 
         shell->setVisible(hasVisibleContent);
         const float scale = run.contentScale;
@@ -959,7 +1022,7 @@ namespace {
             }
           }
         };
-        if (!hasVisibleInk) {
+        if (!hasCapsuleContent) {
           shell->setSize(iw, ih);
           if (run.accordionClip != nullptr) {
             run.accordionClip->setPosition(0.0F, 0.0F);
@@ -1261,41 +1324,34 @@ namespace {
           shellX -= underlayX;
           shellY -= underlayY;
           const float shellMainStart = isVertical ? shellY : shellX;
-          const float shellMainEnd = shellMainStart + (isVertical ? run.shell->height() : run.shell->width());
           const Widget* radiusSource = !run.widgets.empty() ? run.widgets.front() : nullptr;
           for (Widget* widget : run.widgets) {
-            Box* box = widget != nullptr ? widget->barHoverBox() : nullptr;
             Node* root = widget != nullptr ? widget->outerNode() : nullptr;
-            if (box == nullptr || root == nullptr) {
-              continue;
-            }
-            if (!root->visible() || !root->participatesInLayout()) {
+            Box* box = widget != nullptr ? widget->barHoverBox() : nullptr;
+            if (box != nullptr
+                && (root == nullptr || !root->visible() || !root->participatesInLayout() || !root->hitTestVisible())) {
               box->setSize(0.0F, 0.0F);
+            }
+          }
+
+          const auto laidOut = capsuleMemberSlices(run, isVertical, instance.barConfig.widgetCapsulePadding);
+          for (const auto& member : laidOut) {
+            Widget* widget = run.widgets[member.widgetIndex];
+            Box* box = widget->barHoverBox();
+            if (box == nullptr) {
               continue;
             }
-            float rootX = 0.0F;
-            float rootY = 0.0F;
-            Node::absolutePosition(root, rootX, rootY);
-            rootX -= underlayX;
-            rootY -= underlayY;
-            const float pad = instance.barConfig.widgetCapsulePadding * widget->contentScale();
-            const float rootMainStart = isVertical ? rootY : rootX;
-            const float rootMainExtent = isVertical ? root->height() : root->width();
-            float mainStart = rootMainStart - pad;
-            float mainEnd = rootMainStart + rootMainExtent + pad;
-            // Clamp to the shell's real edges only when the capsule bg is visible, so the pill
-            // never bleeds past a painted background; unclamped (free to overlap neighbors) when
-            // there is no ink to bleed past.
-            if (run.hasVisibleInk) {
-              mainStart = std::max(shellMainStart, mainStart);
-              mainEnd = std::min(shellMainEnd, mainEnd);
-            }
+
+            const float rootX = shellX + member.x;
+            const float rootY = shellY + member.y;
+            const float mainStart = shellMainStart + member.sliceStart;
+            const float mainEnd = shellMainStart + member.sliceEnd;
             const float mainExtent = std::max(0.0F, mainEnd - mainStart);
             const float hoverW = isVertical ? capsuleCross : mainExtent;
             const float hoverH = isVertical ? mainExtent : capsuleCross;
             box->setPosition(
-                isVertical ? rootX + (root->width() - capsuleCross) * 0.5F : mainStart,
-                isVertical ? mainStart : rootY + (root->height() - capsuleCross) * 0.5F
+                isVertical ? rootX + (member.width - capsuleCross) * 0.5F : mainStart,
+                isVertical ? mainStart : rootY + (member.height - capsuleCross) * 0.5F
             );
             box->setSize(hoverW, hoverH);
             box->setRadius(

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -487,7 +487,7 @@ namespace {
   // Extends each member's hit target across the capsule padding and half the gap to its
   // neighbors, so hover/click coverage matches the capsule ink instead of stopping at the
   // content edge. Runs after applyBarWidgetHitTargets (which replaces outsets each layout).
-  void extendCapsuleHitTargets(std::vector<BarCapsuleRun>& runs, bool isVertical) {
+  void extendCapsuleHitTargets(std::vector<BarCapsuleRun>& runs, bool isVertical, float widgetHoverPadding) {
     for (auto& run : runs) {
       if (run.shell == nullptr || run.hoverBoxes.empty()) {
         continue;
@@ -543,9 +543,29 @@ namespace {
       for (std::size_t vi = 0; vi < laidOut.size(); ++vi) {
         const std::size_t i = laidOut[vi];
         Node* area = run.widgets[i]->outerNode();
-        const float sliceStart = vi > 0 ? (memberEnd(laidOut[vi - 1]) + memberStart(i)) * 0.5F : 0.0F;
-        const float sliceEnd =
-            vi + 1 < laidOut.size() ? (memberEnd(i) + memberStart(laidOut[vi + 1])) * 0.5F : shellMain;
+
+        const float pad = widgetHoverPadding * run.widgets[i]->contentScale();
+
+        float sliceStart = memberStart(i) - pad;
+        if (vi == 0) {
+          if (run.hasVisibleInk) {
+            sliceStart = std::max(0.0F, sliceStart);
+          }
+        } else {
+          const float mid = (memberEnd(laidOut[vi - 1]) + memberStart(i)) * 0.5F;
+          sliceStart = std::max(sliceStart, mid);
+        }
+
+        float sliceEnd = memberEnd(i) + pad;
+        if (vi + 1 == laidOut.size()) {
+          if (run.hasVisibleInk) {
+            sliceEnd = std::min(shellMain, sliceEnd);
+          }
+        } else {
+          const float mid = (memberEnd(i) + memberStart(laidOut[vi + 1])) * 0.5F;
+          sliceEnd = std::min(sliceEnd, mid);
+        }
+
         auto outset = area->hitTestOutset();
         const float before = std::max(0.0F, memberStart(i) - sliceStart);
         const float after = std::max(0.0F, sliceEnd - memberEnd(i));
@@ -924,6 +944,7 @@ namespace {
           hasVisibleContent = hasVisibleContent || widget->root()->visible();
           hasVisibleInk = hasVisibleInk || widget->shouldShowBarCapsule();
         }
+        run.hasVisibleInk = hasVisibleInk;
 
         shell->setVisible(hasVisibleContent);
         const float scale = run.contentScale;
@@ -1023,7 +1044,11 @@ namespace {
         const float capsuleRadius = radiusSource != nullptr ? radiusSource->resolvedBarCapsuleRadius(shellW, shellH)
                                                             : std::max(0.0F, std::min(shellW, shellH) * 0.5F);
         bg->setRadius(capsuleRadius);
-        placeCapsuleHoverBoxes(run, isVertical, shellW, shellH, contentX, contentY, capsuleRadius, widgetHoverPadding);
+        if (run.container == nullptr) {
+          placeCapsuleHoverBoxes(
+              run, isVertical, shellW, shellH, contentX, contentY, capsuleRadius, widgetHoverPadding
+          );
+        }
         // Members outside the reveal window are clipped out; while collapsed (or collapsing) the
         // non-primary members are pointer-suppressed by reveal window so their hidden slots don't
         // capture clicks. While expanded, every valid layout member stays unsuppressed so hover
@@ -1167,11 +1192,12 @@ namespace {
     }
 
     applyBarWidgetHitTargets(instance.startSection, instance.startSlot, isVertical);
+    applyBarWidgetHitTargets(instance.startSection, instance.startSlot, isVertical);
     applyBarWidgetHitTargets(instance.centerSection, instance.centerSlot, isVertical);
     applyBarWidgetHitTargets(instance.endSection, instance.endSlot, isVertical);
-    extendCapsuleHitTargets(instance.startCapsuleRuns, isVertical);
-    extendCapsuleHitTargets(instance.centerCapsuleRuns, isVertical);
-    extendCapsuleHitTargets(instance.endCapsuleRuns, isVertical);
+    extendCapsuleHitTargets(instance.startCapsuleRuns, isVertical, instance.barConfig.widgetCapsulePadding);
+    extendCapsuleHitTargets(instance.centerCapsuleRuns, isVertical, instance.barConfig.widgetCapsulePadding);
+    extendCapsuleHitTargets(instance.endCapsuleRuns, isVertical, instance.barConfig.widgetCapsulePadding);
 
     // Ghost pills for capsule-less widgets: positioned on the bar-level underlay with the
     // metrics an enabled capsule would have (capsuleCross across the bar, capsule padding
@@ -1223,6 +1249,65 @@ namespace {
       placeGhostPills(instance.startWidgets);
       placeGhostPills(instance.centerWidgets);
       placeGhostPills(instance.endWidgets);
+
+      auto placeGroupHoverPills = [&](std::vector<BarCapsuleRun>& runs) {
+        for (auto& run : runs) {
+          if (run.container == nullptr || run.shell == nullptr) {
+            continue;
+          }
+          float shellX = 0.0F;
+          float shellY = 0.0F;
+          Node::absolutePosition(run.shell, shellX, shellY);
+          shellX -= underlayX;
+          shellY -= underlayY;
+          const float shellMainStart = isVertical ? shellY : shellX;
+          const float shellMainEnd = shellMainStart + (isVertical ? run.shell->height() : run.shell->width());
+          const Widget* radiusSource = !run.widgets.empty() ? run.widgets.front() : nullptr;
+          for (Widget* widget : run.widgets) {
+            Box* box = widget != nullptr ? widget->barHoverBox() : nullptr;
+            Node* root = widget != nullptr ? widget->outerNode() : nullptr;
+            if (box == nullptr || root == nullptr) {
+              continue;
+            }
+            if (!root->visible() || !root->participatesInLayout()) {
+              box->setSize(0.0F, 0.0F);
+              continue;
+            }
+            float rootX = 0.0F;
+            float rootY = 0.0F;
+            Node::absolutePosition(root, rootX, rootY);
+            rootX -= underlayX;
+            rootY -= underlayY;
+            const float pad = instance.barConfig.widgetCapsulePadding * widget->contentScale();
+            const float rootMainStart = isVertical ? rootY : rootX;
+            const float rootMainExtent = isVertical ? root->height() : root->width();
+            float mainStart = rootMainStart - pad;
+            float mainEnd = rootMainStart + rootMainExtent + pad;
+            // Clamp to the shell's real edges only when the capsule bg is visible, so the pill
+            // never bleeds past a painted background; unclamped (free to overlap neighbors) when
+            // there is no ink to bleed past.
+            if (run.hasVisibleInk) {
+              mainStart = std::max(shellMainStart, mainStart);
+              mainEnd = std::min(shellMainEnd, mainEnd);
+            }
+            const float mainExtent = std::max(0.0F, mainEnd - mainStart);
+            const float hoverW = isVertical ? capsuleCross : mainExtent;
+            const float hoverH = isVertical ? mainExtent : capsuleCross;
+            box->setPosition(
+                isVertical ? rootX + (root->width() - capsuleCross) * 0.5F : mainStart,
+                isVertical ? mainStart : rootY + (root->height() - capsuleCross) * 0.5F
+            );
+            box->setSize(hoverW, hoverH);
+            box->setRadius(
+                radiusSource != nullptr ? radiusSource->resolvedBarCapsuleRadius(hoverW, hoverH)
+                                        : widget->resolvedBarCapsuleRadius(hoverW, hoverH)
+            );
+          }
+        }
+      };
+      placeGroupHoverPills(instance.startCapsuleRuns);
+      placeGroupHoverPills(instance.centerCapsuleRuns);
+      placeGroupHoverPills(instance.endCapsuleRuns);
     }
     if (screenEdgeClick) {
       auto extendHitTestOutsetToScreenEdge = [&](Node* node, bool start) {
@@ -2645,7 +2730,9 @@ void Bar::attachWidgetsToSections(BarInstance& instance) {
       if (hoverHighlight) {
         hoverBoxes.reserve(memberOrder.size());
         for (const std::size_t memberIndex : memberOrder) {
-          hoverBoxes.push_back(addHoverBox(*widgets[memberIndex], *shellPtr));
+          hoverBoxes.push_back(
+              instance.hoverUnderlay != nullptr ? addHoverBox(*widgets[memberIndex], *instance.hoverUnderlay) : nullptr
+          );
         }
       }
 
@@ -3099,14 +3186,14 @@ void Bar::buildScene(BarInstance& instance, std::uint32_t width, std::uint32_t h
     }
     // Note: shadow is inserted before bar sections so it renders below them (z=-1 is set below).
 
+    auto contentClip = ui::node({});
+    contentClip->setClipChildren(true);
+    instance.contentClip = instance.slideRoot->addChild(std::move(contentClip));
+
     auto hoverUnderlay = ui::node({});
     hoverUnderlay->setHitTestVisible(false);
     hoverUnderlay->setSize(static_cast<float>(w), static_cast<float>(h));
     instance.hoverUnderlay = instance.slideRoot->addChild(std::move(hoverUnderlay));
-
-    auto contentClip = ui::node({});
-    contentClip->setClipChildren(true);
-    instance.contentClip = instance.slideRoot->addChild(std::move(contentClip));
 
     auto makeSlot = [&instance]() {
       auto slot = ui::node({});

--- a/src/shell/bar/bar_instance.h
+++ b/src/shell/bar/bar_instance.h
@@ -27,10 +27,8 @@ struct BarCapsuleRun {
   Node* content = nullptr;
   WidgetBarCapsuleSpec spec{};
   float contentScale = 1.0F;
-  // Set by finalizeCapsules each layout pass: whether any member currently draws visible ink (capsule bg).
-  // Read by placeGroupHoverPills and extendCapsuleHitTargets to decide whether group-member hovers/triggers
-  // need the clipped/clamped treatment (ink visible) or the unclamped treatment (no ink).
-  bool hasVisibleInk = false;
+  // Capsule geometry can exist without a painted fill or border.
+  bool hasPaintedCapsuleBackground = false;
   std::vector<Widget*> widgets;
   // Hover highlight overlays, parallel to `widgets` for group runs; one shared box for single runs.
   std::vector<Box*> hoverBoxes;

--- a/src/shell/bar/bar_instance.h
+++ b/src/shell/bar/bar_instance.h
@@ -27,6 +27,10 @@ struct BarCapsuleRun {
   Node* content = nullptr;
   WidgetBarCapsuleSpec spec{};
   float contentScale = 1.0F;
+  // Set by finalizeCapsules each layout pass: whether any member currently draws visible ink (capsule bg).
+  // Read by placeGroupHoverPills and extendCapsuleHitTargets to decide whether group-member hovers/triggers
+  // need the clipped/clamped treatment (ink visible) or the unclamped treatment (no ink).
+  bool hasVisibleInk = false;
   std::vector<Widget*> widgets;
   // Hover highlight overlays, parallel to `widgets` for group runs; one shared box for single runs.
   std::vector<Box*> hoverBoxes;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
This PR detaches group hover pills from their original clipping boundaries and corrects both their visual rendering and hit-box dimensions.

## Motivation

<!-- What problem does this solve? -->
The primary issue stems from how capsule groups render their hover highlights, particularly when using a transparent background to make use of accordions. Previously, the hover highlights for widgets inside a capsule group were inappropriately clipped along the main axis, which became glaringly obvious when the group's opacity was set to zero.

Additionally, capsule groups had a larger hit-test area for widgets at the edges, noticeable with high padding values. Hovering or clicking on this extra padding would incorrectly trigger the widget at the edge, rather than restricting the interactive area to the actual visual bounds of the hover pill. This update addresses these visual and interactive inconsistencies to ensure the hover state behaves exactly as expected.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
 Closes #3954
 
## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

- `just format`
- `just tests` 85/85
- `just lint`, all ok
- Tested vertical and horizontal bars
- Tested single widget capsules, capsule groups
- Tested various capsule thickness values
- Tested capsules with background color and without background color (0 opacity)
- Tested default, low and high padding values
- Tested with accordion enabled, both directions

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
Before

<img width="200" height="100" alt="image" src="https://github.com/user-attachments/assets/ffe96b7a-b231-4352-b6e0-203e6f3032c6" />

<img width="124" height="96" alt="image" src="https://github.com/user-attachments/assets/2b4c26d4-4919-4b45-96a7-0c8a93bb2157" />


<img width="210" height="76" alt="image" src="https://github.com/user-attachments/assets/dd63e06d-9672-46cc-a10f-69e472bf2571" />


After

<img width="162" height="114" alt="image" src="https://github.com/user-attachments/assets/8f856a0b-b8de-4311-a3fb-bcd4096aceeb" />

<img width="124" height="96" alt="image" src="https://github.com/user-attachments/assets/ebaf1f38-c30a-4a83-939e-68a344458894" />

<img width="190" height="80" alt="image" src="https://github.com/user-attachments/assets/a52ab1a2-304d-4013-9b16-d41d2c78a8c1" />

<img width="200" height="106" alt="image" src="https://github.com/user-attachments/assets/6bb19988-2d04-4177-a974-89249f140535" />


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
Currently, capsules have a larger surrounding spacing than standalone widgets, which leads to inconsistent gaps when using transparent backgrounds. While tweaking the group's padding works as a temporary workaround, it ends up making the hover box look visually off. As a future enhancement, it would be great to introduce a dedicated capsule margin setting, configured similarly to the capsule radius. I plan to open a separate PR for this soon.