### PR TITLE
fix: compile icon_resolver with libc++

### DIFF
--- a/src/system/icon_resolver.cpp
+++ b/src/system/icon_resolver.cpp
@@ -3,6 +3,7 @@
 #include "util/string_utils.h"
 
 #include <algorithm>
+#include <chrono> // IWYU pragma: keep
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -148,7 +149,7 @@ namespace {
       signature += ':';
       std::error_code ec;
       const auto modified = fs::last_write_time(path, ec);
-      signature += ec ? "missing" : std::to_string(modified.time_since_epoch().count());
+      signature += ec ? "missing" : std::format("{}", modified);
       signature += '\n';
     };
     for (const auto& root : plan.baseDirs) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

The build is currently broken when built against libc++ instead of libstdc++.

```
../src/system/icon_resolver.cpp:151:37: error: call to 'to_string' is ambiguous
  151 |       signature += ec ? "missing" : std::to_string(modified.time_since_epoch().count());
      |                                     ^~~~~~~~~~~~~~
/usr/include/c++/v1/string:3868:52: note: candidate function
 3868 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(int __val);
      |                                                    ^
/usr/include/c++/v1/string:3869:52: note: candidate function
 3869 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(unsigned __val);
      |                                                    ^
/usr/include/c++/v1/string:3870:52: note: candidate function
 3870 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(long __val);
      |                                                    ^
/usr/include/c++/v1/string:3871:52: note: candidate function
 3871 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(unsigned long __val);
      |                                                    ^
/usr/include/c++/v1/string:3872:52: note: candidate function
 3872 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(long long __val);
      |                                                    ^
/usr/include/c++/v1/string:3873:52: note: candidate function
 3873 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(unsigned long long __val);
      |                                                    ^
/usr/include/c++/v1/string:3874:52: note: candidate function
 3874 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(float __val);
      |                                                    ^
/usr/include/c++/v1/string:3875:52: note: candidate function
 3875 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(double __val);
      |                                                    ^
/usr/include/c++/v1/string:3876:52: note: candidate function
 3876 | [[__nodiscard__]] _LIBCPP_EXPORTED_FROM_ABI string to_string(long double __val);
      |                                                    ^
2 warnings and 1 error generated.
```

This is because in libc++ the returned duration has a representation type of
`__int128`. You could fix this with a static cast down to a 64-bit integer,
which is what libstdc++ uses and what to_string has a valid overload for. But
that's truncation, and we can actually avoid a cast altogether while using a
better timestamp format than epoch time. I chose to change the timestamp portion
of the cache key to use std::chrono's file_time_type std::format output
instead.

## Motivation

<!-- What problem does this solve? -->

This allows libc++ to remain a supported build configuration.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [X] Build / packaging

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

I ran `just test` and the icon_resolver test passed. The test covers the
changed line and confirms change detection still works. Since the test only
cares about equality and not format, it didn't need to be changed.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested on Niri
- [X] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

<!-- Include screenshots or videos for UI, visual, animation, or layout changes. -->

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [X] I ran the relevant build or test commands, or explained why they were not run.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [X] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [X] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [X] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
