### PR TITLE
fix(settings): stop inflating tiled settings buffers past compositor size

### DIFF
--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -57,6 +57,22 @@ namespace {
   constexpr float kWindowMinWidth = 1020.0F;
   constexpr float kWindowMinHeight = 500.0F;
 
+  // min_size hints are orientation-aware: portrait outputs constrain width, so the hint
+  // follows the same 66% short-edge budget as the default open size instead of 1020.
+  [[nodiscard]] std::pair<float, float> settingsWindowMinSize(float outputW, float outputH, float scale) {
+    float minW = kWindowMinWidth * scale;
+    float minH = kWindowMinHeight * scale;
+    if (outputW <= 0.0F || outputH <= 0.0F) {
+      return {minW, minH};
+    }
+    if (outputW < outputH) {
+      minW = std::min(minW, outputW * kWindowOutputFraction);
+    }
+    minW = std::min(minW, outputW);
+    minH = std::min(minH, outputH);
+    return {minW, minH};
+  }
+
   // Build the {"bar", name, <lane>} path the widget inspector expects, resolving which lane the widget
   // currently lives in (the inspector keys off the bar name at index 1 and the lane at the tail).
   std::vector<std::string>
@@ -423,13 +439,14 @@ void SettingsWindow::open(std::string context) {
   m_surface->setUpdateCallback([]() {});
 
   const float scale = uiScale();
-  const float minWidthF = kWindowMinWidth * scale;
-  const float minHeightF = kWindowMinHeight * scale;
   float desiredWidth = kWindowWidth * scale;
   float desiredHeight = kWindowHeight * scale;
+  float minWidthF = kWindowMinWidth * scale;
+  float minHeightF = kWindowMinHeight * scale;
   if (const WaylandOutput* info = m_wayland->findOutputByWl(output); info != nullptr && info->hasUsableGeometry()) {
     const auto outputW = static_cast<float>(info->effectiveLogicalWidth());
     const auto outputH = static_cast<float>(info->effectiveLogicalHeight());
+    std::tie(minWidthF, minHeightF) = settingsWindowMinSize(outputW, outputH, scale);
     if (outputW >= outputH) {
       desiredHeight = util::clampOrdered(outputH * kWindowOutputFraction, std::min(minHeightF, outputH), outputH);
       desiredWidth = util::clampOrdered(desiredHeight * kGoldenRatio, std::min(minWidthF, outputW), outputW);
@@ -653,8 +670,17 @@ void SettingsWindow::prepareFrame(bool needsUpdate, bool needsLayout) {
     m_filterRowRefreshRequested = false;
     phaseProfileWatch.reset();
     const float scale = uiScale();
-    const auto newMinW = static_cast<std::uint32_t>(std::round(kWindowMinWidth * scale));
-    const auto newMinH = static_cast<std::uint32_t>(std::round(kWindowMinHeight * scale));
+    float minWidthF = kWindowMinWidth * scale;
+    float minHeightF = kWindowMinHeight * scale;
+    if (m_wayland != nullptr && m_output != nullptr) {
+      if (const WaylandOutput* info = m_wayland->findOutputByWl(m_output); info != nullptr && info->hasUsableGeometry()) {
+        std::tie(minWidthF, minHeightF) = settingsWindowMinSize(
+            static_cast<float>(info->effectiveLogicalWidth()), static_cast<float>(info->effectiveLogicalHeight()), scale
+        );
+      }
+    }
+    const auto newMinW = static_cast<std::uint32_t>(std::round(minWidthF));
+    const auto newMinH = static_cast<std::uint32_t>(std::round(minHeightF));
     m_surface->setMinSize(newMinW, newMinH);
     m_surface->clampToMinSize(newMinW, newMinH);
     logSettingsProfile("prepareFrame updateMinSize", phaseProfileWatch);

--- a/src/shell/settings/settings_window.cpp
+++ b/src/shell/settings/settings_window.cpp
@@ -426,6 +426,13 @@ void SettingsWindow::open(std::string context) {
 
   m_surface->setClosedCallback([this]() { destroyWindow(); });
 
+  m_surface->setOutputChangedCallback([this](wl_output* currentOutput) {
+    m_output = currentOutput;
+    if (currentOutput != nullptr && m_surface != nullptr) {
+      m_surface->requestLayout();
+    }
+  });
+
   m_surface->setConfigureCallback([this](std::uint32_t /*width*/, std::uint32_t /*height*/) {
     if (m_surface != nullptr) {
       m_surface->requestLayout();
@@ -474,6 +481,8 @@ void SettingsWindow::open(std::string context) {
     m_surface.reset();
     return;
   }
+  m_minWidthHint = minWidth;
+  m_minHeightHint = minHeight;
   m_pointerInside = false;
   m_lastSceneWidth = 0;
   m_lastSceneHeight = 0;
@@ -572,6 +581,8 @@ void SettingsWindow::destroyWindow() {
   m_surface.reset();
   m_pointerInside = false;
   m_output = nullptr;
+  m_minWidthHint = 0;
+  m_minHeightHint = 0;
   m_lastSceneWidth = 0;
   m_lastSceneHeight = 0;
   m_settingsRegistry.clear();
@@ -649,6 +660,32 @@ void SettingsWindow::prepareFrame(bool needsUpdate, bool needsLayout) {
   const bool sizeChanged = !firstBuild && (m_lastSceneWidth != width || m_lastSceneHeight != height);
   const bool needRebuild = firstBuild || m_rebuildRequested;
 
+  const float scale = uiScale();
+  float minWidthF = kWindowMinWidth * scale;
+  float minHeightF = kWindowMinHeight * scale;
+  wl_output* currentOutput = nullptr;
+  if (m_wayland != nullptr && m_surface != nullptr) {
+    currentOutput = m_wayland->outputForSurface(m_surface->wlSurface());
+  }
+  if (currentOutput == nullptr) {
+    currentOutput = m_output;
+  }
+  if (const WaylandOutput* info = m_wayland->findOutputByWl(currentOutput);
+      info != nullptr && info->hasUsableGeometry()) {
+    std::tie(minWidthF, minHeightF) = settingsWindowMinSize(
+        static_cast<float>(info->effectiveLogicalWidth()), static_cast<float>(info->effectiveLogicalHeight()), scale
+    );
+  }
+  const auto newMinW = static_cast<std::uint32_t>(std::round(minWidthF));
+  const auto newMinH = static_cast<std::uint32_t>(std::round(minHeightF));
+  if (newMinW != m_minWidthHint || newMinH != m_minHeightHint) {
+    phaseProfileWatch.reset();
+    m_surface->setMinSize(newMinW, newMinH);
+    m_minWidthHint = newMinW;
+    m_minHeightHint = newMinH;
+    logSettingsProfile("prepareFrame updateMinSize", phaseProfileWatch);
+  }
+
   if (needRebuild) {
     phaseProfileWatch.reset();
     UiPhaseScope layoutPhase(UiPhase::Layout);
@@ -668,22 +705,6 @@ void SettingsWindow::prepareFrame(bool needsUpdate, bool needsLayout) {
     m_contentRebuildRequested = false;
     m_settingsRegistryRefreshRequested = false;
     m_filterRowRefreshRequested = false;
-    phaseProfileWatch.reset();
-    const float scale = uiScale();
-    float minWidthF = kWindowMinWidth * scale;
-    float minHeightF = kWindowMinHeight * scale;
-    if (m_wayland != nullptr && m_output != nullptr) {
-      if (const WaylandOutput* info = m_wayland->findOutputByWl(m_output); info != nullptr && info->hasUsableGeometry()) {
-        std::tie(minWidthF, minHeightF) = settingsWindowMinSize(
-            static_cast<float>(info->effectiveLogicalWidth()), static_cast<float>(info->effectiveLogicalHeight()), scale
-        );
-      }
-    }
-    const auto newMinW = static_cast<std::uint32_t>(std::round(minWidthF));
-    const auto newMinH = static_cast<std::uint32_t>(std::round(minHeightF));
-    m_surface->setMinSize(newMinW, newMinH);
-    m_surface->clampToMinSize(newMinW, newMinH);
-    logSettingsProfile("prepareFrame updateMinSize", phaseProfileWatch);
   } else if ((m_contentRebuildRequested || sizeChanged || needsLayout) && m_sceneRoot != nullptr) {
     phaseProfileWatch.reset();
     UiPhaseScope layoutPhase(UiPhase::Layout);

--- a/src/shell/settings/settings_window.h
+++ b/src/shell/settings/settings_window.h
@@ -272,6 +272,8 @@ private:
   std::unique_ptr<SelectDropdownPopup> m_selectPopup;
   bool m_pointerInside = false;
   wl_output* m_output = nullptr;
+  std::uint32_t m_minWidthHint = 0;
+  std::uint32_t m_minHeightHint = 0;
 
   std::uint32_t m_lastSceneWidth = 0;
   std::uint32_t m_lastSceneHeight = 0;

--- a/src/wayland/surface.cpp
+++ b/src/wayland/surface.cpp
@@ -385,6 +385,9 @@ void Surface::onSurfaceOutputEnter(wl_surface* surface, wl_output* output) {
     return;
   }
   m_connection.notifySurfaceOutputEnter(surface, output);
+  if (m_outputChangedCallback) {
+    m_outputChangedCallback(output);
+  }
 
   const WaylandOutput* outputInfo = m_connection.findOutputByWl(output);
   if (outputInfo == nullptr) {
@@ -414,6 +417,9 @@ void Surface::onSurfaceOutputLeave(wl_surface* surface, wl_output* output) {
     return;
   }
   m_connection.notifySurfaceOutputLeave(surface, output);
+  if (m_outputChangedCallback) {
+    m_outputChangedCallback(m_connection.outputForSurface(m_surface));
+  }
 }
 
 bool Surface::createWlSurface() {
@@ -469,6 +475,10 @@ void Surface::setUpdateCallback(UpdateCallback callback) { m_updateCallback = st
 void Surface::setFrameTickCallback(FrameTickCallback callback) { m_frameTickCallback = std::move(callback); }
 
 void Surface::setScaleChangedCallback(ScaleChangedCallback callback) { m_scaleChangedCallback = std::move(callback); }
+
+void Surface::setOutputChangedCallback(OutputChangedCallback callback) {
+  m_outputChangedCallback = std::move(callback);
+}
 
 void Surface::setSceneRoot(Node* root) {
   if (m_sceneRoot == root) {

--- a/src/wayland/surface.h
+++ b/src/wayland/surface.h
@@ -65,6 +65,7 @@ public:
   using UpdateCallback = std::function<void()>;
   using FrameTickCallback = std::function<void(float deltaMs)>;
   using ScaleChangedCallback = std::function<void(float scale)>;
+  using OutputChangedCallback = std::function<void(wl_output* output)>;
 
   explicit Surface(WaylandConnection& connection);
   virtual ~Surface();
@@ -81,6 +82,7 @@ public:
   void setUpdateCallback(UpdateCallback callback);
   void setFrameTickCallback(FrameTickCallback callback);
   void setScaleChangedCallback(ScaleChangedCallback callback);
+  void setOutputChangedCallback(OutputChangedCallback callback);
   void setInputRegion(const std::vector<InputRect>& rects);
   void setBlurRegion(const std::vector<InputRect>& rects);
   void clearBlurRegion();
@@ -190,6 +192,7 @@ private:
   UpdateCallback m_updateCallback;
   FrameTickCallback m_frameTickCallback;
   ScaleChangedCallback m_scaleChangedCallback;
+  OutputChangedCallback m_outputChangedCallback;
   wl_callback* m_frameCallback = nullptr;
   ext_background_effect_surface_v1* m_backgroundEffect = nullptr;
   wp_viewport* m_viewport = nullptr;

--- a/src/wayland/toplevel_surface.cpp
+++ b/src/wayland/toplevel_surface.cpp
@@ -99,19 +99,6 @@ void ToplevelSurface::setMinSize(std::uint32_t minWidth, std::uint32_t minHeight
   }
 }
 
-void ToplevelSurface::clampToMinSize(std::uint32_t minWidth, std::uint32_t minHeight) {
-  if (width() == 0 || height() == 0) {
-    return;
-  }
-
-  if (width() < minWidth || height() < minHeight) {
-    kLog.debug(
-        "toplevel: configured {}x{} is below min_size {}x{}; keeping compositor size (layout adapts, no buffer inflate)",
-        width(), height(), minWidth, minHeight
-    );
-  }
-}
-
 void ToplevelSurface::beginMove(std::uint32_t serial) {
   if (m_toplevel != nullptr) {
     xdg_toplevel_move(m_toplevel, m_connection.seat(), serial);

--- a/src/wayland/toplevel_surface.cpp
+++ b/src/wayland/toplevel_surface.cpp
@@ -100,10 +100,15 @@ void ToplevelSurface::setMinSize(std::uint32_t minWidth, std::uint32_t minHeight
 }
 
 void ToplevelSurface::clampToMinSize(std::uint32_t minWidth, std::uint32_t minHeight) {
-  const auto w = std::max(width(), minWidth);
-  const auto h = std::max(height(), minHeight);
-  if (w != width() || h != height()) {
-    onConfigure(w, h);
+  if (width() == 0 || height() == 0) {
+    return;
+  }
+
+  if (width() < minWidth || height() < minHeight) {
+    kLog.debug(
+        "toplevel: configured {}x{} is below min_size {}x{}; keeping compositor size (layout adapts, no buffer inflate)",
+        width(), height(), minWidth, minHeight
+    );
   }
 }
 

--- a/src/wayland/toplevel_surface.h
+++ b/src/wayland/toplevel_surface.h
@@ -31,6 +31,8 @@ public:
 
   void setClosedCallback(std::function<void()> callback);
   void setMinSize(std::uint32_t minWidth, std::uint32_t minHeight);
+  // Compare configured size to min_size hints. Never inflates the local buffer beyond
+  // the compositor configure size (that caused settings crop on tiled/portrait outputs).
   void clampToMinSize(std::uint32_t minWidth, std::uint32_t minHeight);
   void beginMove(std::uint32_t serial);
 

--- a/src/wayland/toplevel_surface.h
+++ b/src/wayland/toplevel_surface.h
@@ -31,9 +31,6 @@ public:
 
   void setClosedCallback(std::function<void()> callback);
   void setMinSize(std::uint32_t minWidth, std::uint32_t minHeight);
-  // Compare configured size to min_size hints. Never inflates the local buffer beyond
-  // the compositor configure size (that caused settings crop on tiled/portrait outputs).
-  void clampToMinSize(std::uint32_t minWidth, std::uint32_t minHeight);
   void beginMove(std::uint32_t serial);
 
   [[nodiscard]] xdg_surface* xdgSurface() const noexcept { return m_xdgSurface; }


### PR DESCRIPTION
## Summary

- Stop `clampToMinSize()` from inflating the settings toplevel buffer beyond the compositor-configured size, which cropped the UI when the window was tiled smaller than our `min_size` hint.
- Make portrait `min_size` hints orientation-aware by capping width to the same 66% short-edge budget used for the default open size.

Fixes #3977

## Context

Community report: https://discord.com/channels/1401598189823590460/1536363850855874612

Reproduced on a portrait 1440p monitor at 1.5 scale with a second window open (tiled layout). Moving the settings window refreshed the layout and masked the bug until the next configure mismatch.

## Test plan

- [ ] Open Settings on a portrait monitor at fractional scale; verify no horizontal crop at full width
- [ ] Open Settings with another window present so the compositor tiles/splits; verify the UI is not cropped without moving the window
- [ ] Resize/maximize Settings after open; verify layout tracks configure events
- [ ] Confirm landscape behavior is unchanged (min width hint still ~1020 at `ui_scale = 1.0`)

Made with [Cursor](https://cursor.com)