### PR TITLE
feat(notification): route to source app output

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2274,6 +2274,10 @@
           "description": "Screen position for notification toasts",
           "label": "Screen Position"
         },
+        "route-to-source-output": {
+          "description": "Use the monitor containing a uniquely matched source-app window; otherwise use the selected monitors",
+          "label": "Route to Source App Monitor"
+        },
         "scale": {
           "description": "Scale notification toasts relative to the shell UI scale",
           "label": "Size"

--- a/example.toml
+++ b/example.toml
@@ -171,6 +171,7 @@ scale              = 1.0            # notification size multiplier applied on to
 background_opacity = 0.97
 offset_x           = 20             # absolute horizontal margin from the screen edge
 offset_y           = 8              # absolute vertical margin from the screen edge
+route_to_source_output = false      # use a uniquely matched source-app monitor when available
 # [notification.filter.rhythmbox]
 # enabled         = true
 # match           = "rhythmbox"

--- a/src/app/application_services.cpp
+++ b/src/app/application_services.cpp
@@ -805,6 +805,7 @@ void Application::initWaylandCallbacks() {
     m_bar.refresh();
     m_dock.refresh();
     m_windowSwitcher.onToplevelChange();
+    m_notificationToast.onToplevelChange();
   });
   if constexpr (kLockKeysEnabled) {
     if (lockKeysConsumersEnabled(m_configService.config())) {

--- a/src/app/application_ui.cpp
+++ b/src/app/application_ui.cpp
@@ -706,7 +706,9 @@ void Application::initPanelManagerAndPanels() {
 }
 
 void Application::initNotificationAndOsd() {
-  m_notificationToast.initialize(m_wayland, &m_configService, &m_notificationManager, &m_renderContext, &m_httpClient);
+  m_notificationToast.initialize(
+      m_wayland, &m_configService, &m_notificationManager, &m_renderContext, &m_compositorPlatform, &m_httpClient
+  );
   m_configService.addReloadCallback([this]() { m_notificationToast.onConfigReload(); });
   auto applyNotificationFilterConfig = [this]() {
     m_notificationManager.setFilters(m_configService.config().notification.filters);

--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -747,6 +747,7 @@ struct NotificationConfig {
   int offsetX = 20;                // absolute horizontal margin from the screen edge
   int offsetY = 8;                 // absolute vertical margin from the screen edge
   std::vector<std::string> monitors;
+  bool routeToSourceOutput = false;
   bool collapseOnDismiss = true;
   int historyRetentionHours = 0;
   int maxVisible = 0; // 0 = unlimited (space-based only)

--- a/src/config/schema/config_schema.cpp
+++ b/src/config/schema/config_schema.cpp
@@ -256,6 +256,7 @@ namespace noctalia::config::schema {
         field(&NotificationConfig::offsetX, "offset_x"),
         field(&NotificationConfig::offsetY, "offset_y"),
         field(&NotificationConfig::monitors, "monitors"),
+        field(&NotificationConfig::routeToSourceOutput, "route_to_source_output"),
         field(&NotificationConfig::collapseOnDismiss, "collapse_on_dismiss"),
         field(&NotificationConfig::historyRetentionHours, "history_retention_hours", Range<std::int64_t>{0, 8760}),
         field(&NotificationConfig::maxVisible, "max_visible", Range<std::int64_t>{0, 20}),

--- a/src/shell/notification/notification_toast.cpp
+++ b/src/shell/notification/notification_toast.cpp
@@ -1,5 +1,6 @@
 #include "shell/notification/notification_toast.h"
 
+#include "compositors/compositor_platform.h"
 #include "config/config_service.h"
 #include "config/config_types.h"
 #include "core/deferred_call.h"
@@ -16,6 +17,8 @@
 #include "render/render_target.h"
 #include "render/scene/input_area.h"
 #include "shell/surface/edge_inset.h"
+#include "system/app_identity.h"
+#include "system/desktop_entry.h"
 #include "ui/builders.h"
 #include "ui/palette.h"
 #include "ui/style.h"
@@ -511,12 +514,13 @@ NotificationToast::~NotificationToast() {
 
 void NotificationToast::initialize(
     WaylandConnection& wayland, ConfigService* config, NotificationManager* notifications, RenderContext* renderContext,
-    HttpClient* httpClient
+    CompositorPlatform* platform, HttpClient* httpClient
 ) {
   m_wayland = &wayland;
   m_config = config;
   m_notifications = notifications;
   m_renderContext = renderContext;
+  m_platform = platform;
   m_httpClient = httpClient;
 
   m_callbackToken = m_notifications->addEventCallback([this](const Notification& n, NotificationEvent event) {
@@ -534,6 +538,7 @@ void NotificationToast::onConfigReload() {
     return;
   }
   ensureSurfaces();
+  refreshNotificationOutputs();
   std::vector<bool> wasPlaced(m_entries.size(), false);
   for (std::size_t i = 0; i < m_entries.size(); ++i) {
     wasPlaced[i] = hasPlacement(m_entries[i]);
@@ -573,10 +578,21 @@ void NotificationToast::onOutputChange() {
     return;
   }
   ensureSurfaces();
+  refreshNotificationOutputs();
   for (std::size_t i = 0; i < m_entries.size(); ++i) {
     syncEntryVisibility(i);
   }
   requestLayout();
+}
+
+void NotificationToast::onToplevelChange() {
+  if (m_entries.empty() || m_config == nullptr || !m_config->config().notification.routeToSourceOutput) {
+    return;
+  }
+  refreshNotificationOutputs();
+  for (std::size_t i = 0; i < m_entries.size(); ++i) {
+    syncEntryVisibility(i);
+  }
 }
 
 void NotificationToast::hideDndSuppressed() {
@@ -650,6 +666,8 @@ void NotificationToast::onNotificationEvent(const Notification& n, NotificationE
         const float previousHeight = m_entries[i].height;
         const int prevToastBodyLines = m_entries[i].toastBodyLines;
         const bool previouslyPlaced = hasPlacement(m_entries[i]);
+        const wl_output* previousOutput = m_entries[i].targetOutput;
+        m_entries[i].targetOutput = resolveNotificationOutput(n);
         m_entries[i].appName = notificationDisplayAppName(n);
         m_entries[i].summary = n.summary;
         m_entries[i].body = n.body;
@@ -817,7 +835,7 @@ void NotificationToast::onNotificationEvent(const Notification& n, NotificationE
           m_notifications->pauseExpiry(n.id);
         }
 
-        if (!hasPlacement(m_entries[i])) {
+        if (previousOutput != m_entries[i].targetOutput || !hasPlacement(m_entries[i])) {
           syncEntryVisibility(i);
           revealQueuedEntries();
         } else if (std::abs(previousHeight - m_entries[i].height) > 0.5F) {
@@ -870,6 +888,7 @@ void NotificationToast::addPopup(const Notification& n) {
 
   PopupEntry entry;
   entry.notificationId = n.id;
+  entry.targetOutput = resolveNotificationOutput(n);
   entry.appName = notificationDisplayAppName(n);
   entry.summary = n.summary;
   entry.body = n.body;
@@ -903,7 +922,10 @@ void NotificationToast::addPopup(const Notification& n) {
   revealQueuedEntries();
   enforceMaxVisible();
 
-  kLog.debug("notification toast: showing #{}", n.id);
+  const auto* output = m_wayland != nullptr ? m_wayland->findOutputByWl(m_entries[index].targetOutput) : nullptr;
+  kLog.debug(
+      "notification toast: showing #{} on {}", n.id, output != nullptr ? output->connectorName : "all eligible outputs"
+  );
 }
 
 void NotificationToast::requestClose(uint32_t notificationId, CloseReason reason) {
@@ -1001,7 +1023,9 @@ void NotificationToast::finishRemoval(uint32_t notificationId) {
 
 void NotificationToast::addCardToInstance(Instance& inst, std::size_t entryIndex) {
   auto& entry = m_entries[entryIndex];
-  if (!hasPlacement(entry) || !fitsOnSurface(entry, static_cast<float>(inst.surface->height()))) {
+  if (!hasPlacement(entry)
+      || (entry.targetOutput != nullptr && entry.targetOutput != inst.output)
+      || !fitsOnSurface(entry, static_cast<float>(inst.surface->height()))) {
     return;
   }
 
@@ -1182,6 +1206,7 @@ void NotificationToast::syncEntryVisibility(std::size_t entryIndex) {
 
     auto& cs = inst->cards[entryIndex];
     const bool shouldShow = hasPlacement(m_entries[entryIndex])
+        && (m_entries[entryIndex].targetOutput == nullptr || m_entries[entryIndex].targetOutput == inst->output)
         && fitsOnSurface(m_entries[entryIndex], static_cast<float>(inst->surface->height()));
     if (shouldShow) {
       if (cs.cardNode == nullptr) {
@@ -1978,6 +2003,59 @@ uint32_t NotificationToast::surfaceHeightForOutput(wl_output* output) const {
   }
 
   return fallbackSurfaceHeight(notificationUiScale(m_config));
+}
+
+wl_output* NotificationToast::resolveNotificationOutput(const Notification& notification) const {
+  if (m_config == nullptr || !m_config->config().notification.routeToSourceOutput || m_platform == nullptr) {
+    return nullptr;
+  }
+
+  std::string appKey = notification.desktopEntry.value_or("");
+  if (StringUtils::isBlank(appKey)) {
+    appKey = notification.appName;
+  }
+  if (appKey.ends_with(".desktop")) {
+    appKey.resize(appKey.size() - std::string_view(".desktop").size());
+  }
+  if (const auto slash = appKey.find_last_of('/'); slash != std::string::npos) {
+    appKey.erase(0, slash + 1);
+  }
+  if (StringUtils::isBlank(appKey)) {
+    return nullptr;
+  }
+
+  std::string idLower = StringUtils::toLower(appKey);
+  std::string wmClassLower = idLower;
+  if (const auto entry = app_identity::findDesktopEntry(appKey, desktopEntries()); entry.has_value()) {
+    idLower = !entry->idLower.empty() ? entry->idLower : StringUtils::toLower(entry->id);
+    wmClassLower = !entry->startupWmClassLower.empty() ? entry->startupWmClassLower : idLower;
+  }
+
+  wl_output* match = nullptr;
+  for (const auto& inst : m_instances) {
+    if (inst == nullptr
+        || inst->output == nullptr
+        || m_platform->enrichedWindowsForApp(idLower, wmClassLower, inst->output).empty()) {
+      continue;
+    }
+    if (match != nullptr) {
+      return nullptr;
+    }
+    match = inst->output;
+  }
+  return match;
+}
+
+void NotificationToast::refreshNotificationOutputs() {
+  if (m_notifications == nullptr) {
+    return;
+  }
+  for (auto& entry : m_entries) {
+    const auto notification = std::ranges::find(m_notifications->all(), entry.notificationId, &Notification::id);
+    if (notification != m_notifications->all().end()) {
+      entry.targetOutput = resolveNotificationOutput(*notification);
+    }
+  }
 }
 
 // --- Surface lifecycle ---

--- a/src/shell/notification/notification_toast.h
+++ b/src/shell/notification/notification_toast.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class ConfigService;
+class CompositorPlatform;
 class HttpClient;
 class Input;
 class InputArea;
@@ -40,10 +41,11 @@ public:
 
   void initialize(
       WaylandConnection& wayland, ConfigService* config, NotificationManager* notifications,
-      RenderContext* renderContext, HttpClient* httpClient = nullptr
+      RenderContext* renderContext, CompositorPlatform* platform, HttpClient* httpClient = nullptr
   );
   void onConfigReload();
   void onOutputChange();
+  void onToplevelChange();
   void hideDndSuppressed();
   void requestLayout();
   void requestRedraw();
@@ -57,6 +59,7 @@ private:
   // Per-notification visual state (shared across all instances)
   struct PopupEntry {
     uint32_t notificationId = 0;
+    wl_output* targetOutput = nullptr;
     std::string appName;
     std::string summary;
     std::string body;
@@ -189,6 +192,8 @@ private:
   [[nodiscard]] std::optional<float>
   findPlacementY(float entryHeight, std::optional<uint32_t> ignoreNotificationId = std::nullopt) const;
   [[nodiscard]] uint32_t surfaceHeightForOutput(wl_output* output) const;
+  [[nodiscard]] wl_output* resolveNotificationOutput(const Notification& notification) const;
+  void refreshNotificationOutputs();
   // Configured render scale of a notification output, for pre-surface sizing.
   [[nodiscard]] float notificationScale() const;
   [[nodiscard]] std::string resolveNotificationIconPath(const PopupEntry& entry);
@@ -197,6 +202,7 @@ private:
   ConfigService* m_config = nullptr;
   NotificationManager* m_notifications = nullptr;
   RenderContext* m_renderContext = nullptr;
+  CompositorPlatform* m_platform = nullptr;
   HttpClient* m_httpClient = nullptr;
 
   std::vector<PopupEntry> m_entries;

--- a/src/shell/settings/settings_registry.cpp
+++ b/src/shell/settings/settings_registry.cpp
@@ -2954,6 +2954,12 @@ namespace settings {
         "monitor output display screen"
     ));
     entries.push_back(makeEntry(
+        SettingsSection::Notifications, "toasts", tr("settings.schema.notifications.route-to-source-output.label"),
+        tr("settings.schema.notifications.route-to-source-output.description"),
+        {"notification", "route_to_source_output"}, ToggleSetting{cfg.notification.routeToSourceOutput},
+        "source application monitor output route"
+    ));
+    entries.push_back(makeEntry(
         SettingsSection::Notifications, "history", tr("settings.schema.notifications.history-retention-hours.label"),
         tr("settings.schema.notifications.history-retention-hours.description"),
         {"notification", "history_retention_hours"},

--- a/tests/config_schema_roundtrip_test.cpp
+++ b/tests/config_schema_roundtrip_test.cpp
@@ -377,6 +377,7 @@ location = "https://example.invalid/bad"
         .offsetX = 12,
         .offsetY = 6,
         .monitors = {"DP-2"},
+        .routeToSourceOutput = true,
         .collapseOnDismiss = false,
         .historyRetentionHours = 48,
         .filters = {NotificationFilterConfig{


### PR DESCRIPTION
## Summary

- Add a default-off `notification.route_to_source_output` setting and matching Notifications → Toasts toggle
- Route a toast to the single eligible output containing a matched source-application window
- Re-evaluate routing when toplevels, outputs, or notification configuration change
- Preserve the existing selected-monitor behavior when source output matching is disabled, unavailable, or ambiguous

## Motivation

On multi-monitor desktops, the source application can be on one output while focus is on another. Mirroring the same notification on every selected output is distracting, while focus-based routing can send it away from the source application.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging

## Related Issue

Closes #4043

## Testing

- `just format`
- `find src tests \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 clang-format --dry-run -Werror`
- `just build`
- `just test debug --print-errorlogs` — 91/91 passed
- `python3 tools/i18n-check.py`
- `git diff --check`
- Manually verified the unique-output routing path on a two-monitor Niri session: a Chrome notification appeared only on Chrome's `DP-1` output while Alacritty held focus on `HDMI-A-2`

## Manual Coverage

- [x] Tested on Niri
- [ ] Tested on Hyprland
- [ ] Tested on Sway
- [ ] Tested on another compositor:
- [ ] Tested with different bar positions and density settings
- [x] Tested at different interface scaling values
- [x] Tested with multiple monitors

The manual routing check used outputs at 1.0 and 1.25 scale. The PR branch was also built and exercised by the full automated test suite on current `main`.

## Screenshots / Videos

Not attached because the full-desktop capture contained unrelated private content. The live check confirmed one toast on the matched output and no duplicate on the other output.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format` with clang-format v22+ installed, or this PR has no code changes.
- [x] I ran the relevant build or test commands, or explained why they were not run.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I will update end-user documentation after merge, or this PR does not change user-facing configuration or behavior.
- [x] I added or updated `assets/translations/en.json`, or this PR adds no new user-facing strings.
- [x] I did not edit non-English translation files unless this PR is explicitly for translation tooling, an import/export sync, or a maintainer-requested locale change.
- [x] I used the existing canonical names for config keys, IPC names, paths, and identifiers.

## Additional Notes

`notification.monitors` remains the allow-list. Routing only selects a target inside that list.

Desktop notifications do not carry a portable originating toplevel identifier. If the same application has windows on multiple eligible outputs, this intentionally falls back to the current selected-monitor behavior instead of choosing an arbitrary window.
