### PR TITLE
feat(control-centre): Use session username for host line

### DIFF
--- a/src/shell/control_center/tabs/home_tab.cpp
+++ b/src/shell/control_center/tabs/home_tab.cpp
@@ -117,7 +117,7 @@ namespace {
     return formatLocalTime(format);
   }
 
-  std::string userHostLine() { return std::format("{}@{}", sessionDisplayName(), hostName()); }
+  std::string userHostLine() { return std::format("{}@{}", sessionUserName(), hostName()); }
 
   std::string noctaliaVersionLine() { return std::format("Noctalia {}", noctalia::build_info::displayVersion()); }
 

--- a/src/system/distro_info.cpp
+++ b/src/system/distro_info.cpp
@@ -3,8 +3,9 @@
 #include "i18n/i18n.h"
 #include "util/string_utils.h"
 
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <ctime>
 #include <fcntl.h>
 #include <filesystem>
@@ -17,6 +18,7 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace {
 
@@ -45,6 +47,47 @@ namespace {
     }
 
     return values;
+  }
+
+  struct SessionUserInfo {
+    std::string userName;
+    std::string displayName;
+  };
+
+  std::optional<SessionUserInfo> resolveSessionUser(uid_t uid) {
+    constexpr std::size_t kMaxBufferSize = 1U << 20;
+
+    passwd pwd{};
+    passwd* result = nullptr;
+    std::vector<char> buffer(4096);
+
+    while (true) {
+      const int rc = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &result);
+      if (rc == 0) {
+        if (result == nullptr || result->pw_name == nullptr || result->pw_name[0] == '\0') {
+          return std::nullopt;
+        }
+
+        SessionUserInfo info{
+            .userName = result->pw_name,
+            .displayName = result->pw_name,
+        };
+        if (result->pw_gecos != nullptr && result->pw_gecos[0] != '\0') {
+          const std::string_view gecos(result->pw_gecos);
+          const auto comma = gecos.find(',');
+          const auto displayName = gecos.substr(0, comma);
+          if (!displayName.empty()) {
+            info.displayName = displayName;
+          }
+        }
+        return info;
+      }
+
+      if (rc != ERANGE || buffer.size() >= kMaxBufferSize) {
+        return std::nullopt;
+      }
+      buffer.resize(buffer.size() * 2);
+    }
   }
 
 } // namespace
@@ -152,35 +195,19 @@ std::string osAgeLabel() {
 }
 
 std::string sessionUserName() {
-  struct passwd* pw = getpwuid(getuid());
-  if (pw != nullptr) {
-    return pw->pw_name;
+  const uid_t uid = getuid();
+  if (const auto user = resolveSessionUser(uid); user.has_value()) {
+    return user->userName;
   }
-
-  const char* loginEnv = std::getenv("USER");
-  if (loginEnv != nullptr) {
-    return loginEnv;
-  }
-
-  return "user";
+  return std::to_string(uid);
 }
 
 std::string sessionDisplayName() {
-  struct passwd* pw = getpwuid(getuid());
-  const char* loginEnv = std::getenv("USER");
-  std::string login = "user";
-  if (pw != nullptr) {
-    login = pw->pw_name;
-  } else if (loginEnv != nullptr) {
-    login = loginEnv;
+  const uid_t uid = getuid();
+  if (const auto user = resolveSessionUser(uid); user.has_value()) {
+    return user->displayName;
   }
-
-  if (pw != nullptr && pw->pw_gecos != nullptr && pw->pw_gecos[0] != '\0') {
-    std::string gecos = pw->pw_gecos;
-    const auto comma = gecos.find(',');
-    return comma == std::string::npos ? gecos : gecos.substr(0, comma);
-  }
-  return login;
+  return std::to_string(uid);
 }
 
 std::string hostName() {

--- a/src/system/distro_info.cpp
+++ b/src/system/distro_info.cpp
@@ -151,6 +151,20 @@ std::string osAgeLabel() {
   return i18n::trp("time.units.day", static_cast<long>(days));
 }
 
+std::string sessionUserName() {
+  struct passwd* pw = getpwuid(getuid());
+  if (pw != nullptr) {
+    return pw->pw_name;
+  }
+
+  const char* loginEnv = std::getenv("USER");
+  if (loginEnv != nullptr) {
+    return loginEnv;
+  }
+
+  return "user";
+}
+
 std::string sessionDisplayName() {
   struct passwd* pw = getpwuid(getuid());
   const char* loginEnv = std::getenv("USER");

--- a/src/system/distro_info.h
+++ b/src/system/distro_info.h
@@ -25,6 +25,9 @@ public:
 // Approximate OS install age, formatted as "{y}y {m}mo" / "{y}y" / "{d}d".
 [[nodiscard]] std::string osAgeLabel();
 
+// Name of the current session user.
+[[nodiscard]] std::string sessionUserName();
+
 // Display name of the current session user (gecos or login).
 [[nodiscard]] std::string sessionDisplayName();
 

--- a/src/system/distro_info.h
+++ b/src/system/distro_info.h
@@ -25,10 +25,10 @@ public:
 // Approximate OS install age, formatted as "{y}y {m}mo" / "{y}y" / "{d}d".
 [[nodiscard]] std::string osAgeLabel();
 
-// Name of the current session user.
+// Login name of the current session user, or its numeric UID if unavailable.
 [[nodiscard]] std::string sessionUserName();
 
-// Display name of the current session user (gecos or login).
+// Display name of the current session user (gecos or login), or its numeric UID if unavailable.
 [[nodiscard]] std::string sessionDisplayName();
 
 // Machine hostname (uname nodename), or "unknown" on failure.


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

This changes the control centre to display (for example) "jamie@lucia" rather than "Jamie Mansfield@lucia".

## Motivation

<!-- What problem does this solve? -->

The previous solution displaying the session display name followed by the same value, and differing from the conventional username@hostname was jarring to look at.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

I had a brief look, but could not see any corresponding issues or existing pull requests :^)

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

```
just configure
just build
just run
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

### Before

<img width="638" height="275" alt="Screenshot from 2026-08-19 01-41-25" src="https://github.com/user-attachments/assets/68b6038d-4516-46b0-b821-3e7f9d6c31b4" />

### After

<img width="638" height="275" alt="Screenshot from 2026-08-19 01-35-53" src="https://github.com/user-attachments/assets/f061ec4c-f76b-4367-8bf9-cb104d3a312e" />

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
