### PR TITLE
fix(ui): preserve fractional button content centering

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1123,6 +1123,7 @@ if build_tests
     'app_identity',
     'audio_glyphs',
     'battery_hook_state',
+    'button_layout',
     'cairo_text_renderer',
     'calendar_cache_permissions',
     'cli_help',

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -778,12 +778,15 @@ void Button::doLayout(Renderer& renderer) {
       const float contentHeight = contentBottom - contentTop;
       float targetLeft = 0.0F;
       if (m_contentAlign == ButtonContentAlign::Center) {
-        targetLeft = std::round((width() - contentWidth) * 0.5F);
+        // Keep the exact centered position, including half logical pixels. The
+        // text and glyph renderers perform buffer-scale-aware pixel snapping;
+        // rounding here biases odd residual space toward the right and bottom.
+        targetLeft = (width() - contentWidth) * 0.5F;
       } else { // End
         targetLeft = std::round(Style::rtl() ? paddingLeft() : width() - contentWidth - paddingRight());
       }
       const float shiftX = targetLeft - contentLeft;
-      const float targetTop = std::round((height() - contentHeight) * 0.5F);
+      const float targetTop = (height() - contentHeight) * 0.5F;
       const float shiftY = targetTop - contentTop;
       if (std::abs(shiftX) > 0.01F || std::abs(shiftY) > 0.01F) {
         for (auto& child : children()) {

--- a/src/ui/controls/button.cpp
+++ b/src/ui/controls/button.cpp
@@ -778,9 +778,6 @@ void Button::doLayout(Renderer& renderer) {
       const float contentHeight = contentBottom - contentTop;
       float targetLeft = 0.0F;
       if (m_contentAlign == ButtonContentAlign::Center) {
-        // Keep the exact centered position, including half logical pixels. The
-        // text and glyph renderers perform buffer-scale-aware pixel snapping;
-        // rounding here biases odd residual space toward the right and bottom.
         targetLeft = (width() - contentWidth) * 0.5F;
       } else { // End
         targetLeft = std::round(Style::rtl() ? paddingLeft() : width() - contentWidth - paddingRight());

--- a/tests/button_layout_test.cpp
+++ b/tests/button_layout_test.cpp
@@ -1,0 +1,92 @@
+#include "render/core/renderer.h"
+#include "render/core/texture_manager.h"
+#include "ui/controls/button.h"
+#include "ui/controls/glyph.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <print>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+  class StubRenderer final : public Renderer {
+  public:
+    TextMetrics measureText(
+        std::string_view, float fontSize, FontWeight, float, int, TextAlign, std::string_view, TextEllipsize, bool
+    ) override {
+      return TextMetrics{.bottom = fontSize};
+    }
+
+    TextMetrics measureFont(float fontSize, FontWeight) override { return TextMetrics{.bottom = fontSize}; }
+
+    void measureTextCursorStops(
+        std::string_view, float, const std::vector<std::size_t>&, std::vector<float>&, FontWeight
+    ) override {}
+
+    void measureTextCursorStopsWrapped(
+        std::string_view, float, const std::vector<std::size_t>&, float, std::vector<TextCursorStop>&, FontWeight
+    ) override {}
+
+    TextMetrics measureGlyph(char32_t, float) override {
+      return TextMetrics{
+          .width = 18.0F,
+          .left = 1.5F,
+          .right = 19.5F,
+          .top = -15.0F,
+          .bottom = 3.0F,
+          .inkTop = -15.0F,
+          .inkBottom = 3.0F,
+          .inkLeft = 1.5F,
+          .inkRight = 19.5F,
+      };
+    }
+
+    TextureManager& textureManager() override { std::abort(); }
+    [[nodiscard]] float renderScale() const noexcept override { return 1.0F; }
+  };
+
+  bool near(float actual, float expected) { return std::abs(actual - expected) < 0.001F; }
+
+} // namespace
+
+int main() {
+  StubRenderer renderer;
+  Button button;
+  button.setGlyph("home");
+  button.setGlyphSize(21.0F);
+  button.setContentAlign(ButtonContentAlign::Center);
+  button.setPadding(4.0F);
+  button.setSize(32.0F, 32.0F);
+  button.layout(renderer);
+
+  const Glyph* glyph = button.glyph();
+  if (glyph == nullptr) {
+    std::println(stderr, "button_layout_test: glyph was not created");
+    return 1;
+  }
+
+  const float glyphCenterX = glyph->x() + glyph->width() * 0.5F;
+  const float glyphCenterY = glyph->y() + glyph->height() * 0.5F;
+  const float buttonCenterX = button.width() * 0.5F;
+  const float buttonCenterY = button.height() * 0.5F;
+
+  if (!near(glyphCenterX, buttonCenterX) || !near(glyphCenterY, buttonCenterY)) {
+    std::println(
+        stderr, "button_layout_test: centered glyph mismatch: glyph center=({}, {}), button center=({}, {})",
+        glyphCenterX, glyphCenterY, buttonCenterX, buttonCenterY
+    );
+    return 1;
+  }
+
+  if (!near(glyph->x(), 5.5F) || !near(glyph->y(), 5.5F)) {
+    std::println(
+        stderr, "button_layout_test: expected a 21px glyph in a 32px button at (5.5, 5.5), got ({}, {})", glyph->x(),
+        glyph->y()
+    );
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Preserve half-logical-pixel positions when `Button` centers its content.
- Leave physical-pixel snapping to the text and glyph renderers, which already account for the output buffer scale.
- Add a regression test covering a 21 px glyph centered inside a 32 px button.

## Motivation

`Button::doLayout()` rounded centered content offsets before rendering. When the button and its content have opposite pixel parity, the exact offset ends in `.5`; for example, `(32 - 21) / 2` is `5.5`, but the layout rounded it to `6`. This introduced a systematic one-rendered-pixel bias toward the right and bottom in the Control Center sidebar icons.

Keeping the fractional logical position preserves the true geometric center. The downstream text/glyph renderers remain responsible for buffer-scale-aware raster snapping.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

N/A — reproduced and verified locally against Noctalia v5.

## Testing

- `just format` with clang-format 22.1.8
- `just test debug --print-errorlogs` — 91/91 tests passed
- `just lint debug` — clang-tidy passed with warnings treated as errors
- Built the v5 debug executable as part of the full test build
- Added `button_layout_test`, which verifies that a 21 px glyph in a 32 px button is positioned at `(5.5, 5.5)` and that the glyph and button centers are identical
- Manually opened the Control Center on Hyprland at interface scale 1.0 and compared pixel centers before and after the change

## Manual Coverage

- [ ] Tested on Niri
- [x] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [ ] Tested at different interface scaling values
- [ ] Tested with multiple monitors

## Screenshots / Videos

The red crosshairs in the Before capture mark each button's geometric center. The After capture is left unannotated for a clear visual comparison. Both use the same 270×1260 crop and 3× nearest-neighbor zoom.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/blackbartblues/noctalia/pr-assets-button-content-centering/.github/pr-assets/button-content-centering/before.png" width="270" alt="Control Center sidebar icons before the centering fix"> | <img src="https://raw.githubusercontent.com/blackbartblues/noctalia/pr-assets-button-content-centering/.github/pr-assets/button-content-centering/after-clean.png" width="270" alt="Control Center sidebar icons after the centering fix"> |

The original implementation showed a consistent `+1 px` horizontal and `+1 px` vertical bias for the affected sidebar icons. After preserving the fractional center, the systematic `+1/+1 px` offset was removed (`0/0 px` for Home, Media, Audio, Monitor, System, Calendar, and Notifications in the verification capture).

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

This intentionally does not force glyph sizes to odd integer values. Integer parity is not stable across interface/output scales, while retaining the exact logical center allows the existing scale-aware renderer to make the final rasterization decision.
