### PR TITLE
fix(tray): align hover pills with bar capsule thickness

### DIFF
--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -969,8 +969,15 @@ namespace {
   ) {
     const float slotCross = isVertical ? barAreaW : barAreaH;
 
+    // Capsule cross-size is a fraction of the bar thickness (capsule_thickness), the same for every capsule
+    // regardless of per-widget content scale. The max() guard keeps a thin bar from yielding a 0px capsule.
+    const float capsuleCross = std::max(1.0F, std::round(slotCross * instance.barConfig.capsuleThickness));
+
     auto layoutWidgets = [&](std::vector<std::unique_ptr<Widget>>& widgets) {
       for (auto& widget : widgets) {
+        if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {
+          tray->setCapsuleCross(capsuleCross);
+        }
         if (widget->root() != nullptr) {
           widget->layout(renderer, barAreaW, barAreaH);
         }
@@ -979,21 +986,6 @@ namespace {
     layoutWidgets(instance.startWidgets);
     layoutWidgets(instance.centerWidgets);
     layoutWidgets(instance.endWidgets);
-
-    // Capsule cross-size is a fraction of the bar thickness (capsule_thickness), the same for every capsule
-    // regardless of per-widget content scale. The max() guard keeps a thin bar from yielding a 0px capsule.
-    const float capsuleCross = std::max(1.0F, std::round(slotCross * instance.barConfig.capsuleThickness));
-
-    auto updateTrayCross = [capsuleCross](std::vector<std::unique_ptr<Widget>>& widgets) {
-      for (auto& widget : widgets) {
-        if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {
-          tray->setCapsuleCross(capsuleCross);
-        }
-      }
-    };
-    updateTrayCross(instance.startWidgets);
-    updateTrayCross(instance.centerWidgets);
-    updateTrayCross(instance.endWidgets);
 
     auto finalizeCapsules = [isVertical, capsuleCross, widgetHoverPadding = instance.barConfig.widgetCapsulePadding,
                              &renderer](std::vector<BarCapsuleRun>& runs) {

--- a/src/shell/bar/bar.cpp
+++ b/src/shell/bar/bar.cpp
@@ -983,6 +983,18 @@ namespace {
     // Capsule cross-size is a fraction of the bar thickness (capsule_thickness), the same for every capsule
     // regardless of per-widget content scale. The max() guard keeps a thin bar from yielding a 0px capsule.
     const float capsuleCross = std::max(1.0F, std::round(slotCross * instance.barConfig.capsuleThickness));
+
+    auto updateTrayCross = [capsuleCross](std::vector<std::unique_ptr<Widget>>& widgets) {
+      for (auto& widget : widgets) {
+        if (auto* tray = dynamic_cast<TrayWidget*>(widget.get())) {
+          tray->setCapsuleCross(capsuleCross);
+        }
+      }
+    };
+    updateTrayCross(instance.startWidgets);
+    updateTrayCross(instance.centerWidgets);
+    updateTrayCross(instance.endWidgets);
+
     auto finalizeCapsules = [isVertical, capsuleCross, widgetHoverPadding = instance.barConfig.widgetCapsulePadding,
                              &renderer](std::vector<BarCapsuleRun>& runs) {
       for (auto& run : runs) {

--- a/src/shell/bar/widgets/tray_widget.cpp
+++ b/src/shell/bar/widgets/tray_widget.cpp
@@ -467,7 +467,7 @@ void TrayWidget::rebuild(Renderer& renderer) {
     Box* hoverBoxPtr = nullptr;
     ColorSpec hoverFill = widgetForegroundOr(colorSpecFromRole(ColorRole::OnSurface));
     hoverFill.alpha = 0.0F;
-    const float padding = Style::spaceXs * m_contentScale;
+    const float padding = barCapsuleSpec().padding * m_contentScale;
     const float boxSize = size + padding * 2.0F;
 
     auto hoverBox = ui::box({
@@ -1060,7 +1060,27 @@ void TrayWidget::layoutHoverOverlays() {
     float areaX = 0.0F;
     float areaY = 0.0F;
     Node::absolutePosition(entry.area, areaX, areaY);
-    entry.box->setPosition(areaX - underlayX - entry.padding, areaY - underlayY - entry.padding);
+
+    const float mainExtent = m_isVertical ? entry.area->height() : entry.area->width();
+
+    const float hoverW = m_isVertical ? m_capsuleCross : mainExtent + 2.0F * entry.padding;
+    const float hoverH = m_isVertical ? mainExtent + 2.0F * entry.padding : m_capsuleCross;
+
+    entry.box->setSize(hoverW, hoverH);
+    entry.box->setRadius(resolvedBarCapsuleRadius(hoverW, hoverH));
+
+    float boxX = areaX - underlayX;
+    float boxY = areaY - underlayY;
+
+    if (m_isVertical) {
+      boxX += (entry.area->width() - m_capsuleCross) * 0.5F;
+      boxY -= entry.padding;
+    } else {
+      boxX -= entry.padding;
+      boxY += (entry.area->height() - m_capsuleCross) * 0.5F;
+    }
+
+    entry.box->setPosition(boxX, boxY);
   }
 }
 

--- a/src/shell/bar/widgets/tray_widget.h
+++ b/src/shell/bar/widgets/tray_widget.h
@@ -44,6 +44,7 @@ public:
   ~TrayWidget() override;
 
   void setHoverOverlayParent(Node* node) noexcept { m_hoverOverlayParent = node; }
+  void setCapsuleCross(float cross) noexcept { m_capsuleCross = cross; }
   void create() override;
   [[nodiscard]] bool wantsBarHoverHighlight() const noexcept override { return false; }
 
@@ -108,4 +109,5 @@ private:
   Signal<>::ScopedConnection m_appIconColorizeConn;
   Node* m_hoverOverlayParent = nullptr;
   std::vector<HoverOverlayEntry> m_hoverOverlays;
+  float m_capsuleCross = 0.0F;
 };


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

`bar.cpp` now injects the globally calculated `capsuleCross` dimension directly into `TrayWidget` during the layout phase. `TrayWidget` uses this official thickness to stretch its inline hover pills along the cross axis, rather than drawing square boxes based solely on its internal padding.

## Motivation

Tray widget hover box was fixed, not following capsule thickness like any other widget.
This is a follow-up to the hover pills refactor in #3960, commit `c3b6364`.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [x] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->
N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
N/A