### PR TITLE
fix(widget-editor): add correct title for lockscreen widget editor toolbar

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -579,6 +579,7 @@
         "grid": "Grid"
       },
       "title": "Desktop Widgets",
+      "title-lockscreen": "Lockscreen Widgets",
       "types": {
         "audio-visualizer": "Audio Visualizer",
         "button": "Button",
@@ -716,11 +717,6 @@
     "ready": "Type your password and press Enter.",
     "unlocked": "Unlocked",
     "waiting": "Waiting for lock confirmation…"
-  },
-  "lockscreen-widgets":{
-    "editor":{
-      "title": "Lockscreen Widgets"
-    }
   },
   "notifications": {
     "actions": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -717,6 +717,11 @@
     "unlocked": "Unlocked",
     "waiting": "Waiting for lock confirmation…"
   },
+  "lockscreen-widgets":{
+    "editor":{
+      "title": "Lockscreen Widgets"
+    }
+  },
   "notifications": {
     "actions": {
       "fallback": "Action",

--- a/src/shell/desktop/editor/desktop_widgets_editor.cpp
+++ b/src/shell/desktop/editor/desktop_widgets_editor.cpp
@@ -1199,20 +1199,22 @@ void DesktopWidgetsEditor::rebuildScene(OverlaySurface& surface) {
                       .tooltip = i18n::tr("desktop-widgets.editor.actions.flip-vertical"),
                       .onClick = [this]() { deferEditorMutation([this]() { flipSelectedWidgetVertical(); }); },
                   }),
-                  ui::button({
-                      .glyph = "settings",
-                      .enabled = hasSelectedWidget,
-                      .selected = m_inspectorOpen,
-                      .variant = ButtonVariant::Default,
-                      .tooltip = i18n::tr("desktop-widgets.editor.actions.settings"),
-                      .onClick =
-                          [this]() {
-                            deferEditorMutation([this]() {
-                              m_inspectorOpen = !m_inspectorOpen;
-                              requestLayout();
-                            });
-                          },
-                  }),
+                  ui::button(
+                      {
+                          .glyph = "settings",
+                          .enabled = hasSelectedWidget,
+                          .selected = m_inspectorOpen,
+                          .variant = ButtonVariant::Default,
+                          .tooltip = i18n::tr("desktop-widgets.editor.actions.settings"),
+                          .onClick =
+                              [this]() {
+                                deferEditorMutation([this]() {
+                                  m_inspectorOpen = !m_inspectorOpen;
+                                  requestLayout();
+                                });
+                              },
+                      }
+                  ),
                   [&]() -> std::unique_ptr<Node> {
                     bool canToggleVisibility = hasSelectedWidget;
                     if (hasSelectedWidget

--- a/src/shell/desktop/editor/desktop_widgets_editor.cpp
+++ b/src/shell/desktop/editor/desktop_widgets_editor.cpp
@@ -1134,7 +1134,7 @@ void DesktopWidgetsEditor::rebuildScene(OverlaySurface& surface) {
                           .glyphSize = 14.0F,
                       }),
                       ui::label({
-                          .text = i18n::tr("desktop-widgets.editor.title"),
+                          .text = i18n::tr(m_profile.titleKey),
                           .fontSize = Style::fontSizeBody,
                           .fontWeight = FontWeight::Bold,
                       }),

--- a/src/shell/desktop/editor/desktop_widgets_editor_types.cpp
+++ b/src/shell/desktop/editor/desktop_widgets_editor_types.cpp
@@ -5,6 +5,7 @@ DesktopWidgetsEditorProfile DesktopWidgetsEditorProfile::desktop() {
       .logSection = "desktop",
       .layerNamespace = "noctalia-desktop-widgets-editor",
       .widgetIdPrefix = "desktop-widget-",
+      .titleKey = "desktop-widgets.editor.title",
       .showLockscreenLoginPreview = false,
   };
 }
@@ -14,6 +15,7 @@ DesktopWidgetsEditorProfile DesktopWidgetsEditorProfile::lockscreen() {
       .logSection = "lockscreen",
       .layerNamespace = "noctalia-lockscreen-widgets-editor",
       .widgetIdPrefix = "lockscreen-widget-",
+      .titleKey = "lockscreen-widgets.editor.title",
       .showLockscreenLoginPreview = true,
   };
 }

--- a/src/shell/desktop/editor/desktop_widgets_editor_types.cpp
+++ b/src/shell/desktop/editor/desktop_widgets_editor_types.cpp
@@ -15,7 +15,7 @@ DesktopWidgetsEditorProfile DesktopWidgetsEditorProfile::lockscreen() {
       .logSection = "lockscreen",
       .layerNamespace = "noctalia-lockscreen-widgets-editor",
       .widgetIdPrefix = "lockscreen-widget-",
-      .titleKey = "lockscreen-widgets.editor.title",
+      .titleKey = "desktop-widgets.editor.title-lockscreen",
       .showLockscreenLoginPreview = true,
   };
 }

--- a/src/shell/desktop/editor/desktop_widgets_editor_types.h
+++ b/src/shell/desktop/editor/desktop_widgets_editor_types.h
@@ -11,6 +11,7 @@ struct DesktopWidgetsEditorProfile {
   std::string_view logSection;
   std::string_view layerNamespace;
   std::string_view widgetIdPrefix;
+  std::string_view titleKey;
   bool showLockscreenLoginPreview = false;
 
   [[nodiscard]] static DesktopWidgetsEditorProfile desktop();


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

The widget editor toolbar title is now taken from `DesktopWidgetsEditorProfile::titleKey` instead of a hardcoded translation key. Also added the missing `"lockscreen-widgets.editor.title"` translation to `en.json`

## Motivation

The widget editor toolbar was hardcoded and therefore when opening the lockscreen widget editor it displayed "Desktop Widgets".

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
1. Ran `just format` and `just build`.
2. Ran the debug binary directly.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos


https://github.com/user-attachments/assets/8bf8f852-b863-4f74-80a0-819f15d992b8



## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
