### PR TITLE
fix(lockscreen): preserve fcitx context after unlock

### DIFF
--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -182,9 +182,6 @@ void LockScreen::unlock() {
   stopFingerprint();
 
   const bool wasLockedInteractive = m_locked;
-  for (auto& instance : m_instances) {
-    instance.surface->setLockedState(false);
-  }
 
   if (m_lock != nullptr) {
     if (m_locked) {

--- a/src/shell/lockscreen/lock_screen.cpp
+++ b/src/shell/lockscreen/lock_screen.cpp
@@ -182,6 +182,9 @@ void LockScreen::unlock() {
   stopFingerprint();
 
   const bool wasLockedInteractive = m_locked;
+  for (auto& instance : m_instances) {
+    instance.surface->setLockedState(false);
+  }
 
   if (m_lock != nullptr) {
     if (m_locked) {

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -585,7 +585,9 @@ bool LockSurface::initialize(ext_session_lock_v1* lock, wl_output* output, std::
   if (!createWlSurface()) {
     return false;
   }
-  m_inputDispatcher.setTextInputContext(m_surface, m_connection.textInputService());
+
+  // Keep the lock surface out of text-input-v3; it can leave Chromium's fcitx
+  // context inactive after unlock. Password input still uses wl_keyboard.
 
   m_output = output;
   m_connection.registerSurfaceOutput(m_surface, output);

--- a/src/shell/lockscreen/lock_surface.cpp
+++ b/src/shell/lockscreen/lock_surface.cpp
@@ -585,9 +585,7 @@ bool LockSurface::initialize(ext_session_lock_v1* lock, wl_output* output, std::
   if (!createWlSurface()) {
     return false;
   }
-
-  // Keep the lock surface out of text-input-v3; it can leave Chromium's fcitx
-  // context inactive after unlock. Password input still uses wl_keyboard.
+  m_inputDispatcher.setTextInputContext(m_surface, m_connection.textInputService());
 
   m_output = output;
   m_connection.registerSurfaceOutput(m_surface, output);


### PR DESCRIPTION
## Summary

Stop registering the session lock surface with `text-input-v3`.

This prevents the lock screen from leaving Chromium's fcitx input context inactive after unlocking. Password input continues to be handled through `wl_keyboard`.

## Motivation

When unlocking while Chrome is focused, fcitx may stop accepting input in Chrome. Focusing another application such as Ghostty restores fcitx, after which it also works
again in Chrome.

The lock screen was creating its own `text-input-v3` context for the password field. Removing that context prevents fcitx from being left in the inactive state when focus
returns to Chrome.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A

## Testing

- Built successfully with:
  - `nix develop --command just build debug`
- Manually verified on Niri:
  1. Focus Chrome.
  2. Lock and unlock the session.
  3. Confirm that fcitx works immediately in Chrome without focusing another application first.
- Confirmed that password entry and unlocking still work through `wl_keyboard`.

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

N/A — this change has no visual impact.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

The lock-screen password field intentionally no longer uses an input method. Direct keyboard input remains available through `wl_keyboard`.