### PR TITLE
feat(plugins): auto-update options All/Official/None

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1376,6 +1376,13 @@
       "panel-position": {
         "auto": "Follow Bar"
       },
+      "plugins": {
+        "auto-update": {
+          "all": "All sources",
+          "none": "None",
+          "official": "Official only"
+        }
+      },
       "screen-position": {
         "bottom-center": "Bottom Center",
         "bottom-left": "Bottom Left",
@@ -1498,7 +1505,7 @@
         "add": "Add Source",
         "add-title": "Add Plugin Source",
         "auto-update": "Auto-Update Plugins",
-        "auto-update-desc": "Check enabled sources for new versions in the background and keep installed plugins current",
+        "auto-update-desc": "Check selected sources for new versions in the background and keep installed plugins current",
         "edit": "Edit source",
         "edit-title": "Edit plugin source",
         "empty": "No sources configured.",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1379,8 +1379,8 @@
       "plugins": {
         "auto-update": {
           "all": "All sources",
-          "none": "None",
-          "official": "Official only"
+          "official": "Official only",
+          "none": "None"
         }
       },
       "screen-position": {

--- a/src/app/application.h
+++ b/src/app/application.h
@@ -188,8 +188,8 @@ private:
   void reloadDmenuProviders();
   // (Re)register plugin-backed panels from the enabled plugin set.
   void reloadPluginPanels();
-  // When [plugins].auto_update is on, pull every git source. Run once at startup and on
-  // a 6h repeating timer so long-lived sessions pick up new plugin versions.
+  // When [plugins].auto_update is on, pull git sources per the configured mode. Run once at
+  // startup and on a 6h repeating timer so long-lived sessions pick up new plugin versions.
   void runPluginAutoUpdate();
   void startTrayService();
   void syncNotificationDaemon();

--- a/src/app/application_plugins.cpp
+++ b/src/app/application_plugins.cpp
@@ -138,11 +138,7 @@ void Application::reloadPluginPanels() {
 }
 
 void Application::runPluginAutoUpdate() {
-  // With [plugins].auto_update on, pull every git source in the background. Each update
-  // runs off-thread and serializes per-source via a source lock, so a tick that overlaps
-  // a still-running update queues behind it rather than racing (at 6h it never does).
-  if (!m_configService.config().plugins.autoUpdate) {
-    return;
-  }
-  m_pluginManager.updateAll();
+  // Each update runs off-thread and serializes per-source via a source lock, so a tick
+  // that overlaps a still-running update queues behind it rather than racing (at 6h it never does).
+  m_pluginManager.updateAutoUpdateScope(m_configService.config().plugins.autoUpdate);
 }

--- a/src/config/config_migrations.cpp
+++ b/src/config/config_migrations.cpp
@@ -25,6 +25,7 @@ namespace noctalia::config {
     constexpr int kKeyboardLayoutShowGlyphMigrationVersion = 10;
     constexpr int kWorkspacesDisplayMigrationVersion = 11;
     constexpr int kKeyboardLayoutCustomLabelsMigrationVersion = 12;
+    constexpr int kPluginAutoUpdateModeMigrationVersion = 13;
     constexpr std::int64_t kMaxBarRadius = 500;
     constexpr std::array<std::string_view, 5> kBarRadiusKeys = {
         "radius", "radius_top_left", "radius_top_right", "radius_bottom_left", "radius_bottom_right",
@@ -642,6 +643,28 @@ namespace noctalia::config {
       });
     }
 
+    template <typename OnChanged> void migratePluginAutoUpdateMode(toml::table& root, OnChanged&& onChanged) {
+      auto* plugins = root["plugins"].as_table();
+      if (plugins == nullptr) {
+        return;
+      }
+
+      const auto legacy = (*plugins)["auto_update"].value<bool>();
+      if (!legacy.has_value()) {
+        return;
+      }
+
+      const std::string_view mode = *legacy ? "all" : "none";
+      plugins->insert_or_assign("auto_update", std::string(mode));
+      onChanged("plugins.auto_update", mode);
+    }
+
+    void migratePluginAutoUpdateModeSidecar(toml::table& root, schema::Diagnostics& diag) {
+      migratePluginAutoUpdateMode(root, [&diag](const std::string& path, std::string_view mode) {
+        diag.warn(path, "migrated boolean plugin auto-update setting to \"" + std::string(mode) + "\"");
+      });
+    }
+
     std::uint64_t stableIssueHash(int migrationVersion, std::string_view path) {
       constexpr std::uint64_t kOffset = 14695981039346656037ULL;
       constexpr std::uint64_t kPrime = 1099511628211ULL;
@@ -738,6 +761,11 @@ namespace noctalia::config {
             .toVersion = kKeyboardLayoutCustomLabelsMigrationVersion,
             .summary = "keyboard layout: move custom labels to shell configuration",
             .apply = migrateKeyboardLayoutCustomLabelsSidecar,
+        },
+        {
+            .toVersion = kPluginAutoUpdateModeMigrationVersion,
+            .summary = "plugins: migrate boolean auto-update to source scope",
+            .apply = migratePluginAutoUpdateModeSidecar,
         },
     };
     return migrations;
@@ -876,6 +904,13 @@ namespace noctalia::config {
               ? "keyboard layout custom_labels moved to shell.keyboard_layout.custom_labels; conflicting canonical "
                 "labels were kept"
               : "keyboard layout custom_labels moved to shell.keyboard_layout.custom_labels",
+      });
+    });
+    migratePluginAutoUpdateMode(root, [&issues](const std::string& path, std::string_view mode) {
+      issues.push_back({
+          .migrationVersion = kPluginAutoUpdateModeMigrationVersion,
+          .path = path,
+          .message = "boolean plugin auto-update is deprecated; use \"" + std::string(mode) + "\"",
       });
     });
   }

--- a/src/config/config_overrides.cpp
+++ b/src/config/config_overrides.cpp
@@ -1129,18 +1129,19 @@ void ConfigService::setDockEnabled(bool enabled) {
   fireReloadCallbacks();
 }
 
-void ConfigService::setPluginsAutoUpdate(bool enabled) {
+void ConfigService::setPluginsAutoUpdate(PluginAutoUpdateMode mode) {
   if (m_overridesPath.empty()) {
     return;
   }
 
   auto* pluginsTbl = ensureTable(m_overridesTable, "plugins");
-  const auto existing = (*pluginsTbl)["auto_update"].value<bool>();
-  if (existing.has_value() && *existing == enabled && m_config.plugins.autoUpdate == enabled) {
+  const auto existingKey = (*pluginsTbl)["auto_update"].value<std::string>();
+  const auto existingMode = existingKey.has_value() ? enumFromKey(kPluginAutoUpdateModes, *existingKey) : std::nullopt;
+  if (existingMode.has_value() && *existingMode == mode && m_config.plugins.autoUpdate == mode) {
     return;
   }
 
-  pluginsTbl->insert_or_assign("auto_update", enabled);
+  pluginsTbl->insert_or_assign("auto_update", std::string(enumToKey(kPluginAutoUpdateModes, mode)));
 
   if (!writeOverridesToFile()) {
     kLog.warn("failed to write {}", m_overridesPath);

--- a/src/config/config_service.h
+++ b/src/config/config_service.h
@@ -117,9 +117,9 @@ public:
   void addPluginSource(const PluginSourceConfig& source);
   void removePluginSource(std::string_view name);
 
-  // Persist the global [plugins].auto_update override to settings.toml and trigger the
-  // reload pipeline. Drives background auto-update of every git source.
-  void setPluginsAutoUpdate(bool enabled);
+  // Persist the global [plugins].auto_update mode to settings.toml and trigger the
+  // reload pipeline. Drives background auto-update of git sources per mode.
+  void setPluginsAutoUpdate(PluginAutoUpdateMode mode);
 
   // Persist a theme-mode override to settings.toml and trigger the reload pipeline.
   void setThemeMode(ThemeMode mode);

--- a/src/config/config_types.cpp
+++ b/src/config/config_types.cpp
@@ -72,6 +72,17 @@ bool isDefaultPluginSourceName(std::string_view name) {
   return std::ranges::contains(sources, name, &PluginSourceConfig::name);
 }
 
+bool sourceInAutoUpdateScope(const PluginSourceConfig& source, PluginAutoUpdateMode mode) {
+  if (mode == PluginAutoUpdateMode::None || source.kind != PluginSourceKind::Git || !source.enabled) {
+    return false;
+  }
+  if (mode == PluginAutoUpdateMode::All) {
+    return true;
+  }
+  const auto official = defaultPluginSources()[0];
+  return source.name == official.name && source.location == official.location;
+}
+
 bool isValidPluginSourceName(std::string_view name) {
   if (name.empty()) {
     return false;

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1558,9 +1558,9 @@ enum class PluginAutoUpdateMode : std::uint8_t {
 };
 
 constexpr EnumOption<PluginAutoUpdateMode> kPluginAutoUpdateModes[] = {
-    {PluginAutoUpdateMode::None, "none", "settings.options.plugins.auto-update.none"},
-    {PluginAutoUpdateMode::Official, "official", "settings.options.plugins.auto-update.official"},
     {PluginAutoUpdateMode::All, "all", "settings.options.plugins.auto-update.all"},
+    {PluginAutoUpdateMode::Official, "official", "settings.options.plugins.auto-update.official"},
+    {PluginAutoUpdateMode::None, "none", "settings.options.plugins.auto-update.none"},
 };
 
 struct PluginSourceConfig {

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1550,6 +1550,19 @@ constexpr EnumOption<PluginSourceKind> kPluginSourceKinds[] = {
     {PluginSourceKind::Path, "path", "settings.options.plugins.source.path"},
 };
 
+// Background auto-update scope for git plugin sources.
+enum class PluginAutoUpdateMode : std::uint8_t {
+  None = 0,     // never auto-update
+  Official = 1, // only the built-in "official" source
+  All = 2,      // every enabled git source
+};
+
+constexpr EnumOption<PluginAutoUpdateMode> kPluginAutoUpdateModes[] = {
+    {PluginAutoUpdateMode::None, "none", "settings.options.plugins.auto-update.none"},
+    {PluginAutoUpdateMode::Official, "official", "settings.options.plugins.auto-update.official"},
+    {PluginAutoUpdateMode::All, "all", "settings.options.plugins.auto-update.all"},
+};
+
 struct PluginSourceConfig {
   PluginSourceKind kind = PluginSourceKind::Git;
   std::string name;     // stable handle (also the clone subdir for git sources)
@@ -1563,7 +1576,7 @@ struct PluginSourceConfig {
 struct PluginsConfig {
   std::vector<PluginSourceConfig> sources;
   std::vector<std::string> enabled; // active plugin ids ("author/plugin"); opt-in for every source
-  bool autoUpdate = true;           // background auto-update of all git sources (startup + every 6h)
+  PluginAutoUpdateMode autoUpdate = PluginAutoUpdateMode::All; // background auto-update scope (startup + every 6h)
   // Plugin-level setting overrides, keyed by plugin id then setting key. Seeded
   // into every entry runtime of the plugin (widget/shortcut/service). Open-ended
   // (validated against the manifest schema), so compared via configEqual rather
@@ -1573,7 +1586,7 @@ struct PluginsConfig {
 };
 
 // Default sources seeded when [plugins] declares no [[plugins.source]]: the
-// official + community plugin repos (auto-update off).
+// official + community plugin repos.
 [[nodiscard]] std::vector<PluginSourceConfig> defaultPluginSources();
 [[nodiscard]] bool isDefaultPluginSourceName(std::string_view name);
 // Source names are stable user-facing handles and git source storage directory names.

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -1589,6 +1589,11 @@ struct PluginsConfig {
 // official + community plugin repos.
 [[nodiscard]] std::vector<PluginSourceConfig> defaultPluginSources();
 [[nodiscard]] bool isDefaultPluginSourceName(std::string_view name);
+// Whether the background auto-update mode covers `source` (kind, enabled state, and
+// official identity for PluginAutoUpdateMode::Official). The official source matches
+// by name AND location, so a user-added source that reuses the name is not the
+// official source. Pure, so the auto-update tick and its tests share one decision.
+[[nodiscard]] bool sourceInAutoUpdateScope(const PluginSourceConfig& source, PluginAutoUpdateMode mode);
 // Source names are stable user-facing handles and git source storage directory names.
 // Keep them flat so they can never escape the plugin source cache.
 [[nodiscard]] bool isValidPluginSourceName(std::string_view name);

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -536,13 +536,12 @@ namespace noctalia::config::schema {
             [](const PluginSourceConfig& src) { return isValidPluginSourceName(src.name); }
         ),
         field(&PluginsConfig::enabled, "enabled"),
-        // auto_update accepts the legacy booleans (true = all, false = none)
-        // and the string modes none|official|all.
+        // auto_update accepts only "all"|"official"|"none"
         custom<PluginsConfig>(
             "auto_update",
             [](const toml::table& tbl, PluginsConfig& out, std::string_view parentPath, Diagnostics& diag) {
               if (auto v = tbl["auto_update"].value<bool>()) {
-                out.autoUpdate = *v ? PluginAutoUpdateMode::All : PluginAutoUpdateMode::None;
+                out.autoUpdate = *v ? PluginAutoUpdateMode::All : PluginAutoUpdateMode::Official : PLuginAutoUpdateMode::None;
               } else if (auto v = tbl["auto_update"].value<std::string>()) {
                 const std::string trimmed = StringUtils::trim(*v);
                 if (auto parsed = enumFromKey(kPluginAutoUpdateModes, trimmed)) {
@@ -551,7 +550,7 @@ namespace noctalia::config::schema {
                   diag.warn(joinPath(parentPath, "auto_update"), "unknown value \"" + *v + "\"");
                 }
               } else if (tbl.contains("auto_update")) {
-                diag.warn(joinPath(parentPath, "auto_update"), "expected a boolean or none|official|all");
+                diag.warn(joinPath(parentPath, "auto_update"), "expected all|official|none");
               }
             },
             [](toml::table& tbl, const PluginsConfig& in) {

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -545,10 +545,12 @@ namespace noctalia::config::schema {
                 if (auto parsed = enumFromKey(kPluginAutoUpdateModes, trimmed)) {
                   out.autoUpdate = *parsed;
                 } else {
-                  diag.warn(joinPath(parentPath, "auto_update"), "unknown value \"" + *v + "\"");
+                  diag.error(
+                      joinPath(parentPath, "auto_update"), "unknown value \"" + *v + "\"; expected all|official|none"
+                  );
                 }
               } else if (tbl.contains("auto_update")) {
-                diag.warn(joinPath(parentPath, "auto_update"), "expected all|official|none");
+                diag.error(joinPath(parentPath, "auto_update"), "expected all|official|none");
               }
             },
             [](toml::table& tbl, const PluginsConfig& in) {

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -536,7 +536,28 @@ namespace noctalia::config::schema {
             [](const PluginSourceConfig& src) { return isValidPluginSourceName(src.name); }
         ),
         field(&PluginsConfig::enabled, "enabled"),
-        field(&PluginsConfig::autoUpdate, "auto_update"),
+        // auto_update accepts the legacy booleans (true = all, false = none)
+        // and the string modes none|official|all.
+        custom<PluginsConfig>(
+            "auto_update",
+            [](const toml::table& tbl, PluginsConfig& out, std::string_view parentPath, Diagnostics& diag) {
+              if (auto v = tbl["auto_update"].value<bool>()) {
+                out.autoUpdate = *v ? PluginAutoUpdateMode::All : PluginAutoUpdateMode::None;
+              } else if (auto v = tbl["auto_update"].value<std::string>()) {
+                const std::string trimmed = StringUtils::trim(*v);
+                if (auto parsed = enumFromKey(kPluginAutoUpdateModes, trimmed)) {
+                  out.autoUpdate = *parsed;
+                } else {
+                  diag.warn(joinPath(parentPath, "auto_update"), "unknown value \"" + *v + "\"");
+                }
+              } else if (tbl.contains("auto_update")) {
+                diag.warn(joinPath(parentPath, "auto_update"), "expected a boolean or none|official|all");
+              }
+            },
+            [](toml::table& tbl, const PluginsConfig& in) {
+              tbl.insert_or_assign("auto_update", std::string(enumToKey(kPluginAutoUpdateModes, in.autoUpdate)));
+            }
+        ),
         finalize<PluginsConfig>([](PluginsConfig& plugins, std::string_view parentPath, Diagnostics& diag) {
           for (auto it = plugins.enabled.begin(); it != plugins.enabled.end();) {
             if (scripting::isValidPluginId(*it)) {

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -566,6 +566,19 @@ namespace noctalia::config::schema {
             diag.warn(joinPath(parentPath, "enabled"), "invalid plugin id \"" + *it + "\"; expected author/plugin");
             it = plugins.enabled.erase(it);
           }
+          // Duplicate names would share one checkout on disk: keep the first, error on the rest.
+          std::unordered_set<std::string> seen;
+          for (auto it = plugins.sources.begin(); it != plugins.sources.end();) {
+            if (seen.insert(it->name).second) {
+              ++it;
+              continue;
+            }
+            diag.error(
+                joinPath(parentPath, "source"),
+                "duplicate plugin source name \"" + it->name + "\"; source names must be unique"
+            );
+            it = plugins.sources.erase(it);
+          }
         }),
     };
     return s;

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -540,9 +540,7 @@ namespace noctalia::config::schema {
         custom<PluginsConfig>(
             "auto_update",
             [](const toml::table& tbl, PluginsConfig& out, std::string_view parentPath, Diagnostics& diag) {
-              if (auto v = tbl["auto_update"].value<bool>()) {
-                out.autoUpdate = *v ? PluginAutoUpdateMode::All : PluginAutoUpdateMode::Official : PLuginAutoUpdateMode::None;
-              } else if (auto v = tbl["auto_update"].value<std::string>()) {
+              if (auto v = tbl["auto_update"].value<std::string>()) {
                 const std::string trimmed = StringUtils::trim(*v);
                 if (auto parsed = enumFromKey(kPluginAutoUpdateModes, trimmed)) {
                   out.autoUpdate = *parsed;

--- a/src/scripting/plugin_catalog.cpp
+++ b/src/scripting/plugin_catalog.cpp
@@ -302,6 +302,14 @@ namespace scripting {
         return {.ok = false, .error = "clone failed: " + cloned.err, .entries = {}, .revision = {}};
       }
     }
+    if (const auto configured = plugin_git::setOrigin(dest, source.location); !configured) {
+      return {
+          .ok = false,
+          .error = "cannot configure origin for source '" + source.name + "': " + configured.err,
+          .entries = {},
+          .revision = {}
+      };
+    }
     // Browse the freshest catalog: when a prior fetch left FETCH_HEAD ahead of the
     // applied HEAD, read the catalog there so newly published plugins are listed.
     // Return the exact chosen revision so later file reads/exports use the same tree.

--- a/src/scripting/plugin_git.cpp
+++ b/src/scripting/plugin_git.cpp
@@ -144,7 +144,17 @@ namespace scripting::plugin_git {
     );
   }
 
-  GitResult fetch(const std::filesystem::path& dest) {
+  GitResult setOrigin(const std::filesystem::path& dest, std::string_view sourceLocation) {
+    return run(
+        {"git", "-C", dest.string(), "remote", "set-url", "origin", std::string(sourceLocation)}, kLocalTimeout,
+        kProgressCap
+    );
+  }
+
+  GitResult fetch(const std::filesystem::path& dest, std::string_view sourceLocation) {
+    if (auto configured = setOrigin(dest, sourceLocation); !configured) {
+      return configured;
+    }
     // Updates remote-tracking refs + FETCH_HEAD without touching the working tree.
     return run({"git", "-C", dest.string(), "fetch", "origin"}, kNetworkTimeout, kProgressCap);
   }

--- a/src/scripting/plugin_git.h
+++ b/src/scripting/plugin_git.h
@@ -48,9 +48,14 @@ namespace scripting {
         const std::filesystem::path& workTree
     );
 
-    // `git -C dest fetch origin` — update remote-tracking refs + FETCH_HEAD; the
-    // working tree is untouched, so the new revision can be inspected before applying.
-    [[nodiscard]] GitResult fetch(const std::filesystem::path& dest);
+    // Bind the checkout's canonical `origin` URL to the configured source location.
+    // This is local-only and must precede operations that may lazy-fetch blobs.
+    [[nodiscard]] GitResult setOrigin(const std::filesystem::path& dest, std::string_view sourceLocation);
+
+    // Bind `origin` to `sourceLocation`, then fetch it. This prevents a checkout
+    // retained from an older source configuration from fetching its stale remote.
+    // Updates remote-tracking refs + FETCH_HEAD without touching the working tree.
+    [[nodiscard]] GitResult fetch(const std::filesystem::path& dest, std::string_view sourceLocation);
 
     // `git -C dest rev-parse FETCH_HEAD` — out = the just-fetched revision (trimmed).
     [[nodiscard]] GitResult remoteHead(const std::filesystem::path& dest);

--- a/src/scripting/plugin_manager.cpp
+++ b/src/scripting/plugin_manager.cpp
@@ -733,10 +733,17 @@ namespace scripting {
 
   void PluginManager::update(std::string sourceName) {
     const auto source = findSource(sourceName);
-    if (!source.has_value() || source->kind != PluginSourceKind::Git) {
-      return; // path / unknown sources are externally owned
+    if (!source.has_value()) {
+      return; // unknown source
     }
-    const std::filesystem::path repoRoot = plugin_paths::gitRepoRoot(*source);
+    updateSource(*source);
+  }
+
+  void PluginManager::updateSource(const PluginSourceConfig& source) {
+    if (source.kind != PluginSourceKind::Git) {
+      return; // path sources are externally owned
+    }
+    const std::filesystem::path repoRoot = plugin_paths::gitRepoRoot(source);
     if (repoRoot.empty()) {
       return;
     }
@@ -754,8 +761,8 @@ namespace scripting {
 
     // The whole git sequence runs off-thread; only the final registry rescan marshals
     // back to the main thread. `this` is an Application member, so it outlives the worker.
-    std::thread([this, source = *source, repoRoot, sourceName = std::move(sourceName),
-                 enabled = std::move(enabled)]() mutable {
+    const std::string sourceName = source.name;
+    std::thread([this, source, repoRoot, sourceName, enabled = std::move(enabled)]() mutable {
       auto sourceLock = plugin_source_locks::acquire(source.name);
       const auto fetched = plugin_git::fetch(repoRoot);
       if (!fetched) {
@@ -928,18 +935,9 @@ namespace scripting {
   }
 
   void PluginManager::updateAutoUpdateScope(PluginAutoUpdateMode mode) {
-    if (mode == PluginAutoUpdateMode::None) {
-      return;
-    }
-    // The trusted built-in official source is matched by name and location; a
-    // user-added source that reuses the name is not the official source.
-    const auto official = defaultPluginSources()[0];
     for (const auto& source : m_config.config().plugins.sources) {
-      if (source.kind == PluginSourceKind::Git
-          && source.enabled
-          && (mode == PluginAutoUpdateMode::All
-              || (source.name == official.name && source.location == official.location))) {
-        update(source.name);
+      if (sourceInAutoUpdateScope(source, mode)) {
+        updateSource(source);
       }
     }
   }

--- a/src/scripting/plugin_manager.cpp
+++ b/src/scripting/plugin_manager.cpp
@@ -927,15 +927,24 @@ namespace scripting {
     }
   }
 
-  void PluginManager::updateAll() {
+  void PluginManager::updateAutoUpdateScope(PluginAutoUpdateMode mode) {
+    if (mode == PluginAutoUpdateMode::None) {
+      return;
+    }
+    // The trusted built-in official source is matched by name and location; a
+    // user-added source that reuses the name is not the official source.
+    const auto official = defaultPluginSources()[0];
     for (const auto& source : m_config.config().plugins.sources) {
-      if (source.kind == PluginSourceKind::Git && source.enabled) {
+      if (source.kind == PluginSourceKind::Git
+          && source.enabled
+          && (mode == PluginAutoUpdateMode::All
+              || (source.name == official.name && source.location == official.location))) {
         update(source.name);
       }
     }
   }
 
-  void PluginManager::setAutoUpdateEnabled(bool enabled) { m_config.setPluginsAutoUpdate(enabled); }
+  void PluginManager::setAutoUpdateMode(PluginAutoUpdateMode mode) { m_config.setPluginsAutoUpdate(mode); }
 
   void PluginManager::removeSource(std::string sourceName) {
     if (isDefaultPluginSourceName(sourceName)) {

--- a/src/scripting/plugin_manager.cpp
+++ b/src/scripting/plugin_manager.cpp
@@ -427,6 +427,10 @@ namespace scripting {
           return; // offline / unreachable — list/enable will retry
         }
       }
+      if (const auto configured = plugin_git::setOrigin(repoRoot, source.location); !configured) {
+        kLog.warn("plugin source '{}': cannot configure origin: {}", source.name, configured.err);
+        return;
+      }
       if (!materializeEnabledFromRepo(source, repoRoot, enabled)) {
         return; // nothing exported; the startup registry scan already reflects disk state
       }
@@ -509,15 +513,19 @@ namespace scripting {
           error = "source '" + offering->source.name + "' did not resolve a catalog revision";
         } else {
           auto sourceLock = plugin_source_locks::acquire(offering->source.name);
-          logHeldBack(offering->source, offering->entry);
-          auto materialized = materializeGitPlugin(
-              offering->source, plugin_paths::gitRepoRoot(offering->source), offering->entry.resolvedRevision, id, true
-          );
-          ok = materialized && materialized.manifest.id == id;
-          incompatible = materialized.incompatible;
-          timedOut = materialized.timedOut;
-          pluginApiVersion = materialized.pluginApiVersion;
-          error = std::move(materialized.error);
+          const auto repoRoot = plugin_paths::gitRepoRoot(offering->source);
+          if (const auto configured = plugin_git::setOrigin(repoRoot, offering->source.location); !configured) {
+            error = "cannot configure source origin: " + configured.err;
+          } else {
+            logHeldBack(offering->source, offering->entry);
+            auto materialized =
+                materializeGitPlugin(offering->source, repoRoot, offering->entry.resolvedRevision, id, true);
+            ok = materialized && materialized.manifest.id == id;
+            incompatible = materialized.incompatible;
+            timedOut = materialized.timedOut;
+            pluginApiVersion = materialized.pluginApiVersion;
+            error = std::move(materialized.error);
+          }
         }
       } else if (offering.has_value()) {
         const auto manifest = parsePluginManifest(sourceRootFor(offering->source) / subdir / "plugin.toml", &error);
@@ -764,7 +772,7 @@ namespace scripting {
     const std::string sourceName = source.name;
     std::thread([this, source, repoRoot, sourceName, enabled = std::move(enabled)]() mutable {
       auto sourceLock = plugin_source_locks::acquire(source.name);
-      const auto fetched = plugin_git::fetch(repoRoot);
+      const auto fetched = plugin_git::fetch(repoRoot, source.location);
       if (!fetched) {
         DeferredCall::callLater([sourceName, err = fetched.err]() {
           kLog.warn("update '{}': fetch failed: {}", sourceName, err);
@@ -928,7 +936,7 @@ namespace scripting {
         continue; // nothing cloned yet; discoverCatalog clones on first browse
       }
       auto sourceLock = plugin_source_locks::acquire(source.name);
-      if (const auto fetched = plugin_git::fetch(repoRoot); !fetched) {
+      if (const auto fetched = plugin_git::fetch(repoRoot, source.location); !fetched) {
         kLog.warn("browse fetch '{}' failed: {}", source.name, fetched.err);
       }
     }

--- a/src/scripting/plugin_manager.h
+++ b/src/scripting/plugin_manager.h
@@ -153,7 +153,7 @@ namespace scripting {
     [[nodiscard]] std::optional<PluginSourceConfig> findSource(std::string_view name) const;
     // The work behind update(name), on the exact configured source. Callers that
     // already hold the matched PluginSourceConfig must use this directly rather
-    // than resolving by name again (duplicate names are accepted by the schema).
+    // than resolving by name again.
     void updateSource(const PluginSourceConfig& source);
     // Plugin ids offered by the implicit local dev source.
     [[nodiscard]] std::unordered_set<std::string> localPluginIds() const;

--- a/src/scripting/plugin_manager.h
+++ b/src/scripting/plugin_manager.h
@@ -123,12 +123,16 @@ namespace scripting {
     // FETCH_HEAD (browsable catalog); it never advances HEAD or exports files.
     void fetchStaleCatalogs(const PluginsConfig& plugins);
 
-    // Update every enabled git source (each via update()). Backs the store's "update all".
-    void updateAll();
+    // Update enabled git sources scoped by the background auto-update mode
+    // (None = nothing, Official = only the built-in official source, All = every
+    // enabled git source). Backs the background auto-update tick and the store's
+    // "update all" action (All).
+    void updateAutoUpdateScope(PluginAutoUpdateMode mode);
 
-    // Turn the global background auto-update ([plugins].auto_update) on/off. Backs the
-    // single "auto-update plugins" settings toggle; drives every git source at once.
-    void setAutoUpdateEnabled(bool enabled);
+    // Set the global background auto-update mode ([plugins].auto_update).
+    // Backs the "auto-update plugins" settings dropdown; the mode is applied
+    // per source by the auto-update tick.
+    void setAutoUpdateMode(PluginAutoUpdateMode mode);
 
     // Add (or replace) a source and refresh.
     void addSource(const PluginSourceConfig& source);

--- a/src/scripting/plugin_manager.h
+++ b/src/scripting/plugin_manager.h
@@ -151,6 +151,10 @@ namespace scripting {
 
   private:
     [[nodiscard]] std::optional<PluginSourceConfig> findSource(std::string_view name) const;
+    // The work behind update(name), on the exact configured source. Callers that
+    // already hold the matched PluginSourceConfig must use this directly rather
+    // than resolving by name again (duplicate names are accepted by the schema).
+    void updateSource(const PluginSourceConfig& source);
     // Plugin ids offered by the implicit local dev source.
     [[nodiscard]] std::unordered_set<std::string> localPluginIds() const;
     // Re-derive any enabled git-source plugin missing from disk, per source on a worker

--- a/src/shell/settings/settings_content_plugins.cpp
+++ b/src/shell/settings/settings_content_plugins.cpp
@@ -746,12 +746,9 @@ namespace settings {
               .fontSize = Style::fontSizeBody * scale,
               .controlHeight = Style::controlHeight * scale,
               .glyphSize = Style::fontSizeBody * scale,
-              .onSelectionChanged = [cb = ctx.setAutoUpdate,
-                                     modeOptions](std::size_t index, std::string_view /*label*/) {
-                if (cb && index < modeOptions.size()) {
-                  if (auto mode = enumFromKey(kPluginAutoUpdateModes, modeOptions[index].value)) {
-                    cb(*mode);
-                  }
+              .onSelectionChanged = [cb = ctx.setAutoUpdate](std::size_t index, std::string_view /*label*/) {
+                if (cb && index < std::size(kPluginAutoUpdateModes)) {
+                  cb(kPluginAutoUpdateModes[index].value);
                 }
               },
           })

--- a/src/shell/settings/settings_content_plugins.cpp
+++ b/src/shell/settings/settings_content_plugins.cpp
@@ -720,7 +720,7 @@ namespace settings {
       return s.kind == PluginSourceKind::Git && s.enabled;
     });
     if (hasGitSource && ctx.setAutoUpdate) {
-      // Separate from the source list so the toggle doesn't read as another source.
+      // Separate from the source list so the dropdown doesn't read as another source.
       section->addChild(ui::separator({.spacing = Style::spaceSm * scale}));
       auto autoRow = ui::row({.align = FlexAlign::Center, .gap = Style::spaceSm * scale, .fillWidth = true});
       auto autoInfo = ui::column({.align = FlexAlign::Start, .gap = 2.0F * scale, .flexGrow = 1.0F});
@@ -732,14 +732,26 @@ namespace settings {
           i18n::tr("settings.plugins.sources.auto-update-desc"), Style::fontSizeCaption * scale,
           ColorRole::OnSurfaceVariant
       ));
+      std::vector<SelectOption> modeOptions;
+      modeOptions.reserve(std::size(kPluginAutoUpdateModes));
+      for (const auto& opt : kPluginAutoUpdateModes) {
+        modeOptions.push_back(SelectOption{std::string(opt.key), i18n::tr(opt.labelKey)});
+      }
+      const auto selectedModeIndex = optionIndex(modeOptions, enumToKey(kPluginAutoUpdateModes, ctx.autoUpdateMode));
       autoRow->addChild(std::move(autoInfo));
       autoRow->addChild(
-          ui::toggle({
-              .checked = ctx.autoUpdateEnabled,
-              .scale = scale,
-              .onChange = [cb = ctx.setAutoUpdate](bool on) {
-                if (cb) {
-                  cb(on);
+          ui::select({
+              .options = optionLabels(modeOptions),
+              .selectedIndex = selectedModeIndex,
+              .fontSize = Style::fontSizeBody * scale,
+              .controlHeight = Style::controlHeight * scale,
+              .glyphSize = Style::fontSizeBody * scale,
+              .onSelectionChanged = [cb = ctx.setAutoUpdate,
+                                     modeOptions](std::size_t index, std::string_view /*label*/) {
+                if (cb && index < modeOptions.size()) {
+                  if (auto mode = enumFromKey(kPluginAutoUpdateModes, modeOptions[index].value)) {
+                    cb(*mode);
+                  }
                 }
               },
           })

--- a/src/shell/settings/settings_content_plugins.h
+++ b/src/shell/settings/settings_content_plugins.h
@@ -37,10 +37,10 @@ namespace settings {
     std::function<void(std::string source)> updateSource;
     std::function<void()> refresh;
 
-    // True when every enabled git source has background auto-update on; drives the
-    // single "auto-update plugins" toggle. setAutoUpdate flips it for all git sources.
-    bool autoUpdateEnabled = false;
-    std::function<void(bool)> setAutoUpdate;
+    // Background auto-update scope for git sources; drives the "auto-update plugins"
+    // dropdown. setAutoUpdate persists the mode for all git sources.
+    PluginAutoUpdateMode autoUpdateMode = PluginAutoUpdateMode::All;
+    std::function<void(PluginAutoUpdateMode)> setAutoUpdate;
     // Update every enabled git source at once (the "update all" action).
     std::function<void()> updateAll;
 

--- a/src/shell/settings/settings_window_scene.cpp
+++ b/src/shell/settings/settings_window_scene.cpp
@@ -1077,14 +1077,14 @@ void SettingsWindow::rebuildSettingsContent() {
                   markPluginListDirty();
                   requestSceneRebuild();
                 },
-            .autoUpdateEnabled = cfg.plugins.autoUpdate,
+            .autoUpdateMode = cfg.plugins.autoUpdate,
             .setAutoUpdate =
-                [this](bool on) {
-                  m_pluginManager->setAutoUpdateEnabled(on);
+                [this](PluginAutoUpdateMode mode) {
+                  m_pluginManager->setAutoUpdateMode(mode);
                   markPluginListDirty();
                   requestSceneRebuild();
                 },
-            .updateAll = [this]() { m_pluginManager->updateAll(); },
+            .updateAll = [this]() { m_pluginManager->updateAutoUpdateScope(PluginAutoUpdateMode::All); },
             .config = &cfg,
             .onConfigure = [this](std::string id) { openPluginSettingsEditor(std::move(id)); },
             .onRemove =

--- a/tests/config_migration_test.cpp
+++ b/tests/config_migration_test.cpp
@@ -752,6 +752,33 @@ German = "Clock"
     expect(secondPassIssues.empty(), "keyboard layout custom_labels normalization was not idempotent");
   }
 
+  void checkPluginAutoUpdateModeMigration() {
+    for (const bool enabled : {true, false}) {
+      toml::table config = toml::parse(std::format("[plugins]\nauto_update = {}", enabled));
+      noctalia::config::LegacyConfigIssues issues;
+      noctalia::config::normalizeLegacyConfig(config, issues);
+
+      const std::string_view expected = enabled ? "all" : "none";
+      expect(
+          config["plugins"]["auto_update"].value<std::string_view>() == expected,
+          "legacy plugin auto-update boolean was not converted to its matching scope"
+      );
+      expect(
+          issues.size() == 1 && hasIssuePath(issues, "plugins.auto_update"),
+          "plugin auto-update migration did not identify its source key"
+      );
+    }
+
+    toml::table sidecar = toml::parse("config_version = 12\n[plugins]\nauto_update = false");
+    noctalia::config::schema::Diagnostics diagnostics;
+    const int applied = noctalia::config::applyPendingConfigMigrations(sidecar, 12, diagnostics);
+    expect(applied == noctalia::config::currentConfigVersion(), "plugin auto-update sidecar migration was not applied");
+    expect(
+        sidecar["plugins"]["auto_update"].value<std::string_view>() == std::optional<std::string_view>{"none"},
+        "plugin auto-update sidecar migration did not preserve false as none"
+    );
+  }
+
   void checkVersionGating() {
     toml::table legacy = toml::parse(R"(
 [bar.main]
@@ -901,6 +928,7 @@ int main() {
   checkKeyboardLayoutShowGlyphMigration();
   checkKeyboardLayoutCustomLabelsMigration();
   checkWorkspacesDisplayMigration();
+  checkPluginAutoUpdateModeMigration();
   checkVersionGating();
   checkReminderFingerprint();
   checkRegistryOrdering();

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -624,13 +624,11 @@ location = "https://example.invalid/bad"
       });
     };
 
-    // Cases: config snippet, expected mode, whether a warning is expected.
-    // Legacy booleans coerce (true = all, false = none); unknown strings and
-    // unsupported types warn and leave the default in place.
+    // Cases: config snippet, expected mode
     const auto cases = {
-        std::pair{"auto_update = true", PluginAutoUpdateMode::All},
-        std::pair{"auto_update = false", PluginAutoUpdateMode::None},
+        std::pair{"auto_update = \"all\"", PluginAutoUpdateMode::All},
         std::pair{"auto_update = \"official\"", PluginAutoUpdateMode::Official},
+        std::pair{"auto_update = \"none\"", PluginAutoUpdateMode::None},
     };
     for (const auto& [text, expected] : cases) {
       const auto [mode, diag] = parse(text);
@@ -643,7 +641,10 @@ location = "https://example.invalid/bad"
         );
       }
     }
-    for (const auto text : {"auto_update = \"sometimes\"", "auto_update = 1.5"}) {
+    // Unknown strings, unsupported types, and the legacy boolean form warn
+    // and leave the default in place.
+    for (const auto text :
+         {"auto_update = \"sometimes\"", "auto_update = 1.5", "auto_update = true", "auto_update = false"}) {
       const auto [mode, diag] = parse(text);
       if (mode != PluginAutoUpdateMode::All || !warnedOnAutoUpdate(diag)) {
         fail(std::string("plugins.auto_update: '") + text + "' should warn and keep the default");

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -610,14 +610,15 @@ location = "https://example.invalid/bad"
     }
   }
 
+  std::pair<PluginsConfig, Diagnostics> parsePlugins(std::string_view config) {
+    PluginsConfig plugins;
+    Diagnostics diagnostics;
+    const toml::table root = toml::parse(config);
+    readInto(root, plugins, pluginsSchema(), "plugins", diagnostics);
+    return {std::move(plugins), std::move(diagnostics)};
+  }
+
   void checkPluginAutoUpdateMode() {
-    const auto parse = [](std::string_view config) {
-      PluginsConfig plugins;
-      Diagnostics diagnostics;
-      const toml::table root = toml::parse(config);
-      readInto(root, plugins, pluginsSchema(), "plugins", diagnostics);
-      return std::pair{plugins.autoUpdate, diagnostics};
-    };
     const auto erroredOnAutoUpdate = [](const Diagnostics& diag) {
       return std::ranges::any_of(diag.entries, [](const auto& entry) {
         return entry.severity == Diagnostics::Severity::Error && entry.path == "plugins.auto_update";
@@ -631,8 +632,8 @@ location = "https://example.invalid/bad"
         std::pair{"auto_update = \"none\"", PluginAutoUpdateMode::None},
     };
     for (const auto& [text, expected] : cases) {
-      const auto [mode, diag] = parse(text);
-      if (mode != expected || diag.hasErrors()) {
+      const auto [plugins, diag] = parsePlugins(text);
+      if (plugins.autoUpdate != expected || diag.hasErrors()) {
         fail(
             std::string("plugins.auto_update: '")
             + text
@@ -645,19 +646,18 @@ location = "https://example.invalid/bad"
     // and leave the default in place.
     for (const auto text :
          {"auto_update = \"sometimes\"", "auto_update = 1.5", "auto_update = true", "auto_update = false"}) {
-      const auto [mode, diag] = parse(text);
-      if (mode != PluginAutoUpdateMode::All || !erroredOnAutoUpdate(diag)) {
+      const auto [plugins, diag] = parsePlugins(text);
+      if (plugins.autoUpdate != PluginAutoUpdateMode::All || !erroredOnAutoUpdate(diag)) {
         fail(std::string("plugins.auto_update: '") + text + "' should error and keep the default");
       }
     }
   }
 
   void checkAutoUpdateScopeSelection() {
-    // Duplicate source names pass schema validation, so the official scope must
-    // match by name AND location — the first same-named entry must not win.
+    // The official scope matches by name AND location: a user-added source that
+    // reuses the "official" name is not the official source.
     const std::vector<PluginSourceConfig> sources = {
-        {.kind = PluginSourceKind::Git, .name = "official", .location = "https://example.invalid/untrusted"},
-        defaultPluginSources()[0], // the real official source, listed second
+        defaultPluginSources()[0], // the official source
         {.kind = PluginSourceKind::Git,
          .name = "community",
          .location = "https://github.com/noctalia-dev/community-plugins"},
@@ -667,30 +667,71 @@ location = "https://example.invalid/bad"
          .enabled = false},
         {.kind = PluginSourceKind::Path, .name = "local", .location = "/tmp/plugins"},
     };
-    const auto expectLocations = [&](PluginAutoUpdateMode mode, std::vector<std::string_view> locations) {
+    const auto expectLocations = [](std::string_view fixtureName, const std::vector<PluginSourceConfig>& fixture,
+                                    PluginAutoUpdateMode mode, std::vector<std::string_view> locations) {
       std::vector<std::string_view> selected;
-      for (const auto& source : sources) {
+      for (const auto& source : fixture) {
         if (sourceInAutoUpdateScope(source, mode)) {
           selected.push_back(source.location);
         }
       }
       if (!std::ranges::equal(selected, locations)) {
         fail(
-            "auto-update scope: unexpected sources selected for " + std::string(enumToKey(kPluginAutoUpdateModes, mode))
+            "auto-update scope ("
+            + std::string(fixtureName)
+            + "): unexpected sources selected for "
+            + std::string(enumToKey(kPluginAutoUpdateModes, mode))
         );
       }
     };
-    expectLocations(PluginAutoUpdateMode::None, {});
-    // Only the entry with the official name AND location; the untrusted first
-    // "official" entry must never be selected.
-    expectLocations(PluginAutoUpdateMode::Official, {"https://github.com/noctalia-dev/official-plugins"});
-    // Every enabled git source, each distinct entry, duplicates included; disabled
-    // and path sources stay out.
+    expectLocations("defaults", sources, PluginAutoUpdateMode::None, {});
     expectLocations(
-        PluginAutoUpdateMode::All,
-        {"https://example.invalid/untrusted", "https://github.com/noctalia-dev/official-plugins",
-         "https://github.com/noctalia-dev/community-plugins"}
+        "defaults", sources, PluginAutoUpdateMode::Official, {"https://github.com/noctalia-dev/official-plugins"}
     );
+    // Every enabled git source; disabled and path sources stay out.
+    expectLocations(
+        "defaults", sources, PluginAutoUpdateMode::All,
+        {"https://github.com/noctalia-dev/official-plugins", "https://github.com/noctalia-dev/community-plugins"}
+    );
+    // A single source reusing the "official" name with an untrusted location is
+    // legal config (names must be unique, locations need not), but the location
+    // check must keep it out of the official scope.
+    const std::vector<PluginSourceConfig> untrustedOfficial = {
+        {.kind = PluginSourceKind::Git, .name = "official", .location = "https://example.invalid/untrusted"},
+        {.kind = PluginSourceKind::Git,
+         .name = "community",
+         .location = "https://github.com/noctalia-dev/community-plugins"},
+    };
+    expectLocations("untrustedOfficial", untrustedOfficial, PluginAutoUpdateMode::Official, {});
+    expectLocations(
+        "untrustedOfficial", untrustedOfficial, PluginAutoUpdateMode::All,
+        {"https://example.invalid/untrusted", "https://github.com/noctalia-dev/community-plugins"}
+    );
+  }
+
+  void checkDuplicatePluginSourceRejection() {
+    const auto erroredOnSource = [](const Diagnostics& diag) {
+      return std::ranges::any_of(diag.entries, [](const auto& entry) {
+        return entry.severity == Diagnostics::Severity::Error && entry.path == "plugins.source";
+      });
+    };
+    // Legit official source first: the duplicate is dropped, the legit entry kept.
+    const auto [legitPlugins, legitDiag] = parsePlugins(R"(
+[[source]]
+name = "official"
+kind = "git"
+location = "https://github.com/noctalia-dev/official-plugins"
+
+[[source]]
+name = "official"
+kind = "git"
+location = "https://example.invalid/untrusted"
+)");
+    if (!erroredOnSource(legitDiag)
+        || legitPlugins.sources.size() != 1
+        || legitPlugins.sources[0].location != "https://github.com/noctalia-dev/official-plugins") {
+      fail("plugins.source: duplicate names must error and keep the first entry");
+    }
   }
 
   void checkCalendarCredentialSourceValidation() {
@@ -1153,6 +1194,7 @@ widget_spacing = 8
   checkClamps();
   checkPluginAutoUpdateMode();
   checkAutoUpdateScopeSelection();
+  checkDuplicatePluginSourceRejection();
   checkCustomColorFallback();
   checkTemplateConfigCustomColorsExport();
 

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -19,6 +19,7 @@
 #include "core/toml.h"
 #include "scripting/plugin_id.h"
 
+#include <algorithm>
 #include <optional>
 #include <print>
 #include <set>
@@ -558,7 +559,7 @@ location = "https://example.invalid/bad"
          .location = "https://github.com/noctalia-dev/official-plugins"},
     };
     c.plugins.enabled = {"noctalia/notes"};
-    c.plugins.autoUpdate = false; // non-default (default is true) so the round-trip exercises it
+    c.plugins.autoUpdate = PluginAutoUpdateMode::None; // non-default (default is All) so the round-trip exercises it
 
     c.bars = {makeProbeBar()};
     return c;
@@ -605,6 +606,47 @@ location = "https://example.invalid/bad"
       readInto(t, s, shellSchema(), "shell", d);
       if (s.clipboardHistoryMaxEntries != 10000) {
         fail("shell.clipboard_history_max_entries clamp: expected 10000");
+      }
+    }
+  }
+
+  void checkPluginAutoUpdateMode() {
+    const auto parse = [](std::string_view config) {
+      PluginsConfig plugins;
+      Diagnostics diagnostics;
+      const toml::table root = toml::parse(config);
+      readInto(root, plugins, pluginsSchema(), "plugins", diagnostics);
+      return std::pair{plugins.autoUpdate, diagnostics};
+    };
+    const auto warnedOnAutoUpdate = [](const Diagnostics& diag) {
+      return std::ranges::any_of(diag.entries, [](const auto& entry) {
+        return entry.severity == Diagnostics::Severity::Warning && entry.path == "plugins.auto_update";
+      });
+    };
+
+    // Cases: config snippet, expected mode, whether a warning is expected.
+    // Legacy booleans coerce (true = all, false = none); unknown strings and
+    // unsupported types warn and leave the default in place.
+    const auto cases = {
+        std::pair{"auto_update = true", PluginAutoUpdateMode::All},
+        std::pair{"auto_update = false", PluginAutoUpdateMode::None},
+        std::pair{"auto_update = \"official\"", PluginAutoUpdateMode::Official},
+    };
+    for (const auto& [text, expected] : cases) {
+      const auto [mode, diag] = parse(text);
+      if (mode != expected || diag.hasErrors()) {
+        fail(
+            std::string("plugins.auto_update: '")
+            + text
+            + "' should parse to "
+            + std::string(enumToKey(kPluginAutoUpdateModes, expected))
+        );
+      }
+    }
+    for (const auto text : {"auto_update = \"sometimes\"", "auto_update = 1.5"}) {
+      const auto [mode, diag] = parse(text);
+      if (mode != PluginAutoUpdateMode::All || !warnedOnAutoUpdate(diag)) {
+        fail(std::string("plugins.auto_update: '") + text + "' should warn and keep the default");
       }
     }
   }
@@ -1067,6 +1109,7 @@ widget_spacing = 8
   checkStorageKeySourceValidation();
   checkPanelFloatingLayerValidation();
   checkClamps();
+  checkPluginAutoUpdateMode();
   checkCustomColorFallback();
   checkTemplateConfigCustomColorsExport();
 

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -652,6 +652,47 @@ location = "https://example.invalid/bad"
     }
   }
 
+  void checkAutoUpdateScopeSelection() {
+    // Duplicate source names pass schema validation, so the official scope must
+    // match by name AND location — the first same-named entry must not win.
+    const std::vector<PluginSourceConfig> sources = {
+        {.kind = PluginSourceKind::Git, .name = "official", .location = "https://example.invalid/untrusted"},
+        defaultPluginSources()[0], // the real official source, listed second
+        {.kind = PluginSourceKind::Git,
+         .name = "community",
+         .location = "https://github.com/noctalia-dev/community-plugins"},
+        {.kind = PluginSourceKind::Git,
+         .name = "disabled",
+         .location = "https://example.invalid/disabled",
+         .enabled = false},
+        {.kind = PluginSourceKind::Path, .name = "local", .location = "/tmp/plugins"},
+    };
+    const auto expectLocations = [&](PluginAutoUpdateMode mode, std::vector<std::string_view> locations) {
+      std::vector<std::string_view> selected;
+      for (const auto& source : sources) {
+        if (sourceInAutoUpdateScope(source, mode)) {
+          selected.push_back(source.location);
+        }
+      }
+      if (!std::ranges::equal(selected, locations)) {
+        fail(
+            "auto-update scope: unexpected sources selected for " + std::string(enumToKey(kPluginAutoUpdateModes, mode))
+        );
+      }
+    };
+    expectLocations(PluginAutoUpdateMode::None, {});
+    // Only the entry with the official name AND location; the untrusted first
+    // "official" entry must never be selected.
+    expectLocations(PluginAutoUpdateMode::Official, {"https://github.com/noctalia-dev/official-plugins"});
+    // Every enabled git source, each distinct entry, duplicates included; disabled
+    // and path sources stay out.
+    expectLocations(
+        PluginAutoUpdateMode::All,
+        {"https://example.invalid/untrusted", "https://github.com/noctalia-dev/official-plugins",
+         "https://github.com/noctalia-dev/community-plugins"}
+    );
+  }
+
   void checkCalendarCredentialSourceValidation() {
     const auto parse = [](std::string_view accountConfig) {
       const toml::table table = toml::parse(accountConfig);
@@ -1111,6 +1152,7 @@ widget_spacing = 8
   checkPanelFloatingLayerValidation();
   checkClamps();
   checkPluginAutoUpdateMode();
+  checkAutoUpdateScopeSelection();
   checkCustomColorFallback();
   checkTemplateConfigCustomColorsExport();
 

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -618,9 +618,9 @@ location = "https://example.invalid/bad"
       readInto(root, plugins, pluginsSchema(), "plugins", diagnostics);
       return std::pair{plugins.autoUpdate, diagnostics};
     };
-    const auto warnedOnAutoUpdate = [](const Diagnostics& diag) {
+    const auto erroredOnAutoUpdate = [](const Diagnostics& diag) {
       return std::ranges::any_of(diag.entries, [](const auto& entry) {
-        return entry.severity == Diagnostics::Severity::Warning && entry.path == "plugins.auto_update";
+        return entry.severity == Diagnostics::Severity::Error && entry.path == "plugins.auto_update";
       });
     };
 
@@ -641,13 +641,13 @@ location = "https://example.invalid/bad"
         );
       }
     }
-    // Unknown strings, unsupported types, and the legacy boolean form warn
+    // Unknown strings, unsupported types, and the legacy boolean form error
     // and leave the default in place.
     for (const auto text :
          {"auto_update = \"sometimes\"", "auto_update = 1.5", "auto_update = true", "auto_update = false"}) {
       const auto [mode, diag] = parse(text);
-      if (mode != PluginAutoUpdateMode::All || !warnedOnAutoUpdate(diag)) {
-        fail(std::string("plugins.auto_update: '") + text + "' should warn and keep the default");
+      if (mode != PluginAutoUpdateMode::All || !erroredOnAutoUpdate(diag)) {
+        fail(std::string("plugins.auto_update: '") + text + "' should error and keep the default");
       }
     }
   }

--- a/tests/plugin_git_export_test.cpp
+++ b/tests/plugin_git_export_test.cpp
@@ -115,7 +115,7 @@ int main() {
        )
       && ok;
 
-  const auto fetchResult = scripting::plugin_git::fetch(repo);
+  const auto fetchResult = scripting::plugin_git::fetch(repo, source.string());
   ok = expect(static_cast<bool>(fetchResult), "fetch failed") && ok;
   const auto fetchedHead = scripting::plugin_git::remoteHead(repo);
   ok = expect(static_cast<bool>(fetchedHead), "failed to resolve FETCH_HEAD") && ok;
@@ -148,7 +148,8 @@ int main() {
             "-q", "-m", "clock requires a newer api"}
        )
       && ok;
-  ok = expect(static_cast<bool>(scripting::plugin_git::fetch(repo)), "fetch after the api bump failed") && ok;
+  ok = expect(static_cast<bool>(scripting::plugin_git::fetch(repo, source.string())), "fetch after the api bump failed")
+      && ok;
   const auto bumpedHead = scripting::plugin_git::remoteHead(repo);
   ok = expect(static_cast<bool>(bumpedHead), "failed to resolve the bumped revision") && ok;
 
@@ -166,6 +167,32 @@ int main() {
   const auto olderManifest = readText(root / "older-export/clock/plugin.toml");
   ok = expect(olderManifest.contains("plugin_api = 3"), "the older export did not carry its own api level") && ok;
   ok = expect(olderManifest.contains("version = \"1.0.0\""), "the older export did not carry its own version") && ok;
+
+  // A checkout retained after its configured source location changes must fetch
+  // the new canonical location, never the stale origin recorded by the clone.
+  const auto replacementSource = root / "replacement-source";
+  std::filesystem::create_directories(replacementSource);
+  ok = runGit({"git", "-C", replacementSource.string(), "init", "-q"}) && ok;
+  ok = writeText(replacementSource / "replacement.txt", "replacement\n") && ok;
+  ok = runGit({"git", "-C", replacementSource.string(), "add", "replacement.txt"}) && ok;
+  ok = runGit(
+           {"git", "-C", replacementSource.string(), "-c", "user.name=test", "-c", "user.email=test@example.invalid",
+            "commit", "-q", "-m", "replacement source"}
+       )
+      && ok;
+  const auto replacementHead = scripting::plugin_git::headRevision(replacementSource);
+  ok = expect(static_cast<bool>(replacementHead), "failed to resolve replacement source HEAD") && ok;
+  ok = expect(
+           static_cast<bool>(scripting::plugin_git::fetch(repo, replacementSource.string())),
+           "fetch did not accept the replacement source location"
+       )
+      && ok;
+  const auto reboundHead = scripting::plugin_git::remoteHead(repo);
+  ok = expect(static_cast<bool>(reboundHead), "failed to resolve rebound FETCH_HEAD") && ok;
+  ok = expect(
+           reboundHead.out == replacementHead.out, "fetch used the stale clone origin instead of the configured source"
+       )
+      && ok;
 
   std::error_code ec;
   std::filesystem::remove_all(root, ec);


### PR DESCRIPTION
## Summary

This PR adds dropdown option in Auto-Update Plugins-  All Sources / Official only/ None.

## Motivation

Users should have feature to choose which plugins they want to auto update.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #3991

## Testing

- Ran `just format`,`just build` clean
- Ran`just test` clean
- Tested the debug build and see the dropdown function showing  All sources | Official Only | None

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<img width="766" height="277" alt="image" src="https://github.com/user-attachments/assets/dc1e6947-0bc0-451c-a7b9-c7e5d1b51021" />


## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed.
- [x] I ran the relevant build or test commands.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.
