### PR TITLE
fix(settings): display inherited radius for capsule group auto mode

### DIFF
--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -2334,11 +2334,7 @@ namespace settings {
           )
       );
 
-      const float inheritedRadius = laneOvr != nullptr && laneOvr->widgetCapsuleRadius.has_value()
-          ? static_cast<float>(*laneOvr->widgetCapsuleRadius)
-          : (laneBar != nullptr && laneBar->widgetCapsuleRadius.has_value()
-                 ? static_cast<float>(*laneBar->widgetCapsuleRadius)
-                 : 12.0F);
+      const auto inheritedRadius = static_cast<float>(inheritedCapsuleRadiusForLane(ctx.config, laneListPath));
 
       ctx.makeRow(
           *panelPtr, groupEntry("radius"),

--- a/src/shell/settings/bar_widget_editor.cpp
+++ b/src/shell/settings/bar_widget_editor.cpp
@@ -2137,10 +2137,10 @@ namespace settings {
 
     // Radius Auto | Custom segmented control + stepper (no label).
     std::unique_ptr<Node> makeGroupRadiusControl(
-        const BarWidgetEditorContext& ctx, std::optional<float> radius,
+        const BarWidgetEditorContext& ctx, std::optional<float> radius, float inheritedRadius,
         std::function<void(std::optional<float>)> onChange
     ) {
-      const int radiusValue = static_cast<int>(std::lround(std::clamp(radius.value_or(12.0F), 0.0F, 80.0F)));
+      const int radiusValue = static_cast<int>(std::lround(std::clamp(radius.value_or(inheritedRadius), 0.0F, 80.0F)));
       auto wrap = ui::row({.align = FlexAlign::Center, .gap = Style::spaceSm * ctx.scale});
       wrap->addChild(
           ui::segmented({
@@ -2333,9 +2333,16 @@ namespace settings {
               }
           )
       );
+
+      const float inheritedRadius = laneOvr != nullptr && laneOvr->widgetCapsuleRadius.has_value()
+          ? static_cast<float>(*laneOvr->widgetCapsuleRadius)
+          : (laneBar != nullptr && laneBar->widgetCapsuleRadius.has_value()
+                 ? static_cast<float>(*laneBar->widgetCapsuleRadius)
+                 : 12.0F);
+
       ctx.makeRow(
           *panelPtr, groupEntry("radius"),
-          makeGroupRadiusControl(ctx, style.radius, [mutateGroup](std::optional<float> r) {
+          makeGroupRadiusControl(ctx, style.radius, inheritedRadius, [mutateGroup](std::optional<float> r) {
             mutateGroup([&](BarCapsuleGroupStyle& g) { g.radius = r; });
           })
       );


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Updated the `makeGroupRadiusControl` in the bar widget editor to display the dynamically resolved inherited radius when a capsule group's radius is set to "Auto", replacing a hardcoded fallback value.

## Motivation

Previously, when a capsule group's radius was set to "Auto" (`std::nullopt`), the settings UI stepper would always display a hardcoded value of `12`. This was visually confusing if the global bar configuration or monitor override had a different radius set, as the UI did not reflect the actual inherited value. 

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->
N/A 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- `just format`
- `just test`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
<img width="740" height="94" alt="screenshot_20260815_191602-region" src="https://github.com/user-attachments/assets/ab134366-8a45-42f0-8652-d481fa29beea" />

Before
<img width="737" height="62" alt="screenshot_20260815_191610-region" src="https://github.com/user-attachments/assets/73142abe-bc2f-4458-b922-cb4e97810a6a" />

After
<img width="737" height="62" alt="screenshot_20260815_191657-region" src="https://github.com/user-attachments/assets/0ef5b6e8-65dd-4ce3-b5e0-aec057371943" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
N/A